### PR TITLE
remove dependency on lazy_static and regex by getting rid of some dead validation hack

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,7 @@ required-features = ["cargo_miri"]
 [dependencies]
 byteorder = { version = "1.1", features = ["i128"]}
 cargo_metadata = { version = "0.6", optional = true }
-regex = "1.0"
-lazy_static = "1.0"
-env_logger = "0.5.0-rc.1"
+env_logger = "0.5"
 log = "0.4"
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,9 +17,6 @@ extern crate rustc_data_structures;
 extern crate rustc_mir;
 extern crate rustc_target;
 extern crate syntax;
-extern crate regex;
-#[macro_use]
-extern crate lazy_static;
 
 use rustc::ty::{self, TyCtxt};
 use rustc::ty::layout::{TyLayout, LayoutOf, Size};


### PR DESCRIPTION
Not depending on regex should help for building miri in earlier stages of rustbuild.

EDIT: Nvm it does not help for that, but still it's entirely unnecessary to keep these dependencies for a hack in dead code.