### PR TITLE
we can't have profiles because we are also in the rustc worksapce

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,3 @@ rustc_tests = []
 [dev-dependencies]
 compiletest_rs = { version = "0.3.17", features = ["tmp"] }
 colored = "1.6"
-
-[profile.release]
-debug = true


### PR DESCRIPTION
Otherwise we get
```
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /home/r/src/rust/rustc.3/src/tools/miri/Cargo.toml
workspace: /home/r/src/rust/rustc.3/Cargo.toml
```