### PR TITLE
the stable part of compiletest_rs is enough

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,5 +54,5 @@ cargo_miri = ["cargo_metadata", "directories", "rustc_version"]
 rustc_tests = []
 
 [dev-dependencies]
-compiletest_rs = { version = "0.3.17", features = ["tmp"] }
+compiletest_rs = { version = "0.3.17", features = ["tmp", "stable"] }
 colored = "1.6"


### PR DESCRIPTION
This should fix the fallout from https://github.com/rust-lang/rust/pull/58689.