### PR TITLE
Use edition flag for 2phase test

### DIFF
--- a/tests/run-pass/2phase.rs
+++ b/tests/run-pass/2phase.rs
@@ -1,5 +1,3 @@
-// edition:2018
-
 trait S: Sized {
     fn tpb(&mut self, _s: Self) {}
 }

--- a/tests/run-pass/2phase.rs
+++ b/tests/run-pass/2phase.rs
@@ -1,4 +1,4 @@
-#![feature(nll)]
+// edition:2018
 
 trait S: Sized {
     fn tpb(&mut self, _s: Self) {}
@@ -54,6 +54,8 @@ fn with_interior_mutability() {
 
     let mut x = Cell::new(1);
     let l = &x;
+
+    #[allow(unknown_lints, mutable_borrow_reservation_conflict)]
     x
         .do_the_thing({
             x.set(3);


### PR DESCRIPTION
The compiler now rejects one of the examples with #![feature(nll)].

Use edition:2018 and suppress the lint.