### PR TITLE
temporarily ignore async fn test

### DIFF
--- a/tests/run-pass/async-fn.rs
+++ b/tests/run-pass/async-fn.rs
@@ -1,3 +1,4 @@
+// ignore-test FIXME ignored to let https://github.com/rust-lang/rust/pull/59119 land
 #![feature(
     async_await,
     await_macro,


### PR DESCRIPTION
to let https://github.com/rust-lang/rust/pull/59119 land