### PR TITLE
Update compiletest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,5 +54,5 @@ cargo_miri = ["cargo_metadata", "directories", "rustc_version"]
 rustc_tests = []
 
 [dev-dependencies]
-compiletest_rs = { version = "=0.3.19", features = ["tmp", "stable"] }
+compiletest_rs = { version = "0.3.21", features = ["tmp", "stable"] }
 colored = "1.6"


### PR DESCRIPTION
Needed to make https://github.com/rust-lang/rust/pull/59783 land

Compiletest reverted the changes made in 0.3.20, so the `=` bound (introduced in https://github.com/rust-lang/miri/pull/664)  isn't necessary anymore.

This needs to be landed soon.

r? @RalfJung @solson @oli-obk 