### PR TITLE
Implement non-deterministc mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ shell-escape = "0.1.4"
 rustc-workspace-hack = "1.0.0"
 hex = "0.3.2"
 rand = "0.6.5"
-libc = "0.2.51"
 
 [build-dependencies]
 vergen = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ shell-escape = "0.1.4"
 rustc-workspace-hack = "1.0.0"
 hex = "0.3.2"
 rand = "0.6.5"
+libc = "0.2.51"
 
 [build-dependencies]
 vergen = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ shell-escape = "0.1.4"
 # See the `src/tools/rustc-workspace-hack/README.md` file in `rust-lang/rust`
 # for more information.
 rustc-workspace-hack = "1.0.0"
+hex = "0.3.2"
+rand = "0.6.5"
 
 [build-dependencies]
 vergen = "3"

--- a/benches/helpers/miri_helper.rs
+++ b/benches/helpers/miri_helper.rs
@@ -24,7 +24,7 @@ impl rustc_driver::Callbacks for MiriCompilerCalls<'_> {
             );
 
             self.bencher.iter(|| {
-                let config = miri::MiriConfig { validate: true, args: vec![] };
+                let config = miri::MiriConfig { validate: true, args: vec![], seed: None };
                 eval_main(tcx, entry_def_id, config);
             });
         });

--- a/src/bin/miri-rustc-tests.rs
+++ b/src/bin/miri-rustc-tests.rs
@@ -48,7 +48,7 @@ impl rustc_driver::Callbacks for MiriCompilerCalls {
                     fn visit_item(&mut self, i: &'hir hir::Item) {
                         if let hir::ItemKind::Fn(.., body_id) = i.node {
                             if i.attrs.iter().any(|attr| attr.check_name("test")) {
-                                let config = MiriConfig { validate: true, args: vec![] };
+                                let config = MiriConfig { validate: true, args: vec![], seed: None };
                                 let did = self.0.hir().body_owner_def_id(body_id);
                                 println!("running test: {}", self.0.def_path_debug_str(did));
                                 miri::eval_main(self.0, did, config);
@@ -61,7 +61,7 @@ impl rustc_driver::Callbacks for MiriCompilerCalls {
                 }
                 tcx.hir().krate().visit_all_item_likes(&mut Visitor(tcx));
             } else if let Some((entry_def_id, _)) = tcx.entry_fn(LOCAL_CRATE) {
-                let config = MiriConfig { validate: true, args: vec![] };
+                let config = MiriConfig { validate: true, args: vec![], seed: None };
                 miri::eval_main(tcx, entry_def_id, config);
 
                 compiler.session().abort_if_errors();

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -146,23 +146,22 @@ fn main() {
                 "--" => {
                     after_dashdash = true;
                 }
-                _ => {
-                    let split: Vec<String> = arg.split("-Zmiri-seed=").map(|s| s.to_owned()).collect();
-                    if split.len() == 2 {
-                        if seed.is_some() {
-                            panic!("Cannot specify -Zmiri-seed multiple times!");
-                        }
-                        let seed_raw = hex::decode(&split[1]).unwrap();
-                        if seed_raw.len() > 8 {
-                            panic!(format!("-Zmiri-seed must be at most 8 bytes, was {}", seed_raw.len()));
-                        }
-
-                        let mut bytes = [0; 8];
-                        bytes[..seed_raw.len()].copy_from_slice(&hex::decode(&split[1]).unwrap());
-                        seed = Some(u64::from_be_bytes(bytes));
-                    } else {
-                        rustc_args.push(arg);
+                arg if arg.starts_with("-Zmiri-seed=") => {
+                    if seed.is_some() {
+                        panic!("Cannot specify -Zmiri-seed multiple times!");
                     }
+                    let seed_raw = hex::decode(arg.trim_start_matches("-Zmiri-seed=")).unwrap();
+                    if seed_raw.len() > 8 {
+                        panic!(format!("-Zmiri-seed must be at most 8 bytes, was {}", seed_raw.len()));
+                    }
+
+                    let mut bytes = [0; 8];
+                    bytes[..seed_raw.len()].copy_from_slice(&seed_raw);
+                    seed = Some(u64::from_be_bytes(bytes));
+
+                },
+                _ => {
+                    rustc_args.push(arg);
                 }
             }
         }

--- a/src/fn_call.rs
+++ b/src/fn_call.rs
@@ -216,8 +216,8 @@ pub trait EvalContextExt<'a, 'mir, 'tcx: 'a + 'mir>: crate::MiriEvalContextExt<'
                 //
                 // `libc::syscall(NR_GETRANDOM, buf.as_mut_ptr(), buf.len(), GRND_NONBLOCK)`
                 // is called if a `HashMap` is created the regular way.
-                match this.read_scalar(args[0])?.to_usize(this)? {
-                    318 | 511 => {
+                match this.read_scalar(args[0])?.to_usize(this)? as i64 {
+                    libc::SYS_getrandom => {
                         match this.machine.rng.as_ref() {
                             Some(rng) => {
                                 let ptr = this.read_scalar(args[1])?.to_ptr()?;

--- a/src/fn_call.rs
+++ b/src/fn_call.rs
@@ -216,9 +216,9 @@ pub trait EvalContextExt<'a, 'mir, 'tcx: 'a + 'mir>: crate::MiriEvalContextExt<'
                 //
                 // `libc::syscall(NR_GETRANDOM, buf.as_mut_ptr(), buf.len(), GRND_NONBLOCK)`
                 // is called if a `HashMap` is created the regular way (e.g. HashMap<K, V>).
-                match this.read_scalar(args[0])?.to_usize(this)? as i64 {
+                match (this.read_scalar(args[0])?.to_usize(this)? as i64, tcx.data_layout.pointer_size.bits()) {
                     // SYS_getrandom on x86_64 and x86 respectively
-                    318 | 355 => {
+                    (318, 64) | (355, 32) => {
                         let ptr = this.read_scalar(args[1])?.to_ptr()?;
                         let len = this.read_scalar(args[2])?.to_usize(this)?;
 
@@ -232,7 +232,7 @@ pub trait EvalContextExt<'a, 'mir, 'tcx: 'a + 'mir>: crate::MiriEvalContextExt<'
 
                         this.write_scalar(Scalar::from_uint(len, dest.layout.size), dest)?;
                     }
-                    id => {
+                    (id, _size) => {
                         return err!(Unimplemented(
                             format!("miri does not support syscall ID {}", id),
                         ))

--- a/src/fn_call.rs
+++ b/src/fn_call.rs
@@ -756,8 +756,8 @@ pub trait EvalContextExt<'a, 'mir, 'tcx: 'a + 'mir>: crate::MiriEvalContextExt<'
             }
             // The actual name of 'RtlGenRandom'
             "SystemFunction036" => {
-                let ptr = this.read_scalar(args[1])?.to_ptr()?;
-                let len = this.read_scalar(args[2])?.to_usize(this)?;
+                let ptr = this.read_scalar(args[0])?.to_ptr()?;
+                let len = this.read_scalar(args[1])?.to_usize(this)?;
 
                 let data = gen_random(this, len as usize)?;
                 this.memory_mut().get_mut(ptr.alloc_id)?

--- a/src/fn_call.rs
+++ b/src/fn_call.rs
@@ -795,8 +795,10 @@ fn gen_random<'a, 'mir, 'tcx>(this: &mut MiriEvalContext<'a, 'mir, 'tcx>,
         }
         None => {
             err!(Unimplemented(
-                "miri does not support random number generators in deterministic mode!
-                Use '-Zmiri-seed=<seed>' to enable random number generation".to_owned(),
+                "miri does not support gathering system entropy in deterministic mode!
+                Use '-Zmiri-seed=<seed>' to enable random number generation.
+                WARNING: Miri does *not* generate cryptographically secure entropy -
+                do not use Miri to run any program that need secure random number generation".to_owned(),
             ))
         }
     }

--- a/src/fn_call.rs
+++ b/src/fn_call.rs
@@ -217,7 +217,8 @@ pub trait EvalContextExt<'a, 'mir, 'tcx: 'a + 'mir>: crate::MiriEvalContextExt<'
                 // `libc::syscall(NR_GETRANDOM, buf.as_mut_ptr(), buf.len(), GRND_NONBLOCK)`
                 // is called if a `HashMap` is created the regular way.
                 match this.read_scalar(args[0])?.to_usize(this)? as i64 {
-                    libc::SYS_getrandom => {
+                    // SYS_getrandom on x86_64 and x86 respectively
+                    318 | 355 => {
                         match this.machine.rng.as_ref() {
                             Some(rng) => {
                                 let ptr = this.read_scalar(args[1])?.to_ptr()?;

--- a/src/fn_call.rs
+++ b/src/fn_call.rs
@@ -826,7 +826,7 @@ fn gen_random<'a, 'mir, 'tcx>(
                 "miri does not support gathering system entropy in deterministic mode!
                 Use '-Zmiri-seed=<seed>' to enable random number generation.
                 WARNING: Miri does *not* generate cryptographically secure entropy -
-                do not use Miri to run any program that need secure random number generation".to_owned(),
+                do not use Miri to run any program that needs secure random number generation".to_owned(),
             ))
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,6 @@ mod stacked_borrows;
 
 use std::collections::HashMap;
 use std::borrow::Cow;
-use std::cell::RefCell;
 
 use rand::rngs::StdRng;
 use rand::SeedableRng;
@@ -336,7 +335,7 @@ pub struct Evaluator<'tcx> {
 
     /// The random number generator to use if Miri
     /// is running in non-deterministic mode
-    pub(crate) rng: Option<RefCell<StdRng>>
+    pub(crate) rng: Option<StdRng>
 }
 
 impl<'tcx> Evaluator<'tcx> {
@@ -350,7 +349,7 @@ impl<'tcx> Evaluator<'tcx> {
             tls: TlsData::default(),
             validate,
             stacked_borrows: stacked_borrows::State::default(),
-            rng: seed.map(|s| RefCell::new(StdRng::seed_from_u64(s)))
+            rng: seed.map(|s| StdRng::seed_from_u64(s))
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,10 @@ mod stacked_borrows;
 
 use std::collections::HashMap;
 use std::borrow::Cow;
+use std::cell::RefCell;
+
+use rand::rngs::StdRng;
+use rand::SeedableRng;
 
 use rustc::ty::{self, TyCtxt, query::TyCtxtAt};
 use rustc::ty::layout::{LayoutOf, Size, Align};
@@ -60,6 +64,9 @@ pub fn miri_default_args() -> &'static [&'static str] {
 pub struct MiriConfig {
     pub validate: bool,
     pub args: Vec<String>,
+
+    // The seed to use when non-determinism is required (e.g. getrandom())
+    pub seed: Option<u64>
 }
 
 // Used by priroda.
@@ -71,7 +78,7 @@ pub fn create_ecx<'a, 'mir: 'a, 'tcx: 'mir>(
     let mut ecx = InterpretCx::new(
         tcx.at(syntax::source_map::DUMMY_SP),
         ty::ParamEnv::reveal_all(),
-        Evaluator::new(config.validate),
+        Evaluator::new(config.validate, config.seed),
     );
 
     let main_instance = ty::Instance::mono(ecx.tcx.tcx, main_id);
@@ -326,10 +333,14 @@ pub struct Evaluator<'tcx> {
 
     /// Stacked Borrows state.
     pub(crate) stacked_borrows: stacked_borrows::State,
+
+    /// The random number generator to use if Miri
+    /// is running in non-deterministic mode
+    pub(crate) rng: Option<RefCell<StdRng>>
 }
 
 impl<'tcx> Evaluator<'tcx> {
-    fn new(validate: bool) -> Self {
+    fn new(validate: bool, seed: Option<u64>) -> Self {
         Evaluator {
             env_vars: HashMap::default(),
             argc: None,
@@ -339,6 +350,7 @@ impl<'tcx> Evaluator<'tcx> {
             tls: TlsData::default(),
             validate,
             stacked_borrows: stacked_borrows::State::default(),
+            rng: seed.map(|s| RefCell::new(StdRng::seed_from_u64(s)))
         }
     }
 }

--- a/tests/compile-fail/getrandom.rs
+++ b/tests/compile-fail/getrandom.rs
@@ -8,6 +8,6 @@ fn main() {
     let mut buf = [0u8; 5];
     unsafe {
         libc::syscall(libc::SYS_getrandom, buf.as_mut_ptr() as *mut libc::c_void, 5 as libc::size_t, 0 as libc::c_uint);
-        //~^ ERROR constant evaluation error: miri does not support random number generators in deterministic mode!
+        //~^ ERROR constant evaluation error: miri does not support gathering system entropy in deterministic mode!
     }
 }

--- a/tests/compile-fail/getrandom.rs
+++ b/tests/compile-fail/getrandom.rs
@@ -1,3 +1,5 @@
+// only-linux
+
 #![feature(rustc_private)]
 extern crate libc;
 

--- a/tests/compile-fail/getrandom.rs
+++ b/tests/compile-fail/getrandom.rs
@@ -4,7 +4,7 @@ extern crate libc;
 fn main() {
     let mut buf = [0u8; 5];
     unsafe {
-        libc::syscall(libc::SYS_getrandom, &mut buf as &mut [u8] as *mut [u8] as *mut u8 as *mut libc::c_void, 5, 0);
+        libc::syscall(libc::SYS_getrandom, buf.as_mut_ptr() as *mut libc::c_void, 5, 0);
         //~^ ERROR constant evaluation error: miri does not support random number generators in deterministic mode!
     }
 }

--- a/tests/compile-fail/getrandom.rs
+++ b/tests/compile-fail/getrandom.rs
@@ -1,4 +1,5 @@
-// only-linux
+// ignore-macos
+// ignore-windows
 
 #![feature(rustc_private)]
 extern crate libc;

--- a/tests/compile-fail/getrandom.rs
+++ b/tests/compile-fail/getrandom.rs
@@ -1,0 +1,10 @@
+#![feature(rustc_private)]
+extern crate libc;
+
+fn main() {
+    let mut buf = [0u8; 5];
+    unsafe {
+        libc::syscall(libc::SYS_getrandom, &mut buf as &mut [u8] as *mut [u8] as *mut u8 as *mut libc::c_void, 5, 0);
+        //~^ ERROR constant evaluation error: miri does not support random number generators in deterministic mode!
+    }
+}

--- a/tests/compile-fail/getrandom.rs
+++ b/tests/compile-fail/getrandom.rs
@@ -4,7 +4,7 @@ extern crate libc;
 fn main() {
     let mut buf = [0u8; 5];
     unsafe {
-        libc::syscall(libc::SYS_getrandom, buf.as_mut_ptr() as *mut libc::c_void, 5, 0);
+        libc::syscall(libc::SYS_getrandom, buf.as_mut_ptr() as *mut libc::c_void, 5 as libc::size_t, 0 as libc::c_uint);
         //~^ ERROR constant evaluation error: miri does not support random number generators in deterministic mode!
     }
 }

--- a/tests/run-pass/hashmap.rs
+++ b/tests/run-pass/hashmap.rs
@@ -28,7 +28,12 @@ fn test_map<S: BuildHasher>(mut map: HashMap<i32, i32, S>) {
 
 fn main() {
     let _map : HashMap<i32, i32, BuildHasherDefault<collections::hash_map::DefaultHasher>> = Default::default();
-    let map_normal: HashMap<i32, i32> = HashMap::new();
 
-    test_map(map_normal);
+    // TODO: Implement random number generation on OS X
+    if cfg!(not(target_os = "darwin")) {
+        let map_normal: HashMap<i32, i32> = HashMap::new();
+        test_map(map_normal);
+    } else {
+        test_map(_map);
+    }
 }

--- a/tests/run-pass/hashmap.rs
+++ b/tests/run-pass/hashmap.rs
@@ -27,9 +27,8 @@ fn test_map<S: BuildHasher>(mut map: HashMap<i32, i32, S>) {
 }
 
 fn main() {
-    let map : HashMap<i32, i32, BuildHasherDefault<collections::hash_map::DefaultHasher>> = Default::default();
+    let _map : HashMap<i32, i32, BuildHasherDefault<collections::hash_map::DefaultHasher>> = Default::default();
     let map_normal: HashMap<i32, i32> = HashMap::new();
 
-    test_map(map);
     test_map(map_normal);
 }

--- a/tests/run-pass/hashmap.rs
+++ b/tests/run-pass/hashmap.rs
@@ -27,13 +27,12 @@ fn test_map<S: BuildHasher>(mut map: HashMap<i32, i32, S>) {
 }
 
 fn main() {
-    let _map : HashMap<i32, i32, BuildHasherDefault<collections::hash_map::DefaultHasher>> = Default::default();
-
     // TODO: Implement random number generation on OS X
     if cfg!(not(target_os = "macos")) {
         let map_normal: HashMap<i32, i32> = HashMap::new();
         test_map(map_normal);
     } else {
-        test_map(_map);
+        let map : HashMap<i32, i32, BuildHasherDefault<collections::hash_map::DefaultHasher>> = Default::default();
+        test_map(map);
     }
 }

--- a/tests/run-pass/hashmap.rs
+++ b/tests/run-pass/hashmap.rs
@@ -1,8 +1,9 @@
-use std::collections::{self, HashMap};
-use std::hash::BuildHasherDefault;
+// compile-flags: -Zmiri-seed=0000000000000000
 
-fn main() {
-    let mut map : HashMap<i32, i32, BuildHasherDefault<collections::hash_map::DefaultHasher>> = Default::default();
+use std::collections::{self, HashMap};
+use std::hash::{BuildHasherDefault, BuildHasher};
+
+fn test_map<S: BuildHasher>(mut map: HashMap<i32, i32, S>) {
     map.insert(0, 0);
     assert_eq!(map.values().fold(0, |x, y| x+y), 0);
 
@@ -22,4 +23,13 @@ fn main() {
     assert_eq!(map.values().fold(0, |x, y| x+y), num*(num-1)/2);
 
     // TODO: Test Entry API, Iterators, ...
+
+}
+
+fn main() {
+    let map : HashMap<i32, i32, BuildHasherDefault<collections::hash_map::DefaultHasher>> = Default::default();
+    let map_normal: HashMap<i32, i32> = HashMap::new();
+
+    test_map(map);
+    test_map(map_normal);
 }

--- a/tests/run-pass/hashmap.rs
+++ b/tests/run-pass/hashmap.rs
@@ -30,7 +30,7 @@ fn main() {
     let _map : HashMap<i32, i32, BuildHasherDefault<collections::hash_map::DefaultHasher>> = Default::default();
 
     // TODO: Implement random number generation on OS X
-    if cfg!(not(target_os = "darwin")) {
+    if cfg!(not(target_os = "macos")) {
         let map_normal: HashMap<i32, i32> = HashMap::new();
         test_map(map_normal);
     } else {


### PR DESCRIPTION
Part of #653

This allows us to properly implement getrandom(),
which unlocks the default HashMap type (e.g. HashMap<K, V>)
with RandomState)

This commit adds a new '-Zmiri-seed=<seed>' option. When present,
this option takes a 64-bit hex value, which is used as the seed
to an internal PRNG. This PRNG is used to implement the 'getrandom()'
syscall.

When '-Zmiri-seed' is not passed, 'getrandom()' will be disabled.