### PR TITLE
test and support two-phase reborrows of raw pointers

### DIFF
--- a/test-cargo-miri/test.stdout.ref
+++ b/test-cargo-miri/test.stdout.ref
@@ -5,10 +5,9 @@ test test::rng ... ok
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
 
 
-running 3 tests
+running 2 tests
 test entropy_rng ... ok
-test fixed_rng ... ok
 test simple ... ok
 
-test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
 

--- a/test-cargo-miri/test.stdout.ref2
+++ b/test-cargo-miri/test.stdout.ref2
@@ -7,5 +7,5 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out
 running 1 test
 test simple ... ok
 
-test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out
 

--- a/test-cargo-miri/tests/test.rs
+++ b/test-cargo-miri/tests/test.rs
@@ -1,4 +1,4 @@
-use rand::{SeedableRng, FromEntropy, Rng, rngs::SmallRng};
+use rand::{FromEntropy, Rng, rngs::SmallRng};
 
 // Having more than 1 test does seem to make a difference
 // (i.e., this calls ptr::swap which having just one test does not).

--- a/test-cargo-miri/tests/test.rs
+++ b/test-cargo-miri/tests/test.rs
@@ -1,5 +1,7 @@
 use rand::{SeedableRng, FromEntropy, Rng, rngs::SmallRng};
 
+// Having more than 1 test does seem to make a difference
+// (i.e., this calls ptr::swap which having just one test does not).
 #[test]
 fn simple() {
     assert_eq!(4, 4);
@@ -7,14 +9,6 @@ fn simple() {
 
 // Having more than 1 test does seem to make a difference
 // (i.e., this calls ptr::swap which having just one test does not).
-#[test]
-fn fixed_rng() {
-    let mut rng = rand::rngs::StdRng::seed_from_u64(0xdeadcafe);
-    let x: u32 = rng.gen();
-    let y: u32 = rng.gen();
-    assert_ne!(x, y);
-}
-
 #[test]
 fn entropy_rng() {
     // Use this opportunity to test querying the RNG (needs an external crate, hence tested here and not in the compiletest suite)

--- a/tests/compile-fail/stacked_borrows/deallocate_against_barrier.rs
+++ b/tests/compile-fail/stacked_borrows/deallocate_against_barrier.rs
@@ -1,4 +1,4 @@
-// error-pattern: deallocating with active protect
+// error-pattern: deallocating while item is protected
 
 fn inner(x: &mut i32, f: fn(&mut i32)) {
     // `f` may mutate, but it may not deallocate!

--- a/tests/compile-fail/stacked_borrows/interior_mut1.rs
+++ b/tests/compile-fail/stacked_borrows/interior_mut1.rs
@@ -1,0 +1,10 @@
+use std::cell::UnsafeCell;
+
+fn main() { unsafe {
+    let c = &UnsafeCell::new(UnsafeCell::new(0));
+    let inner_uniq = &mut *c.get();
+    let inner_shr = &*inner_uniq; // a SharedRW with a tag
+    *c.get() = UnsafeCell::new(1); // invalidates the SharedRW
+    let _val = *inner_shr.get(); //~ ERROR borrow stack
+    let _val = *inner_uniq.get();
+} }

--- a/tests/run-pass/stacked-borrows/interior_mutability.rs
+++ b/tests/run-pass/stacked-borrows/interior_mutability.rs
@@ -1,12 +1,12 @@
 #![feature(maybe_uninit, maybe_uninit_ref)]
 use std::mem::MaybeUninit;
-use std::cell::Cell;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell, UnsafeCell};
 
 fn main() {
     aliasing_mut_and_shr();
     aliasing_frz_and_shr();
     into_interior_mutability();
+    unsafe_cell_2phase();
 }
 
 fn aliasing_mut_and_shr() {
@@ -57,3 +57,12 @@ fn into_interior_mutability() {
     let ptr = unsafe { x.get_ref() };
     assert_eq!(ptr.1, 1);
 }
+
+// Two-phase borrows of the pointer returned by UnsafeCell::get() should not
+// invalidate aliases.
+fn unsafe_cell_2phase() { unsafe {
+    let x = &UnsafeCell::new(vec![]);
+    let x2 = &*x;
+    (*x.get()).push(0);
+    let _val = (*x2.get()).get(0);
+} }


### PR DESCRIPTION
This gives up on "two-phase borrows as weak reborrows", which is nice because then we can remove the entire idea of "weak granting/reborrows", and the double-reborrowing upon creating a two-phase borrow.

However, this also makes two-phase borrows even weaker: they now basically allow any aliasing references. This is probably weaker than what we want.