### PR TITLE
adapt CI for bors

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,8 @@ environment:
 branches:
   # whitelist
   only:
-    - master
+    - auto
+    - try
 
 cache:
     - '%USERPROFILE%\.cargo'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ os:
 dist: xenial
 
 # Run in PRs and for bors, but not on master.
-if: branch = staging OR branch = trying OR type = pull_request
+if: branch = auto OR branch = try OR type = pull_request
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ os:
 - osx
 dist: xenial
 
+# Run in PRs and for bors, but not on master.
+if: branch = staging OR branch = trying OR type = pull_request
+
 env:
   global:
   - RUST_TEST_NOCAPTURE=1
@@ -53,3 +56,5 @@ notifications:
 branches:
   only:
   - master
+  - auto
+  - try


### PR DESCRIPTION
With this, we should run the Travis tests (Linux+macOS) in PRs, and run that plus AppVeyor in bors.