### PR TITLE
Show usage if run without arguments

### DIFF
--- a/miri
+++ b/miri
@@ -89,7 +89,7 @@ find_sysroot() {
 
 # Determine command.
 COMMAND="$1"
-shift
+[ $# -gt 0 ] && shift
 
 # Determine flags passed to all cargo invocations.
 # This is a bit more annoying that one would hope due to


### PR DESCRIPTION
Before, running `./miri` without arguments gave
'./miri: 92: shift: can't shift that many' if run with /bin/sh,
or no output at all when run with bash (because of the `set -e` at the top).

Although that gives some indication of the error, it's not as helpful as
showing the usage.