### PR TITLE
Fix `unused_must_use` inside `Box`

### DIFF
--- a/tests/run-pass/issue-30530.rs
+++ b/tests/run-pass/issue-30530.rs
@@ -21,7 +21,9 @@ pub enum Handler {
 }
 
 fn main() {
-    take(Handler::Default, Box::new(main));
+    #[allow(unused_must_use)] {
+        take(Handler::Default, Box::new(main));
+    }
 }
 
 #[inline(never)]


### PR DESCRIPTION
After https://github.com/rust-lang/rust/pull/62228, this will be linted against (and causes the test to fail). (This blocks https://github.com/rust-lang/rust/pull/62228.)