### PR TITLE
avoid Scalar::is_null_ptr, it is going away

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -43,6 +43,28 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             })
     }
 
+    /// Write a 0 of the appropriate size to `dest`.
+    fn write_null(&mut self, dest: PlaceTy<'tcx, Tag>) -> InterpResult<'tcx> {
+        self.eval_context_mut().write_scalar(Scalar::from_int(0, dest.layout.size), dest)
+    }
+
+    /// Test if this immediate equals 0.
+    fn is_null(&self, val: Scalar<Tag>) -> InterpResult<'tcx, bool> {
+        let this = self.eval_context_ref();
+        let null = Scalar::from_int(0, this.memory().pointer_size());
+        this.ptr_eq(val, null)
+    }
+
+    /// Turn a Scalar into an Option<NonNullScalar>
+    fn test_null(&self, val: Scalar<Tag>) -> InterpResult<'tcx, Option<Scalar<Tag>>> {
+        let this = self.eval_context_ref();
+        Ok(if this.is_null(val)? {
+            None
+        } else {
+            Some(val)
+        })
+    }
+
     /// Visits the memory covered by `place`, sensitive to freezing: the 3rd parameter
     /// will be true if this is frozen, false if this is in an `UnsafeCell`.
     fn visit_freeze_sensitive(

--- a/src/shims/tls.rs
+++ b/src/shims/tls.rs
@@ -6,6 +6,7 @@ use rustc::{ty, ty::layout::HasDataLayout, mir};
 use crate::{
     InterpResult, InterpError, StackPopCleanup,
     MPlaceTy, Scalar, Tag,
+    HelpersEvalContextExt,
 };
 
 pub type TlsKey = u128;
@@ -111,7 +112,6 @@ impl<'tcx> TlsData<'tcx> {
     fn fetch_tls_dtor(
         &mut self,
         key: Option<TlsKey>,
-        cx: &impl HasDataLayout,
     ) -> Option<(ty::Instance<'tcx>, Scalar<Tag>, TlsKey)> {
         use std::collections::Bound::*;
 
@@ -123,10 +123,10 @@ impl<'tcx> TlsData<'tcx> {
         for (&key, &mut TlsEntry { ref mut data, dtor }) in
             thread_local.range_mut((start, Unbounded))
         {
-            if let Some(ref mut data) = *data {
+            if let Some(data_scalar) = *data {
                 if let Some(dtor) = dtor {
-                    let ret = Some((dtor, *data, key));
-                    *data = Scalar::ptr_null(cx);
+                    let ret = Some((dtor, data_scalar, key));
+                    *data = None;
                     return ret;
                 }
             }
@@ -139,10 +139,11 @@ impl<'mir, 'tcx> EvalContextExt<'mir, 'tcx> for crate::MiriEvalContext<'mir, 'tc
 pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx> {
     fn run_tls_dtors(&mut self) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
-        let mut dtor = this.machine.tls.fetch_tls_dtor(None, &*this.tcx);
+        let mut dtor = this.machine.tls.fetch_tls_dtor(None);
         // FIXME: replace loop by some structure that works with stepping
         while let Some((instance, ptr, key)) = dtor {
             trace!("Running TLS dtor {:?} on {:?}", instance, ptr);
+            assert!(!this.is_null(ptr).unwrap(), "Data can't be NULL when dtor is called!");
             // TODO: Potentially, this has to support all the other possible instances?
             // See eval_fn_call in interpret/terminator/mod.rs
             let mir = this.load_mir(instance.def)?;
@@ -163,9 +164,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             // step until out of stackframes
             this.run()?;
 
-            dtor = match this.machine.tls.fetch_tls_dtor(Some(key), &*this.tcx) {
+            dtor = match this.machine.tls.fetch_tls_dtor(Some(key)) {
                 dtor @ Some(_) => dtor,
-                None => this.machine.tls.fetch_tls_dtor(None, &*this.tcx),
+                None => this.machine.tls.fetch_tls_dtor(None),
             };
         }
         // FIXME: On a windows target, call `unsafe extern "system" fn on_tls_callback`.


### PR DESCRIPTION
Comparing pointers should be done more carefully than that