### PR TITLE
gen_random helper: move ptr argument to front

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -78,8 +78,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
     /// Generate some random bytes, and write them to `dest`.
     fn gen_random(
         &mut self,
-        len: usize,
         ptr: Scalar<Tag>,
+        len: usize,
     ) -> InterpResult<'tcx>  {
         let this = self.eval_context_mut();
 

--- a/src/shims/dlsym.rs
+++ b/src/shims/dlsym.rs
@@ -41,7 +41,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             GetEntropy => {
                 let ptr = this.read_scalar(args[0])?.not_undef()?;
                 let len = this.read_scalar(args[1])?.to_usize(this)?;
-                this.gen_random(len as usize, ptr)?;
+                this.gen_random(ptr, len as usize)?;
                 this.write_null(dest)?;
             }
         }

--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -300,7 +300,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                         // neither of which have any effect on our current PRNG
                         let _flags = this.read_scalar(args[3])?.to_i32()?;
 
-                        this.gen_random(len as usize, ptr)?;
+                        this.gen_random(ptr, len as usize)?;
                         this.write_scalar(Scalar::from_uint(len, dest.layout.size), dest)?;
                     }
                     id => {
@@ -776,7 +776,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             "SecRandomCopyBytes" => {
                 let len = this.read_scalar(args[1])?.to_usize(this)?;
                 let ptr = this.read_scalar(args[2])?.not_undef()?;
-                this.gen_random(len as usize, ptr)?;
+                this.gen_random(ptr, len as usize)?;
                 this.write_null(dest)?;
             }
 
@@ -938,7 +938,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             "SystemFunction036" => {
                 let ptr = this.read_scalar(args[0])?.not_undef()?;
                 let len = this.read_scalar(args[1])?.to_u32()?;
-                this.gen_random(len as usize, ptr)?;
+                this.gen_random(ptr, len as usize)?;
                 this.write_scalar(Scalar::from_bool(true), dest)?;
             }
 


### PR DESCRIPTION
This matches, for example, the `getrandom` syscall.