### PR TITLE
Allowing passing a null pointer to getrandom() when length is 0

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -81,6 +81,14 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         ptr: Scalar<Tag>,
         len: usize,
     ) -> InterpResult<'tcx>  {
+        // Some programs pass in a null pointer and a length of 0
+        // to their platform's random-generation function (e.g. getrandom())
+        // on Linux. For compatibility with these programs, we don't perform
+        // any additional checks - it's okay if the pointer is invalid,
+        // since we wouldn't actually be writing to it.
+        if len == 0 {
+            return Ok(())
+        }
         let this = self.eval_context_mut();
 
         let ptr = match this.memory().check_ptr_access(ptr, Size::from_bytes(len as u64), Align::from_bytes(1).unwrap())? {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -87,7 +87,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         // any additional checks - it's okay if the pointer is invalid,
         // since we wouldn't actually be writing to it.
         if len == 0 {
-            return Ok(())
+            return Ok(());
         }
         let this = self.eval_context_mut();
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -91,10 +91,11 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         }
         let this = self.eval_context_mut();
 
-        let ptr = match this.memory().check_ptr_access(ptr, Size::from_bytes(len as u64), Align::from_bytes(1).unwrap())? {
-            Some(ptr) => ptr,
-            None => return Ok(()), // zero-sized access
-        };
+        let ptr = this.memory().check_ptr_access(
+            ptr,
+            Size::from_bytes(len as u64),
+            Align::from_bytes(1).unwrap()
+        )?.expect("we already checked for size 0");
 
         let rng = this.memory_mut().extra.rng.get_mut();
         let mut data = vec![0; len];


### PR DESCRIPTION
The Linux kernel will handle a null pointer passed to 'getrandom'
without error, as long as the length is also 0. The `getrandom` crate
relies on this behavior: https://github.com/rust-random/getrandom/blob/ab44edf3c7af721a00e22648b6c811ccb559ba81/src/linux_android.rs#L26

Since it works fine on the actual kernel (and should continue to, due to
the kernel's backwards-compatibility guarantees), Miri should support it
as well.