### PR TITLE
Use host's rng when communication is enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ byteorder = { version = "1.1", features = ["i128"]}
 cargo_metadata = { version = "0.8", optional = true }
 directories = { version = "2.0", optional = true }
 rustc_version = { version = "0.2.3", optional = true }
+getrandom = "0.1.10"
 env_logger = "0.6"
 log = "0.4"
 shell-escape = "0.1.4"

--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ Several `-Z` flags are relevant for Miri:
   will miss bugs in your program.  However, this can also help to make Miri run
   faster.
 * `-Zmiri-enable-communication` enables communication between the host
-  environment and Miri, i.e., all the host environment variables are available
-  during Miri runtime.
+  environment and Miri, i.e., Miri uses the host's random number generator and 
+  all the host environment variables are available during runtime.
 * `-Zmir-opt-level` controls how many MIR optimizations are performed.  Miri
   overrides the default to be `0`; be advised that using any higher level can
   make Miri miss bugs in your program because they got optimized away.

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -101,9 +101,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
         if this.machine.communicate {
             // Fill the buffer using the host's rng.
-            getrandom::getrandom(&mut data).map_err(|err| {
-                InterpError::Unsupported(UnsupportedOpInfo::Unsupported(err.to_string()))
-            })?;
+            getrandom::getrandom(&mut data)
+                .map_err(|err| err_unsup_format!("getrandom failed: {}", err))?;
         }
         else {
             let rng = this.memory_mut().extra.rng.get_mut();

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -93,7 +93,8 @@ pub struct Evaluator<'tcx> {
     /// TLS state.
     pub(crate) tls: TlsData<'tcx>,
 
-    /// If enabled, the `env_vars` field is populated with the host env vars during initialization.
+    /// If enabled, the `env_vars` field is populated with the host env vars during initialization
+    /// and random number generation is delegated to the host.
     pub(crate) communicate: bool,
 }
 


### PR DESCRIPTION
This uses the host's randomness when the communication enabled flag is used. I am not sure about the error handling. I was thinking about fallbacking to `rand` if `getrandom` fails and also print something so the user knows miri is not using the host's rng because it failed. Let me know what you think. 

Related issue: https://github.com/rust-lang/miri/issues/800.

r? @RalfJung @oli-obk 