### PR TITLE
decrease getrandom version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ byteorder = { version = "1.1", features = ["i128"]}
 cargo_metadata = { version = "0.8", optional = true }
 directories = { version = "2.0", optional = true }
 rustc_version = { version = "0.2.3", optional = true }
-getrandom = "0.1.10"
+getrandom = "0.1.8"
 env_logger = "0.6"
 log = "0.4"
 shell-escape = "0.1.4"


### PR DESCRIPTION
so that we dont have to bump Cargo.toml in rustc