### PR TITLE
explicitly enable getrandom/std feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,11 +31,11 @@ doctest = false # and no doc tests
 required-features = ["rustc_tests"]
 
 [dependencies]
-byteorder = { version = "1.1", features = ["i128"]}
+byteorder = { version = "1.1", features = ["i128"] }
 cargo_metadata = { version = "0.8", optional = true }
 directories = { version = "2.0", optional = true }
 rustc_version = { version = "0.2.3", optional = true }
-getrandom = "0.1.8"
+getrandom = { version = "0.1.8", features = ["std"] }
 env_logger = "0.6"
 log = "0.4"
 shell-escape = "0.1.4"


### PR DESCRIPTION
This seems to be what rand_core does, and then we need to do it as well or else the rustc feature checker complains.