### PR TITLE
Add MemoryExtra to find_foreign_static

### DIFF
--- a/src/machine.rs
+++ b/src/machine.rs
@@ -239,6 +239,7 @@ impl<'mir, 'tcx> Machine<'mir, 'tcx> for Evaluator<'tcx> {
     }
 
     fn find_foreign_static(
+        _memory_extra: &MemoryExtra,
         tcx: TyCtxt<'tcx>,
         def_id: DefId,
     ) -> InterpResult<'tcx, Cow<'tcx, Allocation>> {


### PR DESCRIPTION
In order to s0lve https://github.com/rust-lang/miri/issues/756 the `find_foreign_static` method need to access an allocation with pointers to each env variable, @oli-obk suggested storing this in `MemoryExtra` and thus this change includes `MemoryExtra` as an argument for `find_foreign_static`. r? @RalfJung 

Related rust PR: https://github.com/rust-lang/rust/pull/63951