### PR TITLE
test that build scripts do not run in Miri

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ license = "MIT/Apache-2.0"
 name = "miri"
 repository = "https://github.com/rust-lang/miri"
 version = "0.1.0"
-build = "build.rs"
 default-run = "miri"
 edition = "2018"
 

--- a/test-cargo-miri/Cargo.toml
+++ b/test-cargo-miri/Cargo.toml
@@ -3,6 +3,7 @@ name = "cargo-miri-test"
 version = "0.1.0"
 authors = ["Oliver Schneider <git-spam-no-reply9815368754983@oli-obk.de>"]
 edition = "2018"
+build = "build.rs"
 
 [dependencies]
 byteorder = "1.0"

--- a/test-cargo-miri/Cargo.toml
+++ b/test-cargo-miri/Cargo.toml
@@ -3,7 +3,6 @@ name = "cargo-miri-test"
 version = "0.1.0"
 authors = ["Oliver Schneider <git-spam-no-reply9815368754983@oli-obk.de>"]
 edition = "2018"
-build = "build.rs"
 
 [dependencies]
 byteorder = "1.0"

--- a/test-cargo-miri/build.rs
+++ b/test-cargo-miri/build.rs
@@ -1,0 +1,15 @@
+#![feature(asm)]
+
+fn not_in_miri() -> i32 {
+    // Inline assembly definitely does not work in Miri.
+    let dummy = 42;
+    unsafe {
+        asm!("" : : "r"(&dummy));
+    }
+    return dummy;
+}
+
+fn main() {
+    not_in_miri();
+    println!("cargo:rerun-if-changed=build.rs");
+}


### PR DESCRIPTION
@elichai reported something that sounded a lot like build script running in Miri. But as this test shows, build scripts are not run by Miri, they are run normally.

@elichai are you sure the [env var usage you were referring to](https://github.com/rust-lang/miri/issues/641#issuecomment-524989482) was only in a build script? Those shouldn't be affected by Miri flags at all. Is your code available somewhere so that I can try to reproduce?