### PR TITLE
Fix cargo-miri with disabled isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ Several `-Z` flags are relevant for Miri:
   the program has access to host resources such as environment variables and
   randomness (and, eventually, file systems and more).
 * `-Zmiri-env-exclude=<var>` keeps the `var` environment variable isolated from 
-  the host. Can be used multiple times to exclude several variables.
+  the host. Can be used multiple times to exclude several variables. The `TERM`
+  environment variable is excluded by default.
 * `-Zmir-opt-level` controls how many MIR optimizations are performed.  Miri
   overrides the default to be `0`; be advised that using any higher level can
   make Miri miss bugs in your program because they got optimized away.

--- a/src/shims/env.rs
+++ b/src/shims/env.rs
@@ -17,8 +17,9 @@ impl EnvVars {
         ecx: &mut InterpCx<'mir, 'tcx, Evaluator<'tcx>>,
         mut excluded_env_vars: Vec<String>,
     ) {
-        // Exclude TERM var to avoid calls to the file system
+        // Exclude `TERM` var to avoid terminfo trying to open the termcap file.
         excluded_env_vars.push("TERM".to_owned());
+
         if ecx.machine.communicate {
             for (name, value) in std::env::vars() {
                 if !excluded_env_vars.contains(&name) {

--- a/src/shims/env.rs
+++ b/src/shims/env.rs
@@ -15,8 +15,10 @@ pub struct EnvVars {
 impl EnvVars {
     pub(crate) fn init<'mir, 'tcx>(
         ecx: &mut InterpCx<'mir, 'tcx, Evaluator<'tcx>>,
-        excluded_env_vars: Vec<String>,
+        mut excluded_env_vars: Vec<String>,
     ) {
+        // Exclude TERM var to avoid calls to the file system
+        excluded_env_vars.push("TERM".to_owned());
         if ecx.machine.communicate {
             for (name, value) in std::env::vars() {
                 if !excluded_env_vars.contains(&name) {

--- a/test-cargo-miri/run-test.py
+++ b/test-cargo-miri/run-test.py
@@ -60,6 +60,10 @@ def test_cargo_miri_test():
         cargo_miri("test") + ["--", "--", "le1"],
         "test.stdout.ref2", "test.stderr.ref"
     )
+    test("cargo miri test (without isolation)",
+        cargo_miri("test") + ["--", "-Zmiri-disable-isolation", "--", "num_cpus"],
+        "test.stdout.ref3", "test.stderr.ref"
+    )
 
 os.chdir(os.path.dirname(os.path.realpath(__file__)))
 

--- a/test-cargo-miri/test.stdout.ref3
+++ b/test-cargo-miri/test.stdout.ref3
@@ -1,0 +1,11 @@
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out
+
+
+running 1 test
+test num_cpus ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out
+


### PR DESCRIPTION
Related issue: https://github.com/rust-lang/miri/issues/933
I'm not sure if that's the better place to blacklist `TERM`, @RalfJung let me know if there is a less hacky place to put it.