### PR TITLE
Bump byteorder and remove no-op feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,11 @@ doctest = false # and no doc tests
 required-features = ["rustc_tests"]
 
 [dependencies]
-byteorder = { version = "1.1", features = ["i128"] }
 cargo_metadata = { version = "0.8", optional = true }
 directories = { version = "2.0", optional = true }
 rustc_version = { version = "0.2.3", optional = true }
 getrandom = { version = "0.1.8", features = ["std"] }
+byteorder = "1.3"
 env_logger = "0.6"
 log = "0.4"
 shell-escape = "0.1.4"


### PR DESCRIPTION
It's automatically detected: https://github.com/BurntSushi/byteorder/commit/5b3ffeeed2d04ec5051336ea2c6e6d36abc94581

With this PR `byteorder` can be from [rustc-workspace-hack](https://github.com/rust-lang/rust/blob/f71826e8f26fd4fa331574caa462960db8ed961a/src/tools/rustc-workspace-hack/Cargo.toml#L74).