### PR TITLE
change cargo-miri.rs to fix issue #978

### DIFF
--- a/src/bin/cargo-miri.rs
+++ b/src/bin/cargo-miri.rs
@@ -334,7 +334,6 @@ path = "lib.rs"
         Some(target) => target == rustc_version::version_meta().unwrap().host,
     };
     let sysroot = if is_host { dir.join("HOST") } else { PathBuf::from(dir) };
-
     std::env::set_var("MIRI_SYSROOT", &sysroot); // pass the env var to the processes we spawn, which will turn it into "--sysroot" flags
     if print_env {
         println!("MIRI_SYSROOT='{}'", sysroot.display().to_string().replace('\'', r#"'"'"'"#));

--- a/src/bin/cargo-miri.rs
+++ b/src/bin/cargo-miri.rs
@@ -333,11 +333,11 @@ path = "lib.rs"
         None => true,
         Some(target) => target == rustc_version::version_meta().unwrap().host,
     };
-    let sysroot = if is_host { dir.join("HOST") } else { PathBuf::from(dir) }; 
-    
+    let sysroot = if is_host { dir.join("HOST") } else { PathBuf::from(dir) };
+
     std::env::set_var("MIRI_SYSROOT", &sysroot); // pass the env var to the processes we spawn, which will turn it into "--sysroot" flags
     if print_env {
-        println!("MIRI_SYSROOT={:?}", &sysroot); // for Windows users, prints path with backslashes escaped.
+        println!("MIRI_SYSROOT='{}'", sysroot.display().to_string().replace('\'', r#"'"'"'"#));
     } else if !ask_user {
         println!("A libstd for Miri is now available in `{}`.", sysroot.display());
     }

--- a/src/bin/cargo-miri.rs
+++ b/src/bin/cargo-miri.rs
@@ -333,7 +333,14 @@ path = "lib.rs"
         None => true,
         Some(target) => target == rustc_version::version_meta().unwrap().host,
     };
-    let sysroot = if is_host { dir.join("HOST") } else { PathBuf::from(dir) };
+    let mut sysroot = if is_host { dir.join("HOST") } else { PathBuf::from(dir) }; 
+    if cfg!(target_os = "windows") {
+        // Replace backslashes in path to slashes as they cause problems.
+        // Win10 Powershell can work with slashes in paths.
+        sysroot = PathBuf::from(
+            String::from(sysroot.to_str().unwrap()).replace("\\", "/")
+        );
+    }
     std::env::set_var("MIRI_SYSROOT", &sysroot); // pass the env var to the processes we spawn, which will turn it into "--sysroot" flags
     if print_env {
         println!("MIRI_SYSROOT={}", sysroot.display());

--- a/src/bin/cargo-miri.rs
+++ b/src/bin/cargo-miri.rs
@@ -333,17 +333,11 @@ path = "lib.rs"
         None => true,
         Some(target) => target == rustc_version::version_meta().unwrap().host,
     };
-    let mut sysroot = if is_host { dir.join("HOST") } else { PathBuf::from(dir) }; 
-    if cfg!(target_os = "windows") {
-        // Replace backslashes in path to slashes as they cause problems.
-        // Win10 Powershell can work with slashes in paths.
-        sysroot = PathBuf::from(
-            String::from(sysroot.to_str().unwrap()).replace("\\", "/")
-        );
-    }
+    let sysroot = if is_host { dir.join("HOST") } else { PathBuf::from(dir) }; 
+    
     std::env::set_var("MIRI_SYSROOT", &sysroot); // pass the env var to the processes we spawn, which will turn it into "--sysroot" flags
     if print_env {
-        println!("MIRI_SYSROOT={}", sysroot.display());
+        println!("MIRI_SYSROOT={:?}", &sysroot); // for Windows users, prints path with backslashes escaped.
     } else if !ask_user {
         println!("A libstd for Miri is now available in `{}`.", sysroot.display());
     }


### PR DESCRIPTION
In Windows 10, there was an issue with building MIRI locally and getting it running,
due to unpredictable backslash escaping issues in paths.
I added a code snippet that would only be compiled in Windows OS, which replaces all backslashes in paths to slashes.
This fix should only affect Windows users. 
Building and testing MIRI locally now works fine after the fix. 
![miri_result_after_fix0](https://user-images.githubusercontent.com/10286488/66260998-344abc80-e794-11e9-9d7c-b4ef098443de.PNG)

Fixes https://github.com/rust-lang/miri/issues/978
