### PR TITLE
cleanup now that borrow checker knows memory is a field

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -155,7 +155,6 @@ pub fn create_ecx<'mir, 'tcx: 'mir>(
     }
     // Store command line as UTF-16 for Windows `GetCommandLineW`.
     {
-        let tcx = &{ ecx.tcx.tcx };
         let cmd_utf16: Vec<u16> = cmd.encode_utf16().collect();
         let cmd_ptr = ecx.memory.allocate(
             Size::from_bytes(cmd_utf16.len() as u64 * 2),
@@ -169,12 +168,12 @@ pub fn create_ecx<'mir, 'tcx: 'mir>(
         let mut cur_ptr = cmd_ptr;
         for &c in cmd_utf16.iter() {
             cmd_alloc.write_scalar(
-                tcx,
+                &*ecx.tcx,
                 cur_ptr,
                 Scalar::from_uint(c, char_size).into(),
                 char_size,
             )?;
-            cur_ptr = cur_ptr.offset(char_size, tcx)?;
+            cur_ptr = cur_ptr.offset(char_size, &*ecx.tcx)?;
         }
     }
 

--- a/src/shims/fs.rs
+++ b/src/shims/fs.rs
@@ -157,8 +157,6 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
         this.check_no_isolation("read")?;
 
-        let tcx = &{ this.tcx.tcx };
-
         let count = this.read_scalar(count_op)?.to_usize(&*this.tcx)?;
         // Reading zero bytes should not change `buf`
         if count == 0 {
@@ -173,7 +171,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             let bytes = this.force_ptr(buf_scalar).and_then(|buf| {
                 this.memory
                     .get_mut(buf.alloc_id)?
-                    .get_bytes_mut(tcx, buf, Size::from_bytes(count))
+                    .get_bytes_mut(&*this.tcx, buf, Size::from_bytes(count))
                     .map(|buffer| handle.file.read(buffer))
             });
             // Reinsert the file handle
@@ -192,8 +190,6 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
         this.check_no_isolation("write")?;
 
-        let tcx = &{ this.tcx.tcx };
-
         let count = this.read_scalar(count_op)?.to_usize(&*this.tcx)?;
         // Writing zero bytes should not change `buf`
         if count == 0 {
@@ -205,7 +201,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         this.remove_handle_and(fd, |mut handle, this| {
             let bytes = this.memory.get(buf.alloc_id).and_then(|alloc| {
                 alloc
-                    .get_bytes(tcx, buf, Size::from_bytes(count))
+                    .get_bytes(&*this.tcx, buf, Size::from_bytes(count))
                     .map(|bytes| handle.file.write(bytes).map(|bytes| bytes as i64))
             });
             this.machine.file_handler.handles.insert(fd, handle);

--- a/src/shims/intrinsics.rs
+++ b/src/shims/intrinsics.rs
@@ -28,7 +28,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         // (as opposed to through a place), we have to remember to erase any tag
         // that might still hang around!
 
-        let intrinsic_name = &*this.tcx.item_name(instance.def_id()).as_str();
+        let intrinsic_name = &*tcx.item_name(instance.def_id()).as_str();
         match intrinsic_name {
             "arith_offset" => {
                 let offset = this.read_scalar(args[1])?.to_isize(this)?;


### PR DESCRIPTION
@christianpoveda you said, I think, that `fs.rs` could also be cleaned up to longer remove-and-then-add file descriptors from the table? Could you make a PR for that?