### PR TITLE
error code E0080 is no longer printed with MIRI error message

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -9,7 +9,7 @@ use rustc::ty::{self, TyCtxt};
 use syntax::source_map::DUMMY_SP;
 
 use crate::{
-    struct_error, EnvVars, Evaluator, FnVal, HelpersEvalContextExt, InterpCx, InterpError,
+    EnvVars, Evaluator, FnVal, HelpersEvalContextExt, InterpCx, InterpError,
     InterpResult, MemoryExtra, MiriMemoryKind, Pointer, Scalar, StackPopCleanup, Tag,
     TlsEvalContextExt,
 };
@@ -221,7 +221,10 @@ pub fn eval_main<'tcx>(tcx: TyCtxt<'tcx>, main_id: DefId, config: MiriConfig) {
                 };
 
                 let msg = format!("Miri evaluation error: {}", msg);
-                let mut err = struct_error(ecx.tcx.tcx.at(span), msg.as_str());
+                let mut err = {
+                    let new_tcx = ecx.tcx.tcx.at(span);
+                    new_tcx.sess.struct_span_err(new_tcx.span, msg.as_str())
+                };
                 let frames = ecx.generate_stacktrace(None);
                 err.span_label(span, msg);
                 // We iterate with indices because we need to look at the next frame (the caller).

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -221,10 +221,7 @@ pub fn eval_main<'tcx>(tcx: TyCtxt<'tcx>, main_id: DefId, config: MiriConfig) {
                 };
 
                 let msg = format!("Miri evaluation error: {}", msg);
-                let mut err = {
-                    let new_tcx = ecx.tcx.tcx.at(span);
-                    new_tcx.sess.struct_span_err(new_tcx.span, msg.as_str())
-                };
+                let mut err = ecx.tcx.sess.struct_span_err(span, msg.as_str());
                 let frames = ecx.generate_stacktrace(None);
                 err.span_label(span, msg);
                 // We iterate with indices because we need to look at the next frame (the caller).


### PR DESCRIPTION
Thanks to help from @bjorn3, @RalfJung, and @oli-obk on issue #1035 , I fixed the miri code so that error code **E0080** is no longer printed out for MIRI evaluation errors. I tested my code in my Linux machine as below.
![image](https://user-images.githubusercontent.com/10286488/68264744-e71e6c80-0017-11ea-9028-f83e19164ea2.png)

Remaining concern is whether the variable name `new_tcx` which I used is misleading or not.

Fixes https://github.com/rust-lang/miri/issues/1035