### PR TITLE
Implment intrinsics::copysignf32 and intrinsics::copysignf64

### DIFF
--- a/src/shims/intrinsics.rs
+++ b/src/shims/intrinsics.rs
@@ -291,24 +291,26 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.binop_ignore_overflow(op, a, b, dest)?;
             }
 
-            "minnumf32" | "maxnumf32" => {
+            "minnumf32" | "maxnumf32" | "copysignf32" => {
                 let a = this.read_scalar(args[0])?.to_f32()?;
                 let b = this.read_scalar(args[1])?.to_f32()?;
-                let res = if intrinsic_name.starts_with("min") {
-                    a.min(b)
-                } else {
-                    a.max(b)
+                let res = match intrinsic_name {
+                    "minnumf32" => a.min(b),
+                    "maxnumf32" => a.max(b),
+                    "copysignf32" => a.copy_sign(b),
+                    _ => bug!(),
                 };
                 this.write_scalar(Scalar::from_f32(res), dest)?;
             }
 
-            "minnumf64" | "maxnumf64" => {
+            "minnumf64" | "maxnumf64" | "copysignf64" => {
                 let a = this.read_scalar(args[0])?.to_f64()?;
                 let b = this.read_scalar(args[1])?.to_f64()?;
-                let res = if intrinsic_name.starts_with("min") {
-                    a.min(b)
-                } else {
-                    a.max(b)
+                let res = match intrinsic_name {
+                    "minnumf64" => a.min(b),
+                    "maxnumf64" => a.max(b),
+                    "copysignf64" => a.copy_sign(b),
+                    _ => bug!(),
                 };
                 this.write_scalar(Scalar::from_f64(res), dest)?;
             }

--- a/tests/run-pass/floats.rs
+++ b/tests/run-pass/floats.rs
@@ -25,4 +25,16 @@ fn main() {
     assert_eq!(std::f64::NAN.max(-9.0), -9.0);
     assert_eq!((9.0 as f64).min(std::f64::NAN), 9.0);
     assert_eq!((-9.0 as f64).max(std::f64::NAN), -9.0);
+
+    assert_eq!(3.5_f32.copysign(0.42), 3.5_f32);
+    assert_eq!(3.5_f32.copysign(-0.42), -3.5_f32);
+    assert_eq!((-3.5_f32).copysign(0.42), 3.5_f32);
+    assert_eq!((-3.5_f32).copysign(-0.42), -3.5_f32);
+    assert!(std::f32::NAN.copysign(1.0).is_nan());
+
+    assert_eq!(3.5_f64.copysign(0.42), 3.5_f64);
+    assert_eq!(3.5_f64.copysign(-0.42), -3.5_f64);
+    assert_eq!((-3.5_f64).copysign(0.42), 3.5_f64);
+    assert_eq!((-3.5_f64).copysign(-0.42), -3.5_f64);
+    assert!(std::f64::NAN.copysign(1.0).is_nan());
 }


### PR DESCRIPTION
Tries to implment `intrinsics::copysignf32` and `intrinsics::copysignf64`. Fixes #1046.