### PR TITLE
Update suggested nightly version

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If `rustup` says the `miri` component is unavailable, that's because not all
 nightly releases come with all tools. Check out
 [this website](https://rust-lang.github.io/rustup-components-history) to
 determine a nightly version that comes with Miri and install that, e.g. using
-`rustup install nightly-2019-03-28`.
+`rustup install nightly-2019-11-17`.
 
 Now you can run your project in Miri:
 


### PR DESCRIPTION
Update nightly version to one where as many components as possible will install, as rustup install will fail if any installed component is not available in a named nightly.

In particular, the old suggested one didn't work for me, as it didn't have a working clippy.