### PR TITLE
beef up catch_panic test

### DIFF
--- a/tests/run-pass/catch_panic.rs
+++ b/tests/run-pass/catch_panic.rs
@@ -47,6 +47,7 @@ fn main() {
     test(|_old_val| panic!("Hello from panic: std"));
     test(|old_val| panic!(format!("Hello from panic: {:?}", old_val)));
     test(|old_val| panic!("Hello from panic: {:?}", old_val));
+    test(|_old_val| panic!(1337));
     // FIXME https://github.com/rust-lang/miri/issues/1071
     //test(|_old_val| core::panic!("Hello from panic: core"));
     //test(|old_val| core::panic!(&format!("Hello from panic: {:?}", old_val)));

--- a/tests/run-pass/catch_panic.rs
+++ b/tests/run-pass/catch_panic.rs
@@ -1,5 +1,5 @@
 // ignore-windows: Unwind panicking does not currently work on Windows
-use std::panic::catch_unwind;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::cell::Cell;
 
 thread_local! {
@@ -18,7 +18,7 @@ impl Drop for DropTester {
     }
 }
 
-fn do_panic_counter() {
+fn do_panic_counter(do_panic: impl FnOnce(usize) -> !) {
     // If this gets leaked, it will be easy to spot
     // in Miri's leak report
     let _string = "LEAKED FROM do_panic_counter".to_string();
@@ -28,35 +28,62 @@ fn do_panic_counter() {
 
     // Check for bugs in Miri's panic implementation.
     // If do_panic_counter() somehow gets called more than once,
-    // we'll generate a different panic message
+    // we'll generate a different panic message and stderr will differ.
     let old_val = MY_COUNTER.with(|c| {
         let val = c.get();
         c.set(val + 1);
         val
     });
-    panic!(format!("Hello from panic: {:?}", old_val));
+    do_panic(old_val);
 }
 
 fn main() {
-    std::panic::set_hook(Box::new(|_panic_info| {
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic_info| {
         HOOK_CALLED.with(|h| h.set(true));
+        prev(panic_info)
     }));
-    let res = catch_unwind(|| {
-        let _string = "LEAKED FROM CLOSURE".to_string();
-        do_panic_counter()
-    });
-    let expected: Box<String> = Box::new("Hello from panic: 0".to_string());
-    let actual = res.expect_err("do_panic() did not panic!")
-        .downcast::<String>().expect("Failed to cast to string!");
-        
-    assert_eq!(expected, actual);
-    DROPPED.with(|c| {
-        // This should have been set to 'true' by DropTester
-        assert!(c.get());
-    });
 
-    HOOK_CALLED.with(|h| {
-        assert!(h.get());
-    });
+    test(|_old_val| panic!("Hello from panic: std"));
+    test(|old_val| panic!(format!("Hello from panic: {:?}", old_val)));
+    test(|old_val| panic!("Hello from panic: {:?}", old_val));
+    // FIXME https://github.com/rust-lang/miri/issues/1071
+    //test(|_old_val| core::panic!("Hello from panic: core"));
+    //test(|old_val| core::panic!(&format!("Hello from panic: {:?}", old_val)));
+    //test(|old_val| core::panic!("Hello from panic: {:?}", old_val));
+
+    // Cleanup: reset to default hook.
+    drop(std::panic::take_hook());
+
+    eprintln!("Success!"); // Make sure we get this in stderr
+}
+
+fn test(do_panic: impl FnOnce(usize) -> !) {
+    // Reset test flags.
+    DROPPED.with(|c| c.set(false));
+    HOOK_CALLED.with(|c| c.set(false));
+
+    // Cause and catch a panic.
+    let res = catch_unwind(AssertUnwindSafe(|| {
+        let _string = "LEAKED FROM CLOSURE".to_string();
+        do_panic_counter(do_panic)
+    })).expect_err("do_panic() did not panic!");
+
+    // See if we can extract panic message.
+    match res.downcast::<String>() {
+        Ok(s) => {
+            eprintln!("Caught panic message (String): {}", s);
+        }
+        Err(res) =>
+            if let Ok(s) = res.downcast::<&str>() {
+                eprintln!("Caught panic message (&str): {}", s);
+            } else {
+                eprintln!("Failed get caught panic message.");
+            }
+    }
+
+    // Test flags.
+    assert!(DROPPED.with(|c| c.get()));
+    assert!(HOOK_CALLED.with(|c| c.get()));
 }
 

--- a/tests/run-pass/catch_panic.stderr
+++ b/tests/run-pass/catch_panic.stderr
@@ -4,4 +4,6 @@ thread 'main' panicked at 'Hello from panic: 1', $DIR/catch_panic.rs:48:20
 Caught panic message (String): Hello from panic: 1
 thread 'main' panicked at 'Hello from panic: 2', $DIR/catch_panic.rs:49:20
 Caught panic message (String): Hello from panic: 2
+thread 'main' panicked at 'Box<Any>', $DIR/catch_panic.rs:50:21
+Failed get caught panic message.
 Success!

--- a/tests/run-pass/catch_panic.stderr
+++ b/tests/run-pass/catch_panic.stderr
@@ -1,0 +1,7 @@
+thread 'main' panicked at 'Hello from panic: std', $DIR/catch_panic.rs:47:21
+Caught panic message (&str): Hello from panic: std
+thread 'main' panicked at 'Hello from panic: 1', $DIR/catch_panic.rs:48:20
+Caught panic message (String): Hello from panic: 1
+thread 'main' panicked at 'Hello from panic: 2', $DIR/catch_panic.rs:49:20
+Caught panic message (String): Hello from panic: 2
+Success!

--- a/tests/run-pass/panic1.rs
+++ b/tests/run-pass/panic1.rs
@@ -1,4 +1,0 @@
-// ignore-windows: Unwind panicking does not currently work on Windows
-fn main() {
-    panic!("Miri panic!");
-}

--- a/tests/run-pass/panic1.stderr
+++ b/tests/run-pass/panic1.stderr
@@ -1,1 +1,0 @@
-thread 'main' panicked at 'Miri panic!', $DIR/panic1.rs:3:5

--- a/tests/run-pass/panic2.rs
+++ b/tests/run-pass/panic2.rs
@@ -1,5 +1,0 @@
-// ignore-windows: Unwind panicking does not currently work on Windows
-fn main() {
-    let val = "Value".to_string();
-    panic!("Miri panic with value: {}", val);
-}

--- a/tests/run-pass/panic2.stderr
+++ b/tests/run-pass/panic2.stderr
@@ -1,1 +1,0 @@
-thread 'main' panicked at 'Miri panic with value: Value', $DIR/panic2.rs:4:5


### PR DESCRIPTION
Do not silence panic msg printing (so we subsume the tests checking those), and check a few different ways of raising a panic.