### PR TITLE
Add statx shim for linux target

### DIFF
--- a/src/shims/env.rs
+++ b/src/shims/env.rs
@@ -20,8 +20,12 @@ impl EnvVars {
         ecx: &mut InterpCx<'mir, 'tcx, Evaluator<'tcx>>,
         mut excluded_env_vars: Vec<String>,
     ) {
-        // Exclude `TERM` var to avoid terminfo trying to open the termcap file.
-        excluded_env_vars.push("TERM".to_owned());
+
+        // FIXME: this can be removed when we have the `stat64` shim for macos.
+        if ecx.tcx.sess.target.target.target_os.to_lowercase() != "linux" {
+            // Exclude `TERM` var to avoid terminfo trying to open the termcap file.
+            excluded_env_vars.push("TERM".to_owned());
+        }
 
         if ecx.machine.communicate {
             for (name, value) in env::vars() {

--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -303,13 +303,24 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                     .expect("Failed to get libc::SYS_getrandom")
                     .to_machine_usize(this)?;
 
-                // `libc::syscall(NR_GETRANDOM, buf.as_mut_ptr(), buf.len(), GRND_NONBLOCK)`
-                // is called if a `HashMap` is created the regular way (e.g. HashMap<K, V>).
+                let sys_statx = this
+                    .eval_path_scalar(&["libc", "SYS_statx"])?
+                    .expect("Failed to get libc::SYS_statx")
+                    .to_machine_usize(this)?;
+
                 match this.read_scalar(args[0])?.to_machine_usize(this)? {
+                    // `libc::syscall(NR_GETRANDOM, buf.as_mut_ptr(), buf.len(), GRND_NONBLOCK)`
+                    // is called if a `HashMap` is created the regular way (e.g. HashMap<K, V>).
                     id if id == sys_getrandom => {
                         // The first argument is the syscall id,
                         // so skip over it.
                         linux_getrandom(this, &args[1..], dest)?;
+                    }
+                    id if id == sys_statx => {
+                        // The first argument is the syscall id,
+                        // so skip over it.
+                        let result = this.statx(args[1], args[2], args[3], args[4], args[5])?;
+                        this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;
                     }
                     id => throw_unsup_format!("miri does not support syscall ID {}", id),
                 }

--- a/src/shims/time.rs
+++ b/src/shims/time.rs
@@ -1,34 +1,19 @@
 use std::time::{Duration, SystemTime};
 
-use rustc::ty::layout::TyLayout;
-
 use crate::stacked_borrows::Tag;
 use crate::*;
+use helpers::immty_from_int_checked;
 
-// Returns the time elapsed between now and the unix epoch as a `Duration` and the sign of the time
-// interval
+// Returns the time elapsed between now and the unix epoch as a `Duration`.
 fn get_time<'tcx>() -> InterpResult<'tcx, Duration> {
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .map_err(|_| err_unsup_format!("Times before the Unix epoch are not supported").into())
+    system_time_to_duration(&SystemTime::now())
 }
 
-fn int_to_immty_checked<'tcx>(
-    int: i128,
-    layout: TyLayout<'tcx>,
-) -> InterpResult<'tcx, ImmTy<'tcx, Tag>> {
-    // If `int` does not fit in `size` bits, we error instead of letting
-    // `ImmTy::from_int` panic.
-    let size = layout.size;
-    let truncated = truncate(int as u128, size);
-    if sign_extend(truncated, size) as i128 != int {
-        throw_unsup_format!(
-            "Signed value {:#x} does not fit in {} bits",
-            int,
-            size.bits()
-        )
-    }
-    Ok(ImmTy::from_int(int, layout))
+// Returns the time elapsed between the provided time and the unix epoch as a `Duration`.
+pub fn system_time_to_duration<'tcx>(time: &SystemTime) -> InterpResult<'tcx, Duration> {
+    time
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map_err(|_| err_unsup_format!("Times before the Unix epoch are not supported").into())
 }
 
 impl<'mir, 'tcx> EvalContextExt<'mir, 'tcx> for crate::MiriEvalContext<'mir, 'tcx> {}
@@ -57,8 +42,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         let tv_nsec = duration.subsec_nanos() as i128;
 
         let imms = [
-            int_to_immty_checked(tv_sec, this.libc_ty_layout("time_t")?)?,
-            int_to_immty_checked(tv_nsec, this.libc_ty_layout("c_long")?)?,
+            immty_from_int_checked(tv_sec, this.libc_ty_layout("time_t")?)?,
+            immty_from_int_checked(tv_nsec, this.libc_ty_layout("c_long")?)?,
         ];
 
         this.write_packed_immediates(&tp, &imms)?;
@@ -89,8 +74,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         let tv_usec = duration.subsec_micros() as i128;
 
         let imms = [
-            int_to_immty_checked(tv_sec, this.libc_ty_layout("time_t")?)?,
-            int_to_immty_checked(tv_usec, this.libc_ty_layout("suseconds_t")?)?,
+            immty_from_int_checked(tv_sec, this.libc_ty_layout("time_t")?)?,
+            immty_from_int_checked(tv_usec, this.libc_ty_layout("suseconds_t")?)?,
         ];
 
         this.write_packed_immediates(&tv, &imms)?;

--- a/tests/run-pass/fs.rs
+++ b/tests/run-pass/fs.rs
@@ -2,11 +2,32 @@
 // compile-flags: -Zmiri-disable-isolation
 
 use std::fs::{File, remove_file};
-use std::io::{Read, Write, ErrorKind};
+use std::io::{Read, Write, ErrorKind, Result};
+use std::path::{PathBuf, Path};
+
+#[cfg(target_os = "linux")]
+fn test_metadata(bytes: &[u8], path: &Path) -> Result<()> {
+    // Test that the file metadata is correct.
+    let metadata = path.metadata()?;
+    // `path` should point to a file.
+    assert!(metadata.is_file());
+    // The size of the file must be equal to the number of written bytes.
+    assert_eq!(bytes.len() as u64, metadata.len());
+    Ok(())
+}
+
+// FIXME: Implement stat64 for macos.
+#[cfg(not(target_os = "linux"))]
+fn test_metadata(_bytes: &[u8], _path: &Path) -> Result<()> {
+    Ok(())
+}
 
 fn main() {
-    let path = std::env::temp_dir().join("miri_test_fs.txt");
+    let tmp = std::env::temp_dir();
+    let filename = PathBuf::from("miri_test_fs.txt");
+    let path = tmp.join(&filename);
     let bytes = b"Hello, World!\n";
+
     // Test creating, writing and closing a file (closing is tested when `file` is dropped).
     let mut file = File::create(&path).unwrap();
     // Writing 0 bytes should not change the file contents.
@@ -21,7 +42,14 @@ fn main() {
     // Reading until EOF should get the whole text.
     file.read_to_end(&mut contents).unwrap();
     assert_eq!(bytes, contents.as_slice());
-    // Removing file should succeed
+
+    // Test that metadata of an absolute path is correct.
+    test_metadata(bytes, &path).unwrap();
+    // Test that metadata of a relative path is correct.
+    std::env::set_current_dir(tmp).unwrap();
+    test_metadata(bytes, &filename).unwrap();
+
+    // Removing file should succeed.
     remove_file(&path).unwrap();
 
     // The two following tests also check that the `__errno_location()` shim is working properly.
@@ -29,4 +57,8 @@ fn main() {
     assert_eq!(ErrorKind::NotFound, File::open(&path).unwrap_err().kind());
     // Removing a non-existing file should fail with a "not found" error.
     assert_eq!(ErrorKind::NotFound, remove_file(&path).unwrap_err().kind());
+    // Reading the metadata of a non-existing file should fail with a "not found" error.
+    if cfg!(target_os = "linux") { // FIXME: Implement stat64 for macos.
+        assert_eq!(ErrorKind::NotFound, test_metadata(bytes, &path).unwrap_err().kind());
+    }
 }


### PR DESCRIPTION
This is an attempt to fix: https://github.com/rust-lang/miri/issues/999 (for linux only)

Currently there is one problem that I haven't been able to solve. `std::fs::metadata` fails because the creation time is not available even though it is provided in the shim code.

In order to inform the caller that the field was provided, the `stx_flag` field must have the bits of `STATX_BTIME` set (which they are). The creation time is in the `stx_btime` field of the `statx` struct (see [1]). The relevant code in `libstd` is here (probably?): https://github.com/rust-lang/rust/blob/master/src/libstd/sys/unix/fs.rs#L322

Another important point is that we are just providing the fields that are available in "all" platforms (this is, without using any platform specific traits or so). This can be improved later.

References:
[1] Man page: http://man7.org/linux/man-pages/man2/statx.2.html
[2] libc `statx` struct: https://docs.rs/libc/0.2.63/libc/struct.statx.html

Edit: The problem is that my filesystem is not providing it and I thought all filesystems could provide it. I changed the code so it only provides those dates if they are available. now we are ready to go.

r? @RalfJung @oli-obk 