### PR TITLE
better way to ignore tests in Miri

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ interpreted program or test suite after the second `--`.  For example, `cargo
 miri run -- -Zmiri-disable-validation` runs the program without validation of
 basic type invariants and without checking the aliasing of references.
 
-When running code via `cargo miri`, the `miri` config flag is set.  You can
-use this to exclude test cases that will fail under Miri because they do things
+When compiling code via `cargo miri`, the `miri` config flag is set.  You can
+use this to ignore test cases that will fail under Miri because they do things
 Miri does not support:
 
 ```rust
-#[cfg(not(miri))]
 #[test]
+#[cfg_attr(miri, ignore)]
 fn does_not_work_on_miri() {
     std::thread::spawn(|| println!("Hello Thread!"))
         .join()

--- a/test-cargo-miri/test.stdout.ref
+++ b/test-cargo-miri/test.stdout.ref
@@ -5,13 +5,14 @@ test test::rng ... ok
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
 
 
-running 6 tests
+running 7 tests
 test do_panic ... ok
+test does_not_work_on_miri ... ignored
 test entropy_rng ... ok
 test fail_index_check ... ok
 test num_cpus ... ok
 test simple1 ... ok
 test simple2 ... ok
 
-test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+test result: ok. 6 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
 

--- a/test-cargo-miri/test.stdout.ref2
+++ b/test-cargo-miri/test.stdout.ref2
@@ -7,5 +7,5 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out
 running 1 test
 test simple1 ... ok
 
-test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out
 

--- a/test-cargo-miri/test.stdout.ref3
+++ b/test-cargo-miri/test.stdout.ref3
@@ -7,5 +7,5 @@ test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out
 running 1 test
 test num_cpus ... ok
 
-test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out
 

--- a/test-cargo-miri/tests/test.rs
+++ b/test-cargo-miri/tests/test.rs
@@ -13,8 +13,8 @@ fn simple2() {
 }
 
 // A test that won't work on miri (tests disabling tests).
-#[cfg(not(miri))]
 #[test]
+#[cfg_attr(miri, ignore)]
 fn does_not_work_on_miri() {
     let x = 0u8;
     assert!(&x as *const _ as usize % 4 < 4);


### PR DESCRIPTION
This is better because it avoids warnings due to unused imports (the ignored tests still get compiled, just not executed).