### PR TITLE
Updated README to reflect deprecation of rustup install

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If `rustup` says the `miri` component is unavailable, that's because not all
 nightly releases come with all tools. Check out
 [this website](https://rust-lang.github.io/rustup-components-history) to
 determine a nightly version that comes with Miri and install that using
-`rustup install nightly-YYYY-MM-DD`.
+`rustup toolchain install nightly-YYYY-MM-DD`.
 
 Now you can run your project in Miri:
 


### PR DESCRIPTION
This PR from the rustup repository brought me here: https://github.com/rust-lang/rustup/issues/2148

TL;DR With rustup 1.21.0 `rustup install` and `rustup uninstall` are being deprecated in favor of `rustup toolchain install` and `rustup toolchain uninstall`. There's plenty of code/documentation out there that needs to be updated to reflect this.

Thought It would be cool to help, however small the change may be. :)

Keep up the great work!