### PR TITLE
Updated CI config to reflect deprecation of rustup uninstall

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,7 +27,7 @@ install:
     - rustup-init.exe -y --default-host %TARGET% --default-toolchain stable --profile minimal
     - set PATH=%USERPROFILE%\.cargo\bin;%PATH%
     - rustup default stable
-    - rustup uninstall beta
+    - rustup toolchain uninstall beta
     - rustup update
     # Install "master" toolchain
     - cargo install rustup-toolchain-install-master & exit 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_script:
 - curl https://build.travis-ci.org/files/rustup-init.sh -sSf | sh -s -- -y --default-toolchain stable --profile minimal
 - export PATH=$HOME/.cargo/bin:$PATH
 - rustup default stable
-- rustup uninstall beta
+- rustup toolchain uninstall beta
 - rustup update
 # Install "master" toolchain
 - cargo install rustup-toolchain-install-master || echo "rustup-toolchain-install-master already installed"


### PR DESCRIPTION
In the same spirit as #1110 😄 

This PR from the rustup repository brought me here: https://github.com/rust-lang/rustup/issues/2148

TL;DR With rustup 1.21.0 `rustup install` and `rustup uninstall` are being deprecated in favor of `rustup toolchain install` and `rustup toolchain uninstall`. There's plenty of code/documentation out there that needs to be updated to reflect this.

Thought It would be cool to help, however small the change may be. :)

Keep up the great work!