### PR TITLE
support main functions with Result return type

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -62,9 +62,8 @@ pub fn create_ecx<'mir, 'tcx: 'mir>(
     // Setup first stack-frame
     let main_instance = ty::Instance::mono(tcx, main_id);
     let main_mir = ecx.load_mir(main_instance.def, None)?;
-
-    if !main_mir.return_ty().is_unit() || main_mir.arg_count != 0 {
-        throw_unsup_format!("miri does not support main functions without `fn()` type signatures");
+    if main_mir.arg_count != 0 {
+        bug!("main function must not take any arguments");
     }
 
     let start_id = tcx.lang_items().start_fn().unwrap();

--- a/tests/run-pass/main_result.rs
+++ b/tests/run-pass/main_result.rs
@@ -1,0 +1,3 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    Ok(())
+}


### PR DESCRIPTION
Turns out we already properly create the substitution to call the libstd start-fn with an appropriate `main`, we just had an overzealous check in the way.

Fixes https://github.com/rust-lang/miri/issues/1116.