### PR TITLE
no longer test 32bit macOS

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -2,9 +2,7 @@
 set -euo pipefail
 
 # Determine configuration
-if [ "$TRAVIS_OS_NAME" == osx ]; then
-  FOREIGN_TARGET=i686-apple-darwin
-else
+if [ "$TRAVIS_OS_NAME" == linux ]; then
   FOREIGN_TARGET=i686-unknown-linux-gnu
 fi
 export CARGO_EXTRA_FLAGS="--all-features"
@@ -28,6 +26,8 @@ echo "Test host architecture"
 run_tests
 echo
 
-echo "Test foreign architecture ($FOREIGN_TARGET)"
-MIRI_TEST_TARGET="$FOREIGN_TARGET" run_tests
-echo
+if [ -n "$FOREIGN_TARGET" ]; then
+  echo "Test foreign architecture ($FOREIGN_TARGET)"
+  MIRI_TEST_TARGET="$FOREIGN_TARGET" run_tests
+  echo
+fi

--- a/travis.sh
+++ b/travis.sh
@@ -26,7 +26,7 @@ echo "Test host architecture"
 run_tests
 echo
 
-if [ -n "$FOREIGN_TARGET" ]; then
+if [ -n "${FOREIGN_TARGET+exists}" ]; then
   echo "Test foreign architecture ($FOREIGN_TARGET)"
   MIRI_TEST_TARGET="$FOREIGN_TARGET" run_tests
   echo


### PR DESCRIPTION
According to https://blog.rust-lang.org/2020/01/03/reducing-support-for-32-bit-apple-targets.html, these are tier 3 targets now, and might not be available on nightly much longer. So let's stop testing them.