### PR TITLE
Document miri can only be installed on nightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ program, and cannot run all programs:
 
 ## Using Miri
 
-Install Miri via `rustup`:
+Install Miri on Rust nightly via `rustup`:
 
 ```sh
-rustup component add miri
+rustup +nightly component add miri
 ```
 
 If `rustup` says the `miri` component is unavailable, that's because not all


### PR DESCRIPTION
This updates the installation instructions to point out that miri is only available on nightly, and encodes this assumption into the installation instructions.

It took me a bit of research to find out *why* miri wasn't installing on `windows-msvc`:
```txt
C:\Users\yoshu> rustup component add miri
error: component 'miri' for target 'x86_64-pc-windows-msvc' is unavailable for download for channel stable
```

I thought it must 've been something with the `msvc` target, but it turned out I was running on `stable`, and miri can only be installed on `nightly`. Having that be clearer in the installation instructions would've saved me some time debugging. Thanks!