### PR TITLE
Shim intrinsics::atomic_singlethreadfence, etc.

### DIFF
--- a/src/shims/intrinsics.rs
+++ b/src/shims/intrinsics.rs
@@ -113,6 +113,10 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             | "atomic_fence_rel"
             | "atomic_fence_acqrel"
             | "atomic_fence"
+            | "atomic_singlethreadfence_acq"
+            | "atomic_singlethreadfence_rel"
+            | "atomic_singlethreadfence_acqrel"
+            | "atomic_singlethreadfence"
             => {
                 // we are inherently singlethreaded and singlecored, this is a nop
             }

--- a/tests/run-pass/atomic.rs
+++ b/tests/run-pass/atomic.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{fence, AtomicBool, AtomicIsize, AtomicU64, Ordering::*};
+use std::sync::atomic::{compiler_fence, fence, AtomicBool, AtomicIsize, AtomicU64, Ordering::*};
 
 fn main() {
     atomic_bool();
@@ -70,4 +70,8 @@ fn atomic_fences() {
     fence(Release);
     fence(Acquire);
     fence(AcqRel);
+    compiler_fence(SeqCst);
+    compiler_fence(Release);
+    compiler_fence(Acquire);
+    compiler_fence(AcqRel);
 }


### PR DESCRIPTION
This applies the no-op shim for atomic fences to `atomic_singlethreadfence` and related intrinsics.