### PR TITLE
Add support for AT_EMPTY_PATH to statx shim

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -339,7 +339,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
     // different values into a struct.
     fn write_packed_immediates(
         &mut self,
-        place: &MPlaceTy<'tcx, Tag>,
+        place: MPlaceTy<'tcx, Tag>,
         imms: &[ImmTy<'tcx, Tag>],
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();

--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -509,6 +509,11 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;
             }
 
+            "fstat$INODE64" => {
+                let result = this.fstat(args[0], args[1])?;
+                this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;
+            }
+
             "clock_gettime" => {
                 let result = this.clock_gettime(args[0], args[1])?;
                 this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;

--- a/src/shims/fs.rs
+++ b/src/shims/fs.rs
@@ -533,7 +533,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             immty_from_uint_checked(0u128, __u64_layout)?, // stx_dev_minor
         ];
 
-        this.write_packed_immediates(&statxbuf_place, &imms)?;
+        this.write_packed_immediates(statxbuf_place, &imms)?;
 
         Ok(0)
     }
@@ -692,7 +692,7 @@ fn stat_macos_write_buf<'tcx, 'mir>(
     ];
 
     let buf = ecx.deref_operand(buf_op)?;
-    ecx.write_packed_immediates(&buf, &imms)?;
+    ecx.write_packed_immediates(buf, &imms)?;
 
     Ok(0)
 }

--- a/src/shims/fs.rs
+++ b/src/shims/fs.rs
@@ -432,9 +432,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         // * interpreting `path` as a path relative to `dirfd` when the latter is `AT_FDCWD`, or
         // * interpreting `dirfd` as any file descriptor when `path` is empty and AT_EMPTY_PATH is
         // set.
-        // The behavior of `statx` with a relative path and a directory file descriptor other than
-        // `AT_FDCWD` is specified but it cannot be tested from `libstd`. If you found this error,
-        // please open an issue reporting it.
+        // Other behaviors cannot be tested from `libstd` and thus are not implemented. If you
+        // found this error, please open an issue reporting it.
         if !(
             path.is_absolute() ||
             dirfd == this.eval_libc_i32("AT_FDCWD")? ||

--- a/src/shims/time.rs
+++ b/src/shims/time.rs
@@ -45,7 +45,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             immty_from_int_checked(tv_nsec, this.libc_ty_layout("c_long")?)?,
         ];
 
-        this.write_packed_immediates(&tp, &imms)?;
+        this.write_packed_immediates(tp, &imms)?;
 
         Ok(0)
     }
@@ -77,7 +77,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             immty_from_int_checked(tv_usec, this.libc_ty_layout("suseconds_t")?)?,
         ];
 
-        this.write_packed_immediates(&tv, &imms)?;
+        this.write_packed_immediates(tv, &imms)?;
 
         Ok(0)
     }

--- a/tests/run-pass/fs.rs
+++ b/tests/run-pass/fs.rs
@@ -29,8 +29,10 @@ fn main() {
     let mut file = File::create(&path).unwrap();
     // Writing 0 bytes should not change the file contents.
     file.write(&mut []).unwrap();
+    assert_eq!(file.metadata().unwrap().len(), 0);
 
     file.write(bytes).unwrap();
+    assert_eq!(file.metadata().unwrap().len(), bytes.len() as u64);
     // Test opening, reading and closing a file.
     let mut file = File::open(&path).unwrap();
     let mut contents = Vec::new();


### PR DESCRIPTION
This enables use of `File::metadata()`.