### PR TITLE
Add directory-related shims

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -474,35 +474,42 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
     }
 
     /// Helper function to write an OsStr as a null-terminated sequence of bytes, which is what
-    /// the Unix APIs usually handle. This function returns `Ok(false)` without trying to write if
-    /// `size` is not large enough to fit the contents of `os_string` plus a null terminator. It
-    /// returns `Ok(true)` if the writing process was successful.
+    /// the Unix APIs usually handle. This function returns `Ok((false, length))` without trying
+    /// to write if `size` is not large enough to fit the contents of `os_string` plus a null
+    /// terminator. It returns `Ok((true, length))` if the writing process was successful. The
+    /// string length returned does not include the null terminator.
     fn write_os_str_to_c_str(
         &mut self,
         os_str: &OsStr,
         scalar: Scalar<Tag>,
         size: u64,
-    ) -> InterpResult<'tcx, bool> {
+    ) -> InterpResult<'tcx, (bool, u64)> {
+        #[cfg(target_os = "unix")]
+        fn os_str_to_bytes<'tcx, 'a>(os_str: &'a OsStr) -> InterpResult<'tcx, &'a [u8]> {
+            std::os::unix::ffi::OsStringExt::into_bytes(os_str)
+        }
+        #[cfg(not(target_os = "unix"))]
+        fn os_str_to_bytes<'tcx, 'a>(os_str: &'a OsStr) -> InterpResult<'tcx, &'a [u8]> {
+            // On non-unix platforms the best we can do to transform bytes from/to OS strings is to do the
+            // intermediate transformation into strings. Which invalidates non-utf8 paths that are actually
+            // valid.
+            os_str
+                .to_str()
+                .map(|s| s.as_bytes())
+                .ok_or_else(|| err_unsup_format!("{:?} is not a valid utf-8 string", os_str).into())
+        }
+
         let bytes = os_str_to_bytes(os_str)?;
         // If `size` is smaller or equal than `bytes.len()`, writing `bytes` plus the required null
         // terminator to memory using the `ptr` pointer would cause an out-of-bounds access.
-        if size <= bytes.len() as u64 {
-            return Ok(false);
+        let string_length = bytes.len() as u64;
+        if size <= string_length {
+            return Ok((false, string_length));
         }
         self.eval_context_mut()
             .memory
             .write_bytes(scalar, bytes.iter().copied().chain(iter::once(0u8)))?;
-        Ok(true)
-    }
-
-    /// Helper function to determine how long an OsStr would be as a C string, not including the
-    /// null terminator.
-    fn os_str_length_as_c_str(
-        &mut self,
-        os_str: &OsStr,
-    ) -> InterpResult<'tcx, usize> {
-        let bytes = os_str_to_bytes(os_str)?;
-        Ok(bytes.len())
+        Ok((true, string_length))
     }
 
     fn alloc_os_str_as_c_str(
@@ -518,22 +525,6 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         self.write_os_str_to_c_str(os_str, arg_place.ptr, size).unwrap();
         arg_place.ptr.assert_ptr()
     }
-}
-
-#[cfg(target_os = "unix")]
-fn os_str_to_bytes<'tcx, 'a>(os_str: &'a OsStr) -> InterpResult<'tcx, &'a [u8]> {
-    std::os::unix::ffi::OsStringExt::into_bytes(os_str)
-}
-
-#[cfg(not(target_os = "unix"))]
-fn os_str_to_bytes<'tcx, 'a>(os_str: &'a OsStr) -> InterpResult<'tcx, &'a [u8]> {
-    // On non-unix platforms the best we can do to transform bytes from/to OS strings is to do the
-    // intermediate transformation into strings. Which invalidates non-utf8 paths that are actually
-    // valid.
-    os_str
-        .to_str()
-        .map(|s| s.as_bytes())
-        .ok_or_else(|| err_unsup_format!("{:?} is not a valid utf-8 string", os_str).into())
 }
 
 pub fn immty_from_int_checked<'tcx>(

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -483,21 +483,6 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         scalar: Scalar<Tag>,
         size: u64,
     ) -> InterpResult<'tcx, bool> {
-        #[cfg(target_os = "unix")]
-        fn os_str_to_bytes<'tcx, 'a>(os_str: &'a OsStr) -> InterpResult<'tcx, &'a [u8]> {
-            std::os::unix::ffi::OsStringExt::into_bytes(os_str)
-        }
-        #[cfg(not(target_os = "unix"))]
-        fn os_str_to_bytes<'tcx, 'a>(os_str: &'a OsStr) -> InterpResult<'tcx, &'a [u8]> {
-            // On non-unix platforms the best we can do to transform bytes from/to OS strings is to do the
-            // intermediate transformation into strings. Which invalidates non-utf8 paths that are actually
-            // valid.
-            os_str
-                .to_str()
-                .map(|s| s.as_bytes())
-                .ok_or_else(|| err_unsup_format!("{:?} is not a valid utf-8 string", os_str).into())
-        }
-
         let bytes = os_str_to_bytes(os_str)?;
         // If `size` is smaller or equal than `bytes.len()`, writing `bytes` plus the required null
         // terminator to memory using the `ptr` pointer would cause an out-of-bounds access.
@@ -508,6 +493,16 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             .memory
             .write_bytes(scalar, bytes.iter().copied().chain(iter::once(0u8)))?;
         Ok(true)
+    }
+
+    /// Helper function to determine how long an OsStr would be as a C string, not including the
+    /// null terminator.
+    fn os_str_length_as_c_str(
+        &mut self,
+        os_str: &OsStr,
+    ) -> InterpResult<'tcx, usize> {
+        let bytes = os_str_to_bytes(os_str)?;
+        Ok(bytes.len())
     }
 
     fn alloc_os_str_as_c_str(
@@ -523,6 +518,22 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         self.write_os_str_to_c_str(os_str, arg_place.ptr, size).unwrap();
         arg_place.ptr.assert_ptr()
     }
+}
+
+#[cfg(target_os = "unix")]
+fn os_str_to_bytes<'tcx, 'a>(os_str: &'a OsStr) -> InterpResult<'tcx, &'a [u8]> {
+    std::os::unix::ffi::OsStringExt::into_bytes(os_str)
+}
+
+#[cfg(not(target_os = "unix"))]
+fn os_str_to_bytes<'tcx, 'a>(os_str: &'a OsStr) -> InterpResult<'tcx, &'a [u8]> {
+    // On non-unix platforms the best we can do to transform bytes from/to OS strings is to do the
+    // intermediate transformation into strings. Which invalidates non-utf8 paths that are actually
+    // valid.
+    os_str
+        .to_str()
+        .map(|s| s.as_bytes())
+        .ok_or_else(|| err_unsup_format!("{:?} is not a valid utf-8 string", os_str).into())
 }
 
 pub fn immty_from_int_checked<'tcx>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub use rustc_mir::interpret::{self, AllocMap, PlaceTy};
 pub use crate::shims::dlsym::{Dlsym, EvalContextExt as DlsymEvalContextExt};
 pub use crate::shims::env::{EnvVars, EvalContextExt as EnvEvalContextExt};
 pub use crate::shims::foreign_items::EvalContextExt as ForeignItemsEvalContextExt;
-pub use crate::shims::fs::{EvalContextExt as FileEvalContextExt, FileHandler};
+pub use crate::shims::fs::{DirHandler, EvalContextExt as FileEvalContextExt, FileHandler};
 pub use crate::shims::intrinsics::EvalContextExt as IntrinsicsEvalContextExt;
 pub use crate::shims::panic::{CatchUnwindData, EvalContextExt as PanicEvalContextExt};
 pub use crate::shims::time::EvalContextExt as TimeEvalContextExt;

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -115,6 +115,7 @@ pub struct Evaluator<'tcx> {
     pub(crate) communicate: bool,
 
     pub(crate) file_handler: FileHandler,
+    pub(crate) dir_handler: DirHandler,
 
     /// The temporary used for storing the argument of
     /// the call to `miri_start_panic` (the panic payload) when unwinding.
@@ -134,6 +135,7 @@ impl<'tcx> Evaluator<'tcx> {
             tls: TlsData::default(),
             communicate,
             file_handler: Default::default(),
+            dir_handler: Default::default(),
             panic_payload: None,
         }
     }

--- a/src/shims/env.rs
+++ b/src/shims/env.rs
@@ -124,7 +124,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         // If we cannot get the current directory, we return null
         match env::current_dir() {
             Ok(cwd) => {
-                if this.write_os_str_to_c_str(&OsString::from(cwd), buf, size)? {
+                if this.write_os_str_to_c_str(&OsString::from(cwd), buf, size)?.0 {
                     return Ok(buf);
                 }
                 let erange = this.eval_libc("ERANGE")?;

--- a/src/shims/foreign_items/posix.rs
+++ b/src/shims/foreign_items/posix.rs
@@ -109,6 +109,16 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;
             }
 
+            "mkdir" => {
+                let result = this.mkdir(args[0], args[1])?;
+                this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;
+            }
+
+            "rmdir" => {
+                let result = this.rmdir(args[0])?;
+                this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;
+            }
+
             "lseek" | "lseek64" => {
                 let result = this.lseek64(args[0], args[1], args[2])?;
                 this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;

--- a/src/shims/foreign_items/posix.rs
+++ b/src/shims/foreign_items/posix.rs
@@ -119,6 +119,11 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;
             }
 
+            "closedir" => {
+                let result = this.closedir(args[0])?;
+                this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;
+            }
+
             "lseek" | "lseek64" => {
                 let result = this.lseek64(args[0], args[1], args[2])?;
                 this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;

--- a/src/shims/foreign_items/posix/linux.rs
+++ b/src/shims/foreign_items/posix/linux.rs
@@ -27,6 +27,13 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;
             }
 
+            // The only reason this is not in the `posix` module is because the `macos` item has a
+            // different name.
+            "opendir" => {
+                let result = this.opendir(args[0])?;
+                this.write_scalar(result, dest)?;
+            }
+
             // Time related shims
 
             // This is a POSIX function but it has only been tested on linux.

--- a/src/shims/foreign_items/posix/linux.rs
+++ b/src/shims/foreign_items/posix/linux.rs
@@ -37,7 +37,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             // The `macos` module has a parallel foreign item, `readdir_r`, which uses a different
             // struct layout.
             "readdir64_r" => {
-                let result = this.readdir64_r(args[0], args[1], args[2])?;
+                let result = this.linux_readdir64_r(args[0], args[1], args[2])?;
                 this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;
             }
 

--- a/src/shims/foreign_items/posix/linux.rs
+++ b/src/shims/foreign_items/posix/linux.rs
@@ -34,6 +34,13 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_scalar(result, dest)?;
             }
 
+            // The `macos` module has a parallel foreign item, `readdir_r`, which uses a different
+            // struct layout.
+            "readdir64_r" => {
+                let result = this.readdir64_r(args[0], args[1], args[2])?;
+                this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;
+            }
+
             // Time related shims
 
             // This is a POSIX function but it has only been tested on linux.

--- a/src/shims/foreign_items/posix/macos.rs
+++ b/src/shims/foreign_items/posix/macos.rs
@@ -52,7 +52,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             // The `linux` module has a parallel foreign item, `readdir64_r`, which uses a
             // different struct layout.
             "readdir_r$INODE64" => {
-                let result = this.readdir_r(args[0], args[1], args[2])?;
+                let result = this.macos_readdir_r(args[0], args[1], args[2])?;
                 this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;
             }
 

--- a/src/shims/foreign_items/posix/macos.rs
+++ b/src/shims/foreign_items/posix/macos.rs
@@ -42,6 +42,20 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;
             }
 
+            // The only reason this is not in the `posix` module is because the `linux` item has a
+            // different name.
+            "opendir$INODE64" => {
+                let result = this.opendir(args[0])?;
+                this.write_scalar(result, dest)?;
+            }
+
+            // The `linux` module has a parallel foreign item, `readdir64_r`, which uses a
+            // different struct layout.
+            "readdir_r$INODE64" => {
+                let result = this.readdir_r(args[0], args[1], args[2])?;
+                this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;
+            }
+
             // Time related shims
             "gettimeofday" => {
                 let result = this.gettimeofday(args[0], args[1])?;

--- a/src/shims/fs.rs
+++ b/src/shims/fs.rs
@@ -950,7 +950,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                     let c_ushort_layout = this.libc_ty_layout("c_ushort")?;
                     let c_uchar_layout = this.libc_ty_layout("c_uchar")?;
 
-                    let name_offset = dirent_layout.details.fields.offset(4);
+                    let name_offset = dirent_layout.details.fields.offset(5);
                     let name_ptr = entry_ptr.offset(name_offset, this)?;
 
                     #[cfg(unix)]
@@ -969,8 +969,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
                     let imms = [
                         immty_from_uint_checked(ino, ino_t_layout)?, // d_ino
-                        immty_from_uint_checked(0u128, off_t_layout)?, // d_off
+                        immty_from_uint_checked(0u128, off_t_layout)?, // d_seekoff
                         immty_from_uint_checked(0u128, c_ushort_layout)?, // d_reclen
+                        immty_from_uint_checked(file_name.len() as u128, c_ushort_layout)?, // d_namlen
                         immty_from_uint_checked(file_type, c_uchar_layout)?, // d_type
                     ];
                     this.write_packed_immediates(entry_place, &imms)?;

--- a/src/shims/fs.rs
+++ b/src/shims/fs.rs
@@ -874,7 +874,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         if let Some(dir_iter) = this.machine.dir_handler.streams.get_mut(&dirp) {
             match dir_iter.next() {
                 Some(Ok(dir_entry)) => {
-                    // write into entry, write pointer to result, return 0 on success
+                    // Write into entry, write pointer to result, return 0 on success.
+                    // The name is written with write_os_str_to_c_str, while the rest of the
+                    // dirent64 struct is written using write_packed_immediates.
 
                     let name_offset = dirent64_layout.details.fields.offset(4);
                     let name_ptr = entry_ptr.offset(name_offset, this)?;
@@ -944,7 +946,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         if let Some(dir_iter) = this.machine.dir_handler.streams.get_mut(&dirp) {
             match dir_iter.next() {
                 Some(Ok(dir_entry)) => {
-                    // write into entry, write pointer to result, return 0 on success
+                    // Write into entry, write pointer to result, return 0 on success.
+                    // The name is written with write_os_str_to_c_str, while the rest of the
+                    // dirent struct is written using write_packed_Immediates.
 
                     let name_offset = dirent_layout.details.fields.offset(5);
                     let name_ptr = entry_ptr.offset(name_offset, this)?;

--- a/src/shims/fs.rs
+++ b/src/shims/fs.rs
@@ -927,7 +927,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 #[cfg(unix)]
                 let ino = std::os::unix::fs::DirEntryExt::ino(&dir_entry);
                 #[cfg(not(unix))]
-                let ino = 0;
+                let ino = 0u64;
 
                 let file_type = this.file_type_to_d_type(dir_entry.file_type())? as u128;
 
@@ -1015,7 +1015,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 #[cfg(unix)]
                 let ino = std::os::unix::fs::DirEntryExt::ino(&dir_entry);
                 #[cfg(not(unix))]
-                let ino = 0;
+                let ino = 0u64;
 
                 let file_type = this.file_type_to_d_type(dir_entry.file_type())? as u128;
 

--- a/src/shims/fs.rs
+++ b/src/shims/fs.rs
@@ -202,6 +202,16 @@ trait EvalContextExtPrivate<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, '
 
 #[derive(Debug, Default)]
 pub struct DirHandler {
+    /// Directory iterators used to emulate libc "directory streams", as used in opendir, readdir,
+    /// and closedir.
+    ///
+    /// When opendir is called, a new allocation is made, a directory iterator is created on the
+    /// host for the target directory, and an entry is stored in this hash map, indexed by a
+    /// pointer to the allocation which represents the directory stream. When readdir is called,
+    /// the directory stream pointer is used to look up the corresponding ReadDir iterator from
+    /// this HashMap, and information from the next directory entry is returned. When closedir is
+    /// called, the ReadDir iterator is removed from this HashMap, and the allocation that
+    /// represented the directory stream is deallocated.
     streams: HashMap<Pointer<Tag>, ReadDir>,
 }
 

--- a/src/shims/fs.rs
+++ b/src/shims/fs.rs
@@ -173,6 +173,10 @@ trait EvalContextExtPrivate<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, '
                 } else if file_type.is_symlink() {
                     Ok(this.eval_libc("DT_LNK")?.to_u8()? as i32)
                 } else {
+                    // Certain file types are only supported when the host is a Unix system.
+                    // (i.e. devices and sockets) If it is, check those cases, if not, fall back to
+                    // DT_UNKNOWN sooner.
+
                     #[cfg(unix)]
                     {
                         use std::os::unix::fs::FileTypeExt;
@@ -895,6 +899,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 let c_ushort_layout = this.libc_ty_layout("c_ushort")?;
                 let c_uchar_layout = this.libc_ty_layout("c_uchar")?;
 
+                // If the host is a Unix system, fill in the inode number with its real value.
+                // If not, use 0 as a fallback value.
                 #[cfg(unix)]
                 let ino = std::os::unix::fs::DirEntryExt::ino(&dir_entry);
                 #[cfg(not(unix))]
@@ -969,6 +975,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 let c_ushort_layout = this.libc_ty_layout("c_ushort")?;
                 let c_uchar_layout = this.libc_ty_layout("c_uchar")?;
 
+                // If the host is a Unix system, fill in the inode number with its real value.
+                // If not, use 0 as a fallback value.
                 #[cfg(unix)]
                 let ino = std::os::unix::fs::DirEntryExt::ino(&dir_entry);
                 #[cfg(not(unix))]

--- a/src/shims/fs.rs
+++ b/src/shims/fs.rs
@@ -906,7 +906,10 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 let name_place = this.mplace_field(entry_place, 4)?;
 
                 let file_name = dir_entry.file_name();
-                let name_fits = this.write_os_str_to_c_str(&file_name, name_place.ptr, name_place.layout.size.bytes())?;
+                let (name_fits, _) = this.write_os_str_to_c_str(
+                    &file_name, name_place.ptr,
+                    name_place.layout.size.bytes(),
+                )?;
                 if !name_fits {
                     throw_unsup_format!("A directory entry had a name too large to fit in libc::dirent64");
                 }
@@ -990,7 +993,10 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 let name_place = this.mplace_field(entry_place, 5)?;
 
                 let file_name = dir_entry.file_name();
-                let name_fits = this.write_os_str_to_c_str(&file_name, name_place.ptr, name_place.layout.size.bytes())?;
+                let (name_fits, file_name_len) = this.write_os_str_to_c_str(
+                    &file_name, name_place.ptr,
+                    name_place.layout.size.bytes(),
+                )?;
                 if !name_fits {
                     throw_unsup_format!("A directory entry had a name too large to fit in libc::dirent");
                 }
@@ -1007,8 +1013,6 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 let ino = std::os::unix::fs::DirEntryExt::ino(&dir_entry);
                 #[cfg(not(unix))]
                 let ino = 0;
-
-                let file_name_len = this.os_str_length_as_c_str(&file_name)? as u128;
 
                 let file_type = this.file_type_to_d_type(dir_entry.file_type())? as u128;
 

--- a/src/shims/fs.rs
+++ b/src/shims/fs.rs
@@ -785,10 +785,11 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
         this.check_no_isolation("mkdir")?;
 
-        #[cfg(target_os = "linux")]
-        let mode = this.read_scalar(mode_op)?.to_u32()?;
-        #[cfg(not(target_os = "linux"))]
-        let mode = this.read_scalar(mode_op)?.not_undef()?.to_u16()?;
+        let mode = if this.tcx.sess.target.target.target_os.to_lowercase() == "macos" {
+            this.read_scalar(mode_op)?.not_undef()?.to_u16()? as u32
+        } else {
+            this.read_scalar(mode_op)?.to_u32()?
+        };
 
         let path = this.read_os_str_from_c_str(this.read_scalar(path_op)?.not_undef()?)?;
 

--- a/src/shims/fs.rs
+++ b/src/shims/fs.rs
@@ -881,6 +881,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         let this = self.eval_context_mut();
 
         this.check_no_isolation("readdir64_r")?;
+        this.assert_platform("linux", "readdir64_r");
 
         let dirp = this.read_scalar(dirp_op)?.to_machine_usize(this)?;
 
@@ -907,7 +908,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
                 let file_name = dir_entry.file_name();
                 let (name_fits, _) = this.write_os_str_to_c_str(
-                    &file_name, name_place.ptr,
+                    &file_name,
+                    name_place.ptr,
                     name_place.layout.size.bytes(),
                 )?;
                 if !name_fits {
@@ -966,9 +968,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         let this = self.eval_context_mut();
 
         this.check_no_isolation("readdir_r")?;
+        this.assert_platform("macos", "readdir_r");
 
         let dirp = this.read_scalar(dirp_op)?.to_machine_usize(this)?;
-
 
         let dir_iter = this.machine.dir_handler.streams.get_mut(&dirp).ok_or_else(|| {
             err_unsup_format!("The DIR pointer passed to readdir_r did not come from opendir")
@@ -994,7 +996,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
                 let file_name = dir_entry.file_name();
                 let (name_fits, file_name_len) = this.write_os_str_to_c_str(
-                    &file_name, name_place.ptr,
+                    &file_name,
+                    name_place.ptr,
                     name_place.layout.size.bytes(),
                 )?;
                 if !name_fits {

--- a/src/shims/fs.rs
+++ b/src/shims/fs.rs
@@ -902,13 +902,11 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 //     pub d_name: [c_char; 256],
                 // }
 
-                let entry_ptr = this.force_ptr(this.read_scalar(entry_op)?.not_undef()?)?;
-                let dirent64_layout = this.libc_ty_layout("dirent64")?;
-                let name_offset = dirent64_layout.details.fields.offset(4);
-                let name_ptr = entry_ptr.offset(name_offset, this)?;
+                let entry_place = this.deref_operand(entry_op)?;
+                let name_place = this.mplace_field(entry_place, 4)?;
 
                 let file_name = dir_entry.file_name();
-                let name_fits = this.write_os_str_to_c_str(&file_name, Scalar::Ptr(name_ptr), 256)?;
+                let name_fits = this.write_os_str_to_c_str(&file_name, name_place.ptr, name_place.layout.size.bytes())?;
                 if !name_fits {
                     throw_unsup_format!("A directory entry had a name too large to fit in libc::dirent64");
                 }
@@ -988,13 +986,11 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 //     pub d_name: [c_char; 1024],
                 // }
 
-                let entry_ptr = this.force_ptr(this.read_scalar(entry_op)?.not_undef()?)?;
-                let dirent_layout = this.libc_ty_layout("dirent")?;
-                let name_offset = dirent_layout.details.fields.offset(5);
-                let name_ptr = entry_ptr.offset(name_offset, this)?;
+                let entry_place = this.deref_operand(entry_op)?;
+                let name_place = this.mplace_field(entry_place, 5)?;
 
                 let file_name = dir_entry.file_name();
-                let name_fits = this.write_os_str_to_c_str(&file_name, Scalar::Ptr(name_ptr), 1024)?;
+                let name_fits = this.write_os_str_to_c_str(&file_name, name_place.ptr, name_place.layout.size.bytes())?;
                 if !name_fits {
                     throw_unsup_format!("A directory entry had a name too large to fit in libc::dirent");
                 }

--- a/tests/run-pass/fs.rs
+++ b/tests/run-pass/fs.rs
@@ -199,6 +199,8 @@ fn test_directory() {
     create_dir(&dir_path).unwrap();
     // Test that the metadata of a directory is correct.
     assert!(dir_path.metadata().unwrap().is_dir());
+    // Creating a directory when it already exists should fail.
+    assert_eq!(ErrorKind::AlreadyExists, create_dir(&dir_path).unwrap_err().kind());
 
     // Create some files inside the directory
     let path_1 = dir_path.join("test_file_1");

--- a/tests/run-pass/fs.rs
+++ b/tests/run-pass/fs.rs
@@ -201,29 +201,31 @@ fn test_directory() {
     assert!(dir_path.metadata().unwrap().is_dir());
 
     // Create some files inside the directory
-    let f1_path = dir_path.join("f1");
-    drop(File::create(&f1_path).unwrap());
-    let f2_path = dir_path.join("f2");
-    drop(File::create(&f2_path).unwrap());
+    let path_1 = dir_path.join("test_file_1");
+    drop(File::create(&path_1).unwrap());
+    let path_2 = dir_path.join("test_file_2");
+    drop(File::create(&path_2).unwrap());
     // Test that the files are present inside the directory
     let mut dir_iter = read_dir(&dir_path).unwrap();
     let first_dir_entry = dir_iter.next().unwrap().unwrap();
     let second_dir_entry = dir_iter.next().unwrap().unwrap();
     assert!(
-        first_dir_entry.file_name() == "f1" || first_dir_entry.file_name() == "f2",
-        "File name was {:?} instead of f1 or f2",
+        first_dir_entry.file_name() == "test_file_1" ||
+        first_dir_entry.file_name() == "test_file_2",
+        "File name was {:?} instead of test_file_1 or test_file_2",
         first_dir_entry.file_name(),
     );
     assert!(
-        second_dir_entry.file_name() == "f1" || second_dir_entry.file_name() == "f2",
-        "File name was {:?} instead of f1 or f2",
+        second_dir_entry.file_name() == "test_file_1" ||
+        second_dir_entry.file_name() == "test_file_2",
+        "File name was {:?} instead of test_file_1 or test_file_2",
         second_dir_entry.file_name(),
     );
     assert!(dir_iter.next().is_none());
     drop(dir_iter);
     // Clean up the files in the directory
-    remove_file(&f1_path).unwrap();
-    remove_file(&f2_path).unwrap();
+    remove_file(&path_1).unwrap();
+    remove_file(&path_2).unwrap();
 
     // Deleting the directory should succeed.
     remove_dir(&dir_path).unwrap();

--- a/tests/run-pass/fs.rs
+++ b/tests/run-pass/fs.rs
@@ -206,23 +206,10 @@ fn test_directory() {
     let path_2 = dir_path.join("test_file_2");
     drop(File::create(&path_2).unwrap());
     // Test that the files are present inside the directory
-    let mut dir_iter = read_dir(&dir_path).unwrap();
-    let first_dir_entry = dir_iter.next().unwrap().unwrap();
-    let second_dir_entry = dir_iter.next().unwrap().unwrap();
-    assert!(
-        first_dir_entry.file_name() == "test_file_1" ||
-        first_dir_entry.file_name() == "test_file_2",
-        "File name was {:?} instead of test_file_1 or test_file_2",
-        first_dir_entry.file_name(),
-    );
-    assert!(
-        second_dir_entry.file_name() == "test_file_1" ||
-        second_dir_entry.file_name() == "test_file_2",
-        "File name was {:?} instead of test_file_1 or test_file_2",
-        second_dir_entry.file_name(),
-    );
-    assert!(dir_iter.next().is_none());
-    drop(dir_iter);
+    let dir_iter = read_dir(&dir_path).unwrap();
+    let mut file_names = dir_iter.map(|e| e.unwrap().file_name()).collect::<Vec<_>>();
+    file_names.sort_unstable();
+    assert_eq!(file_names, vec!["test_file_1", "test_file_2"]);
     // Clean up the files in the directory
     remove_file(&path_1).unwrap();
     remove_file(&path_2).unwrap();

--- a/tests/run-pass/fs.rs
+++ b/tests/run-pass/fs.rs
@@ -209,8 +209,16 @@ fn test_directory() {
     let mut dir_iter = read_dir(&dir_path).unwrap();
     let first_dir_entry = dir_iter.next().unwrap().unwrap();
     let second_dir_entry = dir_iter.next().unwrap().unwrap();
-    assert!(first_dir_entry.file_name() == "f1" || first_dir_entry.file_name() == "f2");
-    assert!(second_dir_entry.file_name() == "f1" || second_dir_entry.file_name() == "f2");
+    assert!(
+        first_dir_entry.file_name() == "f1" || first_dir_entry.file_name() == "f2",
+        "File name was {:?} instead of f1 or f2",
+        first_dir_entry.file_name(),
+    );
+    assert!(
+        second_dir_entry.file_name() == "f1" || second_dir_entry.file_name() == "f2",
+        "File name was {:?} instead of f1 or f2",
+        second_dir_entry.file_name(),
+    );
     assert!(dir_iter.next().is_none());
     drop(dir_iter);
     // Clean up the files in the directory


### PR DESCRIPTION
This PR adds support for `mkdir`, `rmdir`, `opendir`, `closedir`, and `readdir64_r`.

Open directory streams are tracked through a HashMap indexed by pointer locations, which holds directory iterators. Since `DIR` is an opaque type in glibc, I represent them with 1-byte allocations, and then just use their pointers in HashMap lookups.

Tests are included to exercise the new functionality.