### PR TITLE
Add no-op shim for posix_fadvise

### DIFF
--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -780,6 +780,11 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_null(dest)?;
             }
 
+            "posix_fadvise" => {
+                // fadvise is only informational, we can ignore it.
+                this.write_null(dest)?;
+            }
+
             "mmap" => {
                 // This is a horrible hack, but since the guard page mechanism calls mmap and expects a particular return value, we just give it that value.
                 let addr = this.read_scalar(args[0])?.not_undef()?;

--- a/tests/run-pass/fs.rs
+++ b/tests/run-pass/fs.rs
@@ -1,13 +1,8 @@
 // ignore-windows: File handling is not implemented yet
 // compile-flags: -Zmiri-disable-isolation
 
-#![feature(rustc_private)]
-
-extern crate libc;
-
 use std::fs::{File, remove_file};
 use std::io::{Read, Write, ErrorKind, Result};
-use std::os::unix::io::AsRawFd;
 use std::path::{PathBuf, Path};
 
 fn test_metadata(bytes: &[u8], path: &Path) -> Result<()> {
@@ -44,16 +39,6 @@ fn main() {
     // Reading until EOF should get the whole text.
     file.read_to_end(&mut contents).unwrap();
     assert_eq!(bytes, contents.as_slice());
-
-    // Test calling posix_fadvise on the file.
-    unsafe {
-        libc::posix_fadvise(
-            file.as_raw_fd(),
-            0,
-            bytes.len() as i64,
-            libc::POSIX_FADV_DONTNEED,
-        );
-    }
 
     // Test that metadata of an absolute path is correct.
     test_metadata(bytes, &path).unwrap();

--- a/tests/run-pass/libc.rs
+++ b/tests/run-pass/libc.rs
@@ -1,0 +1,35 @@
+// ignore-windows: No libc on Windows
+// compile-flags: -Zmiri-disable-isolation
+
+#![feature(rustc_private)]
+
+extern crate libc;
+
+use std::env::temp_dir;
+use std::fs::{File, remove_file};
+use std::io::Write;
+use std::os::unix::io::AsRawFd;
+
+fn main() {
+    let path = temp_dir().join("miri_test_libc.txt");
+    // Cleanup before test
+    remove_file(&path).ok();
+
+    // Set up an open file
+    let mut file = File::create(&path).unwrap();
+    let bytes = b"Hello, World!\n";
+    file.write(bytes).unwrap();
+
+    // Test calling posix_fadvise on a file.
+    let result = unsafe {
+        libc::posix_fadvise(
+            file.as_raw_fd(),
+            0,
+            bytes.len() as i64,
+            libc::POSIX_FADV_DONTNEED,
+        )
+    };
+    drop(file);
+    remove_file(&path).unwrap();
+    assert_eq!(result, 0);
+}

--- a/tests/run-pass/libc.rs
+++ b/tests/run-pass/libc.rs
@@ -3,6 +3,7 @@
 
 #![feature(rustc_private)]
 
+#[allow(unused)] // necessary on macos due to conditional compilation
 extern crate libc;
 
 #[cfg(not(target_os = "macos"))]

--- a/tests/run-pass/libc.rs
+++ b/tests/run-pass/libc.rs
@@ -5,6 +5,7 @@
 
 extern crate libc;
 
+use std::convert::TryInto;
 use std::env::temp_dir;
 use std::fs::{File, remove_file};
 use std::io::Write;
@@ -25,7 +26,7 @@ fn main() {
         libc::posix_fadvise(
             file.as_raw_fd(),
             0,
-            bytes.len() as i64,
+            bytes.len().try_into().unwrap(),
             libc::POSIX_FADV_DONTNEED,
         )
     };

--- a/tests/run-pass/libc.rs
+++ b/tests/run-pass/libc.rs
@@ -5,13 +5,14 @@
 
 extern crate libc;
 
-use std::convert::TryInto;
-use std::env::temp_dir;
-use std::fs::{File, remove_file};
-use std::io::Write;
-use std::os::unix::io::AsRawFd;
+#[cfg(not(target_os = "macos"))]
+fn test_posix_fadvise() {
+    use std::convert::TryInto;
+    use std::env::temp_dir;
+    use std::fs::{File, remove_file};
+    use std::io::Write;
+    use std::os::unix::io::AsRawFd;
 
-fn main() {
     let path = temp_dir().join("miri_test_libc.txt");
     // Cleanup before test
     remove_file(&path).ok();
@@ -33,4 +34,9 @@ fn main() {
     drop(file);
     remove_file(&path).unwrap();
     assert_eq!(result, 0);
+}
+
+fn main() {
+    #[cfg(not(target_os = "macos"))]
+    test_posix_fadvise();
 }


### PR DESCRIPTION
This function is present in the libc crate, but not exposed through the standard library anywhere, so I haven't included a test for it.