### PR TITLE
Add shim for rename

### DIFF
--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -521,6 +521,11 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;
             }
 
+            "rename" => {
+                let result = this.rename(args[0], args[1])?;
+                this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;
+            }
+
             "clock_gettime" => {
                 let result = this.clock_gettime(args[0], args[1])?;
                 this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;

--- a/tests/run-pass/fs.rs
+++ b/tests/run-pass/fs.rs
@@ -93,7 +93,7 @@ fn main() {
     rename(&path1, &path2).unwrap();
     assert_eq!(ErrorKind::NotFound, path1.metadata().unwrap_err().kind());
     assert!(path2.metadata().unwrap().is_file());
-    remove_file(&path2).ok();
+    remove_file(&path2).unwrap();
 
     // The two following tests also check that the `__errno_location()` shim is working properly.
     // Opening a non-existing file should fail with a "not found" error.

--- a/tests/run-pass/fs.rs
+++ b/tests/run-pass/fs.rs
@@ -91,6 +91,7 @@ fn main() {
     let file = File::create(&path1).unwrap();
     drop(file);
     rename(&path1, &path2).unwrap();
+    assert_eq!(ErrorKind::NotFound, path1.metadata().unwrap_err().kind());
     assert!(path2.metadata().unwrap().is_file());
     remove_file(&path2).ok();
 

--- a/tests/run-pass/fs.rs
+++ b/tests/run-pass/fs.rs
@@ -1,7 +1,7 @@
 // ignore-windows: File handling is not implemented yet
 // compile-flags: -Zmiri-disable-isolation
 
-use std::fs::{File, remove_file};
+use std::fs::{File, remove_file, rename};
 use std::io::{Read, Write, ErrorKind, Result, Seek, SeekFrom};
 use std::path::{PathBuf, Path};
 
@@ -81,6 +81,18 @@ fn main() {
 
     // Removing file should succeed.
     remove_file(&path).unwrap();
+
+    // Renaming a file should succeed.
+    let path1 = tmp.join("rename_source.txt");
+    let path2 = tmp.join("rename_destination.txt");
+    // Clean files for robustness.
+    remove_file(&path1).ok();
+    remove_file(&path2).ok();
+    let file = File::create(&path1).unwrap();
+    drop(file);
+    rename(&path1, &path2).unwrap();
+    assert!(path2.metadata().unwrap().is_file());
+    remove_file(&path2).ok();
 
     // The two following tests also check that the `__errno_location()` shim is working properly.
     // Opening a non-existing file should fail with a "not found" error.


### PR DESCRIPTION
This adds a straightforward shim for rename, which is used by `std::fs::rename`. Testing is included.

As a heads up, I expect one or two merge conflicts between my PRs, since some of them touch the same `use` statements, or add items near the same places. I'll rebase and fix them as they come up.