### PR TITLE
Import `Alloc` and `Layout` explicitly

### DIFF
--- a/tests/compile-fail/deallocate-bad-alignment.rs
+++ b/tests/compile-fail/deallocate-bad-alignment.rs
@@ -3,7 +3,7 @@
 extern crate alloc;
 
 use alloc::alloc::Global;
-use std::alloc::*;
+use std::alloc::{Alloc, Layout};
 
 // error-pattern: incorrect alloc info: expected size 1 and align 2, got size 1 and align 1
 

--- a/tests/compile-fail/deallocate-bad-size.rs
+++ b/tests/compile-fail/deallocate-bad-size.rs
@@ -3,7 +3,7 @@
 extern crate alloc;
 
 use alloc::alloc::Global;
-use std::alloc::*;
+use std::alloc::{Alloc, Layout};
 
 // error-pattern: incorrect alloc info: expected size 2 and align 1, got size 1 and align 1
 

--- a/tests/compile-fail/deallocate-twice.rs
+++ b/tests/compile-fail/deallocate-twice.rs
@@ -3,7 +3,7 @@
 extern crate alloc;
 
 use alloc::alloc::Global;
-use std::alloc::*;
+use std::alloc::{Alloc, Layout};
 
 // error-pattern: tried to deallocate dangling pointer
 

--- a/tests/compile-fail/reallocate-bad-size.rs
+++ b/tests/compile-fail/reallocate-bad-size.rs
@@ -3,7 +3,7 @@
 extern crate alloc;
 
 use alloc::alloc::Global;
-use std::alloc::*;
+use std::alloc::{Alloc, Layout};
 
 // error-pattern: incorrect alloc info: expected size 2 and align 1, got size 1 and align 1
 

--- a/tests/compile-fail/reallocate-change-alloc.rs
+++ b/tests/compile-fail/reallocate-change-alloc.rs
@@ -3,7 +3,7 @@
 extern crate alloc;
 
 use alloc::alloc::Global;
-use std::alloc::*;
+use std::alloc::{Alloc, Layout};
 
 fn main() {
     unsafe {

--- a/tests/compile-fail/reallocate-dangling.rs
+++ b/tests/compile-fail/reallocate-dangling.rs
@@ -3,7 +3,7 @@
 extern crate alloc;
 
 use alloc::alloc::Global;
-use std::alloc::*;
+use std::alloc::{Layout, Alloc};
 
 // error-pattern: dangling pointer was dereferenced
 


### PR DESCRIPTION
This is required for https://github.com/rust-lang/rust/pull/68529 to land. `Alloc` will be renamed to `AllocRef`, `Alloc` will be added as `#[doc(hidden)]` trait, until `AllocRef` is merged. Then #1154 can be merged, and `Alloc` can be removed. When using a wildcard import, the CI of miri will fail then.