### PR TITLE
rely on improved cargo install

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,7 @@ install:
     - rustup toolchain uninstall beta
     - rustup update
     # Install "master" toolchain
-    - cargo install rustup-toolchain-install-master & exit 0
+    - cargo install rustup-toolchain-install-master
     # We need to install cargo here as well or else the DLL search path inside `cargo run`
     # will be for the wrong toolchain. (On Unix, `./miri` takes care of this, but not here.)
     - rustup-toolchain-install-master -f -n master %RUSTC_HASH% -c rust-src -c rustc-dev -c cargo

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_script:
 - rustup toolchain uninstall beta
 - rustup update
 # Install "master" toolchain
-- cargo install rustup-toolchain-install-master || echo "rustup-toolchain-install-master already installed"
+- cargo install rustup-toolchain-install-master
 - travis_retry rustup-toolchain-install-master -f -n master $RUSTC_HASH -c rust-src -c rustc-dev
 - rustup default master
 - rustc --version


### PR DESCRIPTION
`cargo install` will now update old versions, and not fail if things are up-to-date.