### PR TITLE
Environ shim

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -77,8 +77,8 @@ pub fn create_ecx<'mir, 'tcx: 'mir>(
         ),
     );
     // Complete initialization.
-    MemoryExtra::init_extern_statics(&mut ecx)?;
     EnvVars::init(&mut ecx, config.excluded_env_vars);
+    MemoryExtra::init_extern_statics(&mut ecx)?;
 
     // Setup first stack-frame
     let main_instance = ty::Instance::mono(tcx, main_id);

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -77,8 +77,8 @@ pub fn create_ecx<'mir, 'tcx: 'mir>(
         ),
     );
     // Complete initialization.
-    EnvVars::init(&mut ecx, config.excluded_env_vars);
     MemoryExtra::init_extern_statics(&mut ecx)?;
+    EnvVars::init(&mut ecx, config.excluded_env_vars);
 
     // Setup first stack-frame
     let main_instance = ty::Instance::mono(tcx, main_id);

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -78,7 +78,7 @@ pub fn create_ecx<'mir, 'tcx: 'mir>(
     );
     // Complete initialization.
     MemoryExtra::init_extern_statics(&mut ecx)?;
-    EnvVars::init(&mut ecx, config.excluded_env_vars);
+    EnvVars::init(&mut ecx, config.excluded_env_vars)?;
 
     // Setup first stack-frame
     let main_instance = ty::Instance::mono(tcx, main_id);

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -77,8 +77,8 @@ pub fn create_ecx<'mir, 'tcx: 'mir>(
         ),
     );
     // Complete initialization.
-    MemoryExtra::init_extern_statics(&mut ecx)?;
     EnvVars::init(&mut ecx, config.excluded_env_vars)?;
+    MemoryExtra::init_extern_statics(&mut ecx)?;
 
     // Setup first stack-frame
     let main_instance = ty::Instance::mono(tcx, main_id);

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -85,7 +85,7 @@ pub struct MemoryExtra<'tcx> {
     /// (helps for debugging memory leaks).
     tracked_alloc_id: Option<AllocId>,
 
-    /// Place where the `environ` static is stored. Its value should not change after initialization.
+    /// Place where the `environ` static is stored. Lazily initialized, but then never changes.
     pub(crate) environ: Option<MPlaceTy<'tcx, Tag>>,
 }
 

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -85,7 +85,7 @@ pub struct MemoryExtra<'tcx> {
     /// (helps for debugging memory leaks).
     tracked_alloc_id: Option<AllocId>,
 
-    /// Place where the `environ` static is stored.
+    /// Place where the `environ` static is stored. Its value should not change after initialization.
     pub(crate) environ: Option<MPlaceTy<'tcx, Tag>>,
 }
 

--- a/src/shims/env.rs
+++ b/src/shims/env.rs
@@ -20,7 +20,7 @@ impl EnvVars {
     pub(crate) fn init<'mir, 'tcx>(
         ecx: &mut InterpCx<'mir, 'tcx, Evaluator<'tcx>>,
         excluded_env_vars: Vec<String>,
-    ) {
+    ) -> InterpResult<'tcx> {
         if ecx.machine.communicate {
             for (name, value) in env::vars() {
                 if !excluded_env_vars.contains(&name) {
@@ -30,7 +30,7 @@ impl EnvVars {
                 }
             }
         }
-        ecx.update_environ().unwrap();
+        ecx.update_environ()
     }
 }
 

--- a/src/shims/env.rs
+++ b/src/shims/env.rs
@@ -81,10 +81,10 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         if let Some((name, value)) = new {
             let var_ptr = alloc_env_var_as_c_str(&name, &value, &mut this);
             if let Some(var) = this.machine.env_vars.map.insert(name.to_owned(), var_ptr) {
-                this.update_environ()?;
                 this.memory
                     .deallocate(var, None, MiriMemoryKind::Machine.into())?;
             }
+            this.update_environ()?;
             Ok(0)
         } else {
             Ok(-1)
@@ -100,7 +100,6 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             let name = this.read_os_str_from_c_str(name_ptr)?.to_owned();
             if !name.is_empty() && !name.to_string_lossy().contains('=') {
                 success = Some(this.machine.env_vars.map.remove(&name));
-                this.update_environ()?;
             }
         }
         if let Some(old) = success {
@@ -108,6 +107,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.memory
                     .deallocate(var, None, MiriMemoryKind::Machine.into())?;
             }
+            this.update_environ()?;
             Ok(0)
         } else {
             Ok(-1)

--- a/src/shims/foreign_items/posix/macos.rs
+++ b/src/shims/foreign_items/posix/macos.rs
@@ -41,10 +41,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 let result = this.macos_fstat(args[0], args[1])?;
                 this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;
             }
-            // Environment related shims
-            "_NSGetEnviron" => {
-                this.write_scalar(this.memory.extra.environ.unwrap().ptr, dest)?;
-            }
+
             // The only reason this is not in the `posix` module is because the `linux` item has a
             // different name.
             "opendir$INODE64" => {
@@ -57,6 +54,11 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             "readdir_r$INODE64" => {
                 let result = this.macos_readdir_r(args[0], args[1], args[2])?;
                 this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;
+            }
+
+            // Environment related shims
+            "_NSGetEnviron" => {
+                this.write_scalar(this.memory.extra.environ.unwrap().ptr, dest)?;
             }
 
             // Time related shims

--- a/src/shims/foreign_items/posix/macos.rs
+++ b/src/shims/foreign_items/posix/macos.rs
@@ -41,7 +41,10 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 let result = this.macos_fstat(args[0], args[1])?;
                 this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;
             }
-
+            // Environment related shims
+            "_NSGetEnviron" => {
+                this.write_scalar(this.memory.extra.environ.unwrap().ptr, dest)?;
+            }
             // The only reason this is not in the `posix` module is because the `linux` item has a
             // different name.
             "opendir$INODE64" => {

--- a/tests/compile-fail/environ-gets-deallocated.rs
+++ b/tests/compile-fail/environ-gets-deallocated.rs
@@ -1,0 +1,10 @@
+extern "C" {
+    static environ: *const *const u8;
+}
+
+fn main() {
+    let pointer = unsafe { environ };
+    let _x = unsafe { *pointer };
+    std::env::set_var("FOO", "BAR");
+    let _y = unsafe { *pointer }; //~ ERROR dangling pointer was dereferenced
+}

--- a/tests/compile-fail/environ-gets-deallocated.rs
+++ b/tests/compile-fail/environ-gets-deallocated.rs
@@ -1,9 +1,23 @@
-extern "C" {
+//ignore-windows: TODO env var emulation stubbed out on Windows
+
+#[cfg(target_os="linux")]
+fn get_environ() -> *const *const u8 {
+  extern "C" {
     static environ: *const *const u8;
+  }
+  environ
+}
+
+#[cfg(target_os="macos")]
+fn get_environ() -> *const *const u8 {
+    extern "C" {
+        fn _NSGetEnviron() -> *mut *const *const u8;
+    }
+    unsafe { *_NSGetEnviron() }
 }
 
 fn main() {
-    let pointer = unsafe { environ };
+    let pointer = get_environ();
     let _x = unsafe { *pointer };
     std::env::set_var("FOO", "BAR");
     let _y = unsafe { *pointer }; //~ ERROR dangling pointer was dereferenced

--- a/tests/compile-fail/environ-gets-deallocated.rs
+++ b/tests/compile-fail/environ-gets-deallocated.rs
@@ -3,9 +3,9 @@
 #[cfg(target_os="linux")]
 fn get_environ() -> *const *const u8 {
   extern "C" {
-    static environ: *const *const u8;
+    static mut environ: *const *const u8;
   }
-  environ
+  unsafe { environ }
 }
 
 #[cfg(target_os="macos")]

--- a/tests/run-pass/env.rs
+++ b/tests/run-pass/env.rs
@@ -3,11 +3,26 @@
 use std::env;
 
 fn main() {
+    // Test that miri environment is isolated when communication is disabled.
+    // (`MIRI_ENV_VAR_TEST` is set by the test harness.)
+    assert_eq!(env::var("MIRI_ENV_VAR_TEST"), Err(env::VarError::NotPresent));
+
+    // Test base state.
+    println!("{:#?}", env::vars().collect::<Vec<_>>());
     assert_eq!(env::var("MIRI_TEST"), Err(env::VarError::NotPresent));
+
+    // Set the variable.
     env::set_var("MIRI_TEST", "the answer");
     assert_eq!(env::var("MIRI_TEST"), Ok("the answer".to_owned()));
-    // Test that miri environment is isolated when communication is disabled.
-    assert!(env::var("MIRI_ENV_VAR_TEST").is_err());
-    // Test that the new variable is in the `std::env::Vars` iterator
-    assert!(env::vars().any(|(name, value)| name == "MIRI_TEST"))
+    println!("{:#?}", env::vars().collect::<Vec<_>>());
+
+    // Change the variable.
+    env::set_var("MIRI_TEST", "42");
+    assert_eq!(env::var("MIRI_TEST"), Ok("42".to_owned()));
+    println!("{:#?}", env::vars().collect::<Vec<_>>());
+
+    // Remove the variable.
+    env::remove_var("MIRI_TEST");
+    assert_eq!(env::var("MIRI_TEST"), Err(env::VarError::NotPresent));
+    println!("{:#?}", env::vars().collect::<Vec<_>>());
 }

--- a/tests/run-pass/env.rs
+++ b/tests/run-pass/env.rs
@@ -8,4 +8,6 @@ fn main() {
     assert_eq!(env::var("MIRI_TEST"), Ok("the answer".to_owned()));
     // Test that miri environment is isolated when communication is disabled.
     assert!(env::var("MIRI_ENV_VAR_TEST").is_err());
+    // Test that the new variable is in the `std::env::Vars` iterator
+    assert!(env::vars().any(|(name, value)| name == "MIRI_TEST"))
 }

--- a/tests/run-pass/env.stdout
+++ b/tests/run-pass/env.stdout
@@ -1,0 +1,14 @@
+[]
+[
+    (
+        "MIRI_TEST",
+        "the answer",
+    ),
+]
+[
+    (
+        "MIRI_TEST",
+        "42",
+    ),
+]
+[]


### PR DESCRIPTION
Remake of https://github.com/rust-lang/miri/pull/1147. There are three main problems with this:

1. For some reason `update_environ` is not updating `environ` when `setenv` or `unsetenv` are called. Even then it works during initialization.
2. I am not deallocating the old array with the variables in `update_environ`.
3. I had to store the `environ` place into `MemoryExtra` as a field to update it. I was thinking about changing `extern_statics` to store places instead of `AllocID`s to avoid this.

@RalfJung 

Fixes https://github.com/rust-lang/miri/issues/756