### PR TITLE
move repeated run of test suite (without and with MIR optimizations) out of compiletest

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ Moreover, Miri recognizes some environment variables:
 * `MIRI_TEST_TARGET` (recognized by the test suite) indicates which target
   architecture to test against.  `miri` and `cargo miri` accept the `--target`
   flag for the same purpose.
+* `MIRI_TEST_FLAGS` (recognized by the test suite) defines extra flags to be
+  passed to Miri.
 
 ## Contributing and getting help
 

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -24,9 +24,10 @@ fn rustc_lib_path() -> PathBuf {
     option_env!("RUSTC_LIB_PATH").unwrap().into()
 }
 
-fn run_tests(mode: &str, path: &str, target: &str, mut flags: Vec<String>) {
+fn run_tests(mode: &str, path: &str, target: &str) {
     let in_rustc_test_suite = rustc_test_suite().is_some();
     // Add some flags we always want.
+    let mut flags = Vec::new();
     flags.push("--edition 2018".to_owned());
     if in_rustc_test_suite {
         // Less aggressive warnings to make the rustc toolstate management less painful.
@@ -38,6 +39,12 @@ fn run_tests(mode: &str, path: &str, target: &str, mut flags: Vec<String>) {
     if let Ok(sysroot) = std::env::var("MIRI_SYSROOT") {
         flags.push(format!("--sysroot {}", sysroot));
     }
+    if let Ok(extra_flags) = std::env::var("MIRI_TEST_FLAGS") {
+        flags.push(extra_flags);
+    }
+
+    let flags = flags.join(" ");
+    eprintln!("   Compiler flags: {}", flags);
 
     // The rest of the configuration.
     let mut config = compiletest::Config::default().tempdir();
@@ -51,48 +58,36 @@ fn run_tests(mode: &str, path: &str, target: &str, mut flags: Vec<String>) {
     config.host = get_host();
     config.src_base = PathBuf::from(path);
     config.target = target.to_owned();
-    config.target_rustcflags = Some(flags.join(" "));
+    config.target_rustcflags = Some(flags);
     compiletest::run_tests(&config);
 }
 
-fn compile_fail(path: &str, target: &str, opt: bool) {
-    let opt_str = if opt { " with optimizations" } else { "" };
+fn compile_fail(path: &str, target: &str) {
     eprintln!(
         "{}",
         format!(
-            "## Running compile-fail tests in {} against miri for target {}{}",
-            path, target, opt_str
+            "## Running compile-fail tests in {} against miri for target {}",
+            path, target
         )
         .green()
         .bold()
     );
 
-    let mut flags = Vec::new();
-    if opt {
-        flags.push("-Zmir-opt-level=3".to_owned());
-    }
-
-    run_tests("compile-fail", path, target, flags);
+    run_tests("compile-fail", path, target);
 }
 
-fn miri_pass(path: &str, target: &str, opt: bool) {
-    let opt_str = if opt { " with optimizations" } else { "" };
+fn miri_pass(path: &str, target: &str) {
     eprintln!(
         "{}",
         format!(
-            "## Running run-pass tests in {} against miri for target {}{}",
-            path, target, opt_str
+            "## Running run-pass tests in {} against miri for target {}",
+            path, target
         )
         .green()
         .bold()
     );
 
-    let mut flags = Vec::new();
-    if opt {
-        flags.push("-Zmir-opt-level=3".to_owned());
-    }
-
-    run_tests("ui", path, target, flags);
+    run_tests("ui", path, target);
 }
 
 fn get_host() -> String {
@@ -112,21 +107,11 @@ fn get_target() -> String {
     std::env::var("MIRI_TEST_TARGET").unwrap_or_else(|_| get_host())
 }
 
-fn run_pass_miri(opt: bool) {
-    miri_pass("tests/run-pass", &get_target(), opt);
-}
-
-fn compile_fail_miri(opt: bool) {
-    compile_fail("tests/compile-fail", &get_target(), opt);
-}
-
 fn test_runner(_tests: &[&()]) {
-    // Add a test env var to do environment communication tests
+    // Add a test env var to do environment communication tests.
     std::env::set_var("MIRI_ENV_VAR_TEST", "0");
 
-    run_pass_miri(false);
-    run_pass_miri(true);
-
-    compile_fail_miri(false);
-    compile_fail_miri(true);
+    let target = get_target();
+    miri_pass("tests/run-pass", &target);
+    compile_fail("tests/compile-fail", &target);
 }

--- a/travis.sh
+++ b/travis.sh
@@ -17,6 +17,7 @@ echo
 # Test
 function run_tests {
     ./miri test --locked
+    MIRI_TEST_FLAGS="-Z mir-opt-level=3" ./miri test
     # "miri test" has built the sysroot for us, now this should pass without
     # any interactive questions.
     test-cargo-miri/run-test.py


### PR DESCRIPTION
Just like we already pass the target architecture to our compiletest wrapper via `MIRI_TEST_TARGET` (and then have CI run compiletest with different values for that env var), we now do the same for running the tests with and without MIR optimizations.

This has the advantage of speeding up local `./miri test`, where in the vast majority of cases running tests both with and without optimizations is just a waste of time.