### PR TITLE
whitelist platforms where panicking should work

### DIFF
--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -132,12 +132,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 // This matches calls to the foreign item `panic_impl`.
                 // The implementation is provided by the function with the `#[panic_handler]` attribute.
                 "panic_impl" => {
-                    // Make sure panicking actually works on this platform.
-                    match this.tcx.sess.target.target.target_os.as_str() {
-                        "linux" | "macos" => {},
-                        _ => throw_unsup_format!("panicking is not supported on this platform"),
-                    }
-
+                    this.check_panic_supported()?;
                     let panic_impl_id = this.tcx.lang_items().panic_impl().unwrap();
                     let panic_impl_instance = ty::Instance::mono(*this.tcx, panic_impl_id);
                     return Ok(Some(&*this.load_mir(panic_impl_instance.def, None)?));

--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -132,6 +132,12 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 // This matches calls to the foreign item `panic_impl`.
                 // The implementation is provided by the function with the `#[panic_handler]` attribute.
                 "panic_impl" => {
+                    // Make sure panicking actually works on this platform.
+                    match this.tcx.sess.target.target.target_os.as_str() {
+                        "linux" | "macos" => {},
+                        _ => throw_unsup_format!("panicking is not supported on this platform"),
+                    }
+
                     let panic_impl_id = this.tcx.lang_items().panic_impl().unwrap();
                     let panic_impl_instance = ty::Instance::mono(*this.tcx, panic_impl_id);
                     return Ok(Some(&*this.load_mir(panic_impl_instance.def, None)?));

--- a/src/shims/mod.rs
+++ b/src/shims/mod.rs
@@ -42,6 +42,14 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             return this.emulate_foreign_item(instance.def_id(), args, ret, unwind);
         }
 
+        // Better error message for panics on Windows.
+        let def_id = instance.def_id();
+        if Some(def_id) == this.tcx.lang_items().begin_panic_fn() ||
+            Some(def_id) == this.tcx.lang_items().panic_impl()
+        {
+            this.check_panic_supported()?;
+        }
+
         // Otherwise, load the MIR.
         Ok(Some(&*this.load_mir(instance.def, None)?))
     }

--- a/src/shims/panic.rs
+++ b/src/shims/panic.rs
@@ -32,6 +32,14 @@ pub struct CatchUnwindData<'tcx> {
 
 impl<'mir, 'tcx> EvalContextExt<'mir, 'tcx> for crate::MiriEvalContext<'mir, 'tcx> {}
 pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx> {
+    /// Check if panicking is supported on this platform, and give a good error otherwise.
+    fn check_panic_supported(&self) -> InterpResult<'tcx> {
+        match self.eval_context_ref().tcx.sess.target.target.target_os.as_str() {
+            "linux" | "macos" => Ok(()),
+            _ => throw_unsup_format!("panicking is not supported on this platform"),
+        }
+    }
+
     /// Handles the special `miri_start_panic` intrinsic, which is called
     /// by libpanic_unwind to delegate the actual unwinding process to Miri.
     fn handle_miri_start_panic(

--- a/tests/compile-fail/abort-terminator.rs
+++ b/tests/compile-fail/abort-terminator.rs
@@ -1,4 +1,5 @@
 // error-pattern: the evaluated program aborted
+// ignore-windows (panics dont work on Windows)
 #![feature(unwind_attributes)]
 
 #[unwind(aborts)]

--- a/tests/compile-fail/panic/double_panic.rs
+++ b/tests/compile-fail/panic/double_panic.rs
@@ -1,4 +1,6 @@
- // error-pattern: the evaluated program aborted
+// error-pattern: the evaluated program aborted
+// ignore-windows (panics dont work on Windows)
+
 struct Foo;
 impl Drop for Foo {
     fn drop(&mut self) {

--- a/tests/compile-fail/panic/windows1.rs
+++ b/tests/compile-fail/panic/windows1.rs
@@ -1,0 +1,9 @@
+// ignore-linux
+// ignore-macos
+
+// Test that panics on Windows give a reasonable error message.
+
+// error-pattern: panicking is not supported on this platform
+fn main() {
+    core::panic!("this is {}", "Windows");
+}

--- a/tests/compile-fail/panic/windows2.rs
+++ b/tests/compile-fail/panic/windows2.rs
@@ -1,0 +1,9 @@
+// ignore-linux
+// ignore-macos
+
+// Test that panics on Windows give a reasonable error message.
+
+// error-pattern: panicking is not supported on this platform
+fn main() {
+    std::panic!("this is Windows");
+}

--- a/tests/compile-fail/panic/windows3.rs
+++ b/tests/compile-fail/panic/windows3.rs
@@ -1,0 +1,10 @@
+// ignore-linux
+// ignore-macos
+
+// Test that panics on Windows give a reasonable error message.
+
+// error-pattern: panicking is not supported on this platform
+#[allow(unconditional_panic)]
+fn main() {
+    let _val = 1/0;
+}


### PR DESCRIPTION
@CAD97 [proposed](https://github.com/rust-lang/miri/issues/1059#issuecomment-601217992) trying to get a better error for failed panics on Windows.

Could you test if this works for you?