### PR TITLE
Limit shims to libstd where possible

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -81,6 +81,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
     /// Helper function to get a `libc` constant as an `i32`.
     fn eval_libc_i32(&mut self, name: &str) -> InterpResult<'tcx, i32> {
+        // TODO: Cache the result.
         self.eval_libc(name)?.to_i32()
     }
 

--- a/src/shims/foreign_items/posix.rs
+++ b/src/shims/foreign_items/posix.rs
@@ -115,10 +115,6 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 let result = this.lseek64(args[0], args[1], args[2])?;
                 this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;
             }
-            "posix_fadvise" => {
-                // fadvise is only informational, we can ignore it.
-                this.write_null(dest)?;
-            }
 
             // Allocation
             "posix_memalign" => {

--- a/src/shims/foreign_items/posix/linux.rs
+++ b/src/shims/foreign_items/posix/linux.rs
@@ -34,6 +34,15 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 let result = this.linux_readdir64_r(args[0], args[1], args[2])?;
                 this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;
             }
+            // Linux-only
+            "posix_fadvise" => {
+                let _fd = this.read_scalar(args[0])?.to_i32()?;
+                let _offset = this.read_scalar(args[1])?.to_machine_isize(this)?;
+                let _len = this.read_scalar(args[2])?.to_machine_isize(this)?;
+                let _advice = this.read_scalar(args[3])?.to_i32()?;
+                // fadvise is only informational, we can ignore it.
+                this.write_null(dest)?;
+            }
 
             // Time related shims
             "clock_gettime" => {

--- a/src/shims/foreign_items/posix/linux.rs
+++ b/src/shims/foreign_items/posix/linux.rs
@@ -13,47 +13,56 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         let this = self.eval_context_mut();
 
         match link_name {
+            // errno
             "__errno_location" => {
                 let errno_place = this.machine.last_error.unwrap();
                 this.write_scalar(errno_place.to_ref().to_scalar()?, dest)?;
             }
 
             // File related shims (but also see "syscall" below for statx)
-
-            // The only reason this is not in the `posix` module is because the `macos` item has a
-            // different name.
+            // These symbols have different names on Linux and macOS, which is the only reason they are not
+            // in the `posix` module.
             "close" => {
                 let result = this.close(args[0])?;
                 this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;
             }
-
-            // The only reason this is not in the `posix` module is because the `macos` item has a
-            // different name.
             "opendir" => {
                 let result = this.opendir(args[0])?;
                 this.write_scalar(result, dest)?;
             }
-
-            // The `macos` module has a parallel foreign item, `readdir_r`, which uses a different
-            // struct layout.
             "readdir64_r" => {
                 let result = this.linux_readdir64_r(args[0], args[1], args[2])?;
                 this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;
             }
 
             // Time related shims
-
-            // This is a POSIX function but it has only been tested on linux.
             "clock_gettime" => {
+                // This is a POSIX function but it has only been tested on linux.
                 let result = this.clock_gettime(args[0], args[1])?;
                 this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;
             }
 
-            // Other shims
-            "pthread_getattr_np" => {
+            // Querying system information
+            "pthread_attr_getstack" => {
+                // We don't support "pthread_attr_setstack", so we just pretend all stacks have the same values here.
+                let _attr_place = this.deref_operand(args[0])?;
+                let addr_place = this.deref_operand(args[1])?;
+                let size_place = this.deref_operand(args[2])?;
+
+                this.write_scalar(
+                    Scalar::from_uint(STACK_ADDR, addr_place.layout.size),
+                    addr_place.into(),
+                )?;
+                this.write_scalar(
+                    Scalar::from_uint(STACK_SIZE, size_place.layout.size),
+                    size_place.into(),
+                )?;
+
+                // Return success (`0`).
                 this.write_null(dest)?;
             }
 
+            // Dynamically invoked syscalls
             "syscall" => {
                 let sys_getrandom = this
                     .eval_libc("SYS_getrandom")?
@@ -67,15 +76,13 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                     // `libc::syscall(NR_GETRANDOM, buf.as_mut_ptr(), buf.len(), GRND_NONBLOCK)`
                     // is called if a `HashMap` is created the regular way (e.g. HashMap<K, V>).
                     id if id == sys_getrandom => {
-                        // The first argument is the syscall id,
-                        // so skip over it.
+                        // The first argument is the syscall id, so skip over it.
                         getrandom(this, &args[1..], dest)?;
                     }
                     // `statx` is used by `libstd` to retrieve metadata information on `linux`
                     // instead of using `stat`,`lstat` or `fstat` as on `macos`.
                     id if id == sys_statx => {
-                        // The first argument is the syscall id,
-                        // so skip over it.
+                        // The first argument is the syscall id, so skip over it.
                         let result = this.linux_statx(args[1], args[2], args[3], args[4], args[5])?;
                         this.write_scalar(Scalar::from_int(result, dest.layout.size), dest)?;
                     }
@@ -83,13 +90,24 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 }
             }
 
+            // Miscelanneous
             "getrandom" => {
                 getrandom(this, args, dest)?;
             }
-
             "sched_getaffinity" => {
-                // Return an error; `num_cpus` then falls back to `sysconf`.
+                let _pid = this.read_scalar(args[0])?.to_i32()?;
+                let _cpusetsize = this.read_scalar(args[1])?.to_machine_usize(this)?;
+                let _mask = this.deref_operand(args[2])?;
+                // FIXME: we just return an error; `num_cpus` then falls back to `sysconf`.
+                let einval = this.eval_libc("EINVAL")?;
+                this.set_last_error(einval)?;
                 this.write_scalar(Scalar::from_int(-1, dest.layout.size), dest)?;
+            }
+
+            // Incomplete shims that we "stub out" just to get pre-main initialziation code to work.
+            // These shims are enabled only when the caller is in the standard library.
+            "pthread_getattr_np" if this.frame().instance.to_string().starts_with("std::sys::unix::") => {
+                this.write_null(dest)?;
             }
 
             _ => throw_unsup_format!("can't call foreign function: {}", link_name),


### PR DESCRIPTION
Also organize them better by category.
Fixes https://github.com/rust-lang/miri/issues/1181 (by making mmap not callable from user code)