### PR TITLE
implement TLS cleanup for macOS

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -186,8 +186,8 @@ pub fn create_ecx<'mir, 'tcx: 'mir>(
 pub fn eval_main<'tcx>(tcx: TyCtxt<'tcx>, main_id: DefId, config: MiriConfig) -> Option<i64> {
     // FIXME: We always ignore leaks on some OSs where we do not
     // correctly implement TLS destructors.
-    let target_os = tcx.sess.target.target.target_os.as_str();
-    let ignore_leaks = config.ignore_leaks || target_os == "windows" || target_os == "macos";
+    let target_os = &tcx.sess.target.target.target_os;
+    let ignore_leaks = config.ignore_leaks || target_os == "windows";
 
     let (mut ecx, ret_place) = match create_ecx(tcx, main_id, config) {
         Ok(v) => v,

--- a/src/shims/foreign_items/posix/macos.rs
+++ b/src/shims/foreign_items/posix/macos.rs
@@ -87,7 +87,10 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             }
 
             "_tlv_atexit" => {
-                // FIXME: register the destructor.
+                let dtor = this.read_scalar(args[0])?.not_undef()?;
+                let dtor = this.memory.get_fn(dtor)?.as_instance()?;
+                let data = this.read_scalar(args[1])?.not_undef()?;
+                this.machine.tls.set_global_dtor(dtor, data)?;
             }
 
             "_NSGetArgc" => {

--- a/tests/compile-fail/memleak.rs
+++ b/tests/compile-fail/memleak.rs
@@ -1,5 +1,4 @@
 // ignore-windows: We do not check leaks on Windows
-// ignore-macos: We do not check leaks on macOS
 
 //error-pattern: the evaluated program leaked memory
 

--- a/tests/compile-fail/memleak_rc.rs
+++ b/tests/compile-fail/memleak_rc.rs
@@ -1,5 +1,4 @@
 // ignore-windows: We do not check leaks on Windows
-// ignore-macos: We do not check leaks on macOS
 
 //error-pattern: the evaluated program leaked memory
 


### PR DESCRIPTION
Now that I can run macOS interpretation locally, this was not that hard to fix. ;)
Fixes https://github.com/rust-lang/miri/issues/443