### PR TITLE
env shim: make sure we clean up all the memory we allocate

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -199,15 +199,20 @@ pub fn eval_main<'tcx>(tcx: TyCtxt<'tcx>, main_id: DefId, config: MiriConfig) ->
 
     // Perform the main execution.
     let res: InterpResult<'_, i64> = (|| {
+        // Main loop.
         while ecx.step()? {
             ecx.process_diagnostics();
         }
         // Read the return code pointer *before* we run TLS destructors, to assert
         // that it was written to by the time that `start` lang item returned.
         let return_code = ecx.read_scalar(ret_place.into())?.not_undef()?.to_machine_isize(&ecx)?;
+        // Global destructors.
         ecx.run_tls_dtors()?;
         Ok(return_code)
     })();
+
+    // Machine cleanup.
+    EnvVars::cleanup(&mut ecx).unwrap();
 
     // Process the result.
     match res {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 #![feature(option_expect_none, option_unwrap_none)]
 #![feature(map_first_last)]
 #![feature(never_type)]
+#![feature(or_patterns)]
+
 #![warn(rust_2018_idioms)]
 #![allow(clippy::cast_lossless)]
 

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -48,9 +48,13 @@ pub enum MiriMemoryKind {
     C,
     /// Windows `HeapAlloc` memory.
     WinHeap,
-    /// Memory for env vars and args, errno, extern statics and other parts of the machine-managed environment.
+    /// Memory for args, errno, extern statics and other parts of the machine-managed environment.
+    /// This memory may leak.
     Machine,
+    /// Memory for env vars. Separate from `Machine` because we clean it up and leak-check it.
+    Env,
     /// Globals copied from `tcx`.
+    /// This memory may leak.
     Global,
 }
 
@@ -484,7 +488,7 @@ impl MayLeak for MiriMemoryKind {
     fn may_leak(self) -> bool {
         use self::MiriMemoryKind::*;
         match self {
-            Rust | C | WinHeap => false,
+            Rust | C | WinHeap | Env => false,
             Machine | Global => true,
         }
     }

--- a/src/stacked_borrows.rs
+++ b/src/stacked_borrows.rs
@@ -460,8 +460,10 @@ impl Stacks {
             // Global memory can be referenced by global pointers from `tcx`.
             // Thus we call `global_base_ptr` such that the global pointers get the same tag
             // as what we use here.
+            // `Machine` is used for extern statics, and thus must also be listed here.
+            // `Env` we list because we can get away with precise tracking there.
             // The base pointer is not unique, so the base permission is `SharedReadWrite`.
-            MemoryKind::Machine(MiriMemoryKind::Global) | MemoryKind::Machine(MiriMemoryKind::Machine) =>
+            MemoryKind::Machine(MiriMemoryKind::Global | MiriMemoryKind::Machine | MiriMemoryKind::Env) =>
                 (extra.borrow_mut().global_base_ptr(id), Permission::SharedReadWrite),
             // Everything else we handle entirely untagged for now.
             // FIXME: experiment with more precise tracking.


### PR DESCRIPTION
`Machine` memory is not leak-checked, so if we forgot to deallocate part of the env shim memory, we wouldn't even notice. Thus add a dedicated memory kind that is leak-checked.