### PR TITLE
Add support for OpenOptions::create_new()/O_EXCL

### DIFF
--- a/src/shims/fs.rs
+++ b/src/shims/fs.rs
@@ -288,8 +288,15 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         }
         let o_creat = this.eval_libc_i32("O_CREAT")?;
         if flag & o_creat != 0 {
-            options.create(true);
             mirror |= o_creat;
+
+            let o_excl = this.eval_libc_i32("O_EXCL")?;
+            if flag & o_excl != 0 {
+                mirror |= o_excl;
+                options.create_new(true);
+            } else {
+                options.create(true);
+            }
         }
         let o_cloexec = this.eval_libc_i32("O_CLOEXEC")?;
         if flag & o_cloexec != 0 {


### PR DESCRIPTION
This PR extends the POSIX shim for `open` to support the `O_EXCL` flag, when it is used alongside `O_CREAT`, and exercises it by testing `OpenOptions::create_new`.