### PR TITLE
Check that shims are called with the correct number of arguments

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -477,7 +477,7 @@ pub fn check_arg_count<'a, 'tcx, const N: usize>(args: &'a [OpTy<'tcx, Tag>]) ->
     if let Ok(ops) = args.try_into() {
         return Ok(ops);
     }
-    throw_ub_format!("incorrect number of arguments, got {}, needed {}", args.len(), N)
+    throw_ub_format!("incorrect number of arguments: got {}, expected {}", args.len(), N)
 }
 
 pub fn immty_from_int_checked<'tcx>(

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,4 +1,4 @@
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 use std::mem;
 use std::num::NonZeroUsize;
 
@@ -469,6 +469,15 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             }
         }
     }
+}
+
+/// Check that the number of args is what we expect.
+pub fn check_arg_count<'a, 'tcx, const N: usize>(args: &'a [OpTy<'tcx, Tag>]) -> InterpResult<'tcx, &'a [OpTy<'tcx, Tag>; N]>
+    where &'a [OpTy<'tcx, Tag>; N]: TryFrom<&'a [OpTy<'tcx, Tag>]> {
+    if let Ok(ops) = args.try_into() {
+        return Ok(ops);
+    }
+    throw_ub_format!("incorrect number of arguments, got {}, needed {}", args.len(), N)
 }
 
 pub fn immty_from_int_checked<'tcx>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,9 @@
 #![warn(rust_2018_idioms)]
 #![allow(clippy::cast_lossless)]
 
+#![allow(incomplete_features)]
+#![feature(const_generics)]
+
 extern crate rustc_apfloat;
 extern crate rustc_ast;
 #[macro_use] extern crate rustc_middle;

--- a/src/shims/dlsym.rs
+++ b/src/shims/dlsym.rs
@@ -1,6 +1,7 @@
 use rustc_middle::mir;
 
 use crate::*;
+use helpers::check_arg_count;
 
 #[derive(Debug, Copy, Clone)]
 pub enum Dlsym {
@@ -35,8 +36,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
         match dlsym {
             GetEntropy => {
-                let ptr = this.read_scalar(args[0])?.not_undef()?;
-                let len = this.read_scalar(args[1])?.to_machine_usize(this)?;
+                let &[ptr, len] = check_arg_count(args)?;
+                let ptr = this.read_scalar(ptr)?.not_undef()?;
+                let len = this.read_scalar(len)?.to_machine_usize(this)?;
                 this.gen_random(ptr, len)?;
                 this.write_null(dest)?;
             }

--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -454,6 +454,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
             // Architecture-specific shims
             "llvm.x86.sse2.pause" if this.tcx.sess.target.target.arch == "x86" || this.tcx.sess.target.target.arch == "x86_64" => {
+                let &[] = check_arg_count(args)?;
                 this.sched_yield()?;
             }
 

--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -11,6 +11,7 @@ use rustc_span::symbol::sym;
 use rustc_ast::attr;
 
 use crate::*;
+use helpers::check_arg_count;
 
 impl<'mir, 'tcx: 'mir> EvalContextExt<'mir, 'tcx> for crate::MiriEvalContext<'mir, 'tcx> {}
 pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx> {
@@ -139,8 +140,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 | "exit"
                 | "ExitProcess"
                 => {
+                    let &[code] = check_arg_count(args)?;
                     // it's really u32 for ExitProcess, but we have to put it into the `Exit` variant anyway
-                    let code = this.read_scalar(args[0])?.to_i32()?;
+                    let code = this.read_scalar(code)?.to_i32()?;
                     throw_machine_stop!(TerminationInfo::Exit(code.into()));
                 }
                 _ => throw_unsup_format!("can't call (diverging) foreign function: {}", link_name),
@@ -197,25 +199,29 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         match link_name {
             // Standard C allocation
             "malloc" => {
-                let size = this.read_scalar(args[0])?.to_machine_usize(this)?;
+                let &[size] = check_arg_count(args)?;
+                let size = this.read_scalar(size)?.to_machine_usize(this)?;
                 let res = this.malloc(size, /*zero_init:*/ false, MiriMemoryKind::C);
                 this.write_scalar(res, dest)?;
             }
             "calloc" => {
-                let items = this.read_scalar(args[0])?.to_machine_usize(this)?;
-                let len = this.read_scalar(args[1])?.to_machine_usize(this)?;
+                let &[items, len] = check_arg_count(args)?;
+                let items = this.read_scalar(items)?.to_machine_usize(this)?;
+                let len = this.read_scalar(len)?.to_machine_usize(this)?;
                 let size =
                     items.checked_mul(len).ok_or_else(|| err_ub_format!("overflow during calloc size computation"))?;
                 let res = this.malloc(size, /*zero_init:*/ true, MiriMemoryKind::C);
                 this.write_scalar(res, dest)?;
             }
             "free" => {
-                let ptr = this.read_scalar(args[0])?.not_undef()?;
+                let &[ptr] = check_arg_count(args)?;
+                let ptr = this.read_scalar(ptr)?.not_undef()?;
                 this.free(ptr, MiriMemoryKind::C)?;
             }
             "realloc" => {
-                let old_ptr = this.read_scalar(args[0])?.not_undef()?;
-                let new_size = this.read_scalar(args[1])?.to_machine_usize(this)?;
+                let &[old_ptr, new_size] = check_arg_count(args)?;
+                let old_ptr = this.read_scalar(old_ptr)?.not_undef()?;
+                let new_size = this.read_scalar(new_size)?.to_machine_usize(this)?;
                 let res = this.realloc(old_ptr, new_size, MiriMemoryKind::C)?;
                 this.write_scalar(res, dest)?;
             }
@@ -224,8 +230,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             // (Usually these would be forwarded to to `#[global_allocator]`; we instead implement a generic
             // allocation that also checks that all conditions are met, such as not permitting zero-sized allocations.)
             "__rust_alloc" => {
-                let size = this.read_scalar(args[0])?.to_machine_usize(this)?;
-                let align = this.read_scalar(args[1])?.to_machine_usize(this)?;
+                let &[size, align] = check_arg_count(args)?;
+                let size = this.read_scalar(size)?.to_machine_usize(this)?;
+                let align = this.read_scalar(align)?.to_machine_usize(this)?;
                 Self::check_alloc_request(size, align)?;
                 let ptr = this.memory.allocate(
                     Size::from_bytes(size),
@@ -235,8 +242,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_scalar(ptr, dest)?;
             }
             "__rust_alloc_zeroed" => {
-                let size = this.read_scalar(args[0])?.to_machine_usize(this)?;
-                let align = this.read_scalar(args[1])?.to_machine_usize(this)?;
+                let &[size, align] = check_arg_count(args)?;
+                let size = this.read_scalar(size)?.to_machine_usize(this)?;
+                let align = this.read_scalar(align)?.to_machine_usize(this)?;
                 Self::check_alloc_request(size, align)?;
                 let ptr = this.memory.allocate(
                     Size::from_bytes(size),
@@ -248,9 +256,10 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_scalar(ptr, dest)?;
             }
             "__rust_dealloc" => {
-                let ptr = this.read_scalar(args[0])?.not_undef()?;
-                let old_size = this.read_scalar(args[1])?.to_machine_usize(this)?;
-                let align = this.read_scalar(args[2])?.to_machine_usize(this)?;
+                let &[ptr, old_size, align] = check_arg_count(args)?;
+                let ptr = this.read_scalar(ptr)?.not_undef()?;
+                let old_size = this.read_scalar(old_size)?.to_machine_usize(this)?;
+                let align = this.read_scalar(align)?.to_machine_usize(this)?;
                 // No need to check old_size/align; we anyway check that they match the allocation.
                 let ptr = this.force_ptr(ptr)?;
                 this.memory.deallocate(
@@ -260,12 +269,13 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 )?;
             }
             "__rust_realloc" => {
-                let old_size = this.read_scalar(args[1])?.to_machine_usize(this)?;
-                let align = this.read_scalar(args[2])?.to_machine_usize(this)?;
-                let new_size = this.read_scalar(args[3])?.to_machine_usize(this)?;
+                let &[ptr, old_size, align, new_size] = check_arg_count(args)?;
+                let ptr = this.force_ptr(this.read_scalar(ptr)?.not_undef()?)?;
+                let old_size = this.read_scalar(old_size)?.to_machine_usize(this)?;
+                let align = this.read_scalar(align)?.to_machine_usize(this)?;
+                let new_size = this.read_scalar(new_size)?.to_machine_usize(this)?;
                 Self::check_alloc_request(new_size, align)?;
                 // No need to check old_size; we anyway check that they match the allocation.
-                let ptr = this.force_ptr(this.read_scalar(args[0])?.not_undef()?)?;
                 let align = Align::from_bytes(align).unwrap();
                 let new_ptr = this.memory.reallocate(
                     ptr,
@@ -279,9 +289,10 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
             // C memory handling functions
             "memcmp" => {
-                let left = this.read_scalar(args[0])?.not_undef()?;
-                let right = this.read_scalar(args[1])?.not_undef()?;
-                let n = Size::from_bytes(this.read_scalar(args[2])?.to_machine_usize(this)?);
+                let &[left, right, n] = check_arg_count(args)?;
+                let left = this.read_scalar(left)?.not_undef()?;
+                let right = this.read_scalar(right)?.not_undef()?;
+                let n = Size::from_bytes(this.read_scalar(n)?.to_machine_usize(this)?);
 
                 let result = {
                     let left_bytes = this.memory.read_bytes(left, n)?;
@@ -298,9 +309,10 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "memrchr" => {
-                let ptr = this.read_scalar(args[0])?.not_undef()?;
-                let val = this.read_scalar(args[1])?.to_i32()? as u8;
-                let num = this.read_scalar(args[2])?.to_machine_usize(this)?;
+                let &[ptr, val, num] = check_arg_count(args)?;
+                let ptr = this.read_scalar(ptr)?.not_undef()?;
+                let val = this.read_scalar(val)?.to_i32()? as u8;
+                let num = this.read_scalar(num)?.to_machine_usize(this)?;
                 if let Some(idx) = this
                     .memory
                     .read_bytes(ptr, Size::from_bytes(num))?
@@ -315,9 +327,10 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 }
             }
             "memchr" => {
-                let ptr = this.read_scalar(args[0])?.not_undef()?;
-                let val = this.read_scalar(args[1])?.to_i32()? as u8;
-                let num = this.read_scalar(args[2])?.to_machine_usize(this)?;
+                let &[ptr, val, num] = check_arg_count(args)?;
+                let ptr = this.read_scalar(ptr)?.not_undef()?;
+                let val = this.read_scalar(val)?.to_i32()? as u8;
+                let num = this.read_scalar(num)?.to_machine_usize(this)?;
                 let idx = this
                     .memory
                     .read_bytes(ptr, Size::from_bytes(num))?
@@ -331,7 +344,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 }
             }
             "strlen" => {
-                let ptr = this.read_scalar(args[0])?.not_undef()?;
+                let &[ptr] = check_arg_count(args)?;
+                let ptr = this.read_scalar(ptr)?.not_undef()?;
                 let n = this.memory.read_c_str(ptr)?.len();
                 this.write_scalar(Scalar::from_machine_usize(u64::try_from(n).unwrap(), this), dest)?;
             }
@@ -345,8 +359,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             | "asinf"
             | "atanf"
             => {
+                let &[f] = check_arg_count(args)?;
                 // FIXME: Using host floats.
-                let f = f32::from_bits(this.read_scalar(args[0])?.to_u32()?);
+                let f = f32::from_bits(this.read_scalar(f)?.to_u32()?);
                 let f = match link_name {
                     "cbrtf" => f.cbrt(),
                     "coshf" => f.cosh(),
@@ -363,11 +378,12 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             | "hypotf"
             | "atan2f"
             => {
+                let &[f1, f2] = check_arg_count(args)?;
                 // underscore case for windows, here and below
                 // (see https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/floating-point-primitives?view=vs-2019)
                 // FIXME: Using host floats.
-                let f1 = f32::from_bits(this.read_scalar(args[0])?.to_u32()?);
-                let f2 = f32::from_bits(this.read_scalar(args[1])?.to_u32()?);
+                let f1 = f32::from_bits(this.read_scalar(f1)?.to_u32()?);
+                let f2 = f32::from_bits(this.read_scalar(f2)?.to_u32()?);
                 let n = match link_name {
                     "_hypotf" | "hypotf" => f1.hypot(f2),
                     "atan2f" => f1.atan2(f2),
@@ -383,8 +399,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             | "asin"
             | "atan"
             => {
+                let &[f] = check_arg_count(args)?;
                 // FIXME: Using host floats.
-                let f = f64::from_bits(this.read_scalar(args[0])?.to_u64()?);
+                let f = f64::from_bits(this.read_scalar(f)?.to_u64()?);
                 let f = match link_name {
                     "cbrt" => f.cbrt(),
                     "cosh" => f.cosh(),
@@ -401,9 +418,10 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             | "hypot"
             | "atan2"
             => {
+                let &[f1, f2] = check_arg_count(args)?;
                 // FIXME: Using host floats.
-                let f1 = f64::from_bits(this.read_scalar(args[0])?.to_u64()?);
-                let f2 = f64::from_bits(this.read_scalar(args[1])?.to_u64()?);
+                let f1 = f64::from_bits(this.read_scalar(f1)?.to_u64()?);
+                let f2 = f64::from_bits(this.read_scalar(f2)?.to_u64()?);
                 let n = match link_name {
                     "_hypot" | "hypot" => f1.hypot(f2),
                     "atan2" => f1.atan2(f2),
@@ -415,9 +433,10 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             | "ldexp"
             | "scalbn"
             => {
+                let &[x, exp] = check_arg_count(args)?;
                 // For radix-2 (binary) systems, `ldexp` and `scalbn` are the same.
-                let x = this.read_scalar(args[0])?.to_f64()?;
-                let exp = this.read_scalar(args[1])?.to_i32()?;
+                let x = this.read_scalar(x)?.to_f64()?;
+                let exp = this.read_scalar(exp)?.to_i32()?;
 
                 // Saturating cast to i16. Even those are outside the valid exponent range to
                 // `scalbn` below will do its over/underflow handling.

--- a/src/shims/foreign_items/posix.rs
+++ b/src/shims/foreign_items/posix.rs
@@ -56,7 +56,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "fcntl" => {
-                let result = this.fcntl(args);
+                let result = this.fcntl(args)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "read" => {
@@ -168,8 +168,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
             // Dynamic symbol loading
             "dlsym" => {
-                let &[_handle, symbol] = check_arg_count(args)?;
-                let _handle = this.read_scalar(_handle)?.not_undef()?;
+                let &[handle, symbol] = check_arg_count(args)?;
+                this.read_scalar(handle)?.not_undef()?;
                 let symbol = this.read_scalar(symbol)?.not_undef()?;
                 let symbol_name = this.memory.read_c_str(symbol)?;
                 let err = format!("bad c unicode symbol: {:?}", symbol_name);
@@ -360,8 +360,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
             // Miscellaneous
             "isatty" => {
-                let &[_fd] = check_arg_count(args)?;
-                let _fd = this.read_scalar(_fd)?.to_i32()?;
+                let &[fd] = check_arg_count(args)?;
+                this.read_scalar(fd)?.to_i32()?;
                 // "returns 1 if fd is an open file descriptor referring to a terminal; otherwise 0 is returned, and errno is set to indicate the error"
                 // FIXME: we just say nothing is a terminal.
                 let enotty = this.eval_libc("ENOTTY")?;
@@ -369,10 +369,10 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_null(dest)?;
             }
             "pthread_atfork" => {
-                let &[_prepare, _parent, _child] = check_arg_count(args)?;
-                let _prepare = this.read_scalar(_prepare)?.not_undef()?;
-                let _parent = this.read_scalar(_parent)?.not_undef()?;
-                let _child = this.read_scalar(_child)?.not_undef()?;
+                let &[prepare, parent, child] = check_arg_count(args)?;
+                this.read_scalar(prepare)?.not_undef()?;
+                this.read_scalar(parent)?.not_undef()?;
+                this.read_scalar(child)?.not_undef()?;
                 // We do not support forking, so there is nothing to do here.
                 this.write_null(dest)?;
             }

--- a/src/shims/foreign_items/posix/linux.rs
+++ b/src/shims/foreign_items/posix/linux.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use helpers::check_arg_count;
 use rustc_middle::mir;
 
 impl<'mir, 'tcx: 'mir> EvalContextExt<'mir, 'tcx> for crate::MiriEvalContext<'mir, 'tcx> {}
@@ -15,6 +16,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         match link_name {
             // errno
             "__errno_location" => {
+                let &[] = check_arg_count(args)?;
                 let errno_place = this.machine.last_error.unwrap();
                 this.write_scalar(errno_place.to_ref().to_scalar()?, dest)?;
             }
@@ -23,27 +25,32 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             // These symbols have different names on Linux and macOS, which is the only reason they are not
             // in the `posix` module.
             "close" => {
-                let result = this.close(args[0])?;
+                let &[fd] = check_arg_count(args)?;
+                let result = this.close(fd)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "opendir" => {
-                let result = this.opendir(args[0])?;
+                let &[name] = check_arg_count(args)?;
+                let result = this.opendir(name)?;
                 this.write_scalar(result, dest)?;
             }
             "readdir64_r" => {
-                let result = this.linux_readdir64_r(args[0], args[1], args[2])?;
+                let &[dirp, entry, result] = check_arg_count(args)?;
+                let result = this.linux_readdir64_r(dirp, entry, result)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "ftruncate64" => {
-                let result = this.ftruncate64(args[0], args[1])?;
+                let &[fd, length] = check_arg_count(args)?;
+                let result = this.ftruncate64(fd, length)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             // Linux-only
             "posix_fadvise" => {
-                let _fd = this.read_scalar(args[0])?.to_i32()?;
-                let _offset = this.read_scalar(args[1])?.to_machine_isize(this)?;
-                let _len = this.read_scalar(args[2])?.to_machine_isize(this)?;
-                let _advice = this.read_scalar(args[3])?.to_i32()?;
+                let &[_fd, _offset, _len, _advice] = check_arg_count(args)?;
+                let _fd = this.read_scalar(_fd)?.to_i32()?;
+                let _offset = this.read_scalar(_offset)?.to_machine_isize(this)?;
+                let _len = this.read_scalar(_len)?.to_machine_isize(this)?;
+                let _advice = this.read_scalar(_advice)?.to_i32()?;
                 // fadvise is only informational, we can ignore it.
                 this.write_null(dest)?;
             }
@@ -51,16 +58,18 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             // Time related shims
             "clock_gettime" => {
                 // This is a POSIX function but it has only been tested on linux.
-                let result = this.clock_gettime(args[0], args[1])?;
+                let &[clk_id, tp] = check_arg_count(args)?;
+                let result = this.clock_gettime(clk_id, tp)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
 
             // Querying system information
             "pthread_attr_getstack" => {
                 // We don't support "pthread_attr_setstack", so we just pretend all stacks have the same values here.
-                let _attr_place = this.deref_operand(args[0])?;
-                let addr_place = this.deref_operand(args[1])?;
-                let size_place = this.deref_operand(args[2])?;
+                let &[_attr_place, addr_place, size_place] = check_arg_count(args)?;
+                let _attr_place = this.deref_operand(_attr_place)?;
+                let addr_place = this.deref_operand(addr_place)?;
+                let size_place = this.deref_operand(size_place)?;
 
                 this.write_scalar(
                     Scalar::from_uint(STACK_ADDR, this.pointer_size()),
@@ -77,8 +86,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
             // Threading
             "prctl" => {
-                assert_eq!(args.len(), 5);
-                let result = this.prctl(args[0], args[1], args[2], args[3], args[4])?;
+                let &[option, arg2, arg3, arg4, arg5] = check_arg_count(args)?;
+                let result = this.prctl(option, arg2, arg3, arg4, arg5)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
 
@@ -92,6 +101,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                     .eval_libc("SYS_statx")?
                     .to_machine_usize(this)?;
 
+                if args.is_empty() {
+                    throw_ub_format!("incorrect number of arguments, needed at least 1");
+                }
                 match this.read_scalar(args[0])?.to_machine_usize(this)? {
                     // `libc::syscall(NR_GETRANDOM, buf.as_mut_ptr(), buf.len(), GRND_NONBLOCK)`
                     // is called if a `HashMap` is created the regular way (e.g. HashMap<K, V>).
@@ -103,7 +115,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                     // instead of using `stat`,`lstat` or `fstat` as on `macos`.
                     id if id == sys_statx => {
                         // The first argument is the syscall id, so skip over it.
-                        let result = this.linux_statx(args[1], args[2], args[3], args[4], args[5])?;
+                        let &[_, dirfd, pathname, flags, mask, statxbuf] = check_arg_count(args)?;
+                        let result = this.linux_statx(dirfd, pathname, flags, mask, statxbuf)?;
                         this.write_scalar(Scalar::from_machine_isize(result.into(), this), dest)?;
                     }
                     id => throw_unsup_format!("miri does not support syscall ID {}", id),
@@ -115,9 +128,10 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 getrandom(this, args, dest)?;
             }
             "sched_getaffinity" => {
-                let _pid = this.read_scalar(args[0])?.to_i32()?;
-                let _cpusetsize = this.read_scalar(args[1])?.to_machine_usize(this)?;
-                let _mask = this.deref_operand(args[2])?;
+                let &[_pid, _cpusetsize, _mask] = check_arg_count(args)?;
+                let _pid = this.read_scalar(_pid)?.to_i32()?;
+                let _cpusetsize = this.read_scalar(_cpusetsize)?.to_machine_usize(this)?;
+                let _mask = this.deref_operand(_mask)?;
                 // FIXME: we just return an error; `num_cpus` then falls back to `sysconf`.
                 let einval = this.eval_libc("EINVAL")?;
                 this.set_last_error(einval)?;
@@ -143,12 +157,13 @@ fn getrandom<'tcx>(
     args: &[OpTy<'tcx, Tag>],
     dest: PlaceTy<'tcx, Tag>,
 ) -> InterpResult<'tcx> {
-    let ptr = this.read_scalar(args[0])?.not_undef()?;
-    let len = this.read_scalar(args[1])?.to_machine_usize(this)?;
+    let &[ptr, len, _flags] = check_arg_count(args)?;
+    let ptr = this.read_scalar(ptr)?.not_undef()?;
+    let len = this.read_scalar(len)?.to_machine_usize(this)?;
 
     // The only supported flags are GRND_RANDOM and GRND_NONBLOCK,
     // neither of which have any effect on our current PRNG.
-    let _flags = this.read_scalar(args[2])?.to_i32()?;
+    let _flags = this.read_scalar(_flags)?.to_i32()?;
 
     this.gen_random(ptr, len)?;
     this.write_scalar(Scalar::from_machine_usize(len, this), dest)?;

--- a/src/shims/foreign_items/posix/linux.rs
+++ b/src/shims/foreign_items/posix/linux.rs
@@ -102,7 +102,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                     .to_machine_usize(this)?;
 
                 if args.is_empty() {
-                    throw_ub_format!("incorrect number of arguments for syscall, needed at least 1");
+                    throw_ub_format!("incorrect number of arguments for syscall: got 0, expected at least 1");
                 }
                 match this.read_scalar(args[0])?.to_machine_usize(this)? {
                     // `libc::syscall(NR_GETRANDOM, buf.as_mut_ptr(), buf.len(), GRND_NONBLOCK)`
@@ -143,6 +143,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             // Incomplete shims that we "stub out" just to get pre-main initialization code to work.
             // These shims are enabled only when the caller is in the standard library.
             "pthread_getattr_np" if this.frame().instance.to_string().starts_with("std::sys::unix::") => {
+                let &[_thread, _attr] = check_arg_count(args)?;
                 this.write_null(dest)?;
             }
 

--- a/src/shims/foreign_items/posix/macos.rs
+++ b/src/shims/foreign_items/posix/macos.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use helpers::check_arg_count;
 use rustc_middle::mir;
 
 impl<'mir, 'tcx: 'mir> EvalContextExt<'mir, 'tcx> for crate::MiriEvalContext<'mir, 'tcx> {}
@@ -15,85 +16,102 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         match link_name {
             // errno
             "__error" => {
+                let &[] = check_arg_count(args)?;
                 let errno_place = this.machine.last_error.unwrap();
                 this.write_scalar(errno_place.to_ref().to_scalar()?, dest)?;
             }
 
             // File related shims
             "close$NOCANCEL" => {
-                let result = this.close(args[0])?;
+                let &[result] = check_arg_count(args)?;
+                let result = this.close(result)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "stat$INODE64" => {
-                let result = this.macos_stat(args[0], args[1])?;
+                let &[path, buf] = check_arg_count(args)?;
+                let result = this.macos_stat(path, buf)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "lstat$INODE64" => {
-                let result = this.macos_lstat(args[0], args[1])?;
+                let &[path, buf] = check_arg_count(args)?;
+                let result = this.macos_lstat(path, buf)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "fstat$INODE64" => {
-                let result = this.macos_fstat(args[0], args[1])?;
+                let &[fd, buf] = check_arg_count(args)?;
+                let result = this.macos_fstat(fd, buf)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "opendir$INODE64" => {
-                let result = this.opendir(args[0])?;
+                let &[name] = check_arg_count(args)?;
+                let result = this.opendir(name)?;
                 this.write_scalar(result, dest)?;
             }
             "readdir_r$INODE64" => {
-                let result = this.macos_readdir_r(args[0], args[1], args[2])?;
+                let &[dirp, entry, result] = check_arg_count(args)?;
+                let result = this.macos_readdir_r(dirp, entry, result)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "ftruncate" => {
-                let result = this.ftruncate64(args[0], args[1])?;
+                let &[fd, length] = check_arg_count(args)?;
+                let result = this.ftruncate64(fd, length)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
 
             // Environment related shims
             "_NSGetEnviron" => {
+                let &[] = check_arg_count(args)?;
                 this.write_scalar(this.machine.env_vars.environ.unwrap().ptr, dest)?;
             }
 
             // Time related shims
             "gettimeofday" => {
-                let result = this.gettimeofday(args[0], args[1])?;
+                let &[tv, tz] = check_arg_count(args)?;
+                let result = this.gettimeofday(tv, tz)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "mach_absolute_time" => {
+                let &[] = check_arg_count(args)?;
                 let result = this.mach_absolute_time()?;
                 this.write_scalar(Scalar::from_u64(result), dest)?;
             }
 
             "mach_timebase_info" => {
-                let result = this.mach_timebase_info(args[0])?;
+                let &[info] = check_arg_count(args)?;
+                let result = this.mach_timebase_info(info)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             },
 
             // Access to command-line arguments
             "_NSGetArgc" => {
+                let &[] = check_arg_count(args)?;
                 this.write_scalar(this.machine.argc.expect("machine must be initialized"), dest)?;
             }
             "_NSGetArgv" => {
+                let &[] = check_arg_count(args)?;
                 this.write_scalar(this.machine.argv.expect("machine must be initialized"), dest)?;
             }
 
             // Thread-local storage
             "_tlv_atexit" => {
-                let dtor = this.read_scalar(args[0])?.not_undef()?;
+                let &[dtor, data] = check_arg_count(args)?;
+                let dtor = this.read_scalar(dtor)?.not_undef()?;
                 let dtor = this.memory.get_fn(dtor)?.as_instance()?;
-                let data = this.read_scalar(args[1])?.not_undef()?;
+                let data = this.read_scalar(data)?.not_undef()?;
                 let active_thread = this.get_active_thread()?;
                 this.machine.tls.set_macos_thread_dtor(active_thread, dtor, data)?;
             }
 
             // Querying system information
             "pthread_get_stackaddr_np" => {
-                let _thread = this.read_scalar(args[0])?.not_undef()?;
+                let &[_thread] = check_arg_count(args)?;
+                let _thread = this.read_scalar(_thread)?.not_undef()?;
                 let stack_addr = Scalar::from_uint(STACK_ADDR, this.pointer_size());
                 this.write_scalar(stack_addr, dest)?;
             }
             "pthread_get_stacksize_np" => {
-                let _thread = this.read_scalar(args[0])?.not_undef()?;
+                let &[_thread] = check_arg_count(args)?;
+                let _thread = this.read_scalar(_thread)?.not_undef()?;
                 let stack_size = Scalar::from_uint(STACK_SIZE, this.pointer_size());
                 this.write_scalar(stack_size, dest)?;
             }
@@ -108,7 +126,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             // These shims are enabled only when the caller is in the standard library.
             "mmap" if this.frame().instance.to_string().starts_with("std::sys::unix::") => {
                 // This is a horrible hack, but since the guard page mechanism calls mmap and expects a particular return value, we just give it that value.
-                let addr = this.read_scalar(args[0])?.not_undef()?;
+                let &[addr, _, _, _, _, _] = check_arg_count(args)?;
+                let addr = this.read_scalar(addr)?.not_undef()?;
                 this.write_scalar(addr, dest)?;
             }
 

--- a/src/shims/foreign_items/posix/macos.rs
+++ b/src/shims/foreign_items/posix/macos.rs
@@ -118,8 +118,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
             // Threading
             "pthread_setname_np" => {
-                let ptr = this.read_scalar(args[0])?.not_undef()?;
-                this.pthread_setname_np(ptr)?;
+                let &[name] = check_arg_count(args)?;
+                let name = this.read_scalar(name)?.not_undef()?;
+                this.pthread_setname_np(name)?;
             }
 
             // Incomplete shims that we "stub out" just to get pre-main initialization code to work.

--- a/src/shims/foreign_items/posix/macos.rs
+++ b/src/shims/foreign_items/posix/macos.rs
@@ -104,14 +104,14 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
             // Querying system information
             "pthread_get_stackaddr_np" => {
-                let &[_thread] = check_arg_count(args)?;
-                let _thread = this.read_scalar(_thread)?.not_undef()?;
+                let &[thread] = check_arg_count(args)?;
+                this.read_scalar(thread)?.not_undef()?;
                 let stack_addr = Scalar::from_uint(STACK_ADDR, this.pointer_size());
                 this.write_scalar(stack_addr, dest)?;
             }
             "pthread_get_stacksize_np" => {
-                let &[_thread] = check_arg_count(args)?;
-                let _thread = this.read_scalar(_thread)?.not_undef()?;
+                let &[thread] = check_arg_count(args)?;
+                this.read_scalar(thread)?.not_undef()?;
                 let stack_size = Scalar::from_uint(STACK_SIZE, this.pointer_size());
                 this.write_scalar(stack_size, dest)?;
             }

--- a/src/shims/foreign_items/windows.rs
+++ b/src/shims/foreign_items/windows.rs
@@ -97,8 +97,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
             // Allocation
             "HeapAlloc" => {
-                let &[_handle, flags, size] = check_arg_count(args)?;
-                let _handle = this.read_scalar(_handle)?.to_machine_isize(this)?;
+                let &[handle, flags, size] = check_arg_count(args)?;
+                this.read_scalar(handle)?.to_machine_isize(this)?;
                 let flags = this.read_scalar(flags)?.to_u32()?;
                 let size = this.read_scalar(size)?.to_machine_usize(this)?;
                 let zero_init = (flags & 0x00000008) != 0; // HEAP_ZERO_MEMORY
@@ -106,16 +106,16 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_scalar(res, dest)?;
             }
             "HeapFree" => {
-                let &[_handle, _flags, ptr] = check_arg_count(args)?;
-                let _handle = this.read_scalar(_handle)?.to_machine_isize(this)?;
+                let &[handle, _flags, ptr] = check_arg_count(args)?;
+                this.read_scalar(handle)?.to_machine_isize(this)?;
                 let _flags = this.read_scalar(_flags)?.to_u32()?;
                 let ptr = this.read_scalar(ptr)?.not_undef()?;
                 this.free(ptr, MiriMemoryKind::WinHeap)?;
                 this.write_scalar(Scalar::from_i32(1), dest)?;
             }
             "HeapReAlloc" => {
-                let &[_handle, _flags, ptr, size] = check_arg_count(args)?;
-                let _handle = this.read_scalar(_handle)?.to_machine_isize(this)?;
+                let &[handle, _flags, ptr, size] = check_arg_count(args)?;
+                this.read_scalar(handle)?.to_machine_isize(this)?;
                 let _flags = this.read_scalar(_flags)?.to_u32()?;
                 let ptr = this.read_scalar(ptr)?.not_undef()?;
                 let size = this.read_scalar(size)?.to_machine_usize(this)?;
@@ -216,18 +216,18 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             }
             "GetConsoleScreenBufferInfo" => {
                 // `term` needs this, so we fake it.
-                let &[_console, _buffer_info] = check_arg_count(args)?;
-                let _console = this.read_scalar(_console)?.to_machine_isize(this)?;
-                let _buffer_info = this.deref_operand(_buffer_info)?;
+                let &[console, buffer_info] = check_arg_count(args)?;
+                this.read_scalar(console)?.to_machine_isize(this)?;
+                this.deref_operand(buffer_info)?;
                 // Indicate an error.
                 // FIXME: we should set last_error, but to what?
                 this.write_null(dest)?;
             }
             "GetConsoleMode" => {
                 // Windows "isatty" (in libtest) needs this, so we fake it.
-                let &[_console, _mode] = check_arg_count(args)?;
-                let _console = this.read_scalar(_console)?.to_machine_isize(this)?;
-                let _mode = this.deref_operand(_mode)?;
+                let &[console, mode] = check_arg_count(args)?;
+                this.read_scalar(console)?.to_machine_isize(this)?;
+                this.deref_operand(mode)?;
                 // Indicate an error.
                 // FIXME: we should set last_error, but to what?
                 this.write_null(dest)?;

--- a/src/shims/foreign_items/windows.rs
+++ b/src/shims/foreign_items/windows.rs
@@ -106,17 +106,17 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_scalar(res, dest)?;
             }
             "HeapFree" => {
-                let &[handle, _flags, ptr] = check_arg_count(args)?;
+                let &[handle, flags, ptr] = check_arg_count(args)?;
                 this.read_scalar(handle)?.to_machine_isize(this)?;
-                let _flags = this.read_scalar(_flags)?.to_u32()?;
+                this.read_scalar(flags)?.to_u32()?;
                 let ptr = this.read_scalar(ptr)?.not_undef()?;
                 this.free(ptr, MiriMemoryKind::WinHeap)?;
                 this.write_scalar(Scalar::from_i32(1), dest)?;
             }
             "HeapReAlloc" => {
-                let &[handle, _flags, ptr, size] = check_arg_count(args)?;
+                let &[handle, flags, ptr, size] = check_arg_count(args)?;
                 this.read_scalar(handle)?.to_machine_isize(this)?;
-                let _flags = this.read_scalar(_flags)?.to_u32()?;
+                this.read_scalar(flags)?.to_u32()?;
                 let ptr = this.read_scalar(ptr)?.not_undef()?;
                 let size = this.read_scalar(size)?.to_machine_usize(this)?;
                 let res = this.realloc(ptr, size, MiriMemoryKind::WinHeap)?;

--- a/src/shims/fs.rs
+++ b/src/shims/fs.rs
@@ -328,22 +328,18 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
         this.check_no_isolation("fcntl")?;
 
-        let (fd, cmd, start) = if args.len() == 2 {
-            let &[fd, cmd] = check_arg_count(args)?;
-            (fd, cmd, None)
-        } else {
-            // If args.len() isn't 2 or 3 this will error appropriately.
-            let &[fd, cmd, start] = check_arg_count(args)?;
-            (fd, cmd, Some(start))
-        };
-        let fd = this.read_scalar(fd)?.to_i32()?;
-        let cmd = this.read_scalar(cmd)?.to_i32()?;
+        if args.len() < 2 {
+            throw_ub_format!("incorrect number of arguments for fcntl: got {}, expected at least 2", args.len());
+        }
+        let cmd = this.read_scalar(args[1])?.to_i32()?;
         // We only support getting the flags for a descriptor.
         if cmd == this.eval_libc_i32("F_GETFD")? {
             // Currently this is the only flag that `F_GETFD` returns. It is OK to just return the
             // `FD_CLOEXEC` value without checking if the flag is set for the file because `std`
             // always sets this flag when opening a file. However we still need to check that the
             // file itself is open.
+            let &[fd, _] = check_arg_count(args)?;
+            let fd = this.read_scalar(fd)?.to_i32()?;
             if this.machine.file_handler.handles.contains_key(&fd) {
                 Ok(this.eval_libc_i32("FD_CLOEXEC")?)
             } else {
@@ -356,15 +352,12 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             // because exec() isn't supported. The F_DUPFD and F_DUPFD_CLOEXEC commands only
             // differ in whether the FD_CLOEXEC flag is pre-set on the new file descriptor,
             // thus they can share the same implementation here.
+            let &[fd, _, start] = check_arg_count(args)?;
+            let fd = this.read_scalar(fd)?.to_i32()?;
+            let start = this.read_scalar(start)?.to_i32()?;
             if fd < MIN_NORMAL_FILE_FD {
                 throw_unsup_format!("duplicating file descriptors for stdin, stdout, or stderr is not supported")
             }
-            let start = start.ok_or_else(|| {
-                err_unsup_format!(
-                    "fcntl with command F_DUPFD or F_DUPFD_CLOEXEC requires a third argument"
-                )
-            })?;
-            let start = this.read_scalar(start)?.to_i32()?;
             let fh = &mut this.machine.file_handler;
             let (file_result, writable) = match fh.handles.get(&fd) {
                 Some(FileHandle { file, writable }) => (file.try_clone(), *writable),

--- a/src/shims/fs.rs
+++ b/src/shims/fs.rs
@@ -10,7 +10,7 @@ use rustc_target::abi::{Align, LayoutOf, Size};
 
 use crate::stacked_borrows::Tag;
 use crate::*;
-use helpers::{immty_from_int_checked, immty_from_uint_checked};
+use helpers::{check_arg_count, immty_from_int_checked, immty_from_uint_checked};
 use shims::time::system_time_to_duration;
 
 #[derive(Debug)]
@@ -322,16 +322,22 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
     fn fcntl(
         &mut self,
-        fd_op: OpTy<'tcx, Tag>,
-        cmd_op: OpTy<'tcx, Tag>,
-        start_op: Option<OpTy<'tcx, Tag>>,
+        args: &[OpTy<'tcx, Tag>],
     ) -> InterpResult<'tcx, i32> {
         let this = self.eval_context_mut();
 
         this.check_no_isolation("fcntl")?;
 
-        let fd = this.read_scalar(fd_op)?.to_i32()?;
-        let cmd = this.read_scalar(cmd_op)?.to_i32()?;
+        let (fd, cmd, start) = if args.len() == 2 {
+            let &[fd, cmd] = check_arg_count(args)?;
+            (fd, cmd, None)
+        } else {
+            // If args.len() isn't 2 or 3 this will error appropriately.
+            let &[fd, cmd, start] = check_arg_count(args)?;
+            (fd, cmd, Some(start))
+        };
+        let fd = this.read_scalar(fd)?.to_i32()?;
+        let cmd = this.read_scalar(cmd)?.to_i32()?;
         // We only support getting the flags for a descriptor.
         if cmd == this.eval_libc_i32("F_GETFD")? {
             // Currently this is the only flag that `F_GETFD` returns. It is OK to just return the
@@ -353,12 +359,12 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             if fd < MIN_NORMAL_FILE_FD {
                 throw_unsup_format!("duplicating file descriptors for stdin, stdout, or stderr is not supported")
             }
-            let start_op = start_op.ok_or_else(|| {
+            let start = start.ok_or_else(|| {
                 err_unsup_format!(
                     "fcntl with command F_DUPFD or F_DUPFD_CLOEXEC requires a third argument"
                 )
             })?;
-            let start = this.read_scalar(start_op)?.to_i32()?;
+            let start = this.read_scalar(start)?.to_i32()?;
             let fh = &mut this.machine.file_handler;
             let (file_result, writable) = match fh.handles.get(&fd) {
                 Some(FileHandle { file, writable }) => (file.try_clone(), *writable),
@@ -1064,7 +1070,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
     }
 
     fn ftruncate64(
-        &mut self, fd_op: OpTy<'tcx, Tag>,
+        &mut self,
+        fd_op: OpTy<'tcx, Tag>,
         length_op: OpTy<'tcx, Tag>,
     ) -> InterpResult<'tcx, i32> {
         let this = self.eval_context_mut();

--- a/src/shims/mod.rs
+++ b/src/shims/mod.rs
@@ -17,6 +17,7 @@ use log::trace;
 use rustc_middle::{mir, ty};
 
 use crate::*;
+use helpers::check_arg_count;
 
 impl<'mir, 'tcx: 'mir> EvalContextExt<'mir, 'tcx> for crate::MiriEvalContext<'mir, 'tcx> {}
 pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx> {
@@ -32,7 +33,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
         // There are some more lang items we want to hook that CTFE does not hook (yet).
         if this.tcx.lang_items().align_offset_fn() == Some(instance.def.def_id()) {
-            this.align_offset(args[0], args[1], ret, unwind)?;
+            let &[ptr, align] = check_arg_count(args)?;
+            this.align_offset(ptr, align, ret, unwind)?;
             return Ok(None);
         }
 

--- a/src/shims/thread.rs
+++ b/src/shims/thread.rs
@@ -121,12 +121,12 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
     fn pthread_setname_np(
         &mut self,
-        ptr: Scalar<Tag>,
+        name: Scalar<Tag>,
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
         this.assert_target_os("macos", "pthread_setname_np");
 
-        let name = this.memory.read_c_str(ptr)?.to_owned();
+        let name = this.memory.read_c_str(name)?.to_owned();
         this.set_active_thread_name(name)?;
 
         Ok(())

--- a/tests/compile-fail/check_arg_count.rs
+++ b/tests/compile-fail/check_arg_count.rs
@@ -1,0 +1,7 @@
+#![feature(core_intrinsics)]
+
+use std::intrinsics;
+
+fn main() {
+    unsafe { intrinsics::forget(); } //~ ERROR this function takes 1 argument but 0 arguments were supplied
+}

--- a/tests/compile-fail/check_arg_count.rs
+++ b/tests/compile-fail/check_arg_count.rs
@@ -1,8 +1,0 @@
-#![feature(core_intrinsics)]
-
-use std::intrinsics;
-
-fn main() {
-    unsafe { intrinsics::forget(); } //~ ERROR this function takes 1 argument but 0 arguments were supplied
-    unsafe { intrinsics::forget(1, 2); } //~ ERROR this function takes 1 argument but 2 arguments were supplied
-}

--- a/tests/compile-fail/check_arg_count.rs
+++ b/tests/compile-fail/check_arg_count.rs
@@ -4,4 +4,5 @@ use std::intrinsics;
 
 fn main() {
     unsafe { intrinsics::forget(); } //~ ERROR this function takes 1 argument but 0 arguments were supplied
+    unsafe { intrinsics::forget(1, 2); } //~ ERROR this function takes 1 argument but 2 arguments were supplied
 }

--- a/tests/compile-fail/check_arg_count_too_few_args.rs
+++ b/tests/compile-fail/check_arg_count_too_few_args.rs
@@ -1,0 +1,12 @@
+#![feature(core_intrinsics)]
+#![feature(rustc_private)]
+
+fn main() {
+    extern "C" {
+        fn malloc() -> *mut std::ffi::c_void;
+    }
+
+    unsafe {
+        let _ = malloc(); //~ ERROR Undefined Behavior: incorrect number of arguments: got 0, expected 1
+    };
+}

--- a/tests/compile-fail/check_arg_count_too_many_args.rs
+++ b/tests/compile-fail/check_arg_count_too_many_args.rs
@@ -1,0 +1,12 @@
+#![feature(core_intrinsics)]
+#![feature(rustc_private)]
+
+fn main() {
+    extern "C" {
+        fn malloc(_: i32, _: i32) -> *mut std::ffi::c_void;
+    }
+
+    unsafe {
+        let _ = malloc(1, 2); //~ ERROR Undefined Behavior: incorrect number of arguments: got 2, expected 1
+    };
+}


### PR DESCRIPTION
Fixes #1272

Some shims don't use all their arguments, I've assumed they are being called in tests with the correct number of arguments here.