### PR TITLE
Rust bootstrap sysroot now has src in the same place as rust-src

### DIFF
--- a/rust-version
+++ b/rust-version
@@ -1,1 +1,1 @@
-537ccdf3ac44c8c7a8d36cbdbe6fb224afabb7ae
+6050e523bae6de61de4e060facc43dc512adaccd


### PR DESCRIPTION
So we can remove a special hack. I checked this locally to confirm it works.

Cc https://github.com/rust-lang/rust/pull/70642 @eddyb 