### PR TITLE
add empty line before backtrace, to separate it from help text

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -183,8 +183,7 @@ pub fn create_ecx<'mir, 'tcx: 'mir>(
 /// Returns `Some(return_code)` if program executed completed.
 /// Returns `None` if an evaluation error occured.
 pub fn eval_main<'tcx>(tcx: TyCtxt<'tcx>, main_id: DefId, config: MiriConfig) -> Option<i64> {
-    // FIXME: on Windows, locks and TLS dtor management allocate and leave that memory in `static`s.
-    // So we need https://github.com/rust-lang/miri/issues/940 to fix the leaks there.
+    // FIXME: on Windows, we ignore leaks (https://github.com/rust-lang/miri/issues/1302).
     let ignore_leaks = config.ignore_leaks || tcx.sess.target.target.target_os == "windows";
 
     let (mut ecx, ret_place) = match create_ecx(tcx, main_id, config) {


### PR DESCRIPTION
I think this improves how things look, and makes it easier to see the help text (it currently kind of drowns next to the backtrace).

Before:
```
error: unsupported operation: Miri does not support threading
  --> /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/src/libstd/sys/unix/thread.rs:68:19
   |
68 |         let ret = libc::pthread_create(&mut native, &attr, thread_start, &*p as *const _ as *mut _);
   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Miri does not support threading
   |
   = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
   = note: inside `std::sys::unix::thread::Thread::new` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/src/libstd/sys/unix/thread.rs:68:19
   = note: inside `std::thread::Builder::spawn_unchecked::<[closure@tests/compile-fail/thread-spawn.rs:6:19: 6:24], ()>` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/src/libstd/thread/mod.rs:492:26
   = note: inside `std::thread::Builder::spawn::<[closure@tests/compile-fail/thread-spawn.rs:6:19: 6:24], ()>` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/src/libstd/thread/mod.rs:386:18
   = note: inside `std::thread::spawn::<[closure@tests/compile-fail/thread-spawn.rs:6:19: 6:24], ()>` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/src/libstd/thread/mod.rs:619:5
note: inside `main` at tests/compile-fail/thread-spawn.rs:6:5
  --> tests/compile-fail/thread-spawn.rs:6:5
   |
6  |     thread::spawn(|| {});
   |     ^^^^^^^^^^^^^^^^^^^^
   = note: inside closure at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/src/libstd/rt.rs:67:34
   = note: inside closure at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/src/libstd/rt.rs:52:73
   = note: inside `std::sys_common::backtrace::__rust_begin_short_backtrace::<[closure@DefId(1:6030 ~ std[2f86]::rt[0]::lang_start_internal[0]::{{closure}}[0]::{{closure}}[0]) 0:&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe], i32>` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/src/libstd/sys_common/backtrace.rs:130:5
   = note: inside closure at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/src/libstd/rt.rs:52:13
   = note: inside `std::panicking::try::do_call::<[closure@DefId(1:6029 ~ std[2f86]::rt[0]::lang_start_internal[0]::{{closure}}[0]) 0:&&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe], i32>` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/src/libstd/panicking.rs:331:40
   = note: inside `std::panicking::try::<i32, [closure@DefId(1:6029 ~ std[2f86]::rt[0]::lang_start_internal[0]::{{closure}}[0]) 0:&&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe]>` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/src/libstd/panicking.rs:274:15
   = note: inside `std::panic::catch_unwind::<[closure@DefId(1:6029 ~ std[2f86]::rt[0]::lang_start_internal[0]::{{closure}}[0]) 0:&&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe], i32>` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/src/libstd/panic.rs:394:14
   = note: inside `std::rt::lang_start_internal` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/src/libstd/rt.rs:51:25
   = note: inside `std::rt::lang_start::<()>` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/src/libstd/rt.rs:67:5
```
After:
```
error: unsupported operation: Miri does not support threading
  --> /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/src/libstd/sys/unix/thread.rs:68:19
   |
68 |         let ret = libc::pthread_create(&mut native, &attr, thread_start, &*p as *const _ as *mut _);
   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Miri does not support threading
   |
   = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
           
   = note: inside `std::sys::unix::thread::Thread::new` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/src/libstd/sys/unix/thread.rs:68:19
   = note: inside `std::thread::Builder::spawn_unchecked::<[closure@tests/compile-fail/thread-spawn.rs:6:19: 6:24], ()>` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/src/libstd/thread/mod.rs:492:26
   = note: inside `std::thread::Builder::spawn::<[closure@tests/compile-fail/thread-spawn.rs:6:19: 6:24], ()>` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/src/libstd/thread/mod.rs:386:18
   = note: inside `std::thread::spawn::<[closure@tests/compile-fail/thread-spawn.rs:6:19: 6:24], ()>` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/src/libstd/thread/mod.rs:619:5
note: inside `main` at tests/compile-fail/thread-spawn.rs:6:5
  --> tests/compile-fail/thread-spawn.rs:6:5
   |
6  |     thread::spawn(|| {});
   |     ^^^^^^^^^^^^^^^^^^^^
   = note: inside closure at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/src/libstd/rt.rs:67:34
   = note: inside closure at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/src/libstd/rt.rs:52:73
   = note: inside `std::sys_common::backtrace::__rust_begin_short_backtrace::<[closure@DefId(1:6030 ~ std[2f86]::rt[0]::lang_start_internal[0]::{{closure}}[0]::{{closure}}[0]) 0:&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe], i32>` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/src/libstd/sys_common/backtrace.rs:130:5
   = note: inside closure at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/src/libstd/rt.rs:52:13
   = note: inside `std::panicking::try::do_call::<[closure@DefId(1:6029 ~ std[2f86]::rt[0]::lang_start_internal[0]::{{closure}}[0]) 0:&&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe], i32>` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/src/libstd/panicking.rs:331:40
   = note: inside `std::panicking::try::<i32, [closure@DefId(1:6029 ~ std[2f86]::rt[0]::lang_start_internal[0]::{{closure}}[0]) 0:&&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe]>` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/src/libstd/panicking.rs:274:15
   = note: inside `std::panic::catch_unwind::<[closure@DefId(1:6029 ~ std[2f86]::rt[0]::lang_start_internal[0]::{{closure}}[0]) 0:&&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe], i32>` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/src/libstd/panic.rs:394:14
   = note: inside `std::rt::lang_start_internal` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/src/libstd/rt.rs:51:25
   = note: inside `std::rt::lang_start::<()>` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/src/libstd/rt.rs:67:5
```

What do you think?