### PR TITLE
Replace last_entry with last_key_value

### DIFF
--- a/src/shims/fs.rs
+++ b/src/shims/fs.rs
@@ -56,7 +56,7 @@ impl FileHandler {
         let new_fd = candidate_new_fd.unwrap_or_else(|| {
             // find_map ran out of BTreeMap entries before finding a free fd, use one plus the
             // maximum fd in the map
-            self.handles.last_entry().map(|entry| entry.key().checked_add(1).unwrap()).unwrap_or(min_fd)
+            self.handles.last_key_value().map(|(fd, _)| fd.checked_add(1).unwrap()).unwrap_or(min_fd)
         });
 
         self.handles.insert(new_fd, file_handle).unwrap_none();


### PR DESCRIPTION
Wondering why `last_entry` was introduced (in #1156) while the alternative is shorter and seems clearer to me. 

Also, as the perpetrator of map_first_last, I now think that `first_entry`/`last_entry` are silly methods because they're supposed to be constant time (as opposed to `entry`), so there's no money to be made by doing multiple things with the entry.