### PR TITLE
organize intrinsics in groups

### DIFF
--- a/src/shims/intrinsics.rs
+++ b/src/shims/intrinsics.rs
@@ -444,14 +444,6 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 }
             }
 
-            "pref_align_of" => {
-                let ty = substs.type_at(0);
-                let layout = this.layout_of(ty)?;
-                let align = layout.align.pref.bytes();
-                let align_val = Scalar::from_machine_usize(align, this);
-                this.write_scalar(align_val, dest)?;
-            }
-
             #[rustfmt::skip]
             | "min_align_of_val"
             | "align_of_val"

--- a/src/shims/intrinsics.rs
+++ b/src/shims/intrinsics.rs
@@ -444,10 +444,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 }
             }
 
-            #[rustfmt::skip]
-            | "min_align_of_val"
-            | "align_of_val"
-            => {
+            "min_align_of_val" => {
                 let mplace = this.deref_operand(args[0])?;
                 let (_, align) = this
                     .size_and_align_of_mplace(mplace)?


### PR DESCRIPTION
Also remove `pref_align_of` as it was moved into rustc long ago, and `align_of_val` as it doesn't exist (the name is `min_align_of_val`, which we also already handle).