### PR TITLE
Implement `mach_timebase_info` for macOS

### DIFF
--- a/src/shims/foreign_items/posix/macos.rs
+++ b/src/shims/foreign_items/posix/macos.rs
@@ -60,6 +60,11 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_scalar(Scalar::from_u64(result), dest)?;
             }
 
+            "mach_timebase_info" => {
+                let result = this.mach_timebase_info(args[0])?;
+                this.write_scalar(Scalar::from_i32(result), dest)?;
+            },
+
             // Access to command-line arguments
             "_NSGetArgc" => {
                 this.write_scalar(this.machine.argc.expect("machine must be initialized"), dest)?;

--- a/src/shims/time.rs
+++ b/src/shims/time.rs
@@ -173,13 +173,12 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         // `mach_absolute_time`, we don't need to scale the absolute
         // time.
         let (numer, denom) = (1,1);
-        let uint32_layout = this.layout_of(this.tcx.types.u32)?;
         let imms = [
-            immty_from_int_checked(numer, uint32_layout)?,
-            immty_from_int_checked(denom, uint32_layout)?
+            immty_from_int_checked(numer, this.machine.layouts.u32)?,
+            immty_from_int_checked(denom, this.machine.layouts.u32)?
         ];
 
         this.write_packed_immediates(info, &imms)?;
-        Ok(0)
+        Ok(0) // KERN_SUCCESS
     }
 }

--- a/src/shims/time.rs
+++ b/src/shims/time.rs
@@ -169,9 +169,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
         let info = this.deref_operand(info_op)?;
 
-        // Since we return nanoseconds instead of ticks from
-        // `mach_absolute_time`, we don't need to scale the absolute
-        // time.
+        // Since our emulated ticks in `mach_absolute_time` *are* nanoseconds,
+        // no scaling needs to happen.
         let (numer, denom) = (1,1);
         let imms = [
             immty_from_int_checked(numer, this.machine.layouts.u32)?,

--- a/src/shims/time.rs
+++ b/src/shims/time.rs
@@ -169,13 +169,14 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
         let info = this.deref_operand(info_op)?;
 
-        // Since we return nanoseceonds instead of ticks from
+        // Since we return nanoseconds instead of ticks from
         // `mach_absolute_time`, we don't need to scale the absolute
         // time.
         let (numer, denom) = (1,1);
+        let uint32_layout = this.layout_of(this.tcx.types.u32)?;
         let imms = [
-            immty_from_int_checked(numer, this.libc_ty_layout("uint32_t")?)?,
-            immty_from_int_checked(denom, this.libc_ty_layout("uint32_t")?)?
+            immty_from_int_checked(numer, uint32_layout)?,
+            immty_from_int_checked(denom, uint32_layout)?
         ];
 
         this.write_packed_immediates(info, &imms)?;

--- a/src/shims/time.rs
+++ b/src/shims/time.rs
@@ -13,6 +13,7 @@ pub fn system_time_to_duration<'tcx>(time: &SystemTime) -> InterpResult<'tcx, Du
         .map_err(|_| err_unsup_format!("times before the Unix epoch are not supported").into())
 }
 
+
 impl<'mir, 'tcx> EvalContextExt<'mir, 'tcx> for crate::MiriEvalContext<'mir, 'tcx> {}
 pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx> {
     fn clock_gettime(
@@ -158,5 +159,26 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         let duration = Instant::now().duration_since(this.machine.time_anchor);
         u64::try_from(duration.as_nanos())
             .map_err(|_| err_unsup_format!("programs running longer than 2^64 nanoseconds are not supported").into())
+    }
+
+    fn mach_timebase_info(&mut self, info_op: OpTy<'tcx, Tag>) -> InterpResult<'tcx, i32> {
+        let this = self.eval_context_mut();
+
+        this.assert_target_os("macos", "mach_timebase_info");
+        this.check_no_isolation("mach_timebase_info")?;
+
+        let info = this.deref_operand(info_op)?;
+
+        // Since we return nanoseceonds instead of ticks from
+        // `mach_absolute_time`, we don't need to scale the absolute
+        // time.
+        let (numer, denom) = (1,1);
+        let imms = [
+            immty_from_int_checked(numer, this.libc_ty_layout("uint32_t")?)?,
+            immty_from_int_checked(denom, this.libc_ty_layout("uint32_t")?)?
+        ];
+
+        this.write_packed_immediates(info, &imms)?;
+        Ok(0)
     }
 }

--- a/tests/run-pass/time.rs
+++ b/tests/run-pass/time.rs
@@ -25,13 +25,10 @@ fn main() {
     let now2 = Instant::now();
     assert!(now2 > now1);
 
-    #[cfg(not(target_os = "macos"))] // TODO: macOS does not support Instant subtraction
-    {
-        let diff = now2.duration_since(now1);
-        assert_eq!(now1 + diff, now2);
-        assert_eq!(now2 - diff, now1);
-        // Sanity-check the difference we got.
-        assert!(diff.as_micros() > 1);
-        assert!(diff.as_micros() < 1_000_000);
-    }
+    let diff = now2.duration_since(now1);
+    assert_eq!(now1 + diff, now2);
+    assert_eq!(now2 - diff, now1);
+    // Sanity-check the difference we got.
+    assert!(diff.as_micros() > 1);
+    assert!(diff.as_micros() < 1_000_000);
 }

--- a/tests/run-pass/time.rs
+++ b/tests/run-pass/time.rs
@@ -24,7 +24,6 @@ fn main() {
     for _ in 0..10 { drop(vec![42]); }
     let now2 = Instant::now();
     assert!(now2 > now1);
-
     let diff = now2.duration_since(now1);
     assert_eq!(now1 + diff, now2);
     assert_eq!(now2 - diff, now1);


### PR DESCRIPTION
Since we return nanoseceonds instead of ticks from `mach_absolute_time`, we don't need to scale the absolute time

Fixes #1288 