### PR TITLE
Handle std::sync::atomic::spin_loop_hint()

### DIFF
--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -433,15 +433,14 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_scalar(Scalar::from_f64(res), dest)?;
             }
 
+            // Architecture-specific shims
             "llvm.x86.sse2.pause" if this.tcx.sess.target.target.arch == "x86" || this.tcx.sess.target.target.arch == "x86_64" => {}
 
-            // Target-specific shims
-            _ => {
-                match this.tcx.sess.target.target.target_os.as_str() {
-                    "linux" | "macos" => return posix::EvalContextExt::emulate_foreign_item_by_name(this, link_name, args, dest, ret),
-                    "windows" => return windows::EvalContextExt::emulate_foreign_item_by_name(this, link_name, args, dest, ret),
-                    target => throw_unsup_format!("the target `{}` is not supported", target),
-                }
+            // Platform-specific shims
+            _ => match this.tcx.sess.target.target.target_os.as_str() {
+                "linux" | "macos" => return posix::EvalContextExt::emulate_foreign_item_by_name(this, link_name, args, dest, ret),
+                "windows" => return windows::EvalContextExt::emulate_foreign_item_by_name(this, link_name, args, dest, ret),
+                target => throw_unsup_format!("the target `{}` is not supported", target),
             }
         };
 

--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -434,10 +434,19 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             }
 
             // Target-specific shims
-            _ => match this.tcx.sess.target.target.target_os.as_str() {
-                "linux" | "macos" => return posix::EvalContextExt::emulate_foreign_item_by_name(this, link_name, args, dest, ret),
-                "windows" => return windows::EvalContextExt::emulate_foreign_item_by_name(this, link_name, args, dest, ret),
-                target => throw_unsup_format!("the target `{}` is not supported", target),
+            _ => {
+                match this.tcx.sess.target.target.arch.as_str() {
+                    "x86" | "x86_64" => match link_name {
+                        "llvm.x86.sse2.pause" => return Ok(true),
+                        _ => {}
+                    }
+                    _ => {}
+                }
+                match this.tcx.sess.target.target.target_os.as_str() {
+                    "linux" | "macos" => return posix::EvalContextExt::emulate_foreign_item_by_name(this, link_name, args, dest, ret),
+                    "windows" => return windows::EvalContextExt::emulate_foreign_item_by_name(this, link_name, args, dest, ret),
+                    target => throw_unsup_format!("the target `{}` is not supported", target),
+                }
             }
         };
 

--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -433,15 +433,10 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_scalar(Scalar::from_f64(res), dest)?;
             }
 
+            "llvm.x86.sse2.pause" if this.tcx.sess.target.target.arch == "x86" || this.tcx.sess.target.target.arch == "x86_64" => {}
+
             // Target-specific shims
             _ => {
-                match this.tcx.sess.target.target.arch.as_str() {
-                    "x86" | "x86_64" => match link_name {
-                        "llvm.x86.sse2.pause" => return Ok(true),
-                        _ => {}
-                    }
-                    _ => {}
-                }
                 match this.tcx.sess.target.target.target_os.as_str() {
                     "linux" | "macos" => return posix::EvalContextExt::emulate_foreign_item_by_name(this, link_name, args, dest, ret),
                     "windows" => return windows::EvalContextExt::emulate_foreign_item_by_name(this, link_name, args, dest, ret),

--- a/src/shims/foreign_items/posix.rs
+++ b/src/shims/foreign_items/posix.rs
@@ -312,6 +312,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 // We do not support forking, so there is nothing to do here.
                 this.write_null(dest)?;
             }
+            "sched_yield" => {
+                this.write_null(dest)?;
+            }
 
             // Incomplete shims that we "stub out" just to get pre-main initialization code to work.
             // These shims are enabled only when the caller is in the standard library.

--- a/src/shims/foreign_items/windows.rs
+++ b/src/shims/foreign_items/windows.rs
@@ -201,6 +201,11 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 // FIXME: we should set last_error, but to what?
                 this.write_null(dest)?;
             }
+            "SwitchToThread" => {
+                // Note that once Miri supports concurrency, this will need to return a nonzero
+                // value if this call does result in switching to another thread.
+                this.write_null(dest)?;
+            }
 
             // Better error for attempts to create a thread
             "CreateThread" => {

--- a/tests/run-pass/sync.rs
+++ b/tests/run-pass/sync.rs
@@ -1,6 +1,7 @@
 #![feature(rustc_private)]
 
 use std::sync::{Mutex, TryLockError};
+use std::sync::atomic;
 
 fn main() {
     test_mutex_stdlib();
@@ -8,6 +9,7 @@ fn main() {
     {
         test_rwlock_stdlib();
     }
+    test_spin_loop_hint();
 }
 
 fn test_mutex_stdlib() {
@@ -49,4 +51,8 @@ impl<T> TryLockErrorExt<T> for TryLockError<T> {
             TryLockError::Poisoned(_) => false,
         }
     }
+}
+
+fn test_spin_loop_hint() {
+    atomic::spin_loop_hint();
 }

--- a/tests/run-pass/sync.rs
+++ b/tests/run-pass/sync.rs
@@ -10,6 +10,7 @@ fn main() {
         test_rwlock_stdlib();
     }
     test_spin_loop_hint();
+    test_thread_yield_now();
 }
 
 fn test_mutex_stdlib() {
@@ -55,4 +56,8 @@ impl<T> TryLockErrorExt<T> for TryLockError<T> {
 
 fn test_spin_loop_hint() {
     atomic::spin_loop_hint();
+}
+
+fn test_thread_yield_now() {
+    std::thread::yield_now();
 }


### PR DESCRIPTION
This PR adds support for `std::sync::atomic::spin_loop_hint()` by implementing the `llvm.x86.sse2.pause` intrinsic when the target is x86-based. It appears this is the first LLVM intrinsic in foreign_items, so I added a couple match blocks to handle it or fall through to the different OS-specific methods. I added a basic smoke test to `tests/run-pass/sync.rs`. I came across this by way of `crossbeam::utils::Backoff::spin()`, FWIW.