### PR TITLE
Implement ftruncate64/ftruncate for File::set_len

### DIFF
--- a/src/shims/foreign_items/posix/linux.rs
+++ b/src/shims/foreign_items/posix/linux.rs
@@ -34,6 +34,10 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 let result = this.linux_readdir64_r(args[0], args[1], args[2])?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
+            "ftruncate64" => {
+                let result = this.ftruncate64(args[0], args[1])?;
+                this.write_scalar(Scalar::from_i32(result), dest)?;
+            }
             // Linux-only
             "posix_fadvise" => {
                 let _fd = this.read_scalar(args[0])?.to_i32()?;

--- a/src/shims/foreign_items/posix/macos.rs
+++ b/src/shims/foreign_items/posix/macos.rs
@@ -44,6 +44,10 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 let result = this.macos_readdir_r(args[0], args[1], args[2])?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
+            "ftruncate" => {
+                let result = this.ftruncate64(args[0], args[1])?;
+                this.write_scalar(Scalar::from_i32(result), dest)?;
+            }
 
             // Environment related shims
             "_NSGetEnviron" => {

--- a/src/shims/fs.rs
+++ b/src/shims/fs.rs
@@ -1084,6 +1084,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                     Ok(-1)
                 }
             } else {
+                // The file is not writable
                 let einval = this.eval_libc("EINVAL")?;
                 this.set_last_error(einval)?;
                 Ok(-1)


### PR DESCRIPTION
This adds a shim for `ftruncate64` (on Linux) or `ftruncate` (on macOS) to enable support for `File::set_len`, and includes a test.