### PR TITLE
Print hex dump of alloc on reading undef bytes

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -114,6 +114,9 @@ pub fn report_error<'tcx, 'mir>(
     };
 
     e.print_backtrace();
+    if let UndefinedBehavior(UndefinedBehaviorInfo::InvalidUndefBytes(Some(ptr))) = e.kind {
+        ecx.memory.dump_alloc(ptr.alloc_id);
+    }
     let msg = e.to_string();
     report_msg(ecx, &format!("{}: {}", title, msg), msg, helps, true)
 }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -115,8 +115,9 @@ pub fn report_error<'tcx, 'mir>(
 
     e.print_backtrace();
     let msg = e.to_string();
-    let result = report_msg(ecx, &format!("{}: {}", title, msg), msg, helps, true);
+    report_msg(ecx, &format!("{}: {}", title, msg), msg, helps, true);
 
+    // Extra output to help debug specific issues.
     if let UndefinedBehavior(UndefinedBehaviorInfo::InvalidUndefBytes(Some(ptr))) = e.kind {
         eprintln!(
             "Uninitialized read occurred at offset 0x{:x} into this allocation:",
@@ -126,7 +127,7 @@ pub fn report_error<'tcx, 'mir>(
         eprintln!();
     }
 
-    result
+    None
 }
 
 /// Report an error or note (depending on the `error` argument) at the current frame's current statement.
@@ -137,7 +138,7 @@ fn report_msg<'tcx, 'mir>(
     span_msg: String,
     mut helps: Vec<String>,
     error: bool,
-) -> Option<i64> {
+) {
     let span = if let Some(frame) = ecx.machine.stack.last() {
         frame.current_source_info().unwrap().span
     } else {
@@ -178,8 +179,6 @@ fn report_msg<'tcx, 'mir>(
             trace!("    local {}: {:?}", i, local.value);
         }
     }
-    // Let the reported error determine the return code.
-    return None;
 }
 
 thread_local! {

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -118,7 +118,12 @@ pub fn report_error<'tcx, 'mir>(
     let result = report_msg(ecx, &format!("{}: {}", title, msg), msg, helps, true);
 
     if let UndefinedBehavior(UndefinedBehaviorInfo::InvalidUndefBytes(Some(ptr))) = e.kind {
+        eprintln!(
+            "Uninitialized read occurred at offset 0x{:x} into this allocation:",
+            ptr.offset.bytes(),
+        );
         ecx.memory.dump_alloc(ptr.alloc_id);
+        eprintln!();
     }
 
     result

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -114,11 +114,14 @@ pub fn report_error<'tcx, 'mir>(
     };
 
     e.print_backtrace();
+    let msg = e.to_string();
+    let result = report_msg(ecx, &format!("{}: {}", title, msg), msg, helps, true);
+
     if let UndefinedBehavior(UndefinedBehaviorInfo::InvalidUndefBytes(Some(ptr))) = e.kind {
         ecx.memory.dump_alloc(ptr.alloc_id);
     }
-    let msg = e.to_string();
-    report_msg(ecx, &format!("{}: {}", title, msg), msg, helps, true)
+
+    result
 }
 
 /// Report an error or note (depending on the `error` argument) at the current frame's current statement.

--- a/tests/compile-fail/undefined_buffer.rs
+++ b/tests/compile-fail/undefined_buffer.rs
@@ -1,0 +1,20 @@
+// error-pattern: reading uninitialized memory
+
+use std::alloc::{alloc, dealloc, Layout};
+use std::slice::from_raw_parts;
+
+fn main() {
+    let layout = Layout::from_size_align(32, 8).unwrap();
+    unsafe {
+        let ptr = alloc(layout);
+        *ptr = 0x41;
+        *ptr.add(1) = 0x42;
+        *ptr.add(2) = 0x43;
+        *ptr.add(3) = 0x44;
+        *ptr.add(16) = 0x00;
+        let slice1 = from_raw_parts(ptr, 16);
+        let slice2 = from_raw_parts(ptr.add(16), 16);
+        drop(slice1.cmp(slice2));
+        dealloc(ptr, layout);
+    }
+}


### PR DESCRIPTION
Here's a small addition I made locally to the UB diagnostics, in case you're interested in it. This PR calls `dump_alloc()` on the relevant allocation if Miri fails on UB due to reading undefined bytes. This came in handy when diagnosing such an issue in a large program using unsafe Rust, in part because it wasn't deterministic enough to use `-Zmiri-track-alloc-id=`. If you'd like to put this behind another -Z flag, let me know.