### PR TITLE
test suite: rely on CARGO_BIN_EXE_ env vars

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,5 @@
-extern crate vergen;
-
-use std::env;
-
 fn main() {
-    // Forward the profile to the main compilation
-    println!("cargo:rustc-env=PROFILE={}", env::var("PROFILE").unwrap());
-    // Don't rebuild miri even if nothing changed
+    // Don't rebuild miri when nothing changed.
     println!("cargo:rerun-if-changed=build.rs");
     // vergen
     vergen::generate_cargo_keys(vergen::ConstantsFlags::all())

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -12,7 +12,7 @@ fn miri_path() -> PathBuf {
     if rustc_test_suite().is_some() {
         PathBuf::from(option_env!("MIRI_PATH").unwrap())
     } else {
-        PathBuf::from(concat!("target/", env!("PROFILE"), "/miri"))
+        PathBuf::from(env!("CARGO_BIN_EXE_miri"))
     }
 }
 


### PR DESCRIPTION
Just read about this in the 1.43 release notes. :)