### PR TITLE
Add miri trophy for LazyArray::swap (ink! PR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Violations of [Stacked Borrows] found that are likely bugs (but Stacked Borrows 
 * [Aliasing mutable references in `sized-chunks`](https://github.com/bodil/sized-chunks/issues/8)
 * [`String::push_str` invalidating existing references into the string](https://github.com/rust-lang/rust/issues/70301)
 * [`ryu` using raw pointers outside their valid memory area](https://github.com/dtolnay/ryu/issues/24)
-* [`LazyArray::swap` method creating overlapping mutable references (ink! PR)](https://github.com/rust-lang/miri/issues/1364)
+* [ink! creating overlapping mutable references](https://github.com/rust-lang/miri/issues/1364)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ Violations of [Stacked Borrows] found that are likely bugs (but Stacked Borrows 
 * [Aliasing mutable references in `sized-chunks`](https://github.com/bodil/sized-chunks/issues/8)
 * [`String::push_str` invalidating existing references into the string](https://github.com/rust-lang/rust/issues/70301)
 * [`ryu` using raw pointers outside their valid memory area](https://github.com/dtolnay/ryu/issues/24)
+* [`LazyArray::swap` method creating overlapping mutable references (ink! PR)](https://github.com/rust-lang/miri/issues/1364)
 
 ## License
 


### PR DESCRIPTION
Details to the found in https://github.com/rust-lang/miri/issues/1364.
Note that this was not a found in a `master` or production release of ink!, however without analysing the code via `miri` this could have potentially happened.