### PR TITLE
also enable overflow checks in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ test = false # we have no unit tests
 doctest = false # and no doc tests
 required-features = ["rustc_tests"]
 
+[profile.release]
+overflow-checks = true
+
 [dependencies]
 cargo_metadata = { version = "0.9.0", optional = true }
 directories = { version = "2.0", optional = true }


### PR DESCRIPTION
@oli-obk this means the flag should be picked up for the rustup build... right?