### PR TITLE
re-do cargo-miri host/target detection logic to match rustbuild

### DIFF
--- a/src/bin/cargo-miri.rs
+++ b/src/bin/cargo-miri.rs
@@ -500,7 +500,7 @@ fn inside_cargo_rustc() {
     /// be built like normal; target crates need to be built for or interpreted
     /// by Miri.
     ///
-    /// Currently, we detect this by checking for "--target=", which flag is
+    /// Currently, we detect this by checking for "--target=", which is
     /// never set for host crates. This matches what rustc bootstrap does,
     /// which hopefully makes it "reliable enough".
     fn is_target_crate() -> bool {

--- a/src/bin/cargo-miri.rs
+++ b/src/bin/cargo-miri.rs
@@ -502,7 +502,8 @@ fn inside_cargo_rustc() {
     ///
     /// Currently, we detect this by checking for "--target=", which is
     /// never set for host crates. This matches what rustc bootstrap does,
-    /// which hopefully makes it "reliable enough".
+    /// which hopefully makes it "reliable enough". This relies on us always
+    /// invoking cargo itself with `--target`, which `in_cargo_miri` ensures.
     fn is_target_crate() -> bool {
         get_arg_flag_value("--target").is_some()
     }


### PR DESCRIPTION
@oli-obk I think that's better than looking at `--emit` like we did before... what do you think?