### PR TITLE
cargo-miri: never invoke rustc

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Try deleting `~/.cache/miri`.
 This means the sysroot you are using was not compiled with Miri in mind.  This
 should never happen when you use `cargo miri` because that takes care of setting
 up the sysroot.  If you are using `miri` (the Miri driver) directly, see
-[below][testing-miri] for how to set up the sysroot.
+[CONTRIBUTING.md](CONTRIBUTING.md) for how to use `./miri`.
 
 
 ## Miri `-Z` flags and environment variables

--- a/src/bin/cargo-miri.rs
+++ b/src/bin/cargo-miri.rs
@@ -342,7 +342,6 @@ path = "lib.rs"
         command.env("RUSTC", find_miri());
     }
     command.env("MIRI_BE_RUSTC", "1");
-    command.env("RUSTFLAGS", miri::miri_default_args().join(" "));
     // Finally run it!
     if command.status().expect("failed to run xargo").success().not() {
         show_error(format!("Failed to run xargo"));

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -139,6 +139,10 @@ fn run_compiler(mut args: Vec<String>, callbacks: &mut (dyn rustc_driver::Callba
         }
     }
 
+    // Some options have different defaults in Miri than in plain rustc; apply those by making
+    // them the first arguments after the binary name (but later arguments can overwrite them).
+    args.splice(1..1, miri::miri_default_args().iter().map(ToString::to_string));
+
     // Invoke compiler, and handle return code.
     let result = rustc_driver::catch_fatal_errors(move || {
         rustc_driver::run_compiler(&args, callbacks, None, None)
@@ -182,10 +186,6 @@ fn main() {
         if rustc_args.is_empty() {
             // Very first arg: binary name.
             rustc_args.push(arg);
-            // After this, push Miri default args (before everything else so they can be overwritten).
-            for arg in miri::miri_default_args().iter() {
-                rustc_args.push(arg.to_string());
-            }
         } else if after_dashdash {
             // Everything that comes after `--` is forwarded to the interpreted crate.
             crate_args.push(arg);


### PR DESCRIPTION
Always go through 'MIRI_BE_RUSTC=1 miri' instead. This is based on @oli-obk's great idea to add a way to make Miri behave like rustc, which already helped us in https://github.com/rust-lang/miri/pull/1405. Now it means in `cargo-miri` we run *all* crates through the same binary, and use the env var to determine if we compile or interpret them. This makes sure the compiler is consistent.

The `rustc` binary of the current toolchain is now not used at all, only the `miri` binary is. In particular this means we can kill the sysroot consistency check. :)