### PR TITLE
Add file sync shims

### DIFF
--- a/src/shims/foreign_items/posix.rs
+++ b/src/shims/foreign_items/posix.rs
@@ -136,6 +136,14 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 // "lseek" is only used on macOS which is 64bit-only, so `i64` always works.
                 this.write_scalar(Scalar::from_i64(result), dest)?;
             }
+            "fsync" => {
+                let result = this.fsync(args[0])?;
+                this.write_scalar(Scalar::from_i32(result), dest)?;
+            }
+            "fdatasync" => {
+                let result = this.fdatasync(args[0])?;
+                this.write_scalar(Scalar::from_i32(result), dest)?;
+            }
 
             // Allocation
             "posix_memalign" => {

--- a/src/shims/foreign_items/posix.rs
+++ b/src/shims/foreign_items/posix.rs
@@ -137,11 +137,13 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_scalar(Scalar::from_i64(result), dest)?;
             }
             "fsync" => {
-                let result = this.fsync(args[0])?;
+                let &[fd] = check_arg_count(args)?;
+                let result = this.fsync(fd)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "fdatasync" => {
-                let result = this.fdatasync(args[0])?;
+                let &[fd] = check_arg_count(args)?;
+                let result = this.fdatasync(fd)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
 

--- a/src/shims/foreign_items/posix/linux.rs
+++ b/src/shims/foreign_items/posix/linux.rs
@@ -54,9 +54,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 // fadvise is only informational, we can ignore it.
                 this.write_null(dest)?;
             }
-            // Linux-only
             "sync_file_range" => {
-                let result = this.sync_file_range(args[0], args[1], args[2], args[3])?;
+                let &[fd, offset, nbytes, flags] = check_arg_count(args)?;
+                let result = this.sync_file_range(fd, offset, nbytes, flags)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
 

--- a/src/shims/foreign_items/posix/linux.rs
+++ b/src/shims/foreign_items/posix/linux.rs
@@ -54,6 +54,11 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 // fadvise is only informational, we can ignore it.
                 this.write_null(dest)?;
             }
+            // Linux-only
+            "sync_file_range" => {
+                let result = this.sync_file_range(args[0], args[1], args[2], args[3])?;
+                this.write_scalar(Scalar::from_i32(result), dest)?;
+            }
 
             // Time related shims
             "clock_gettime" => {

--- a/tests/run-pass/fs.rs
+++ b/tests/run-pass/fs.rs
@@ -14,8 +14,7 @@ fn main() {
     test_seek();
     test_metadata();
     test_file_set_len();
-    test_file_sync_all();
-    test_file_sync_data();
+    test_file_sync();
     test_symlink();
     test_errors();
     test_rename();
@@ -184,24 +183,14 @@ fn test_file_set_len() {
     remove_file(&path).unwrap();
 }
 
-fn test_file_sync_all() {
+fn test_file_sync() {
     let bytes = b"Hello, World!\n";
-    let path = prepare_with_content("miri_test_fs_sync_all.txt", bytes);
+    let path = prepare_with_content("miri_test_fs_sync.txt", bytes);
 
-    // Test that we can call sync_all (can't readily test effects of this operation)
-    let file = File::open(&path).unwrap();
-    file.sync_all().unwrap();
-
-    remove_file(&path).unwrap();
-}
-
-fn test_file_sync_data() {
-    let bytes = b"Hello, World!\n";
-    let path = prepare_with_content("miri_test_fs_sync_data.txt", bytes);
-
-    // Test that we can call sync_data (can't readily test effects of this operation)
+    // Test that we can call sync_data and sync_all (can't readily test effects of this operation)
     let file = File::open(&path).unwrap();
     file.sync_data().unwrap();
+    file.sync_all().unwrap();
 
     remove_file(&path).unwrap();
 }

--- a/tests/run-pass/fs.rs
+++ b/tests/run-pass/fs.rs
@@ -188,7 +188,7 @@ fn test_file_sync() {
     let path = prepare_with_content("miri_test_fs_sync.txt", bytes);
 
     // Test that we can call sync_data and sync_all (can't readily test effects of this operation)
-    let file = File::open(&path).unwrap();
+    let file = OpenOptions::new().write(true).open(&path).unwrap();
     file.sync_data().unwrap();
     file.sync_all().unwrap();
 

--- a/tests/run-pass/fs.rs
+++ b/tests/run-pass/fs.rs
@@ -192,6 +192,11 @@ fn test_file_sync() {
     file.sync_data().unwrap();
     file.sync_all().unwrap();
 
+    // Test that we can call sync_data and sync_all on a file opened for reading.
+    let file = File::open(&path).unwrap();
+    file.sync_data().unwrap();
+    file.sync_all().unwrap();
+
     remove_file(&path).unwrap();
 }
 

--- a/tests/run-pass/fs.rs
+++ b/tests/run-pass/fs.rs
@@ -14,6 +14,8 @@ fn main() {
     test_seek();
     test_metadata();
     test_file_set_len();
+    test_file_sync_all();
+    test_file_sync_data();
     test_symlink();
     test_errors();
     test_rename();
@@ -178,6 +180,28 @@ fn test_file_set_len() {
     // Can't use set_len on a file not opened for writing
     let file = OpenOptions::new().read(true).open(&path).unwrap();
     assert_eq!(ErrorKind::InvalidInput, file.set_len(14).unwrap_err().kind());
+
+    remove_file(&path).unwrap();
+}
+
+fn test_file_sync_all() {
+    let bytes = b"Hello, World!\n";
+    let path = prepare_with_content("miri_test_fs_sync_all.txt", bytes);
+
+    // Test that we can call sync_all (can't readily test effects of this operation)
+    let file = File::open(&path).unwrap();
+    file.sync_all().unwrap();
+
+    remove_file(&path).unwrap();
+}
+
+fn test_file_sync_data() {
+    let bytes = b"Hello, World!\n";
+    let path = prepare_with_content("miri_test_fs_sync_data.txt", bytes);
+
+    // Test that we can call sync_data (can't readily test effects of this operation)
+    let file = File::open(&path).unwrap();
+    file.sync_data().unwrap();
 
     remove_file(&path).unwrap();
 }

--- a/tests/run-pass/libc.rs
+++ b/tests/run-pass/libc.rs
@@ -55,8 +55,8 @@ fn test_sync_file_range() {
     let bytes = b"Hello, World!\n";
     file.write(bytes).unwrap();
 
-    // Test calling sync_file_range on a file.
-    let result = unsafe {
+    // Test calling sync_file_range on the file.
+    let result_1 = unsafe {
         libc::sync_file_range(
             file.as_raw_fd(),
             0,
@@ -67,8 +67,24 @@ fn test_sync_file_range() {
         )
     };
     drop(file);
+
+    // Test calling sync_file_range on a file opened for reading.
+    let file = File::open(&path).unwrap();
+    let result_2 = unsafe {
+        libc::sync_file_range(
+            file.as_raw_fd(),
+            0,
+            0,
+            libc::SYNC_FILE_RANGE_WAIT_BEFORE
+                | libc::SYNC_FILE_RANGE_WRITE
+                | libc::SYNC_FILE_RANGE_WAIT_AFTER,
+        )
+    };
+    drop(file);
+
     remove_file(&path).unwrap();
-    assert_eq!(result, 0);
+    assert_eq!(result_1, 0);
+    assert_eq!(result_2, 0);
 }
 
 fn test_mutex_libc_init_recursive() {

--- a/tests/run-pass/libc.rs
+++ b/tests/run-pass/libc.rs
@@ -47,10 +47,10 @@ fn test_sync_file_range() {
     use std::os::unix::io::AsRawFd;
 
     let path = tmp().join("miri_test_libc_sync_file_range.txt");
-    // Cleanup before test
+    // Cleanup before test.
     remove_file(&path).ok();
 
-    // Write to a file
+    // Write to a file.
     let mut file = File::create(&path).unwrap();
     let bytes = b"Hello, World!\n";
     file.write(bytes).unwrap();


### PR DESCRIPTION
This PR adds shim implementations for these related file syncing functions.
* `fsync`, for POSIX targets, backed by `File::sync_all()`
* `fdatasync`, for POSIX targets, backed by `File::sync_data()`
* `fcntl` with command `F_FULLFSYNC`, for macOS targets, backed by `File::sync_all()`
* `sync_file_range`, for Linux targets, backed by `File::sync_data()`