### PR TITLE
prepare Dlsym system for dynamic symbols on Windows

### DIFF
--- a/src/shims/dlsym.rs
+++ b/src/shims/dlsym.rs
@@ -26,6 +26,7 @@ impl Dlsym {
             "windows" => match &*name {
                 "SetThreadStackGuarantee" => None,
                 "AcquireSRWLockExclusive" => None,
+                "GetSystemTimePreciseAsFileTime" => None,
                 _ => throw_unsup_format!("unsupported Windows dlsym: {}", name),
             }
             os => bug!("dlsym not implemented for target_os {}", os),

--- a/src/shims/dlsym.rs
+++ b/src/shims/dlsym.rs
@@ -15,15 +15,18 @@ impl Dlsym {
         use self::Dlsym::*;
         let name = String::from_utf8_lossy(name);
         Ok(match target_os {
-            "linux" | "macos" => match &*name {
-                "getentropy" => Some(GetEntropy),
+            "linux" => match &*name {
                 "__pthread_get_minstack" => None,
-                _ => throw_unsup_format!("unsupported dlsym: {}", name),
+                _ => throw_unsup_format!("unsupported Linux dlsym: {}", name),
+            }
+            "macos" => match &*name {
+                "getentropy" => Some(GetEntropy),
+                _ => throw_unsup_format!("unsupported macOS dlsym: {}", name),
             }
             "windows" => match &*name {
                 "SetThreadStackGuarantee" => None,
                 "AcquireSRWLockExclusive" => None,
-                _ => throw_unsup_format!("unsupported dlsym: {}", name),
+                _ => throw_unsup_format!("unsupported Windows dlsym: {}", name),
             }
             os => bug!("dlsym not implemented for target_os {}", os),
         })

--- a/src/shims/foreign_items/posix.rs
+++ b/src/shims/foreign_items/posix.rs
@@ -173,9 +173,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.read_scalar(handle)?.not_undef()?;
                 let symbol = this.read_scalar(symbol)?.not_undef()?;
                 let symbol_name = this.memory.read_c_str(symbol)?;
-                let err = format!("bad c unicode symbol: {:?}", symbol_name);
-                let symbol_name = ::std::str::from_utf8(symbol_name).unwrap_or(&err);
-                if let Some(dlsym) = Dlsym::from_str(symbol_name)? {
+                if let Some(dlsym) = Dlsym::from_str(symbol_name, &this.tcx.sess.target.target.target_os)? {
                     let ptr = this.memory.create_fn_alloc(FnVal::Other(dlsym));
                     this.write_scalar(Scalar::from(ptr), dest)?;
                 } else {

--- a/src/shims/foreign_items/windows.rs
+++ b/src/shims/foreign_items/windows.rs
@@ -206,6 +206,20 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
 
+            // Dynamic symbol loading
+            "GetProcAddress" => {
+                #[allow(non_snake_case)]
+                let &[hModule, lpProcName] = check_arg_count(args)?;
+                this.read_scalar(hModule)?.not_undef()?;
+                let name = this.memory.read_c_str(this.read_scalar(lpProcName)?.not_undef()?)?;
+                if let Some(dlsym) = Dlsym::from_str(name, &this.tcx.sess.target.target.target_os)? {
+                    let ptr = this.memory.create_fn_alloc(FnVal::Other(dlsym));
+                    this.write_scalar(Scalar::from(ptr), dest)?;
+                } else {
+                    this.write_null(dest)?;
+                }
+            }
+
             // Miscellaneous
             "SystemFunction036" => {
                 // The actual name of 'RtlGenRandom'
@@ -257,17 +271,6 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 let &[_lpModuleName] = check_arg_count(args)?;
                 // Pretend this does not exist / nothing happened, by returning zero.
                 this.write_null(dest)?;
-            }
-            "GetProcAddress" if this.frame().instance.to_string().starts_with("std::sys::windows::") => {
-                #[allow(non_snake_case)]
-                let &[_hModule, lpProcName] = check_arg_count(args)?;
-                let name = this.memory.read_c_str(this.read_scalar(lpProcName)?.not_undef()?)?;
-                if let Some(dlsym) = Dlsym::from_str(name, &this.tcx.sess.target.target.target_os)? {
-                    let ptr = this.memory.create_fn_alloc(FnVal::Other(dlsym));
-                    this.write_scalar(Scalar::from(ptr), dest)?;
-                } else {
-                    this.write_null(dest)?;
-                }
             }
             "SetConsoleTextAttribute" if this.frame().instance.to_string().starts_with("std::sys::windows::") => {
                 #[allow(non_snake_case)]


### PR DESCRIPTION
This makes progress towards https://github.com/rust-lang/miri/issues/1059.