### PR TITLE
test discriminant_value intrinsic

### DIFF
--- a/tests/run-pass/intrinsics.rs
+++ b/tests/run-pass/intrinsics.rs
@@ -25,4 +25,9 @@ fn main() {
     assert_eq!(intrinsics::unlikely(true), true);
 
     unsafe { intrinsics::forget(Bomb); }
+
+    let _v = intrinsics::discriminant_value(&Some(()));
+    let _v = intrinsics::discriminant_value(&0);
+    let _v = intrinsics::discriminant_value(&true);
+    let _v = intrinsics::discriminant_value(&vec![1,2,3]);
 }


### PR DESCRIPTION
Make sure this works for all types, not just enums/generators.