### PR TITLE
Add a case to list of 'StackedBorrows violations'

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Violations of [Stacked Borrows] found that are likely bugs (but Stacked Borrows 
 * [`ryu` using raw pointers outside their valid memory area](https://github.com/dtolnay/ryu/issues/24)
 * [ink! creating overlapping mutable references](https://github.com/rust-lang/miri/issues/1364)
 * [TiKV creating overlapping mutable reference and raw pointer](https://github.com/tikv/tikv/pull/7709)
+* [Windows `Env` iterator creating `*const T` from `&T` to read memory outside of `T`](https://github.com/rust-lang/rust/pull/70479)
 
 ## License
 


### PR DESCRIPTION
A small fix was made to libstd in rust-lang/rust#70479 (back in March).
(Miri reported UB due to Stacked Borrows violation - [link to Miri error log](https://github.com/rust-lang/miri/pull/1225#discussion_r397830221))

Thank you for reviewing :+1: