### PR TITLE
we cannot track all machine memory any more due to int-ptr-casts

### DIFF
--- a/rust-version
+++ b/rust-version
@@ -1,1 +1,1 @@
-e1beee4992ad4b235fc700bf7af1ee86f894ea53
+8ac1525e091d3db28e67adcbbd6db1e1deaa37fb

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -54,7 +54,7 @@ pub enum MiriMemoryKind {
     C,
     /// Windows `HeapAlloc` memory.
     WinHeap,
-    /// Memory for args, errno, extern statics and other parts of the machine-managed environment.
+    /// Memory for args, errno, and other parts of the machine-managed environment.
     /// This memory may leak.
     Machine,
     /// Memory for env vars. Separate from `Machine` because we clean it up and leak-check it.
@@ -62,6 +62,9 @@ pub enum MiriMemoryKind {
     /// Globals copied from `tcx`.
     /// This memory may leak.
     Global,
+    /// Memory for extern statics.
+    /// This memory may leak.
+    ExternGlobal,
 }
 
 impl Into<MemoryKind<MiriMemoryKind>> for MiriMemoryKind {
@@ -77,7 +80,7 @@ impl MayLeak for MiriMemoryKind {
         use self::MiriMemoryKind::*;
         match self {
             Rust | C | WinHeap | Env => false,
-            Machine | Global => true,
+            Machine | Global | ExternGlobal => true,
         }
     }
 }
@@ -92,6 +95,7 @@ impl fmt::Display for MiriMemoryKind {
             Machine => write!(f, "machine-managed memory"),
             Env => write!(f, "environment variable"),
             Global => write!(f, "global"),
+            ExternGlobal => write!(f, "extern global"),
         }
     }
 }
@@ -171,7 +175,7 @@ impl MemoryExtra {
                 // "__cxa_thread_atexit_impl"
                 // This should be all-zero, pointer-sized.
                 let layout = this.machine.layouts.usize;
-                let place = this.allocate(layout, MiriMemoryKind::Machine.into());
+                let place = this.allocate(layout, MiriMemoryKind::ExternGlobal.into());
                 this.write_scalar(Scalar::from_machine_usize(0, this), place.into())?;
                 Self::add_extern_static(this, "__cxa_thread_atexit_impl", place.ptr);
                 // "environ"
@@ -181,7 +185,7 @@ impl MemoryExtra {
                 // "_tls_used"
                 // This is some obscure hack that is part of the Windows TLS story. It's a `u8`.
                 let layout = this.machine.layouts.u8;
-                let place = this.allocate(layout, MiriMemoryKind::Machine.into());
+                let place = this.allocate(layout, MiriMemoryKind::ExternGlobal.into());
                 this.write_scalar(Scalar::from_u8(0), place.into())?;
                 Self::add_extern_static(this, "_tls_used", place.ptr);
             }

--- a/src/shims/env.rs
+++ b/src/shims/env.rs
@@ -383,9 +383,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             this.memory.deallocate(this.force_ptr(old_vars_ptr)?, None, MiriMemoryKind::Env.into())?;
         } else {
             // No `environ` allocated yet, let's do that.
-            // This is memory backing an extern static, hence `Machine`, not `Env`.
+            // This is memory backing an extern static, hence `ExternGlobal`, not `Env`.
             let layout = this.machine.layouts.usize;
-            let place = this.allocate(layout, MiriMemoryKind::Machine.into());
+            let place = this.allocate(layout, MiriMemoryKind::ExternGlobal.into());
             this.machine.env_vars.environ = Some(place);
         }
 

--- a/src/stacked_borrows.rs
+++ b/src/stacked_borrows.rs
@@ -466,13 +466,13 @@ impl Stacks {
             // everything else off the stack, invalidating all previous pointers,
             // and in particular, *all* raw pointers.
             MemoryKind::Stack => (Tag::Tagged(extra.borrow_mut().new_ptr()), Permission::Unique),
-            // Global memory can be referenced by global pointers from `tcx`.
+            // `Global` memory can be referenced by global pointers from `tcx`.
             // Thus we call `global_base_ptr` such that the global pointers get the same tag
             // as what we use here.
-            // `Machine` is used for extern statics, and thus must also be listed here.
+            // `ExternGlobal` is used for extern statics, and thus must also be listed here.
             // `Env` we list because we can get away with precise tracking there.
             // The base pointer is not unique, so the base permission is `SharedReadWrite`.
-            MemoryKind::Machine(MiriMemoryKind::Global | MiriMemoryKind::Machine | MiriMemoryKind::Env) =>
+            MemoryKind::Machine(MiriMemoryKind::Global | MiriMemoryKind::ExternGlobal | MiriMemoryKind::Env) =>
                 (extra.borrow_mut().global_base_ptr(id), Permission::SharedReadWrite),
             // Everything else we handle entirely untagged for now.
             // FIXME: experiment with more precise tracking.


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/rust-lang/rust/pull/74006