### PR TITLE
fix non-fatal diagnostics stacktraces

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -212,7 +212,9 @@ pub fn eval_main<'tcx>(tcx: TyCtxt<'tcx>, main_id: DefId, config: MiriConfig) ->
         loop {
             match ecx.schedule()? {
                 SchedulingAction::ExecuteStep => {
+                    let info = ecx.preprocess_diagnostics();
                     assert!(ecx.step()?, "a terminated thread was scheduled for execution");
+                    ecx.process_diagnostics(info);
                 }
                 SchedulingAction::ExecuteTimeoutCallback => {
                     assert!(ecx.machine.communicate,
@@ -230,7 +232,6 @@ pub fn eval_main<'tcx>(tcx: TyCtxt<'tcx>, main_id: DefId, config: MiriConfig) ->
                     break;
                 }
             }
-            ecx.process_diagnostics();
         }
         let return_code = ecx.read_scalar(ret_place.into())?.not_undef()?.to_machine_isize(&ecx)?;
         Ok(return_code)

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -373,7 +373,7 @@ impl<'mir, 'tcx: 'mir> ThreadManager<'mir, 'tcx> {
 
     /// Change the active thread to some enabled thread.
     fn yield_active_thread(&mut self) {
-        // We do not immediately, as swapping out the current stack while execution a MIR statement
+        // We do not yield immediately, as swapping out the current stack while executing a MIR statement
         // could lead to all sorts of confusion.
         // We should only switch stacks between steps.
         self.yield_active_thread = true;

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -373,6 +373,9 @@ impl<'mir, 'tcx: 'mir> ThreadManager<'mir, 'tcx> {
 
     /// Change the active thread to some enabled thread.
     fn yield_active_thread(&mut self) {
+        // We do not immediately, as swapping out the current stack while execution a MIR statement
+        // could lead to all sorts of confusion.
+        // We should only switch stacks between steps.
         self.yield_active_thread = true;
     }
 


### PR DESCRIPTION
Our non-fatal diagnostics are printed *after* completing the step that triggered them, which means the span and stacktrace used for them is that of the *next* MIR statement being executed. That's quite bad, obviously, as pointing to where in the source something happens is their entire point.

Here's an example:
```rust
use std::ptr;

static mut PTR: *mut u8 = ptr::null_mut();

fn get_ptr() -> *const u8 { unsafe { PTR }}

fn cause_ub() { unsafe {
    let _x = &*get_ptr();
} }

fn main() { unsafe {
   let mut l = 0;
   PTR = &mut l;
   let r = &mut *PTR;
   cause_ub();
   let _x = *r;
} }
```
This example is UB; if you track the pointer tag that is given in the final error, it points to the entire body of `cause_ub` as a span, instead of the `&*get_ptr();`.

I am not sure what the best way is to fix this. The cleanest way would be to capture a stack trace before the step and use it in case of a diagnostic, but that seems silly perf-wise. So instead I went with reconstructing the old stacktrace by going back one step in the MIR. This is however not possible if we were executing a `Terminator`... I think those cannot cause diagnostics but still, this is not great.

Any ideas?
r? @oli-obk 