### PR TITLE
Remove unreachable intrinsic

### DIFF
--- a/src/shims/intrinsics.rs
+++ b/src/shims/intrinsics.rs
@@ -37,7 +37,6 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         let (dest, ret) = match ret {
             None => match intrinsic_name {
                 "miri_start_panic" => return this.handle_miri_start_panic(args, unwind),
-                "unreachable" => throw_ub!(Unreachable),
                 _ => throw_unsup_format!("unimplemented (diverging) intrinsic: {}", intrinsic_name),
             },
             Some(p) => p,


### PR DESCRIPTION
This is now supported by the interpreter with https://github.com/rust-lang/rust/pull/74459. We can remove this intrinsic implementation here.
This is covered by this test: https://github.com/rust-lang/miri/blob/master/tests/compile-fail/unreachable.rs

I guess we need to wait until the rust-lang/rust PR merges into nightly, and then we can update `rust-version` hash in the PR, right?

r? @oli-obk 