### PR TITLE
only check-build the dummy xargo project

### DIFF
--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -338,7 +338,7 @@ path = "lib.rs"
     let target = target.as_ref().unwrap_or(&host);
     // Now invoke xargo.
     let mut command = xargo_check();
-    command.arg("build").arg("-q");
+    command.arg("check").arg("-q");
     command.arg("--target").arg(target);
     command.current_dir(&dir);
     command.env("XARGO_HOME", &dir);


### PR DESCRIPTION
No reason to actually emit any object code.
This helps with some strange ICEs when testing Miri in the rustc workspace.