### PR TITLE
Add FileDescriptor trait to abstract fn's on File's and Stdin,Stdout,Stderr

### DIFF
--- a/src/machine.rs
+++ b/src/machine.rs
@@ -246,7 +246,7 @@ pub struct Evaluator<'mir, 'tcx> {
     /// Whether to enforce the validity invariant.
     pub(crate) validate: bool,
 
-    pub(crate) file_handler: shims::posix::FileHandler,
+    pub(crate) file_handler: shims::posix::FileHandler<'tcx>,
     pub(crate) dir_handler: shims::posix::DirHandler,
 
     /// The temporary used for storing the argument of

--- a/src/shims/posix/fs.rs
+++ b/src/shims/posix/fs.rs
@@ -411,13 +411,13 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             let fh = &mut this.machine.file_handler;
             let (file_result, writable) = match fh.handles.get(&fd) {
                 Some(file_descriptor) => match file_descriptor.as_file_handle() {
-                    Ok(FileHandle { file, writable }) => (file.try_clone(), writable.clone()),
+                    Ok(FileHandle { file, writable }) => (file.try_clone(), *writable),
                     Err(_) => return this.handle_not_found(),
                 },
                 None => return this.handle_not_found(),
             };
             let fd_result = file_result.map(|duplicated| {
-                fh.insert_fd_with_min_fd(FileHandle { file: duplicated, writable: writable }, start)
+                fh.insert_fd_with_min_fd(FileHandle { file: duplicated, writable }, start)
             });
             this.try_unwrap_io_result(fd_result)
         } else if this.tcx.sess.target.target.target_os == "macos"


### PR DESCRIPTION
Related issue: #1486 

Instead of mapping FDs to `FileHandle`, map them to a `FileDescriptor` trait object. The goal is to eventually have both `FileHandle` as well as `Stdin`, `Stdout` and `Stderr` implement this trait so that syscalls involving FDs can handle both `File`s as well as the standard IO streams.

This PR adds the `FileDescriptor` trait and an `impl` for `FileHandle`. I'll open a separate PR for implementing the trait for the standard IO streams.