### PR TITLE
accept some post-monomorphization errors

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -88,6 +88,8 @@ pub fn report_error<'tcx, 'mir>(
                     "Undefined Behavior",
                 ResourceExhaustion(_) =>
                     "resource exhaustion",
+                InvalidProgram(InvalidProgramInfo::ReferencedConstant) =>
+                    "post-monomorphization error",
                 _ =>
                     bug!("This error should be impossible in Miri: {}", e),
             };


### PR DESCRIPTION
For https://github.com/rust-lang/miri/issues/1382, we also need to allow `ReferencedConstant` post-monomorphization errors. The other post-monomorphization errors should still be impossible to trigger in Miri. The fix is not complete though without https://github.com/rust-lang/rust/pull/75339.