### PR TITLE
Test cargo miri target selection

### DIFF
--- a/test-cargo-miri/run-test.py
+++ b/test-cargo-miri/run-test.py
@@ -50,6 +50,10 @@ def test_cargo_miri_run():
         cargo_miri("run"),
         "stdout.ref", "stderr.ref"
     )
+    test("cargo miri run (with target)",
+        cargo_miri("run") + ["--bin", "cargo-miri-test"],
+        "stdout.ref", "stderr.ref"
+    )
     test("cargo miri run (with arguments)",
         cargo_miri("run") + ["--", "--", "hello world", '"hello world"'],
         "stdout.ref", "stderr.ref2"
@@ -67,6 +71,14 @@ def test_cargo_miri_test():
     test("cargo miri test (without isolation)",
         cargo_miri("test") + ["--", "-Zmiri-disable-isolation", "--", "num_cpus"],
         "test.stdout.ref3", "test.stderr.ref"
+    )
+    test("cargo miri test (test target)",
+        cargo_miri("test") + ["--test", "test"],
+        "test.stdout.ref4", "test.stderr.ref"
+    )
+    test("cargo miri test (bin target)",
+        cargo_miri("test") + ["--bin", "cargo-miri-test"],
+        "test.stdout.ref5", "test.stderr.ref"
     )
 
 os.chdir(os.path.dirname(os.path.realpath(__file__)))

--- a/test-cargo-miri/test.stdout.ref4
+++ b/test-cargo-miri/test.stdout.ref4
@@ -1,0 +1,12 @@
+
+running 7 tests
+test do_panic ... ok
+test does_not_work_on_miri ... ignored
+test entropy_rng ... ok
+test fail_index_check ... ok
+test num_cpus ... ok
+test simple1 ... ok
+test simple2 ... ok
+
+test result: ok. 6 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
+

--- a/test-cargo-miri/test.stdout.ref5
+++ b/test-cargo-miri/test.stdout.ref5
@@ -1,0 +1,6 @@
+
+running 1 test
+test test::rng ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+


### PR DESCRIPTION
This is a followup to #1525, adding a few test invocations with targets specified in the cargo arguments.