### PR TITLE
Move panic payload state from Machine to Thread

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -193,12 +193,6 @@ pub fn create_ecx<'mir, 'tcx: 'mir>(
         StackPopCleanup::None { cleanup: true },
     )?;
 
-    // Set the last_error to 0
-    let errno_layout = ecx.machine.layouts.u32;
-    let errno_place = ecx.allocate(errno_layout, MiriMemoryKind::Machine.into());
-    ecx.write_scalar(Scalar::from_u32(0), errno_place.into())?;
-    ecx.machine.last_error = Some(errno_place);
-
     Ok((ecx, ret_place))
 }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -394,17 +394,32 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         )
     }
 
+    /// Get last error variable as a place, lazily allocating thread-local storage for it if
+    /// necessary.
+    fn last_error_place(&mut self) -> InterpResult<'tcx, MPlaceTy<'tcx, Tag>> {
+        let this = self.eval_context_mut();
+        if let Some(errno_place) = this.active_thread_ref().last_error {
+            Ok(errno_place)
+        } else {
+            let errno_layout = this.machine.layouts.u32;
+            let errno_place = this.allocate(errno_layout, MiriMemoryKind::Machine.into());
+            this.write_scalar(Scalar::from_u32(0), errno_place.into())?;
+            this.active_thread_mut().last_error = Some(errno_place);
+            Ok(errno_place)
+        }
+    }
+
     /// Sets the last error variable.
     fn set_last_error(&mut self, scalar: Scalar<Tag>) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
-        let errno_place = this.machine.last_error.unwrap();
+        let errno_place = this.last_error_place()?;
         this.write_scalar(scalar, errno_place.into())
     }
 
     /// Gets the last error variable.
-    fn get_last_error(&self) -> InterpResult<'tcx, Scalar<Tag>> {
-        let this = self.eval_context_ref();
-        let errno_place = this.machine.last_error.unwrap();
+    fn get_last_error(&mut self) -> InterpResult<'tcx, Scalar<Tag>> {
+        let this = self.eval_context_mut();
+        let errno_place = this.last_error_place()?;
         this.read_scalar(errno_place.into())?.check_init()
     }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -401,6 +401,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         if let Some(errno_place) = this.active_thread_ref().last_error {
             Ok(errno_place)
         } else {
+            // Allocate new place, set initial value to 0.
             let errno_layout = this.machine.layouts.u32;
             let errno_place = this.allocate(errno_layout, MiriMemoryKind::Machine.into());
             this.write_scalar(Scalar::from_u32(0), errno_place.into())?;

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -252,11 +252,6 @@ pub struct Evaluator<'mir, 'tcx> {
     pub(crate) file_handler: shims::posix::FileHandler,
     pub(crate) dir_handler: shims::posix::DirHandler,
 
-    /// The temporary used for storing the argument of
-    /// the call to `miri_start_panic` (the panic payload) when unwinding.
-    /// This is pointer-sized, and matches the `Payload` type in `src/libpanic_unwind/miri.rs`.
-    pub(crate) panic_payload: Option<Scalar<Tag>>,
-
     /// The "time anchor" for this machine's monotone clock (for `Instant` simulation).
     pub(crate) time_anchor: Instant,
 
@@ -291,7 +286,6 @@ impl<'mir, 'tcx> Evaluator<'mir, 'tcx> {
             validate,
             file_handler: Default::default(),
             dir_handler: Default::default(),
-            panic_payload: None,
             time_anchor: Instant::now(),
             layouts,
             threads: ThreadManager::default(),

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -236,9 +236,6 @@ pub struct Evaluator<'mir, 'tcx> {
     pub(crate) argv: Option<Scalar<Tag>>,
     pub(crate) cmd_line: Option<Scalar<Tag>>,
 
-    /// Last OS error location in memory. It is a 32-bit integer.
-    pub(crate) last_error: Option<MPlaceTy<'tcx, Tag>>,
-
     /// TLS state.
     pub(crate) tls: TlsData<'tcx>,
 
@@ -280,7 +277,6 @@ impl<'mir, 'tcx> Evaluator<'mir, 'tcx> {
             argc: None,
             argv: None,
             cmd_line: None,
-            last_error: None,
             tls: TlsData::default(),
             communicate,
             validate,

--- a/src/shims/posix/linux/foreign_items.rs
+++ b/src/shims/posix/linux/foreign_items.rs
@@ -21,7 +21,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             // errno
             "__errno_location" => {
                 let &[] = check_arg_count(args)?;
-                let errno_place = this.machine.last_error.unwrap();
+                let errno_place = this.last_error_place()?;
                 this.write_scalar(errno_place.to_ref().to_scalar()?, dest)?;
             }
 

--- a/src/shims/posix/macos/foreign_items.rs
+++ b/src/shims/posix/macos/foreign_items.rs
@@ -20,7 +20,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             // errno
             "__error" => {
                 let &[] = check_arg_count(args)?;
-                let errno_place = this.machine.last_error.unwrap();
+                let errno_place = this.last_error_place()?;
                 this.write_scalar(errno_place.to_ref().to_scalar()?, dest)?;
             }
 

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -120,6 +120,9 @@ pub struct Thread<'mir, 'tcx> {
     /// the call to `miri_start_panic` (the panic payload) when unwinding.
     /// This is pointer-sized, and matches the `Payload` type in `src/libpanic_unwind/miri.rs`.
     pub(crate) panic_payload: Option<Scalar<Tag>>,
+
+    /// Last OS error location in memory. It is a 32-bit integer.
+    pub(crate) last_error: Option<MPlaceTy<'tcx, Tag>>,
 }
 
 impl<'mir, 'tcx> Thread<'mir, 'tcx> {
@@ -159,6 +162,7 @@ impl<'mir, 'tcx> Default for Thread<'mir, 'tcx> {
             stack: Vec::new(),
             join_status: ThreadJoinStatus::Joinable,
             panic_payload: None,
+            last_error: None,
         }
     }
 }
@@ -581,6 +585,12 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
     fn active_thread_mut(&mut self) -> &mut Thread<'mir, 'tcx> {
         let this = self.eval_context_mut();
         this.machine.threads.active_thread_mut()
+    }
+
+    #[inline]
+    fn active_thread_ref(&self) -> &Thread<'mir, 'tcx> {
+        let this = self.eval_context_ref();
+        this.machine.threads.active_thread_ref()
     }
 
     #[inline]

--- a/tests/run-pass/libc.stderr
+++ b/tests/run-pass/libc.stderr
@@ -1,0 +1,2 @@
+warning: thread support is experimental. For example, Miri does not detect data races yet.
+

--- a/tests/run-pass/panic/concurrent-panic.rs
+++ b/tests/run-pass/panic/concurrent-panic.rs
@@ -1,0 +1,80 @@
+// ignore-windows: Concurrency on Windows is not supported yet.
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread::{spawn, JoinHandle};
+
+struct BlockOnDrop(Option<JoinHandle<()>>);
+
+impl BlockOnDrop {
+    fn new(handle: JoinHandle<()>) -> BlockOnDrop {
+        BlockOnDrop(Some(handle))
+    }
+}
+
+impl Drop for BlockOnDrop {
+    fn drop(&mut self) {
+        let _ = self.0.take().unwrap().join();
+    }
+}
+
+/// Cause a panic in one thread while another thread is unwinding.
+fn main() {
+    let t1_started_pair = Arc::new((Mutex::new(false), Condvar::new()));
+    let t2_started_pair = Arc::new((Mutex::new(false), Condvar::new()));
+
+    let t1_continue_mutex = Arc::new(Mutex::new(()));
+    let t1_continue_guard = t1_continue_mutex.lock();
+
+    let t1 = {
+        let t1_started_pair = t1_started_pair.clone();
+        let t1_continue_mutex = t1_continue_mutex.clone();
+        spawn(move || {
+            let (mutex, condvar) = &*t1_started_pair;
+            *mutex.lock().unwrap() = true;
+            condvar.notify_one();
+
+            drop(t1_continue_mutex.lock());
+            panic!("panic in thread 1");
+        })
+    };
+    let t2 = {
+        let t2_started_pair = t2_started_pair.clone();
+        let block_on_drop = BlockOnDrop::new(t1);
+        spawn(move || {
+            let _ = block_on_drop;
+
+            let (mutex, condvar) = &*t2_started_pair;
+            *mutex.lock().unwrap() = true;
+            condvar.notify_one();
+
+            panic!("panic in thread 2");
+        })
+    };
+
+    // Wait for thread 1 to signal it has started.
+    let (t1_started_mutex, t1_started_condvar) = &*t1_started_pair;
+    let mut t1_started_guard = t1_started_mutex.lock().unwrap();
+    while !*t1_started_guard {
+        t1_started_guard = t1_started_condvar.wait(t1_started_guard).unwrap();
+    }
+    // Thread 1 should now be blocked waiting on t1_continue_mutex.
+
+    // Wait for thread 2 to signal it has started.
+    let (t2_started_mutex, t2_started_condvar) = &*t2_started_pair;
+    let mut t2_started_guard = t2_started_mutex.lock().unwrap();
+    while !*t2_started_guard {
+        t2_started_guard = t2_started_condvar.wait(t2_started_guard).unwrap();
+    }
+    // Thread 2 should now have already panicked and be in the middle of
+    // unwinding. It should now be blocked on joining thread 1.
+
+    // Unlock t1_continue_mutex, and allow thread 1 to proceed.
+    drop(t1_continue_guard);
+    // Thread 1 will panic the next time it is scheduled. This will test the
+    // behavior of interest to this test, whether Miri properly handles
+    // concurrent panics in two different threads.
+
+    // Block the main thread on waiting to join thread 2. Thread 2 should
+    // already be blocked on joining thread 1, so thread 1 will be scheduled
+    // to run next, as it is the only ready thread.
+    assert!(t2.join().is_err());
+}

--- a/tests/run-pass/panic/concurrent-panic.rs
+++ b/tests/run-pass/panic/concurrent-panic.rs
@@ -1,4 +1,8 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
+
+//! Cause a panic in one thread while another thread is unwinding. This checks
+//! that separate threads have their own panicking state.
+
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread::{spawn, JoinHandle};
 
@@ -12,11 +16,12 @@ impl BlockOnDrop {
 
 impl Drop for BlockOnDrop {
     fn drop(&mut self) {
+        eprintln!("Thread 2 blocking on thread 1");
         let _ = self.0.take().unwrap().join();
+        eprintln!("Thread 1 has exited");
     }
 }
 
-/// Cause a panic in one thread while another thread is unwinding.
 fn main() {
     let t1_started_pair = Arc::new((Mutex::new(false), Condvar::new()));
     let t2_started_pair = Arc::new((Mutex::new(false), Condvar::new()));
@@ -28,6 +33,7 @@ fn main() {
         let t1_started_pair = t1_started_pair.clone();
         let t1_continue_mutex = t1_continue_mutex.clone();
         spawn(move || {
+            eprintln!("Thread 1 starting, will block on mutex");
             let (mutex, condvar) = &*t1_started_pair;
             *mutex.lock().unwrap() = true;
             condvar.notify_one();
@@ -36,6 +42,16 @@ fn main() {
             panic!("panic in thread 1");
         })
     };
+
+    // Wait for thread 1 to signal it has started.
+    let (t1_started_mutex, t1_started_condvar) = &*t1_started_pair;
+    let mut t1_started_guard = t1_started_mutex.lock().unwrap();
+    while !*t1_started_guard {
+        t1_started_guard = t1_started_condvar.wait(t1_started_guard).unwrap();
+    }
+    eprintln!("Thread 1 reported it has started");
+    // Thread 1 should now be blocked waiting on t1_continue_mutex.
+
     let t2 = {
         let t2_started_pair = t2_started_pair.clone();
         let block_on_drop = BlockOnDrop::new(t1);
@@ -50,24 +66,18 @@ fn main() {
         })
     };
 
-    // Wait for thread 1 to signal it has started.
-    let (t1_started_mutex, t1_started_condvar) = &*t1_started_pair;
-    let mut t1_started_guard = t1_started_mutex.lock().unwrap();
-    while !*t1_started_guard {
-        t1_started_guard = t1_started_condvar.wait(t1_started_guard).unwrap();
-    }
-    // Thread 1 should now be blocked waiting on t1_continue_mutex.
-
     // Wait for thread 2 to signal it has started.
     let (t2_started_mutex, t2_started_condvar) = &*t2_started_pair;
     let mut t2_started_guard = t2_started_mutex.lock().unwrap();
     while !*t2_started_guard {
         t2_started_guard = t2_started_condvar.wait(t2_started_guard).unwrap();
     }
+    eprintln!("Thread 2 reported it has started");
     // Thread 2 should now have already panicked and be in the middle of
     // unwinding. It should now be blocked on joining thread 1.
 
     // Unlock t1_continue_mutex, and allow thread 1 to proceed.
+    eprintln!("Unlocking mutex");
     drop(t1_continue_guard);
     // Thread 1 will panic the next time it is scheduled. This will test the
     // behavior of interest to this test, whether Miri properly handles
@@ -77,4 +87,5 @@ fn main() {
     // already be blocked on joining thread 1, so thread 1 will be scheduled
     // to run next, as it is the only ready thread.
     assert!(t2.join().is_err());
+    eprintln!("Thread 2 has exited");
 }

--- a/tests/run-pass/panic/concurrent-panic.stderr
+++ b/tests/run-pass/panic/concurrent-panic.stderr
@@ -1,0 +1,4 @@
+warning: thread support is experimental. For example, Miri does not detect data races yet.
+
+thread '<unnamed>' panicked at 'panic in thread 2', $DIR/concurrent-panic.rs:49:13
+thread '<unnamed>' panicked at 'panic in thread 1', $DIR/concurrent-panic.rs:36:13

--- a/tests/run-pass/panic/concurrent-panic.stderr
+++ b/tests/run-pass/panic/concurrent-panic.stderr
@@ -1,4 +1,11 @@
 warning: thread support is experimental. For example, Miri does not detect data races yet.
 
-thread '<unnamed>' panicked at 'panic in thread 2', $DIR/concurrent-panic.rs:49:13
-thread '<unnamed>' panicked at 'panic in thread 1', $DIR/concurrent-panic.rs:36:13
+Thread 1 starting, will block on mutex
+Thread 1 reported it has started
+thread '<unnamed>' panicked at 'panic in thread 2', $DIR/concurrent-panic.rs:65:13
+Thread 2 blocking on thread 1
+Thread 2 reported it has started
+Unlocking mutex
+thread '<unnamed>' panicked at 'panic in thread 1', $DIR/concurrent-panic.rs:42:13
+Thread 1 has exited
+Thread 2 has exited


### PR DESCRIPTION
This PR moves the panic payload storage from the `Machine` state to per-thread state. Prior to this change, if one thread panicked while another was still unwinding, Miri would fail with `thread 'rustc' panicked at 'the panic runtime should avoid double-panics', src/shims/panic.rs:51:9`. I ran into this issue while prototyping a round-robin scheduler, but it's also reachable with the current scheduler and contrived programs that use blocking API calls to cause thread switching during unwinding. I wrote a test case along those lines for this change.