### PR TITLE
support panic=abort

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,8 @@ different Miri binaries, and as such worth documenting:
 * `MIRI_BE_RUSTC` when set to any value tells the Miri driver to actually not
   interpret the code but compile it like rustc would. This is useful to be sure
   that the compiled `rlib`s are compatible with Miri.
+  When set while running `cargo-miri`, it indicates that we are part of a sysroot
+  build (for which some crates need special treatment).
 * `MIRI_CWD` when set to any value tells the Miri driver to change to the given
   directory after loading all the source files, but before commencing
   interpretation. This is useful if the interpreted program wants a different

--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -162,7 +162,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             // We forward this to the underlying *implementation* in the panic runtime crate.
             // Normally, this will be either `libpanic_unwind` or `libpanic_abort`, but it could
             // also be a custom user-provided implementation via `#![feature(panic_runtime)]`
-            "__rust_start_panic" | "__rust_panic_cleanup"=> {
+            "__rust_start_panic" | "__rust_panic_cleanup" => {
                 // This replicates some of the logic in `inject_panic_runtime`.
                 // FIXME: is there a way to reuse that logic?
                 let panic_runtime = match this.tcx.sess.panic_strategy() {

--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -4,7 +4,7 @@ use log::trace;
 
 use rustc_hir::def_id::DefId;
 use rustc_middle::{mir, ty};
-use rustc_target::abi::{Align, Size};
+use rustc_target::{abi::{Align, Size}, spec::PanicStrategy};
 use rustc_apfloat::Float;
 use rustc_span::symbol::sym;
 
@@ -146,6 +146,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                     let code = this.read_scalar(code)?.to_i32()?;
                     throw_machine_stop!(TerminationInfo::Exit(code.into()));
                 }
+                "abort" => {
+                    throw_machine_stop!(TerminationInfo::Abort(None))
+                }
                 _ => throw_unsup_format!("can't call (diverging) foreign function: {}", link_name),
             },
             Some(p) => p,
@@ -160,13 +163,12 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             // Normally, this will be either `libpanic_unwind` or `libpanic_abort`, but it could
             // also be a custom user-provided implementation via `#![feature(panic_runtime)]`
             "__rust_start_panic" | "__rust_panic_cleanup"=> {
-                // FIXME we might want to cache this... but it's not really performance-critical.
-                let panic_runtime = tcx
-                    .crates()
-                    .iter()
-                    .find(|cnum| tcx.is_panic_runtime(**cnum))
-                    .expect("No panic runtime found!");
-                let panic_runtime = tcx.crate_name(*panic_runtime);
+                // This replicates some of the logic in `inject_panic_runtime`.
+                // FIXME: is there a way to reuse that logic?
+                let panic_runtime = match this.tcx.sess.panic_strategy() {
+                    PanicStrategy::Unwind => sym::panic_unwind,
+                    PanicStrategy::Abort => sym::panic_abort,
+                };
                 let start_panic_instance =
                     this.resolve_path(&[&*panic_runtime.as_str(), link_name]);
                 return Ok(Some(&*this.load_mir(start_panic_instance.def, None)?));

--- a/src/shims/panic.rs
+++ b/src/shims/panic.rs
@@ -44,6 +44,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         let this = self.eval_context_mut();
 
         trace!("miri_start_panic: {:?}", this.frame().instance);
+        // Make sure we only start unwinding when this matches our panic strategy.
+        assert_eq!(this.tcx.sess.panic_strategy(), PanicStrategy::Unwind);
 
         // Get the raw pointer stored in arg[0] (the panic payload).
         let &[payload] = check_arg_count(args)?;

--- a/tests/compile-fail/panic/panic_abort1.rs
+++ b/tests/compile-fail/panic/panic_abort1.rs
@@ -1,6 +1,7 @@
-// ignore-test: Abort panics are not yet supported
-// error-pattern: the evaluated program panicked
+// error-pattern: the evaluated program aborted execution
 // compile-flags: -C panic=abort
+// ignore-windows: windows panics via inline assembly (FIXME)
+
 fn main() {
     std::panic!("panicking from libstd");
 }

--- a/tests/compile-fail/panic/panic_abort2.rs
+++ b/tests/compile-fail/panic/panic_abort2.rs
@@ -1,6 +1,6 @@
-// ignore-test: Abort panics are not yet supported
-// error-pattern: the evaluated program panicked
+// error-pattern: the evaluated program aborted execution
 // compile-flags: -C panic=abort
+// ignore-windows: windows panics via inline assembly (FIXME)
 
 fn main() {
     std::panic!("{}-panicking from libstd", 42);

--- a/tests/compile-fail/panic/panic_abort3.rs
+++ b/tests/compile-fail/panic/panic_abort3.rs
@@ -1,6 +1,6 @@
-// ignore-test: Abort panics are not yet supported
-//error-pattern: the evaluated program panicked
+// error-pattern: the evaluated program aborted execution
 // compile-flags: -C panic=abort
+// ignore-windows: windows panics via inline assembly (FIXME)
 
 fn main() {
     core::panic!("panicking from libcore");

--- a/tests/compile-fail/panic/panic_abort4.rs
+++ b/tests/compile-fail/panic/panic_abort4.rs
@@ -1,6 +1,6 @@
-// ignore-test: Abort panics are not yet supported
-//error-pattern: the evaluated program panicked
+// error-pattern: the evaluated program aborted execution
 // compile-flags: -C panic=abort
+// ignore-windows: windows panics via inline assembly (FIXME)
 
 fn main() {
     core::panic!("{}-panicking from libcore", 42);


### PR DESCRIPTION
This adds support for abort-on-panic (https://github.com/rust-lang/miri/issues/1058). To achieve this, we insert `cargo-miri` as `RUSTC` when building the standard library, and patch the rustc flags in a way similar to what bootstrap does.

However, this is currently not supported on Windows as the Windows code uses inline assembly to cause an abort (?!?). I'll submit a rustc PR with some `cffg(miri)` to make that work. (EDIT: that would be https://github.com/rust-lang/rust/pull/76871)

Cc @Aaron1011 r? @oli-obk 