### PR TITLE
Add a dummy actions template to enable it on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    # Run in PRs and for bors, but not on master.
+    branches:
+      - 'auto'
+      - 'try'
+  pull_request:
+    branches:
+      - 'master'
+  schedule:
+    # Use <https://crontab.guru> to conveniently edit cron schedule.
+    - cron: "0 7 * * *" # At 07:00 UTC every day.
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    env:
+      RUST_BACKTRACE: 1
+    strategy:
+      matrix:
+        build: [linux64, macos, win32]
+        include:
+          - build: linux64
+            os: ubuntu-latest
+            host_target: x86_64-unknown-linux-gnu
+          - build: macos
+            os: macos-latest
+            host_target: x86_64-apple-darwin
+          - build: win32
+            os: windows-latest
+            host_target: i686-pc-windows-msvc
+    steps:
+      - uses: actions/checkout@v2


### PR DESCRIPTION
I already had a complete template to transition from Travis and Appveyor.
Since actions will not run on repo haven't enabled it before.
I have this dummy template first to enable it on default branch.
We should address a few todo here, merge it and I will send another patch
to complete the migration.