### PR TITLE
Adding a working github actions template

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,7 +3,7 @@ environment:
   global:
     PROJECT_NAME: miri
   matrix:
-    - TARGET: i686-pc-windows-msvc
+    - HOST_TARGET: i686-pc-windows-msvc
 matrix:
   fast_finish: true # Immediately finish build once one of the jobs fails.
 cache:
@@ -23,7 +23,7 @@ install:
 # Install Rust. We use the "stable" toolchain for better caching, it is just used to build `rustup-toolchain-install-master`.
 # But we also need to take into account that the build cache might have a different, outdated default.
 - curl -sSf --retry 3 -o rustup-init.exe https://win.rustup.rs/
-- rustup-init.exe -y --default-host %TARGET% --default-toolchain none --profile minimal
+- rustup-init.exe -y --default-host %HOST_TARGET% --default-toolchain none --profile minimal
 - set PATH=%USERPROFILE%\.cargo\bin;%PATH%
 - rustup default stable
 - rustup toolchain uninstall beta nightly
@@ -36,7 +36,8 @@ install:
 - cargo --version
 
 test_script:
-- set PYTHON=C:\msys64\mingw64\bin\python3.exe
+# Add python3 path: https://www.appveyor.com/docs/windows-images-software/#python
+- set PATH=C:\Python35-x64;%PATH%
 - bash ci.sh
 
 after_test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,14 @@ on:
       - 'master'
   schedule:
     # Use <https://crontab.guru> to conveniently edit cron schedule.
-    - cron: "0 7 * * *" # At 07:00 UTC every day.
+    - cron: '0 7 * * *' # At 07:00 UTC every day.
 
 jobs:
   build:
     runs-on: ${{ matrix.os }}
     env:
       RUST_BACKTRACE: 1
+      HOST_TARGET: ${{ matrix.host_target }}
     strategy:
       matrix:
         build: [linux64, macos, win32]
@@ -33,6 +34,63 @@ jobs:
             host_target: i686-pc-windows-msvc
     steps:
       - uses: actions/checkout@v2
+
+      # We install gnu-tar because BSD tar is buggy on macOS builders of GHA.
+      # See <https://github.com/actions/cache/issues/403>.
+      - name: Install GNU tar
+        if: runner.os == 'macOS'
+        run: |
+          brew install gnu-tar
+          echo "/usr/local/opt/gnu-tar/libexec/gnubin" >> $GITHUB_PATH
+
+      # Cache the global cargo directory, but NOT the local `target` directory which
+      # we cannot reuse anyway when the nightly changes (and it grows quite large
+      # over time).
+      - name: Add cache for cargo
+        uses: actions/cache@v2
+        with:
+          path: |
+            # Taken from <https://doc.rust-lang.org/nightly/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci>.
+            ~/.cargo/bin
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            # contains package information of crates installed via `cargo install`.
+            ~/.cargo/.crates.toml
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo
+
+      - name: Install rustup-toolchain-install-master and xargo
+        run: |
+          cargo install rustup-toolchain-install-master
+          cargo install xargo
+        shell: bash
+
+      - name: Install "master" toolchain
+        run: |
+          if [[ ${{ github.event_name }} == 'schedule' ]]; then
+            RUSTC_HASH=$(git ls-remote https://github.com/rust-lang/rust.git master | awk '{print $1}')
+          else
+            RUSTC_HASH=$(< rust-version)
+          fi
+          rustup-toolchain-install-master \
+            -f \
+            -n master "$RUSTC_HASH" \
+            -c rust-src \
+            -c rustc-dev \
+            -c llvm-tools \
+            --host ${{ matrix.host_target }}
+          rustup default master
+        shell: bash
+
+      - name: Show Rust version
+        run: |
+          rustup show
+          rustc -Vv
+          cargo -V
+
+      - name: Test
+        run: bash ./ci.sh
 
   # These jobs doesn't actually test anything, but they're only used to tell
   # bors the build completed, as there is no practical way to detect when a

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: generic
-os:
-- linux
-- osx
+jobs:
+  include:
+  - os: linux
+    env: HOST_TARGET=x86_64-unknown-linux-gnu
+  - os: osx
+    env: HOST_TARGET=x86_64-apple-darwin
 dist: xenial
 cache:
   # Cache the global cargo directory, but NOT the local `target` directory which

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
-# Miri [![Build Status](https://travis-ci.com/rust-lang/miri.svg?branch=master)](https://travis-ci.com/rust-lang/miri) [![Windows build status](https://ci.appveyor.com/api/projects/status/github/rust-lang/miri?svg=true)](https://ci.appveyor.com/project/rust-lang-libs/miri)
+# Miri
 
+[![Actions build status][actions-badge]][actions-url]
+[![Travis build status](https://travis-ci.com/rust-lang/miri.svg?branch=master)](https://travis-ci.com/rust-lang/miri)
+[![Appveyor Windows build status](https://ci.appveyor.com/api/projects/status/github/rust-lang/miri?svg=true)](https://ci.appveyor.com/project/rust-lang-libs/miri)
+
+[actions-badge]: https://github.com/rust-lang/miri/workflows/CI/badge.svg?branch=master
+[actions-url]: https://github.com/rust-lang/miri/actions
 
 An experimental interpreter for [Rust][rust]'s
 [mid-level intermediate representation][mir] (MIR).  It can run binaries and

--- a/ci.sh
+++ b/ci.sh
@@ -23,32 +23,44 @@ function run_tests {
   fi
 
   ./miri test --locked
-  if ! [ -n "${MIRI_TEST_TARGET+exists}" ]; then
+  if [ -z "${MIRI_TEST_TARGET+exists}" ]; then
     # Only for host architecture: tests with MIR optimizations
     #FIXME: Only testing opt level 1 due to <https://github.com/rust-lang/rust/issues/77564>.
     MIRIFLAGS="-Z mir-opt-level=1" ./miri test --locked
   fi
+
+  # On Windows, there is always "python", not "python3" or "python2".
+  if command -v python3 > /dev/null; then
+    PYTHON=python3
+  else
+    PYTHON=python
+  fi
+
   # "miri test" has built the sysroot for us, now this should pass without
   # any interactive questions.
-  ${PYTHON:-python3} test-cargo-miri/run-test.py
-
+  ${PYTHON} test-cargo-miri/run-test.py
   echo
 }
 
 # host
 run_tests
 
-if [ "${TRAVIS_OS_NAME:-}" == linux ]; then
-  MIRI_TEST_TARGET=i686-unknown-linux-gnu run_tests
-  MIRI_TEST_TARGET=x86_64-apple-darwin run_tests
-  MIRI_TEST_TARGET=i686-pc-windows-msvc run_tests
-elif [ "${TRAVIS_OS_NAME:-}" == osx ]; then
-  MIRI_TEST_TARGET=mips64-unknown-linux-gnuabi64 run_tests # big-endian architecture
-  MIRI_TEST_TARGET=x86_64-pc-windows-msvc run_tests
-elif [ "${CI_WINDOWS:-}" == True ]; then
-  MIRI_TEST_TARGET=x86_64-unknown-linux-gnu run_tests
-  MIRI_TEST_TARGET=x86_64-apple-darwin run_tests
-else
-  echo "FATAL: unknown CI platform"
-  exit 1
-fi
+case $HOST_TARGET in
+  x86_64-unknown-linux-gnu)
+    MIRI_TEST_TARGET=i686-unknown-linux-gnu run_tests
+    MIRI_TEST_TARGET=x86_64-apple-darwin run_tests
+    MIRI_TEST_TARGET=i686-pc-windows-msvc run_tests
+    ;;
+  x86_64-apple-darwin)
+    MIRI_TEST_TARGET=mips64-unknown-linux-gnuabi64 run_tests # big-endian architecture
+    MIRI_TEST_TARGET=x86_64-pc-windows-msvc run_tests
+    ;;
+  i686-pc-windows-msvc)
+    MIRI_TEST_TARGET=x86_64-unknown-linux-gnu run_tests
+    MIRI_TEST_TARGET=x86_64-apple-darwin run_tests
+    ;;
+  *)
+    echo "FATAL: unknown OS"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Complete adding github actions whose dummy template added in #1563 .

But it will need https://github.com/rust-lang/rust-central-station/pull/939 merged first
to be able to gate bors on Actions CI checks.