### PR TITLE
add bors notification jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,25 @@ jobs:
             host_target: i686-pc-windows-msvc
     steps:
       - uses: actions/checkout@v2
+
+  # These jobs doesn't actually test anything, but they're only used to tell
+  # bors the build completed, as there is no practical way to detect when a
+  # workflow is successful listening to webhooks only.
+  #
+  # ALL THE PREVIOUS JOBS NEED TO BE ADDED TO THE `needs` SECTION OF THIS JOB!
+  end-success:
+    name: bors build finished
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: github.event.pusher.name == 'bors' && success()
+    steps:
+      - name: mark the job as a success
+        run: exit 0
+  end-failure:
+    name: bors build finished
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: github.event.pusher.name == 'bors' && (failure() || cancelled())
+    steps:
+      - name: mark the job as a failure
+        run: exit 1


### PR DESCRIPTION
There are probably ways to simplify this... I just copied this from the Rust repo and expanded the anchors and adjusted the `needs` thing. Hopefully this unblocks Miri PR landing.