### PR TITLE
Enable `backtrace` feature in the generated `Xargo.toml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,19 @@ cargo miri test
 When using the above instructions, you may encounter a number of confusing compiler
 errors.
 
+### "note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace"
+
+You may see this when trying to get Miri to display a backtrace. By default, Miri
+doesn't expose any environment to the program, so running
+`RUST_BACKTRACE=1 cargo miri test` will not do what you expect.
+
+To get a backtrace, you need to disable isolation
+[using `-Zmiri-disable-isolation`](#miri-flags):
+
+```sh
+RUST_BACKTRACE=1 MIRIFLAGS="-Zmiri-disable-isolation" cargo miri test
+```
+
 #### "found possibly newer version of crate `std` which `<dependency>` depends on"
 
 Your build directory may contain artifacts from an earlier build that have/have

--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -296,7 +296,7 @@ fn setup(subcommand: MiriCommand) {
 [dependencies.std]
 default_features = false
 # We support unwinding, so enable that panic runtime.
-features = ["panic_unwind"]
+features = ["panic_unwind", "backtrace"]
 
 [dependencies.test]
 "#,

--- a/tests/run-pass/concurrency/simple.stderr
+++ b/tests/run-pass/concurrency/simple.stderr
@@ -1,4 +1,5 @@
 warning: thread support is experimental. For example, Miri does not detect data races yet.
 
 thread '<unnamed>' panicked at 'Hello!', $DIR/simple.rs:54:9
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 thread 'childthread' panicked at 'Hello, world!', $DIR/simple.rs:64:9

--- a/tests/run-pass/panic/catch_panic.stderr
+++ b/tests/run-pass/panic/catch_panic.stderr
@@ -1,4 +1,5 @@
 thread 'main' panicked at 'Hello from panic: std', $DIR/catch_panic.rs:LL:27
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 Caught panic message (&str): Hello from panic: std
 thread 'main' panicked at 'Hello from panic: 1', $DIR/catch_panic.rs:LL:26
 Caught panic message (String): Hello from panic: 1

--- a/tests/run-pass/panic/concurrent-panic.stderr
+++ b/tests/run-pass/panic/concurrent-panic.stderr
@@ -3,6 +3,7 @@ warning: thread support is experimental. For example, Miri does not detect data 
 Thread 1 starting, will block on mutex
 Thread 1 reported it has started
 thread '<unnamed>' panicked at 'panic in thread 2', $DIR/concurrent-panic.rs:65:13
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 Thread 2 blocking on thread 1
 Thread 2 reported it has started
 Unlocking mutex

--- a/tests/run-pass/panic/div-by-zero-2.stderr
+++ b/tests/run-pass/panic/div-by-zero-2.stderr
@@ -1,1 +1,2 @@
 thread 'main' panicked at 'attempt to divide by zero', $DIR/div-by-zero-2.rs:4:14
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/run-pass/panic/overflowing-lsh-neg.stderr
+++ b/tests/run-pass/panic/overflowing-lsh-neg.stderr
@@ -1,1 +1,2 @@
 thread 'main' panicked at 'attempt to shift left with overflow', $DIR/overflowing-lsh-neg.rs:4:14
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/run-pass/panic/overflowing-rsh-1.stderr
+++ b/tests/run-pass/panic/overflowing-rsh-1.stderr
@@ -1,1 +1,2 @@
 thread 'main' panicked at 'attempt to shift right with overflow', $DIR/overflowing-rsh-1.rs:4:14
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/run-pass/panic/overflowing-rsh-2.stderr
+++ b/tests/run-pass/panic/overflowing-rsh-2.stderr
@@ -1,1 +1,2 @@
 thread 'main' panicked at 'attempt to shift right with overflow', $DIR/overflowing-rsh-2.rs:5:14
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/run-pass/panic/panic1.rs
+++ b/tests/run-pass/panic/panic1.rs
@@ -1,3 +1,9 @@
+// rustc-env: RUST_BACKTRACE=1
+// compile-flags: -Zmiri-disable-isolation
+// normalize-stderr-test ".*/(rust|checkout)/library/" -> "RUSTLIB/"
+// normalize-stderr-test "RUSTLIB/(.*):\d+:\d+ "-> "RUSTLIB/$1:LL:COL "
+// normalize-stderr-test "::<.*>" -> ""
+
 fn main() {
     std::panic!("panicking from libstd");
 }

--- a/tests/run-pass/panic/panic1.stderr
+++ b/tests/run-pass/panic/panic1.stderr
@@ -1,1 +1,23 @@
-thread 'main' panicked at 'panicking from libstd', $DIR/panic1.rs:2:5
+thread 'main' panicked at 'panicking from libstd', $DIR/panic1.rs:8:5
+stack backtrace:
+   0: std::rt::begin_panic
+RUSTLIB/std/src/panicking.rs:505:12
+   1: main
+             at $DIR/panic1.rs:8:5
+   2: <fn() as std::ops::FnOnce<()>>::call_once - shim(fn())
+RUSTLIB/core/src/ops/function.rs:227:5
+   3: std::rt::lang_start::{closure#0}
+RUSTLIB/std/src/rt.rs:66:18
+   4: std::ops::function::impls::call_once
+RUSTLIB/core/src/ops/function.rs:259:13
+   5: std::panicking::r#try::do_call
+RUSTLIB/std/src/panicking.rs:381:40
+   6: std::panicking::r#try
+RUSTLIB/std/src/panicking.rs:345:19
+   7: std::panic::catch_unwind
+RUSTLIB/std/src/panic.rs:382:14
+   8: std::rt::lang_start_internal
+RUSTLIB/std/src/rt.rs:51:25
+   9: std::rt::lang_start
+RUSTLIB/std/src/rt.rs:65:5
+note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

--- a/tests/run-pass/panic/panic2.stderr
+++ b/tests/run-pass/panic/panic2.stderr
@@ -1,1 +1,2 @@
 thread 'main' panicked at '42-panicking from libstd', $DIR/panic2.rs:2:5
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/run-pass/panic/panic3.stderr
+++ b/tests/run-pass/panic/panic3.stderr
@@ -1,1 +1,2 @@
 thread 'main' panicked at 'panicking from libcore', $DIR/panic3.rs:2:5
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/run-pass/panic/panic4.stderr
+++ b/tests/run-pass/panic/panic4.stderr
@@ -1,1 +1,2 @@
 thread 'main' panicked at '42-panicking from libcore', $DIR/panic4.rs:2:5
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/run-pass/transmute_fat2.stderr
+++ b/tests/run-pass/transmute_fat2.stderr
@@ -1,1 +1,2 @@
 thread 'main' panicked at 'index out of bounds: the len is 0 but the index is 0', $DIR/transmute_fat2.rs:15:5
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


### PR DESCRIPTION
This allows the normal std panic hook to print a backtrace if
`RUST_BACKTRACE=1` and `-Z miri-disable-isolation` are set