### PR TITLE
Don't force-install xargo

### DIFF
--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -241,7 +241,7 @@ fn setup(subcommand: MiriCommand) {
             show_error(format!("xargo is too old; please upgrade to the latest version"))
         }
         let mut cmd = cargo();
-        cmd.args(&["install", "xargo", "-f"]);
+        cmd.args(&["install", "xargo"]);
         ask_to_run(cmd, ask_user, "install a recent enough xargo");
     }
 


### PR DESCRIPTION
Previously miri used `cargo install xargo -f` which shouldn't be
necessary anymore since `cargo install` will now upgrade without `-f`.

The only reason I can see to use `-f` is from the cargo docs:

> This is also useful if something has changed on the system that you
> want to rebuild with, such as a newer version of `rustc`.

See the [discussion on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/why.20does.20miri.20require.20xargo/near/214351239).
