### PR TITLE
Hide readlink error in `./miri`

### DIFF
--- a/miri
+++ b/miri
@@ -40,7 +40,7 @@ TARGET=$(rustc --version --verbose | grep "^host:" | cut -d ' ' -f 2)
 SYSROOT=$(rustc --print sysroot)
 LIBDIR=$SYSROOT/lib/rustlib/$TARGET/lib
 MIRIDIR=$(dirname "$0")
-if readlink -e . >/dev/null; then
+if readlink -e . &>/dev/null; then
     # This platform supports `readlink -e`.
     MIRIDIR=$(readlink -e "$MIRIDIR")
 fi


### PR DESCRIPTION
Fixes #1597.

`./miri` is just testing whether the platform supports `readlink -e`,
but it didn't hide properly hide the stderr output. This fixes that.
