### PR TITLE
Make `miri_default_args()` a constant

### DIFF
--- a/src/bin/miri-rustc-tests.rs
+++ b/src/bin/miri-rustc-tests.rs
@@ -109,7 +109,7 @@ fn main() {
                 }
             })
             .collect();
-        args.splice(1..1, miri::miri_default_args().iter().map(ToString::to_string));
+        args.splice(1..1, miri::MIRI_DEFAULT_ARGS.iter().map(ToString::to_string));
         // file to process
         args.push(path.display().to_string());
 

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -153,7 +153,7 @@ fn run_compiler(mut args: Vec<String>, callbacks: &mut (dyn rustc_driver::Callba
 
     // Some options have different defaults in Miri than in plain rustc; apply those by making
     // them the first arguments after the binary name (but later arguments can overwrite them).
-    args.splice(1..1, miri::miri_default_args().iter().map(ToString::to_string));
+    args.splice(1..1, miri::MIRI_DEFAULT_ARGS.iter().map(ToString::to_string));
 
     // Invoke compiler, and handle return code.
     let exit_code = rustc_driver::catch_with_exit_code(move || {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,12 +77,10 @@ pub use crate::sync::{
 
 /// Insert rustc arguments at the beginning of the argument list that Miri wants to be
 /// set per default, for maximal validation power.
-pub fn miri_default_args() -> &'static [&'static str] {
-    &[
-        "-Zalways-encode-mir",
-        "-Zmir-emit-retag",
-        "-Zmir-opt-level=0",
-        "--cfg=miri",
-        "-Cdebug-assertions=on",
-    ]
-}
+pub const MIRI_DEFAULT_ARGS: &[&str] = &[
+    "-Zalways-encode-mir",
+    "-Zmir-emit-retag",
+    "-Zmir-opt-level=0",
+    "--cfg=miri",
+    "-Cdebug-assertions=on",
+];


### PR DESCRIPTION
Feel free to close this if this is intentionally not a constant.
