### PR TITLE
disable debug assertions in the standard library

### DIFF
--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -353,6 +353,8 @@ path = "lib.rs"
     // to the sysroot either.
     command.env_remove("RUSTC_WRAPPER");
     command.env_remove("RUSTFLAGS");
+    // Disable debug assertions in the standard library -- Miri is already slow enough.
+    command.env("RUSTFLAGS", "-Cdebug-assertions=off");
     // Finally run it!
     if command.status().expect("failed to run xargo").success().not() {
         show_error(format!("failed to run xargo"));

--- a/tests/run-pass/panic/catch_panic.rs
+++ b/tests/run-pass/panic/catch_panic.rs
@@ -78,7 +78,6 @@ fn main() {
     // Assertion and debug assertion
     test(None, |_old_val| { assert!(false); loop {} });
     test(None, |_old_val| { debug_assert!(false); loop {} });
-    test(None, |_old_val| { unsafe { std::char::from_u32_unchecked(0xFD10000); } loop {} }); // trigger debug-assertion in libstd
 
     eprintln!("Success!"); // Make sure we get this in stderr
 }

--- a/tests/run-pass/panic/catch_panic.stderr
+++ b/tests/run-pass/panic/catch_panic.stderr
@@ -23,6 +23,4 @@ thread 'main' panicked at 'assertion failed: false', $DIR/catch_panic.rs:LL:29
 Caught panic message (&str): assertion failed: false
 thread 'main' panicked at 'assertion failed: false', $DIR/catch_panic.rs:LL:29
 Caught panic message (&str): assertion failed: false
-thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', $LOC
-Caught panic message (&str): called `Option::unwrap()` on a `None` value
 Success!


### PR DESCRIPTION
Debug assertions in the standard library can be somewhat expensive to check, in particular the ones covering each and every `ptr::write/copy/copy_nonoverlapping`. Miri will find most of those problems anyway since they cause UB. There are other debug assertions, such as ensuring internal invariants are maintained, but given how slow Miri already is, I think it is better to skip those checks in Miri and instead figure out a better way for people to use a standard library with debug assertions enabled.