### PR TITLE
increase timeout to avoid spurious test failures

### DIFF
--- a/tests/run-pass/concurrency/sync.rs
+++ b/tests/run-pass/concurrency/sync.rs
@@ -109,7 +109,7 @@ fn check_conditional_variables_timed_wait_notimeout() {
         cvar.notify_one();
     });
 
-    let (_guard, timeout) = cvar.wait_timeout(guard, Duration::from_millis(200)).unwrap();
+    let (_guard, timeout) = cvar.wait_timeout(guard, Duration::from_millis(500)).unwrap();
     assert!(!timeout.timed_out());
     handle.join().unwrap();
 }


### PR DESCRIPTION
just saw this fail on macOS in PR CI, so add some extra safety margin