### PR TITLE
backtrace tests: support more ways of checking out Rust locally

### DIFF
--- a/tests/run-pass/backtrace-api.rs
+++ b/tests/run-pass/backtrace-api.rs
@@ -1,4 +1,4 @@
-// normalize-stderr-test ".*/(rust|checkout)/library/" -> "RUSTLIB/"
+// normalize-stderr-test ".*/(rust[^/]*|checkout)/library/" -> "RUSTLIB/"
 // normalize-stderr-test "RUSTLIB/(.*):\d+:\d+ "-> "RUSTLIB/$1:LL:COL "
 // normalize-stderr-test "::<.*>" -> ""
 

--- a/tests/run-pass/backtrace-std.rs
+++ b/tests/run-pass/backtrace-std.rs
@@ -1,4 +1,4 @@
-// normalize-stderr-test "at .*/(rust|checkout)/library/" -> "at RUSTLIB/"
+// normalize-stderr-test "at .*/(rust[^/]*|checkout)/library/" -> "at RUSTLIB/"
 // normalize-stderr-test "RUSTLIB/(.*):\d+"-> "RUSTLIB/$1:LL"
 // normalize-stderr-test "::<.*>" -> ""
 // compile-flags: -Zmiri-disable-isolation

--- a/tests/run-pass/panic/panic1.rs
+++ b/tests/run-pass/panic/panic1.rs
@@ -1,6 +1,6 @@
 // rustc-env: RUST_BACKTRACE=1
 // compile-flags: -Zmiri-disable-isolation
-// normalize-stderr-test "at .*/(rust|checkout)/library/.*" -> "at RUSTLIB/$$FILE:LL:COL"
+// normalize-stderr-test "at .*/(rust[^/]*|checkout)/library/.*" -> "at RUSTLIB/$$FILE:LL:COL"
 // normalize-stderr-test "::<.*>" -> ""
 
 


### PR DESCRIPTION
Tests failed when using a local build as my folders are called `rustc`, `rustc.2`, ...
Expand the regex to also support that naming scheme.