### PR TITLE
Improve contributing instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,8 +144,9 @@ The setup for a local rustc works as follows:
 # Clone the rust-lang/rust repo.
 git clone https://github.com/rust-lang/rust rustc
 cd rustc
-cp config.toml.example config.toml
-# Now edit `config.toml` and set `debug-assertions = true`.
+# Create a config.toml with defaults for working on miri.
+./x.py setup compiler
+ # Now edit `config.toml` and under `[rust]` set `debug-assertions = true`.
 
 # Build a stage 1 rustc, and build the rustc libraries with that rustc.
 # This step can take 30 minutes or more.
@@ -157,6 +158,9 @@ rustup toolchain link stage1 build/x86_64-unknown-linux-gnu/stage1
 # Now cd to your Miri directory, then configure rustup
 rustup override set stage1
 ```
+
+For more information about building and configuring a local compiler,
+see <https://rustc-dev-guide.rust-lang.org/building/how-to-build-and-run.html>.
 
 With this, you should now have a working development setup! See
 [above](#building-and-testing-miri) for how to proceed working on Miri.


### PR DESCRIPTION
This builds on the changes from https://github.com/rust-lang/miri/pull/1612 and should not be merged before.

- Fix incorrect comment
- Recommend `x.py setup` over manually editing config.toml
- Link to rustc-dev-guide