### PR TITLE
Make weak syscalls in std work.

### DIFF
--- a/src/shims/posix/linux/dlsym.rs
+++ b/src/shims/posix/linux/dlsym.rs
@@ -12,6 +12,8 @@ impl Dlsym {
     pub fn from_str(name: &str) -> InterpResult<'static, Option<Dlsym>> {
         Ok(match &*name {
             "__pthread_get_minstack" => None,
+            "getrandom" => None, // std falls back to syscall(SYS_getrandom, ...) when this is NULL.
+            "statx" => None, // std falls back to syscall(SYS_statx, ...) when this is NULL.
             _ => throw_unsup_format!("unsupported Linux dlsym: {}", name),
         })
     }

--- a/src/shims/posix/linux/foreign_items.rs
+++ b/src/shims/posix/linux/foreign_items.rs
@@ -208,7 +208,11 @@ fn getrandom<'tcx>(
 
     // The only supported flags are GRND_RANDOM and GRND_NONBLOCK,
     // neither of which have any effect on our current PRNG.
-    this.read_scalar(flags)?.to_i32()?;
+    let flags = this.read_scalar(flags)?;
+    // Either `i32` or `isize` is fine.
+    if flags.to_machine_isize(this).is_err() {
+        flags.to_i32()?;
+    }
 
     this.gen_random(ptr, len)?;
     this.write_scalar(Scalar::from_machine_usize(len, this), dest)?;


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/78785, `std` looks up `getrandom` and `statx` with `dlsym` before attempting to use `syscall(SYS_.., ..)`.

It also now passes all arguments as a machine-sized word, instead of their original types.