### PR TITLE
Weaken release sequences to match the C++20 memory model

### DIFF
--- a/src/data_race.rs
+++ b/src/data_race.rs
@@ -292,7 +292,7 @@ impl MemoryCellClocks {
         
         // The handling of release sequences was changed in C++20 and so
         // the code here is different to the paper since now all relaxed
-        // stored block release sequences, the exception for same-thread
+        // stores block release sequences. The exception for same-thread
         // relaxed stores has been removed.
         let atomic = self.atomic_mut();
         atomic.sync_vector.clone_from(&clocks.fence_release);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ pub use crate::sync::{
     EvalContextExt as SyncEvalContextExt, CondvarId, MutexId, RwLockId
 };
 pub use crate::vector_clock::{
-    VClock, VSmallClockMap, VectorIdx, VTimestamp
+    VClock, VectorIdx, VTimestamp
 };
 
 /// Insert rustc arguments at the beginning of the argument list that Miri wants to be

--- a/tests/compile-fail/data_race/release_seq_race_same_thread.rs
+++ b/tests/compile-fail/data_race/release_seq_race_same_thread.rs
@@ -31,7 +31,8 @@ pub fn main() {
 
             // C++20 update to release sequences
             // makes this block the release sequence
-            // despite the same thread.
+            // despite the being on the same thread
+            // as the release store.
             SYNC.store(2, Ordering::Relaxed);
         });
 

--- a/tests/compile-fail/data_race/release_seq_race_same_thread.rs
+++ b/tests/compile-fail/data_race/release_seq_race_same_thread.rs
@@ -1,0 +1,49 @@
+// ignore-windows: Concurrency on Windows is not supported yet.
+// compile-flags: -Zmiri-disable-isolation
+
+use std::thread::spawn;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[derive(Copy, Clone)]
+struct EvilSend<T>(pub T);
+
+unsafe impl<T> Send for EvilSend<T> {}
+unsafe impl<T> Sync for EvilSend<T> {}
+
+static SYNC: AtomicUsize = AtomicUsize::new(0);
+
+pub fn main() {
+    let mut a = 0u32;
+    let b = &mut a as *mut u32;
+    let c = EvilSend(b);
+
+    // Note: this is scheduler-dependent
+    // the operations need to occur in
+    // order, the sleep operations currently
+    // force the desired ordering:
+    //  1. store release : 1
+    //  2. store relaxed : 2
+    //  3. load acquire : 2
+    unsafe {
+        let j1 = spawn(move || {
+            *c.0 = 1;
+            SYNC.store(1, Ordering::Release);
+
+            // C++20 update to release sequences
+            // makes this block the release sequence
+            // despite the same thread.
+            SYNC.store(2, Ordering::Relaxed);
+        });
+
+        let j2 = spawn(move || {
+            if SYNC.load(Ordering::Acquire) == 2 {
+                *c.0 //~ ERROR Data race
+            } else {
+                0
+            }
+        });
+
+        j1.join().unwrap();
+        j2.join().unwrap();
+    }
+}

--- a/tests/run-pass/concurrency/data_race.rs
+++ b/tests/run-pass/concurrency/data_race.rs
@@ -89,7 +89,7 @@ pub fn test_rmw_no_block() {
     }
 }
 
-pub fn test_release_no_block() {
+pub fn test_simple_release() {
     let mut a = 0u32;
     let b = &mut a as *mut u32;
     let c = EvilSend(b);
@@ -98,11 +98,10 @@ pub fn test_release_no_block() {
         let j1 = spawn(move || {
             *c.0 = 1;
             SYNC.store(1, Ordering::Release);
-            SYNC.store(3, Ordering::Relaxed);
         });
 
         let j2 = spawn(move || {
-            if SYNC.load(Ordering::Acquire) == 3 {
+            if SYNC.load(Ordering::Acquire) == 1 {
                 *c.0
             } else {
                 0
@@ -118,5 +117,5 @@ pub fn main() {
     test_fence_sync();
     test_multiple_reads();
     test_rmw_no_block();
-    test_release_no_block();
+    test_simple_release();
 }


### PR DESCRIPTION
See [Weaken Release Sequences](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0982r1.html), since the exception for relaxed writes on the same thread as a release write not blocking release sequences was removed in the C++20 memory model compared to the C11 memory model the paper was based on. The implementation can be updated and simplified to match this.  [Rust is currently specified to use the C++20 memory model](https://doc.rust-lang.org/std/sync/atomic/index.html).