### PR TITLE
WIP: Add in `atomic_{min,max}_x` intrinsics

### DIFF
--- a/src/shims/intrinsics.rs
+++ b/src/shims/intrinsics.rs
@@ -427,6 +427,16 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             "atomic_max_rel" => this.atomic_min_max(args, dest, false, AtomicRwOp::Release)?,
             "atomic_max_acqrel" => this.atomic_min_max(args, dest, false, AtomicRwOp::AcqRel)?,
             "atomic_max_relaxed" => this.atomic_min_max(args, dest, false, AtomicRwOp::Relaxed)?,
+            "atomic_umin" => this.atomic_min_max(args, dest, true, AtomicRwOp::SeqCst)?,
+            "atomic_umin_acq" => this.atomic_min_max(args, dest, true, AtomicRwOp::Acquire)?,
+            "atomic_umin_rel" => this.atomic_min_max(args, dest, true, AtomicRwOp::Release)?,
+            "atomic_umin_acqrel" => this.atomic_min_max(args, dest, true, AtomicRwOp::AcqRel)?,
+            "atomic_umin_relaxed" => this.atomic_min_max(args, dest, true, AtomicRwOp::Relaxed)?,
+            "atomic_umax" => this.atomic_min_max(args, dest, false, AtomicRwOp::SeqCst)?,
+            "atomic_umax_acq" => this.atomic_min_max(args, dest, false, AtomicRwOp::Acquire)?,
+            "atomic_umax_rel" => this.atomic_min_max(args, dest, false, AtomicRwOp::Release)?,
+            "atomic_umax_acqrel" => this.atomic_min_max(args, dest, false, AtomicRwOp::AcqRel)?,
+            "atomic_umax_relaxed" => this.atomic_min_max(args, dest, false, AtomicRwOp::Relaxed)?,
 
             // Query type information
             "assert_zero_valid" |

--- a/tests/run-pass/atomic.rs
+++ b/tests/run-pass/atomic.rs
@@ -63,6 +63,20 @@ fn atomic_u64() {
         Ok(1)
     );
     assert_eq!(ATOMIC.load(Relaxed), 0x100);
+
+    assert_eq!(ATOMIC.fetch_max(0x10, SeqCst), 0x100);
+    assert_eq!(ATOMIC.fetch_max(0x100, SeqCst), 0x100);
+    assert_eq!(ATOMIC.fetch_max(0x1000, SeqCst), 0x100);
+    assert_eq!(ATOMIC.fetch_max(0x1000, SeqCst), 0x1000);
+    assert_eq!(ATOMIC.fetch_max(0x2000, SeqCst), 0x1000);
+    assert_eq!(ATOMIC.fetch_max(0x2000, SeqCst), 0x2000);
+
+    assert_eq!(ATOMIC.fetch_min(0x2000, SeqCst), 0x2000);
+    assert_eq!(ATOMIC.fetch_min(0x2000, SeqCst), 0x2000);
+    assert_eq!(ATOMIC.fetch_max(0x1000, SeqCst), 0x2000);
+    assert_eq!(ATOMIC.fetch_max(0x1000, SeqCst), 0x1000);
+    assert_eq!(ATOMIC.fetch_max(0x100, SeqCst), 0x1000);
+    assert_eq!(ATOMIC.fetch_max(0x10, SeqCst), 0x100);
 }
 
 fn atomic_fences() {


### PR DESCRIPTION
I have probably not got this even remotely right.

Recent rust stable seems to have added `atomic_max` and `atomic_min` intrinsics. I recently bumped into this being unimplemented while using miri to (hopefully) track down some bugs.

I think this is an implementation of these.