### PR TITLE
Build proc-macro crate as "target" crate when unit testing it

### DIFF
--- a/test-cargo-miri/subcrate/Cargo.toml
+++ b/test-cargo-miri/subcrate/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 authors = ["Miri Team"]
 edition = "2018"
 
+[lib]
+proc-macro = true
+doctest = false
+
 [[bin]]
 name = "subcrate"
 path = "main.rs"

--- a/test-cargo-miri/subcrate/src/lib.rs
+++ b/test-cargo-miri/subcrate/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        num_cpus::get();
+    }
+}

--- a/test-cargo-miri/test.subcrate.stdout.ref
+++ b/test-cargo-miri/test.subcrate.stdout.ref
@@ -1,4 +1,9 @@
 
+running 1 test
+.
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+
+
 running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out


### PR DESCRIPTION
This detects proc-macro crate's unit test build by searching for `--extern proc_macro` and `--test` in the command line.

Fixes #1660.