### PR TITLE
Remove `#![feature(const_generics)]` and `#![allow(incomplete_features)]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,6 @@
 #![warn(rust_2018_idioms)]
 #![allow(clippy::cast_lossless)]
 
-#![allow(incomplete_features)]
-#![feature(const_generics)]
-
 extern crate rustc_attr;
 extern crate rustc_apfloat;
 extern crate rustc_ast;


### PR DESCRIPTION
`#![feature(min_const_generics)]` has been [stabilized](https://github.com/rust-lang/rust/pull/79135), so I removed `#![feature(const_generics)]` and `#![allow(incomplete_features)]` (I assume Miri is not built by the beta bootstrap compiler so it's fine to just remove them).

The test [`tests/run-pass/specialization.rs` also has a `#![allow(incomplete_features)]` for `#![feature(specialization)]`](https://github.com/rust-lang/miri/blob/9949d9e4/tests/run-pass/specialization.rs#L1-L2). I think that can be removed and `#![feature(specialization)]` can be replaced with `#![feature(min_specialization)]`, but I'm not sure whether I should do that because it's a test. Feel free to ask me to remove it if it's fine to do so.