### PR TITLE
Add shim for libc::sysconf(libc::_SC_NPROCESSORS_CONF)

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -47,7 +47,7 @@ run_tests
 case $HOST_TARGET in
   x86_64-unknown-linux-gnu)
     MIRI_TEST_TARGET=i686-unknown-linux-gnu run_tests
-    MIRI_TEST_TARGET=x86_64-apple-darwin run_tests
+    MIRI_TEST_TARGET=aarch64-apple-darwin run_tests
     MIRI_TEST_TARGET=i686-pc-windows-msvc run_tests
     ;;
   x86_64-apple-darwin)

--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -484,6 +484,18 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 let &[] = check_arg_count(args)?;
                 this.yield_active_thread();
             }
+            "llvm.aarch64.hint" if this.tcx.sess.target.arch == "aarch64" => {
+                let &[hint] = check_arg_count(args)?;
+                let hint = this.read_scalar(hint)?.to_i32()?;
+                match hint {
+                    1 => { // HINT_YIELD
+                        this.yield_active_thread();
+                    }
+                    _ => {
+                        throw_unsup_format!("unsupported llvm.aarch64.hint argument {}", hint);
+                    }
+                }
+            }
 
             // Platform-specific shims
             _ => match this.tcx.sess.target.os.as_str() {

--- a/src/shims/posix/foreign_items.rs
+++ b/src/shims/posix/foreign_items.rs
@@ -180,6 +180,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
                 let sysconfs = &[
                     ("_SC_PAGESIZE", Scalar::from_int(PAGE_SIZE, this.pointer_size())),
+                    ("_SC_NPROCESSORS_CONF", Scalar::from_int(NUM_CPUS, this.pointer_size())),
                     ("_SC_NPROCESSORS_ONLN", Scalar::from_int(NUM_CPUS, this.pointer_size())),
                 ];
                 let mut result = None;

--- a/src/shims/posix/macos/foreign_items.rs
+++ b/src/shims/posix/macos/foreign_items.rs
@@ -25,32 +25,32 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             }
 
             // File related shims
-            "close$NOCANCEL" => {
+            "close" | "close$NOCANCEL" => {
                 let &[result] = check_arg_count(args)?;
                 let result = this.close(result)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
-            "stat$INODE64" => {
+            "stat" | "stat$INODE64" => {
                 let &[path, buf] = check_arg_count(args)?;
                 let result = this.macos_stat(path, buf)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
-            "lstat$INODE64" => {
+            "lstat" | "lstat$INODE64" => {
                 let &[path, buf] = check_arg_count(args)?;
                 let result = this.macos_lstat(path, buf)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
-            "fstat$INODE64" => {
+            "fstat" | "fstat$INODE64" => {
                 let &[fd, buf] = check_arg_count(args)?;
                 let result = this.macos_fstat(fd, buf)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
-            "opendir$INODE64" => {
+            "opendir" | "opendir$INODE64" => {
                 let &[name] = check_arg_count(args)?;
                 let result = this.opendir(name)?;
                 this.write_scalar(result, dest)?;
             }
-            "readdir_r$INODE64" => {
+            "readdir_r" | "readdir_r$INODE64" => {
                 let &[dirp, entry, result] = check_arg_count(args)?;
                 let result = this.macos_readdir_r(dirp, entry, result)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;


### PR DESCRIPTION
`libc::sysconf(libc::_SC_NPROCESSORS_CONF)` is used by AArch64 devices to get the number of CPUs in the `num_cpus` crate:

https://github.com/seanmonstar/num_cpus/blob/b423db0a698b035914ae1fd6b7ce5d2a4e727b46/src/lib.rs#L337-L342