### PR TITLE
Fix `\n` in Zulip message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,5 +130,11 @@ jobs:
           ZULIP_API_TOKEN: ${{ secrets.ZULIP_API_TOKEN }}
         run: |
           ~/.local/bin/zulip-send --stream miri --subject "Cron Job Failure" \
-            --message 'Dear @**RalfJ** and @**oli**\n\nIt would appear that the Miri cron job build failed. Would you mind investigating this issue?\n\nThanks in advance!\nSincerely,\nThe Miri Cronjobs Bot' \
+            --message 'Dear @**RalfJ** and @**oli**
+
+          It would appear that the Miri cron job build failed. Would you mind investigating this issue?
+
+          Thanks in advance!
+          Sincerely,
+          The Miri Cronjobs Bot' \
             --user $ZULIP_BOT_EMAIL --api-key $ZULIP_API_TOKEN --site https://rust-lang.zulipchat.com


### PR DESCRIPTION
https://rust-lang.zulipchat.com/#narrow/stream/269128-miri/topic/Cron.20Job.20Failure/near/223865005:
> Dear @**RalfJ** and @**oli**\n\nIt would appear that the Miri cron job build failed. Would you mind investigating this issue?\n\nThanks in advance!\nSincerely,\nThe Miri Cronjobs Bot

This PR changes that to:
> Dear @**RalfJ** and @**oli**
>
> It would appear that the Miri cron job build failed. Would you mind investigating this issue?
>
> Thanks in advance!
> Sincerely,
> The Miri Cronjobs Bot