### PR TITLE
Add atomic min and max

### DIFF
--- a/src/data_race.rs
+++ b/src/data_race.rs
@@ -263,7 +263,7 @@ impl MemoryCellClocks {
             atomic_ops: None,
         }
     }
-    
+
     /// Load the internal atomic memory cells if they exist.
     #[inline]
     fn atomic(&self) -> Option<&AtomicMemoryCellClocks> {
@@ -323,7 +323,7 @@ impl MemoryCellClocks {
     /// store relaxed semantics.
     fn store_relaxed(&mut self, clocks: &ThreadClockSet, index: VectorIdx) -> Result<(), DataRace> {
         self.atomic_write_detect(clocks, index)?;
-        
+
         // The handling of release sequences was changed in C++20 and so
         // the code here is different to the paper since now all relaxed
         // stores block release sequences. The exception for same-thread
@@ -678,7 +678,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: MiriEvalContextExt<'mir, 'tcx> {
                     // Either Release | AcqRel | SeqCst
                     clocks.apply_release_fence();
                 }
-                
+
                 // Increment timestamp in case of release semantics.
                 Ok(atomic != AtomicFenceOp::Acquire)
             })

--- a/src/data_race.rs
+++ b/src/data_race.rs
@@ -74,9 +74,9 @@ use rustc_middle::{mir, ty::layout::TyAndLayout};
 use rustc_target::abi::Size;
 
 use crate::{
-    ImmTy, Immediate, InterpResult, MPlaceTy, MemPlaceMeta, MiriEvalContext, MiriEvalContextExt,
-    OpTy, Pointer, RangeMap, Scalar, ScalarMaybeUninit, Tag, ThreadId, VClock, VTimestamp,
-    VectorIdx, MemoryKind, MiriMemoryKind
+    ImmTy, Immediate, InterpResult, MPlaceTy, MemPlaceMeta, MemoryKind, MiriEvalContext,
+    MiriEvalContextExt, MiriMemoryKind, OpTy, Pointer, RangeMap, Scalar, ScalarMaybeUninit, Tag,
+    ThreadId, VClock, VTimestamp, VectorIdx,
 };
 
 pub type AllocExtra = VClockAlloc;
@@ -542,6 +542,34 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: MiriEvalContextExt<'mir, 'tcx> {
         Ok(old)
     }
 
+    /// Perform an conditional atomic exchange with a memory place and a new
+    /// scalar value, the old value is returned.
+    fn atomic_min_max_scalar(
+        &mut self,
+        place: &MPlaceTy<'tcx, Tag>,
+        rhs: ImmTy<'tcx, Tag>,
+        min: bool,
+        atomic: AtomicRwOp,
+    ) -> InterpResult<'tcx, ImmTy<'tcx, Tag>> {
+        let this = self.eval_context_mut();
+
+        let old = this.allow_data_races_mut(|this| this.read_immediate(&place.into()))?;
+        let lt = this.overflowing_binary_op(mir::BinOp::Lt, &old, &rhs)?.0.to_bool()?;
+
+        let new_val = if min {
+            if lt { &old } else { &rhs }
+        } else {
+            if lt { &rhs } else { &old }
+        };
+
+        this.allow_data_races_mut(|this| this.write_immediate_to_mplace(**new_val, place))?;
+
+        this.validate_atomic_rmw(&place, atomic)?;
+
+        // Return the old value.
+        Ok(old)
+    }
+
     /// Perform an atomic compare and exchange at a given memory location.
     /// On success an atomic RMW operation is performed and on failure
     /// only an atomic read occurs. If `can_fail_spuriously` is true,
@@ -687,15 +715,12 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: MiriEvalContextExt<'mir, 'tcx> {
         }
     }
 
-    fn reset_vector_clocks(
-        &mut self,
-        ptr: Pointer<Tag>,
-        size: Size
-    ) -> InterpResult<'tcx> {
+    fn reset_vector_clocks(&mut self, ptr: Pointer<Tag>, size: Size) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
         if let Some(data_race) = &mut this.memory.extra.data_race {
             if data_race.multi_threaded.get() {
-                let alloc_meta = this.memory.get_raw_mut(ptr.alloc_id)?.extra.data_race.as_mut().unwrap();
+                let alloc_meta =
+                    this.memory.get_raw_mut(ptr.alloc_id)?.extra.data_race.as_mut().unwrap();
                 alloc_meta.reset_clocks(ptr.offset, size);
             }
         }
@@ -715,28 +740,37 @@ pub struct VClockAlloc {
 
 impl VClockAlloc {
     /// Create a new data-race detector for newly allocated memory.
-    pub fn new_allocation(global: &MemoryExtra, len: Size, kind: MemoryKind<MiriMemoryKind>) -> VClockAlloc {
+    pub fn new_allocation(
+        global: &MemoryExtra,
+        len: Size,
+        kind: MemoryKind<MiriMemoryKind>,
+    ) -> VClockAlloc {
         let (alloc_timestamp, alloc_index) = match kind {
             // User allocated and stack memory should track allocation.
             MemoryKind::Machine(
-                MiriMemoryKind::Rust | MiriMemoryKind::C | MiriMemoryKind::WinHeap
-            ) | MemoryKind::Stack => {
+                MiriMemoryKind::Rust | MiriMemoryKind::C | MiriMemoryKind::WinHeap,
+            )
+            | MemoryKind::Stack => {
                 let (alloc_index, clocks) = global.current_thread_state();
                 let alloc_timestamp = clocks.clock[alloc_index];
                 (alloc_timestamp, alloc_index)
             }
             // Other global memory should trace races but be allocated at the 0 timestamp.
             MemoryKind::Machine(
-                MiriMemoryKind::Global | MiriMemoryKind::Machine | MiriMemoryKind::Env |
-                MiriMemoryKind::ExternStatic | MiriMemoryKind::Tls
-            ) | MemoryKind::CallerLocation | MemoryKind::Vtable => {
-                (0, VectorIdx::MAX_INDEX)
-            }
+                MiriMemoryKind::Global
+                | MiriMemoryKind::Machine
+                | MiriMemoryKind::Env
+                | MiriMemoryKind::ExternStatic
+                | MiriMemoryKind::Tls,
+            )
+            | MemoryKind::CallerLocation
+            | MemoryKind::Vtable => (0, VectorIdx::MAX_INDEX),
         };
         VClockAlloc {
             global: Rc::clone(global),
             alloc_ranges: RefCell::new(RangeMap::new(
-                len, MemoryCellClocks::new(alloc_timestamp, alloc_index)
+                len,
+                MemoryCellClocks::new(alloc_timestamp, alloc_index),
             )),
         }
     }
@@ -1015,7 +1049,8 @@ trait EvalContextPrivExt<'mir, 'tcx: 'mir>: MiriEvalContextExt<'mir, 'tcx> {
                                 true,
                                 place_ptr,
                                 size,
-                            ).map(|_| true);
+                            )
+                            .map(|_| true);
                         }
                     }
 
@@ -1266,7 +1301,6 @@ impl GlobalState {
             .termination_vector_clock
             .as_ref()
             .expect("Joined with thread but thread has not terminated");
-
 
         // The join thread happens-before the current thread
         // so update the current vector clock.

--- a/src/shims/intrinsics.rs
+++ b/src/shims/intrinsics.rs
@@ -2,9 +2,9 @@ use std::iter;
 
 use log::trace;
 
-use rustc_middle::{mir, mir::BinOp, ty, ty::FloatTy};
-use rustc_middle::ty::layout::IntegerExt;
 use rustc_apfloat::{Float, Round};
+use rustc_middle::ty::layout::IntegerExt;
+use rustc_middle::{mir, mir::BinOp, ty, ty::FloatTy};
 use rustc_target::abi::{Align, Integer, LayoutOf};
 
 use crate::*;
@@ -67,8 +67,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 let val_byte = this.read_scalar(val_byte)?.to_u8()?;
                 let ptr = this.read_scalar(ptr)?.check_init()?;
                 let count = this.read_scalar(count)?.to_machine_usize(this)?;
-                let byte_count = ty_layout.size.checked_mul(count, this)
-                    .ok_or_else(|| err_ub_format!("overflow computing total size of `write_bytes`"))?;
+                let byte_count = ty_layout.size.checked_mul(count, this).ok_or_else(|| {
+                    err_ub_format!("overflow computing total size of `write_bytes`")
+                })?;
                 this.memory
                     .write_bytes(ptr, iter::repeat(val_byte).take(byte_count.bytes() as usize))?;
             }
@@ -258,13 +259,14 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 let val = this.read_immediate(val)?;
 
                 let res = match val.layout.ty.kind() {
-                    ty::Float(FloatTy::F32) => {
-                        this.float_to_int_unchecked(val.to_scalar()?.to_f32()?, dest.layout.ty)?
-                    }
-                    ty::Float(FloatTy::F64) => {
-                        this.float_to_int_unchecked(val.to_scalar()?.to_f64()?, dest.layout.ty)?
-                    }
-                    _ => bug!("`float_to_int_unchecked` called with non-float input type {:?}", val.layout.ty),
+                    ty::Float(FloatTy::F32) =>
+                        this.float_to_int_unchecked(val.to_scalar()?.to_f32()?, dest.layout.ty)?,
+                    ty::Float(FloatTy::F64) =>
+                        this.float_to_int_unchecked(val.to_scalar()?.to_f64()?, dest.layout.ty)?,
+                    _ => bug!(
+                        "`float_to_int_unchecked` called with non-float input type {:?}",
+                        val.layout.ty
+                    ),
                 };
 
                 this.write_scalar(res, dest)?;
@@ -286,7 +288,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
             "atomic_singlethreadfence_acq" => this.compiler_fence(args, AtomicFenceOp::Acquire)?,
             "atomic_singlethreadfence_rel" => this.compiler_fence(args, AtomicFenceOp::Release)?,
-            "atomic_singlethreadfence_acqrel" => this.compiler_fence(args, AtomicFenceOp::AcqRel)?,
+            "atomic_singlethreadfence_acqrel" =>
+                this.compiler_fence(args, AtomicFenceOp::AcqRel)?,
             "atomic_singlethreadfence" => this.compiler_fence(args, AtomicFenceOp::SeqCst)?,
 
             "atomic_xchg" => this.atomic_exchange(args, dest, AtomicRwOp::SeqCst)?,
@@ -295,110 +298,179 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             "atomic_xchg_acqrel" => this.atomic_exchange(args, dest, AtomicRwOp::AcqRel)?,
             "atomic_xchg_relaxed" => this.atomic_exchange(args, dest, AtomicRwOp::Relaxed)?,
 
-            "atomic_cxchg" => this.atomic_compare_exchange(
-                args, dest, AtomicRwOp::SeqCst, AtomicReadOp::SeqCst
-            )?,
+            "atomic_cxchg" =>
+                this.atomic_compare_exchange(args, dest, AtomicRwOp::SeqCst, AtomicReadOp::SeqCst)?,
             "atomic_cxchg_acq" => this.atomic_compare_exchange(
-                args, dest, AtomicRwOp::Acquire, AtomicReadOp::Acquire
+                args,
+                dest,
+                AtomicRwOp::Acquire,
+                AtomicReadOp::Acquire,
             )?,
             "atomic_cxchg_rel" => this.atomic_compare_exchange(
-                args, dest, AtomicRwOp::Release, AtomicReadOp::Relaxed
+                args,
+                dest,
+                AtomicRwOp::Release,
+                AtomicReadOp::Relaxed,
             )?,
-            "atomic_cxchg_acqrel" => this.atomic_compare_exchange
-            (args, dest, AtomicRwOp::AcqRel, AtomicReadOp::Acquire
-            )?,
+            "atomic_cxchg_acqrel" =>
+                this.atomic_compare_exchange(args, dest, AtomicRwOp::AcqRel, AtomicReadOp::Acquire)?,
             "atomic_cxchg_relaxed" => this.atomic_compare_exchange(
-                args, dest, AtomicRwOp::Relaxed, AtomicReadOp::Relaxed
+                args,
+                dest,
+                AtomicRwOp::Relaxed,
+                AtomicReadOp::Relaxed,
             )?,
             "atomic_cxchg_acq_failrelaxed" => this.atomic_compare_exchange(
-                args, dest, AtomicRwOp::Acquire, AtomicReadOp::Relaxed
+                args,
+                dest,
+                AtomicRwOp::Acquire,
+                AtomicReadOp::Relaxed,
             )?,
-            "atomic_cxchg_acqrel_failrelaxed" => this.atomic_compare_exchange(
-                args, dest, AtomicRwOp::AcqRel, AtomicReadOp::Relaxed
-            )?,
-            "atomic_cxchg_failrelaxed" => this.atomic_compare_exchange(
-                args, dest, AtomicRwOp::SeqCst, AtomicReadOp::Relaxed
-            )?,
-            "atomic_cxchg_failacq" => this.atomic_compare_exchange(
-                args, dest, AtomicRwOp::SeqCst, AtomicReadOp::Acquire
-            )?,
+            "atomic_cxchg_acqrel_failrelaxed" =>
+                this.atomic_compare_exchange(args, dest, AtomicRwOp::AcqRel, AtomicReadOp::Relaxed)?,
+            "atomic_cxchg_failrelaxed" =>
+                this.atomic_compare_exchange(args, dest, AtomicRwOp::SeqCst, AtomicReadOp::Relaxed)?,
+            "atomic_cxchg_failacq" =>
+                this.atomic_compare_exchange(args, dest, AtomicRwOp::SeqCst, AtomicReadOp::Acquire)?,
 
             "atomic_cxchgweak" => this.atomic_compare_exchange_weak(
-                args, dest, AtomicRwOp::SeqCst, AtomicReadOp::SeqCst
+                args,
+                dest,
+                AtomicRwOp::SeqCst,
+                AtomicReadOp::SeqCst,
             )?,
             "atomic_cxchgweak_acq" => this.atomic_compare_exchange_weak(
-                args, dest, AtomicRwOp::Acquire, AtomicReadOp::Acquire
+                args,
+                dest,
+                AtomicRwOp::Acquire,
+                AtomicReadOp::Acquire,
             )?,
             "atomic_cxchgweak_rel" => this.atomic_compare_exchange_weak(
-                args, dest, AtomicRwOp::Release, AtomicReadOp::Relaxed
+                args,
+                dest,
+                AtomicRwOp::Release,
+                AtomicReadOp::Relaxed,
             )?,
             "atomic_cxchgweak_acqrel" => this.atomic_compare_exchange_weak(
-                args, dest, AtomicRwOp::AcqRel, AtomicReadOp::Acquire
+                args,
+                dest,
+                AtomicRwOp::AcqRel,
+                AtomicReadOp::Acquire,
             )?,
             "atomic_cxchgweak_relaxed" => this.atomic_compare_exchange_weak(
-                args, dest, AtomicRwOp::Relaxed, AtomicReadOp::Relaxed
+                args,
+                dest,
+                AtomicRwOp::Relaxed,
+                AtomicReadOp::Relaxed,
             )?,
             "atomic_cxchgweak_acq_failrelaxed" => this.atomic_compare_exchange_weak(
-                args, dest, AtomicRwOp::Acquire, AtomicReadOp::Relaxed
+                args,
+                dest,
+                AtomicRwOp::Acquire,
+                AtomicReadOp::Relaxed,
             )?,
             "atomic_cxchgweak_acqrel_failrelaxed" => this.atomic_compare_exchange_weak(
-                args, dest, AtomicRwOp::AcqRel, AtomicReadOp::Relaxed
+                args,
+                dest,
+                AtomicRwOp::AcqRel,
+                AtomicReadOp::Relaxed,
             )?,
             "atomic_cxchgweak_failrelaxed" => this.atomic_compare_exchange_weak(
-                args, dest, AtomicRwOp::SeqCst, AtomicReadOp::Relaxed
+                args,
+                dest,
+                AtomicRwOp::SeqCst,
+                AtomicReadOp::Relaxed,
             )?,
             "atomic_cxchgweak_failacq" => this.atomic_compare_exchange_weak(
-                args, dest, AtomicRwOp::SeqCst, AtomicReadOp::Acquire
+                args,
+                dest,
+                AtomicRwOp::SeqCst,
+                AtomicReadOp::Acquire,
             )?,
 
             "atomic_or" => this.atomic_op(args, dest, BinOp::BitOr, false, AtomicRwOp::SeqCst)?,
-            "atomic_or_acq" => this.atomic_op(args, dest, BinOp::BitOr, false, AtomicRwOp::Acquire)?,
-            "atomic_or_rel" => this.atomic_op(args, dest, BinOp::BitOr, false, AtomicRwOp::Release)?,
-            "atomic_or_acqrel" => this.atomic_op(args, dest, BinOp::BitOr, false, AtomicRwOp::AcqRel)?,
-            "atomic_or_relaxed" => this.atomic_op(args, dest, BinOp::BitOr, false, AtomicRwOp::Relaxed)?,
+            "atomic_or_acq" =>
+                this.atomic_op(args, dest, BinOp::BitOr, false, AtomicRwOp::Acquire)?,
+            "atomic_or_rel" =>
+                this.atomic_op(args, dest, BinOp::BitOr, false, AtomicRwOp::Release)?,
+            "atomic_or_acqrel" =>
+                this.atomic_op(args, dest, BinOp::BitOr, false, AtomicRwOp::AcqRel)?,
+            "atomic_or_relaxed" =>
+                this.atomic_op(args, dest, BinOp::BitOr, false, AtomicRwOp::Relaxed)?,
             "atomic_xor" => this.atomic_op(args, dest, BinOp::BitXor, false, AtomicRwOp::SeqCst)?,
-            "atomic_xor_acq" => this.atomic_op(args, dest, BinOp::BitXor, false, AtomicRwOp::Acquire)?,
-            "atomic_xor_rel" => this.atomic_op(args, dest, BinOp::BitXor, false, AtomicRwOp::Release)?,
-            "atomic_xor_acqrel" => this.atomic_op(args, dest, BinOp::BitXor, false, AtomicRwOp::AcqRel)?,
-            "atomic_xor_relaxed" => this.atomic_op(args, dest, BinOp::BitXor, false, AtomicRwOp::Relaxed)?,
+            "atomic_xor_acq" =>
+                this.atomic_op(args, dest, BinOp::BitXor, false, AtomicRwOp::Acquire)?,
+            "atomic_xor_rel" =>
+                this.atomic_op(args, dest, BinOp::BitXor, false, AtomicRwOp::Release)?,
+            "atomic_xor_acqrel" =>
+                this.atomic_op(args, dest, BinOp::BitXor, false, AtomicRwOp::AcqRel)?,
+            "atomic_xor_relaxed" =>
+                this.atomic_op(args, dest, BinOp::BitXor, false, AtomicRwOp::Relaxed)?,
             "atomic_and" => this.atomic_op(args, dest, BinOp::BitAnd, false, AtomicRwOp::SeqCst)?,
-            "atomic_and_acq" => this.atomic_op(args, dest, BinOp::BitAnd, false, AtomicRwOp::Acquire)?,
-            "atomic_and_rel" => this.atomic_op(args, dest, BinOp::BitAnd, false, AtomicRwOp::Release)?,
-            "atomic_and_acqrel" => this.atomic_op(args, dest, BinOp::BitAnd, false, AtomicRwOp::AcqRel)?,
-            "atomic_and_relaxed" => this.atomic_op(args, dest, BinOp::BitAnd, false, AtomicRwOp::Relaxed)?,
+            "atomic_and_acq" =>
+                this.atomic_op(args, dest, BinOp::BitAnd, false, AtomicRwOp::Acquire)?,
+            "atomic_and_rel" =>
+                this.atomic_op(args, dest, BinOp::BitAnd, false, AtomicRwOp::Release)?,
+            "atomic_and_acqrel" =>
+                this.atomic_op(args, dest, BinOp::BitAnd, false, AtomicRwOp::AcqRel)?,
+            "atomic_and_relaxed" =>
+                this.atomic_op(args, dest, BinOp::BitAnd, false, AtomicRwOp::Relaxed)?,
             "atomic_nand" => this.atomic_op(args, dest, BinOp::BitAnd, true, AtomicRwOp::SeqCst)?,
-            "atomic_nand_acq" => this.atomic_op(args, dest, BinOp::BitAnd, true, AtomicRwOp::Acquire)?,
-            "atomic_nand_rel" => this.atomic_op(args, dest, BinOp::BitAnd, true, AtomicRwOp::Release)?,
-            "atomic_nand_acqrel" => this.atomic_op(args, dest, BinOp::BitAnd, true, AtomicRwOp::AcqRel)?,
-            "atomic_nand_relaxed" => this.atomic_op(args, dest, BinOp::BitAnd, true, AtomicRwOp::Relaxed)?,
+            "atomic_nand_acq" =>
+                this.atomic_op(args, dest, BinOp::BitAnd, true, AtomicRwOp::Acquire)?,
+            "atomic_nand_rel" =>
+                this.atomic_op(args, dest, BinOp::BitAnd, true, AtomicRwOp::Release)?,
+            "atomic_nand_acqrel" =>
+                this.atomic_op(args, dest, BinOp::BitAnd, true, AtomicRwOp::AcqRel)?,
+            "atomic_nand_relaxed" =>
+                this.atomic_op(args, dest, BinOp::BitAnd, true, AtomicRwOp::Relaxed)?,
             "atomic_xadd" => this.atomic_op(args, dest, BinOp::Add, false, AtomicRwOp::SeqCst)?,
-            "atomic_xadd_acq" => this.atomic_op(args, dest, BinOp::Add, false, AtomicRwOp::Acquire)?,
-            "atomic_xadd_rel" => this.atomic_op(args, dest, BinOp::Add, false, AtomicRwOp::Release)?,
-            "atomic_xadd_acqrel" => this.atomic_op(args, dest, BinOp::Add, false, AtomicRwOp::AcqRel)?,
-            "atomic_xadd_relaxed" => this.atomic_op(args, dest, BinOp::Add, false, AtomicRwOp::Relaxed)?,
+            "atomic_xadd_acq" =>
+                this.atomic_op(args, dest, BinOp::Add, false, AtomicRwOp::Acquire)?,
+            "atomic_xadd_rel" =>
+                this.atomic_op(args, dest, BinOp::Add, false, AtomicRwOp::Release)?,
+            "atomic_xadd_acqrel" =>
+                this.atomic_op(args, dest, BinOp::Add, false, AtomicRwOp::AcqRel)?,
+            "atomic_xadd_relaxed" =>
+                this.atomic_op(args, dest, BinOp::Add, false, AtomicRwOp::Relaxed)?,
             "atomic_xsub" => this.atomic_op(args, dest, BinOp::Sub, false, AtomicRwOp::SeqCst)?,
-            "atomic_xsub_acq" => this.atomic_op(args, dest, BinOp::Sub, false, AtomicRwOp::Acquire)?,
-            "atomic_xsub_rel" => this.atomic_op(args, dest, BinOp::Sub, false, AtomicRwOp::Release)?,
-            "atomic_xsub_acqrel" => this.atomic_op(args, dest, BinOp::Sub, false, AtomicRwOp::AcqRel)?,
-            "atomic_xsub_relaxed" => this.atomic_op(args, dest, BinOp::Sub, false, AtomicRwOp::Relaxed)?,
-
+            "atomic_xsub_acq" =>
+                this.atomic_op(args, dest, BinOp::Sub, false, AtomicRwOp::Acquire)?,
+            "atomic_xsub_rel" =>
+                this.atomic_op(args, dest, BinOp::Sub, false, AtomicRwOp::Release)?,
+            "atomic_xsub_acqrel" =>
+                this.atomic_op(args, dest, BinOp::Sub, false, AtomicRwOp::AcqRel)?,
+            "atomic_xsub_relaxed" =>
+                this.atomic_op(args, dest, BinOp::Sub, false, AtomicRwOp::Relaxed)?,
 
             // Query type information
-            "assert_zero_valid" |
-            "assert_uninit_valid" => {
+            "assert_zero_valid" | "assert_uninit_valid" => {
                 let &[] = check_arg_count(args)?;
                 let ty = instance.substs.type_at(0);
                 let layout = this.layout_of(ty)?;
                 // Abort here because the caller might not be panic safe.
                 if layout.abi.is_uninhabited() {
                     // Use this message even for the other intrinsics, as that's what codegen does
-                    throw_machine_stop!(TerminationInfo::Abort(format!("aborted execution: attempted to instantiate uninhabited type `{}`", ty)))
+                    throw_machine_stop!(TerminationInfo::Abort(format!(
+                        "aborted execution: attempted to instantiate uninhabited type `{}`",
+                        ty
+                    )))
                 }
-                if intrinsic_name == "assert_zero_valid" && !layout.might_permit_raw_init(this, /*zero:*/ true).unwrap() {
-                    throw_machine_stop!(TerminationInfo::Abort(format!("aborted execution: attempted to zero-initialize type `{}`, which is invalid", ty)))
+                if intrinsic_name == "assert_zero_valid"
+                    && !layout.might_permit_raw_init(this, /*zero:*/ true).unwrap()
+                {
+                    throw_machine_stop!(TerminationInfo::Abort(format!(
+                        "aborted execution: attempted to zero-initialize type `{}`, which is invalid",
+                        ty
+                    )))
                 }
-                if intrinsic_name == "assert_uninit_valid" && !layout.might_permit_raw_init(this, /*zero:*/ false).unwrap() {
-                    throw_machine_stop!(TerminationInfo::Abort(format!("aborted execution: attempted to leave type `{}` uninitialized, which is invalid", ty)))
+                if intrinsic_name == "assert_uninit_valid"
+                    && !layout.might_permit_raw_init(this, /*zero:*/ false).unwrap()
+                {
+                    throw_machine_stop!(TerminationInfo::Abort(format!(
+                        "aborted execution: attempted to leave type `{}` uninitialized, which is invalid",
+                        ty
+                    )))
                 }
             }
 
@@ -419,11 +491,12 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
     }
 
     fn atomic_load(
-        &mut self, args: &[OpTy<'tcx, Tag>], dest: &PlaceTy<'tcx, Tag>,
-        atomic: AtomicReadOp
+        &mut self,
+        args: &[OpTy<'tcx, Tag>],
+        dest: &PlaceTy<'tcx, Tag>,
+        atomic: AtomicReadOp,
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
-
 
         let &[ref place] = check_arg_count(args)?;
         let place = this.deref_operand(place)?;
@@ -440,7 +513,11 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         Ok(())
     }
 
-    fn atomic_store(&mut self, args: &[OpTy<'tcx, Tag>], atomic: AtomicWriteOp) -> InterpResult<'tcx> {
+    fn atomic_store(
+        &mut self,
+        args: &[OpTy<'tcx, Tag>],
+        atomic: AtomicWriteOp,
+    ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
 
         let &[ref place, ref val] = check_arg_count(args)?;
@@ -458,14 +535,22 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         Ok(())
     }
 
-    fn compiler_fence(&mut self, args: &[OpTy<'tcx, Tag>], atomic: AtomicFenceOp) -> InterpResult<'tcx> {
+    fn compiler_fence(
+        &mut self,
+        args: &[OpTy<'tcx, Tag>],
+        atomic: AtomicFenceOp,
+    ) -> InterpResult<'tcx> {
         let &[] = check_arg_count(args)?;
         let _ = atomic;
         //FIXME: compiler fences are currently ignored
         Ok(())
     }
 
-    fn atomic_fence(&mut self, args: &[OpTy<'tcx, Tag>], atomic: AtomicFenceOp) -> InterpResult<'tcx> {
+    fn atomic_fence(
+        &mut self,
+        args: &[OpTy<'tcx, Tag>],
+        atomic: AtomicFenceOp,
+    ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
         let &[] = check_arg_count(args)?;
         this.validate_atomic_fence(atomic)?;
@@ -473,8 +558,12 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
     }
 
     fn atomic_op(
-        &mut self, args: &[OpTy<'tcx, Tag>], dest: &PlaceTy<'tcx, Tag>,
-        op: mir::BinOp, neg: bool, atomic: AtomicRwOp
+        &mut self,
+        args: &[OpTy<'tcx, Tag>],
+        dest: &PlaceTy<'tcx, Tag>,
+        op: mir::BinOp,
+        neg: bool,
+        atomic: AtomicRwOp,
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
 
@@ -490,14 +579,17 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         // be 8-aligned).
         let align = Align::from_bytes(place.layout.size.bytes()).unwrap();
         this.memory.check_ptr_access(place.ptr, place.layout.size, align)?;
-        
+
         let old = this.atomic_op_immediate(&place, &rhs, op, neg, atomic)?;
         this.write_immediate(*old, dest)?; // old value is returned
         Ok(())
     }
-    
+
     fn atomic_exchange(
-        &mut self, args: &[OpTy<'tcx, Tag>], dest: &PlaceTy<'tcx, Tag>, atomic: AtomicRwOp
+        &mut self,
+        args: &[OpTy<'tcx, Tag>],
+        dest: &PlaceTy<'tcx, Tag>,
+        atomic: AtomicRwOp,
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
 
@@ -517,8 +609,12 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
     }
 
     fn atomic_compare_exchange_impl(
-        &mut self, args: &[OpTy<'tcx, Tag>], dest: &PlaceTy<'tcx, Tag>,
-        success: AtomicRwOp, fail: AtomicReadOp, can_fail_spuriously: bool
+        &mut self,
+        args: &[OpTy<'tcx, Tag>],
+        dest: &PlaceTy<'tcx, Tag>,
+        success: AtomicRwOp,
+        fail: AtomicReadOp,
+        can_fail_spuriously: bool,
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
 
@@ -527,16 +623,19 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         let expect_old = this.read_immediate(expect_old)?; // read as immediate for the sake of `binary_op()`
         let new = this.read_scalar(new)?;
 
-
         // Check alignment requirements. Atomics must always be aligned to their size,
         // even if the type they wrap would be less aligned (e.g. AtomicU64 on 32bit must
         // be 8-aligned).
         let align = Align::from_bytes(place.layout.size.bytes()).unwrap();
         this.memory.check_ptr_access(place.ptr, place.layout.size, align)?;
 
-        
         let old = this.atomic_compare_exchange_scalar(
-            &place, &expect_old, new, success, fail, can_fail_spuriously
+            &place,
+            &expect_old,
+            new,
+            success,
+            fail,
+            can_fail_spuriously,
         )?;
 
         // Return old value.
@@ -545,15 +644,21 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
     }
 
     fn atomic_compare_exchange(
-        &mut self, args: &[OpTy<'tcx, Tag>], dest: &PlaceTy<'tcx, Tag>,
-        success: AtomicRwOp, fail: AtomicReadOp
+        &mut self,
+        args: &[OpTy<'tcx, Tag>],
+        dest: &PlaceTy<'tcx, Tag>,
+        success: AtomicRwOp,
+        fail: AtomicReadOp,
     ) -> InterpResult<'tcx> {
         self.atomic_compare_exchange_impl(args, dest, success, fail, false)
     }
 
     fn atomic_compare_exchange_weak(
-        &mut self, args: &[OpTy<'tcx, Tag>], dest: &PlaceTy<'tcx, Tag>,
-        success: AtomicRwOp, fail: AtomicReadOp
+        &mut self,
+        args: &[OpTy<'tcx, Tag>],
+        dest: &PlaceTy<'tcx, Tag>,
+        success: AtomicRwOp,
+        fail: AtomicReadOp,
     ) -> InterpResult<'tcx> {
         self.atomic_compare_exchange_impl(args, dest, success, fail, true)
     }
@@ -564,7 +669,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         dest_ty: ty::Ty<'tcx>,
     ) -> InterpResult<'tcx, Scalar<Tag>>
     where
-        F: Float + Into<Scalar<Tag>>
+        F: Float + Into<Scalar<Tag>>,
     {
         let this = self.eval_context_ref();
 
@@ -585,7 +690,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                     // `f` was not representable in this integer type.
                     throw_ub_format!(
                         "`float_to_int_unchecked` intrinsic called on {} which cannot be represented in target type `{:?}`",
-                        f, dest_ty,
+                        f,
+                        dest_ty,
                     );
                 }
             }
@@ -600,7 +706,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                     // `f` was not representable in this integer type.
                     throw_ub_format!(
                         "`float_to_int_unchecked` intrinsic called on {} which cannot be represented in target type `{:?}`",
-                        f, dest_ty,
+                        f,
+                        dest_ty,
                     );
                 }
             }

--- a/tests/run-pass/atomic.rs
+++ b/tests/run-pass/atomic.rs
@@ -74,6 +74,20 @@ fn atomic_u64() {
     assert_eq!(ATOMIC.compare_exchange(0, 0x100, AcqRel, Acquire), Err(1));
     compare_exchange_weak_loop!(ATOMIC, 1, 0x100, AcqRel, Acquire);
     assert_eq!(ATOMIC.load(Relaxed), 0x100);
+
+    assert_eq!(ATOMIC.fetch_max(0x10, SeqCst), 0x100);
+    assert_eq!(ATOMIC.fetch_max(0x100, SeqCst), 0x100);
+    assert_eq!(ATOMIC.fetch_max(0x1000, SeqCst), 0x100);
+    assert_eq!(ATOMIC.fetch_max(0x1000, SeqCst), 0x1000);
+    assert_eq!(ATOMIC.fetch_max(0x2000, SeqCst), 0x1000);
+    assert_eq!(ATOMIC.fetch_max(0x2000, SeqCst), 0x2000);
+
+    assert_eq!(ATOMIC.fetch_min(0x2000, SeqCst), 0x2000);
+    assert_eq!(ATOMIC.fetch_min(0x2000, SeqCst), 0x2000);
+    assert_eq!(ATOMIC.fetch_min(0x1000, SeqCst), 0x2000);
+    assert_eq!(ATOMIC.fetch_min(0x1000, SeqCst), 0x1000);
+    assert_eq!(ATOMIC.fetch_min(0x100, SeqCst), 0x1000);
+    assert_eq!(ATOMIC.fetch_min(0x10, SeqCst), 0x100);
 }
 
 fn atomic_fences() {


### PR DESCRIPTION
Closes #1718
Previous attempt: #1653

TODO:

- [x] Merge `atomic_op` and `atomic_min_max` functions
- [x] Fix CI

**Note:** this PR also removes arbitrary trailing whitespace and generally formats the affected files