### PR TITLE
fix reborrowing of tagged ZST references

### DIFF
--- a/tests/compile-fail/stacked_borrows/zst_slice.rs
+++ b/tests/compile-fail/stacked_borrows/zst_slice.rs
@@ -1,0 +1,11 @@
+// compile-flags: -Zmiri-track-raw-pointers
+// error-pattern: does not have an appropriate item in the borrow stack
+
+fn main() {
+    unsafe {
+        let a = [1, 2, 3];
+        let s = &a[0..0];
+        assert_eq!(s.len(), 0);
+        assert_eq!(*s.get_unchecked(1), 2);
+    }
+}


### PR DESCRIPTION
@SkiFire13 [pointed out](https://github.com/rust-lang/rust/pull/82554#issuecomment-787088712) that Miri fails to detect illegal use of empty slices. This PR fixes that. In so doing, it uncovers a flaw of Stacked Borrows: it is incompatible with how the formatting machinery uses `extern type`, so for now we skip reborrowing when we cannot determine the exact size of the pointee.