### PR TITLE
adjust CI test flags

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -2,8 +2,6 @@
 set -euo pipefail
 
 # Determine configuration
-export RUST_TEST_NOCAPTURE=1
-export RUST_BACKTRACE=1
 export RUSTFLAGS="-D warnings"
 export CARGO_INCREMENTAL=0
 export CARGO_EXTRA_FLAGS="--all-features"


### PR DESCRIPTION
`RUST_TEST_NOCAPTURE` seems to make no difference except for making compiletest output not use colors any more; `RUST_BACKTRACE` is already set by `compiletest.rs`.