### PR TITLE
rename atomic_op_min_max -> atomic_op

### DIFF
--- a/src/shims/intrinsics.rs
+++ b/src/shims/intrinsics.rs
@@ -394,226 +394,226 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 AtomicReadOp::Acquire,
             )?,
 
-            "atomic_or" => this.atomic_op_min_max(
+            "atomic_or" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::BitOr, false),
                 AtomicRwOp::SeqCst,
             )?,
-            "atomic_or_acq" => this.atomic_op_min_max(
+            "atomic_or_acq" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::BitOr, false),
                 AtomicRwOp::Acquire,
             )?,
-            "atomic_or_rel" => this.atomic_op_min_max(
+            "atomic_or_rel" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::BitOr, false),
                 AtomicRwOp::Release,
             )?,
-            "atomic_or_acqrel" => this.atomic_op_min_max(
+            "atomic_or_acqrel" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::BitOr, false),
                 AtomicRwOp::AcqRel,
             )?,
-            "atomic_or_relaxed" => this.atomic_op_min_max(
+            "atomic_or_relaxed" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::BitOr, false),
                 AtomicRwOp::Relaxed,
             )?,
-            "atomic_xor" => this.atomic_op_min_max(
+            "atomic_xor" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::BitXor, false),
                 AtomicRwOp::SeqCst,
             )?,
-            "atomic_xor_acq" => this.atomic_op_min_max(
+            "atomic_xor_acq" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::BitXor, false),
                 AtomicRwOp::Acquire,
             )?,
-            "atomic_xor_rel" => this.atomic_op_min_max(
+            "atomic_xor_rel" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::BitXor, false),
                 AtomicRwOp::Release,
             )?,
-            "atomic_xor_acqrel" => this.atomic_op_min_max(
+            "atomic_xor_acqrel" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::BitXor, false),
                 AtomicRwOp::AcqRel,
             )?,
-            "atomic_xor_relaxed" => this.atomic_op_min_max(
+            "atomic_xor_relaxed" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::BitXor, false),
                 AtomicRwOp::Relaxed,
             )?,
-            "atomic_and" => this.atomic_op_min_max(
+            "atomic_and" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::BitAnd, false),
                 AtomicRwOp::SeqCst,
             )?,
-            "atomic_and_acq" => this.atomic_op_min_max(
+            "atomic_and_acq" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::BitAnd, false),
                 AtomicRwOp::Acquire,
             )?,
-            "atomic_and_rel" => this.atomic_op_min_max(
+            "atomic_and_rel" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::BitAnd, false),
                 AtomicRwOp::Release,
             )?,
-            "atomic_and_acqrel" => this.atomic_op_min_max(
+            "atomic_and_acqrel" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::BitAnd, false),
                 AtomicRwOp::AcqRel,
             )?,
-            "atomic_and_relaxed" => this.atomic_op_min_max(
+            "atomic_and_relaxed" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::BitAnd, false),
                 AtomicRwOp::Relaxed,
             )?,
-            "atomic_nand" => this.atomic_op_min_max(
+            "atomic_nand" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::BitAnd, true),
                 AtomicRwOp::SeqCst,
             )?,
-            "atomic_nand_acq" => this.atomic_op_min_max(
+            "atomic_nand_acq" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::BitAnd, true),
                 AtomicRwOp::Acquire,
             )?,
-            "atomic_nand_rel" => this.atomic_op_min_max(
+            "atomic_nand_rel" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::BitAnd, true),
                 AtomicRwOp::Release,
             )?,
-            "atomic_nand_acqrel" => this.atomic_op_min_max(
+            "atomic_nand_acqrel" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::BitAnd, true),
                 AtomicRwOp::AcqRel,
             )?,
-            "atomic_nand_relaxed" => this.atomic_op_min_max(
+            "atomic_nand_relaxed" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::BitAnd, true),
                 AtomicRwOp::Relaxed,
             )?,
-            "atomic_xadd" => this.atomic_op_min_max(
+            "atomic_xadd" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::Add, false),
                 AtomicRwOp::SeqCst,
             )?,
-            "atomic_xadd_acq" => this.atomic_op_min_max(
+            "atomic_xadd_acq" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::Add, false),
                 AtomicRwOp::Acquire,
             )?,
-            "atomic_xadd_rel" => this.atomic_op_min_max(
+            "atomic_xadd_rel" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::Add, false),
                 AtomicRwOp::Release,
             )?,
-            "atomic_xadd_acqrel" => this.atomic_op_min_max(
+            "atomic_xadd_acqrel" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::Add, false),
                 AtomicRwOp::AcqRel,
             )?,
-            "atomic_xadd_relaxed" => this.atomic_op_min_max(
+            "atomic_xadd_relaxed" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::Add, false),
                 AtomicRwOp::Relaxed,
             )?,
-            "atomic_xsub" => this.atomic_op_min_max(
+            "atomic_xsub" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::Sub, false),
                 AtomicRwOp::SeqCst,
             )?,
-            "atomic_xsub_acq" => this.atomic_op_min_max(
+            "atomic_xsub_acq" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::Sub, false),
                 AtomicRwOp::Acquire,
             )?,
-            "atomic_xsub_rel" => this.atomic_op_min_max(
+            "atomic_xsub_rel" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::Sub, false),
                 AtomicRwOp::Release,
             )?,
-            "atomic_xsub_acqrel" => this.atomic_op_min_max(
+            "atomic_xsub_acqrel" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::Sub, false),
                 AtomicRwOp::AcqRel,
             )?,
-            "atomic_xsub_relaxed" => this.atomic_op_min_max(
+            "atomic_xsub_relaxed" => this.atomic_op(
                 args,
                 dest,
                 AtomicOp::MirOp(BinOp::Sub, false),
                 AtomicRwOp::Relaxed,
             )?,
             "atomic_min" =>
-                this.atomic_op_min_max(args, dest, AtomicOp::Min, AtomicRwOp::SeqCst)?,
+                this.atomic_op(args, dest, AtomicOp::Min, AtomicRwOp::SeqCst)?,
             "atomic_min_acq" =>
-                this.atomic_op_min_max(args, dest, AtomicOp::Min, AtomicRwOp::Acquire)?,
+                this.atomic_op(args, dest, AtomicOp::Min, AtomicRwOp::Acquire)?,
             "atomic_min_rel" =>
-                this.atomic_op_min_max(args, dest, AtomicOp::Min, AtomicRwOp::Release)?,
+                this.atomic_op(args, dest, AtomicOp::Min, AtomicRwOp::Release)?,
             "atomic_min_acqrel" =>
-                this.atomic_op_min_max(args, dest, AtomicOp::Min, AtomicRwOp::AcqRel)?,
+                this.atomic_op(args, dest, AtomicOp::Min, AtomicRwOp::AcqRel)?,
             "atomic_min_relaxed" =>
-                this.atomic_op_min_max(args, dest, AtomicOp::Min, AtomicRwOp::Relaxed)?,
+                this.atomic_op(args, dest, AtomicOp::Min, AtomicRwOp::Relaxed)?,
             "atomic_max" =>
-                this.atomic_op_min_max(args, dest, AtomicOp::Max, AtomicRwOp::SeqCst)?,
+                this.atomic_op(args, dest, AtomicOp::Max, AtomicRwOp::SeqCst)?,
             "atomic_max_acq" =>
-                this.atomic_op_min_max(args, dest, AtomicOp::Max, AtomicRwOp::Acquire)?,
+                this.atomic_op(args, dest, AtomicOp::Max, AtomicRwOp::Acquire)?,
             "atomic_max_rel" =>
-                this.atomic_op_min_max(args, dest, AtomicOp::Max, AtomicRwOp::Release)?,
+                this.atomic_op(args, dest, AtomicOp::Max, AtomicRwOp::Release)?,
             "atomic_max_acqrel" =>
-                this.atomic_op_min_max(args, dest, AtomicOp::Max, AtomicRwOp::AcqRel)?,
+                this.atomic_op(args, dest, AtomicOp::Max, AtomicRwOp::AcqRel)?,
             "atomic_max_relaxed" =>
-                this.atomic_op_min_max(args, dest, AtomicOp::Max, AtomicRwOp::Relaxed)?,
+                this.atomic_op(args, dest, AtomicOp::Max, AtomicRwOp::Relaxed)?,
             "atomic_umin" =>
-                this.atomic_op_min_max(args, dest, AtomicOp::Min, AtomicRwOp::SeqCst)?,
+                this.atomic_op(args, dest, AtomicOp::Min, AtomicRwOp::SeqCst)?,
             "atomic_umin_acq" =>
-                this.atomic_op_min_max(args, dest, AtomicOp::Min, AtomicRwOp::Acquire)?,
+                this.atomic_op(args, dest, AtomicOp::Min, AtomicRwOp::Acquire)?,
             "atomic_umin_rel" =>
-                this.atomic_op_min_max(args, dest, AtomicOp::Min, AtomicRwOp::Release)?,
+                this.atomic_op(args, dest, AtomicOp::Min, AtomicRwOp::Release)?,
             "atomic_umin_acqrel" =>
-                this.atomic_op_min_max(args, dest, AtomicOp::Min, AtomicRwOp::AcqRel)?,
+                this.atomic_op(args, dest, AtomicOp::Min, AtomicRwOp::AcqRel)?,
             "atomic_umin_relaxed" =>
-                this.atomic_op_min_max(args, dest, AtomicOp::Min, AtomicRwOp::Relaxed)?,
+                this.atomic_op(args, dest, AtomicOp::Min, AtomicRwOp::Relaxed)?,
             "atomic_umax" =>
-                this.atomic_op_min_max(args, dest, AtomicOp::Max, AtomicRwOp::SeqCst)?,
+                this.atomic_op(args, dest, AtomicOp::Max, AtomicRwOp::SeqCst)?,
             "atomic_umax_acq" =>
-                this.atomic_op_min_max(args, dest, AtomicOp::Max, AtomicRwOp::Acquire)?,
+                this.atomic_op(args, dest, AtomicOp::Max, AtomicRwOp::Acquire)?,
             "atomic_umax_rel" =>
-                this.atomic_op_min_max(args, dest, AtomicOp::Max, AtomicRwOp::Release)?,
+                this.atomic_op(args, dest, AtomicOp::Max, AtomicRwOp::Release)?,
             "atomic_umax_acqrel" =>
-                this.atomic_op_min_max(args, dest, AtomicOp::Max, AtomicRwOp::AcqRel)?,
+                this.atomic_op(args, dest, AtomicOp::Max, AtomicRwOp::AcqRel)?,
             "atomic_umax_relaxed" =>
-                this.atomic_op_min_max(args, dest, AtomicOp::Max, AtomicRwOp::Relaxed)?,
+                this.atomic_op(args, dest, AtomicOp::Max, AtomicRwOp::Relaxed)?,
 
             // Query type information
             "assert_zero_valid" | "assert_uninit_valid" => {
@@ -729,7 +729,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         Ok(())
     }
 
-    fn atomic_op_min_max(
+    fn atomic_op(
         &mut self,
         args: &[OpTy<'tcx, Tag>],
         dest: &PlaceTy<'tcx, Tag>,


### PR DESCRIPTION
The corresponding enum is called `AtomicOp` so IMO this also makes more sense as the name for the function.