### PR TITLE
Support breakpoint intrinsic

### DIFF
--- a/src/shims/intrinsics.rs
+++ b/src/shims/intrinsics.rs
@@ -655,6 +655,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             "try" => return this.handle_try(args, dest, ret),
 
             "breakpoint" => {
+                let &[] = check_arg_count(args)?;
                 // normally this would raise a SIGTRAP, which aborts if no debugger is connected
                 throw_machine_stop!(TerminationInfo::Abort("Trace/breakpoint trap".to_string()))
             }

--- a/src/shims/intrinsics.rs
+++ b/src/shims/intrinsics.rs
@@ -654,6 +654,11 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
             "try" => return this.handle_try(args, dest, ret),
 
+            "breakpoint" => {
+                // normally this would raise a SIGTRAP, which aborts if no debugger is connected
+                throw_machine_stop!(TerminationInfo::Abort("Trace/breakpoint trap".to_string()))
+            }
+
             name => throw_unsup_format!("unimplemented intrinsic: {}", name),
         }
 

--- a/tests/compile-fail/breakpoint.rs
+++ b/tests/compile-fail/breakpoint.rs
@@ -1,0 +1,7 @@
+#![feature(core_intrinsics)]
+
+fn main() {
+    unsafe {
+        core::intrinsics::breakpoint() //~ ERROR Trace/breakpoint trap
+    };
+}


### PR DESCRIPTION
The `breakpoint` intrinsic raises a `SIGTRAP` signal. If a debugger is attached to a normal program, then `SIGTRAP` can be used to trigger breakpoints in debuggers like `gdb`. If there is no debugger, then the program exits with a message like `Trace/breakpoint trap (core dumped)`. This adds support for the intrinsic in Miri. While actually passing through the `SIGTRAP` doesn't make sense in a Miri context (if it just raised the signal normally then it would allow for debugging Miri itself, not the program being evaluated). As such, it just raises an error.