### PR TITLE
Remove unwrap_none/expect_none.

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -179,7 +179,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             )?;
             this.write_immediate(*arg, &callee_arg)?;
         }
-        callee_args.next().expect_none("callee has more arguments than expected");
+        assert_eq!(callee_args.next(), None, "callee has more arguments than expected");
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(rustc_private)]
-#![feature(option_expect_none, option_unwrap_none)]
 #![feature(map_first_last)]
 #![feature(never_type)]
 #![feature(or_patterns)]

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -176,11 +176,13 @@ impl MemoryExtra {
     ) {
         let ptr = ptr.assert_ptr();
         assert_eq!(ptr.offset, Size::ZERO);
-        this.memory
-            .extra
-            .extern_statics
-            .insert(Symbol::intern(name), ptr.alloc_id)
-            .unwrap_none();
+        assert_eq!(
+            this.memory
+                .extra
+                .extern_statics
+                .insert(Symbol::intern(name), ptr.alloc_id),
+            None
+        );
     }
 
     /// Sets up the "extern statics" for this machine.

--- a/src/shims/posix/fs.rs
+++ b/src/shims/posix/fs.rs
@@ -223,7 +223,7 @@ impl<'tcx> FileHandler {
             self.handles.last_key_value().map(|(fd, _)| fd.checked_add(1).unwrap()).unwrap_or(min_fd)
         });
 
-        self.handles.insert(new_fd, file_handle).unwrap_none();
+        assert_eq!(self.handles.insert(new_fd, file_handle), None);
         new_fd
     }
 }
@@ -381,7 +381,7 @@ impl DirHandler {
     fn insert_new(&mut self, read_dir: ReadDir) -> u64 {
         let id = self.next_id;
         self.next_id += 1;
-        self.streams.insert(id, read_dir).unwrap_none();
+        assert_eq!(self.streams.insert(id, read_dir), None);
         id
     }
 }

--- a/src/shims/posix/fs.rs
+++ b/src/shims/posix/fs.rs
@@ -223,7 +223,7 @@ impl<'tcx> FileHandler {
             self.handles.last_key_value().map(|(fd, _)| fd.checked_add(1).unwrap()).unwrap_or(min_fd)
         });
 
-        assert_eq!(self.handles.insert(new_fd, file_handle), None);
+        assert!(self.handles.insert(new_fd, file_handle).is_none());
         new_fd
     }
 }
@@ -381,7 +381,7 @@ impl DirHandler {
     fn insert_new(&mut self, read_dir: ReadDir) -> u64 {
         let id = self.next_id;
         self.next_id += 1;
-        assert_eq!(self.streams.insert(id, read_dir), None);
+        assert!(self.streams.insert(id, read_dir).is_none());
         id
     }
 }

--- a/src/shims/tls.rs
+++ b/src/shims/tls.rs
@@ -65,7 +65,7 @@ impl<'tcx> TlsData<'tcx> {
     pub fn create_tls_key(&mut self, dtor: Option<ty::Instance<'tcx>>, max_size: Size) -> InterpResult<'tcx, TlsKey> {
         let new_key = self.next_key;
         self.next_key += 1;
-        assert_eq!(self.keys.insert(new_key, TlsEntry { data: Default::default(), dtor }), None);
+        assert!(self.keys.insert(new_key, TlsEntry { data: Default::default(), dtor }).is_none());
         trace!("New TLS key allocated: {} with dtor {:?}", new_key, dtor);
 
         if max_size.bits() < 128 && new_key >= (1u128 << max_size.bits() as u128) {

--- a/src/shims/tls.rs
+++ b/src/shims/tls.rs
@@ -65,7 +65,7 @@ impl<'tcx> TlsData<'tcx> {
     pub fn create_tls_key(&mut self, dtor: Option<ty::Instance<'tcx>>, max_size: Size) -> InterpResult<'tcx, TlsKey> {
         let new_key = self.next_key;
         self.next_key += 1;
-        self.keys.insert(new_key, TlsEntry { data: Default::default(), dtor }).unwrap_none();
+        assert_eq!(self.keys.insert(new_key, TlsEntry { data: Default::default(), dtor }), None);
         trace!("New TLS key allocated: {} with dtor {:?}", new_key, dtor);
 
         if max_size.bits() < 128 && new_key >= (1u128 << max_size.bits() as u128) {

--- a/src/stacked_borrows.rs
+++ b/src/stacked_borrows.rs
@@ -201,7 +201,7 @@ impl GlobalState {
         self.base_ptr_ids.get(&id).copied().unwrap_or_else(|| {
             let tag = Tag::Tagged(self.new_ptr());
             trace!("New allocation {:?} has base tag {:?}", id, tag);
-            self.base_ptr_ids.insert(id, tag).unwrap_none();
+            assert_eq!(self.base_ptr_ids.insert(id, tag), None);
             tag
         })
     }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -405,10 +405,10 @@ impl<'mir, 'tcx: 'mir> ThreadManager<'mir, 'tcx> {
         call_time: Time,
         callback: TimeoutCallback<'mir, 'tcx>,
     ) {
-        assert_eq!(
+        assert!(
             self.timeout_callbacks
-                .insert(thread, TimeoutCallbackInfo { call_time, callback }),
-            None,
+                .insert(thread, TimeoutCallbackInfo { call_time, callback })
+                .is_none()
         );
     }
 

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -255,10 +255,12 @@ impl<'mir, 'tcx: 'mir> ThreadManager<'mir, 'tcx> {
     ///
     /// Panics if a thread local is initialized twice for the same thread.
     fn set_thread_local_alloc_id(&self, def_id: DefId, new_alloc_id: AllocId) {
-        self.thread_local_alloc_ids
-            .borrow_mut()
-            .insert((def_id, self.active_thread), new_alloc_id)
-            .unwrap_none();
+        assert_eq!(
+            self.thread_local_alloc_ids
+                .borrow_mut()
+                .insert((def_id, self.active_thread), new_alloc_id),
+            None
+        );
     }
 
     /// Borrow the stack of the active thread.
@@ -403,9 +405,11 @@ impl<'mir, 'tcx: 'mir> ThreadManager<'mir, 'tcx> {
         call_time: Time,
         callback: TimeoutCallback<'mir, 'tcx>,
     ) {
-        self.timeout_callbacks
-            .insert(thread, TimeoutCallbackInfo { call_time, callback })
-            .unwrap_none();
+        assert_eq!(
+            self.timeout_callbacks
+                .insert(thread, TimeoutCallbackInfo { call_time, callback }),
+            None,
+        );
     }
 
     /// Unregister the callback for the `thread`.

--- a/tests/run-pass/panic/std-panic-locations.rs
+++ b/tests/run-pass/panic/std-panic-locations.rs
@@ -35,5 +35,5 @@ fn main() {
     // Cleanup: reset to default hook.
     drop(std::panic::take_hook());
 
-    assert_eq!(HOOK_COUNT.load(Ordering::Relaxed), 8);
+    assert_eq!(HOOK_COUNT.load(Ordering::Relaxed), 6);
 }

--- a/tests/run-pass/panic/std-panic-locations.rs
+++ b/tests/run-pass/panic/std-panic-locations.rs
@@ -1,4 +1,3 @@
-#![feature(option_expect_none, option_unwrap_none)]
 //! Test that panic locations for `#[track_caller]` functions in std have the correct
 //! location reported.
 
@@ -24,10 +23,6 @@ fn main() {
     let nope: Option<()> = None;
     assert_panicked(|| nope.unwrap());
     assert_panicked(|| nope.expect(""));
-
-    let yep: Option<()> = Some(());
-    assert_panicked(|| yep.unwrap_none());
-    assert_panicked(|| yep.expect_none(""));
 
     let oops: Result<(), ()> = Err(());
     assert_panicked(|| oops.unwrap());


### PR DESCRIPTION
We're not going to stabilize `Option::{unwrap_none, expect_none}`. (See https://github.com/rust-lang/rust/issues/62633.) This removes the usage of those unstable methods from miri.