### PR TITLE
Improve error message of calling unsupported non-"C"/"system"-ABI foreign function

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -169,9 +169,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         let this = self.eval_context_mut();
         let param_env = ty::ParamEnv::reveal_all(); // in Miri this is always the param_env we use... and this.param_env is private.
         let callee_abi = f.ty(*this.tcx, param_env).fn_sig(*this.tcx).abi();
-        if callee_abi != caller_abi {
-            throw_ub_format!("calling a function with ABI {} using caller ABI {}", callee_abi.name(), caller_abi.name())
-        }
+        check_abi(caller_abi, callee_abi)?;
 
         // Push frame.
         let mir = &*this.load_mir(f.def, None)?;

--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -13,6 +13,36 @@ use crate::*;
 use super::backtrace::EvalContextExt as _;
 use helpers::{check_abi, check_arg_count};
 
+/// This macro behaves just like `match $link_name { ... }`, but inserts a
+/// `$crate::helpers::check_abi($abi, $exp_abi)?` call at each match arm
+/// except the wildcard one.
+#[macro_export]
+macro_rules! match_with_abi_check {
+    ($link_name:expr, $abi:expr, $exp_abi:expr, {
+        $(|)? $($pattern:pat)|+ $(if $guard:expr)? => $shim_impl:block
+        $($remaining:tt)+
+    }) => {
+        match ($link_name, $abi, $exp_abi) {
+            ($($pattern)|+, abi, exp_abi) $(if $guard)? => {
+                $crate::helpers::check_abi(abi, exp_abi)?;
+                $shim_impl
+            }
+            (link_name, abi, exp_abi) => match_with_abi_check!(
+                link_name,
+                abi,
+                exp_abi,
+                { $($remaining)* }
+            ),
+        }
+    };
+    ($link_name:ident, $abi:ident, $exp_abi:ident, {
+        _ => $fallback:expr $(,)?
+    }) => ({
+        let _ = ($link_name, $abi, $exp_abi);
+        $fallback
+    });
+}
+
 impl<'mir, 'tcx: 'mir> EvalContextExt<'mir, 'tcx> for crate::MiriEvalContext<'mir, 'tcx> {}
 pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx> {
     /// Returns the minimum alignment for the target architecture for allocations of the given size.

--- a/src/shims/posix/macos/foreign_items.rs
+++ b/src/shims/posix/macos/foreign_items.rs
@@ -1,4 +1,5 @@
 use rustc_middle::mir;
+use rustc_target::spec::abi::Abi;
 
 use crate::*;
 use helpers::check_arg_count;
@@ -10,13 +11,14 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
     fn emulate_foreign_item_by_name(
         &mut self,
         link_name: &str,
+        abi: Abi,
         args: &[OpTy<'tcx, Tag>],
         dest: &PlaceTy<'tcx, Tag>,
         _ret: mir::BasicBlock,
     ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
 
-        match link_name {
+        match_with_abi_check!(link_name, abi, Abi::C { unwind: false }, {
             // errno
             "__error" => {
                 let &[] = check_arg_count(args)?;
@@ -83,7 +85,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 let &[ref info] = check_arg_count(args)?;
                 let result = this.mach_timebase_info(info)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
-            },
+            }
 
             // Access to command-line arguments
             "_NSGetArgc" => {
@@ -136,7 +138,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             }
 
             _ => throw_unsup_format!("can't call foreign function: {}", link_name),
-        };
+        });
 
         Ok(true)
     }

--- a/tests/compile-fail/unsupported_foreign_function.rs
+++ b/tests/compile-fail/unsupported_foreign_function.rs
@@ -1,0 +1,9 @@
+fn main() {
+    extern "Rust" {
+        fn foo();
+    }
+
+    unsafe {
+        foo(); //~ ERROR unsupported operation: can't call foreign function: foo
+    }
+}

--- a/tests/compile-fail/unsupported_posix_dlsym.rs
+++ b/tests/compile-fail/unsupported_posix_dlsym.rs
@@ -1,0 +1,14 @@
+// ignore-windows: No dlsym() on Windows
+
+#![feature(rustc_private)]
+
+extern crate libc;
+
+use std::ptr;
+
+fn main() {
+    unsafe {
+        libc::dlsym(ptr::null_mut(), b"foo\0".as_ptr().cast());
+        //~^ ERROR unsupported operation: unsupported
+    }
+}

--- a/tests/compile-fail/unsupported_windows_dlsym.rs
+++ b/tests/compile-fail/unsupported_windows_dlsym.rs
@@ -1,0 +1,18 @@
+// ignore-linux: GetProcAddress() is not available on Linux
+// ignore-macos: GetProcAddress() is not available on macOS
+
+use std::{ffi::c_void, os::raw::c_char, ptr};
+
+extern "system" {
+    fn GetProcAddress(
+        hModule: *mut c_void,
+        lpProcName: *const c_char,
+    ) -> extern "system" fn() -> isize;
+}
+
+fn main() {
+    unsafe {
+        GetProcAddress(ptr::null_mut(), b"foo\0".as_ptr().cast());
+        //~^ ERROR unsupported operation: unsupported Windows dlsym: foo
+    }
+}


### PR DESCRIPTION
Miri currently reports the following `foo()` call has ABI-mismatch UB:
```rust
#[cfg(unix)]
extern "Rust" { // or any non-"C" ABI
    fn foo();
}

#[cfg(windows)]
extern "C" { // or any non-"system" ABI
    fn foo();
}

fn main() {
    unsafe {
        foo();
    }
}
```
[Output when targeting Linux](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2018&gist=72afc3bd4d9fdab962422cfc2c5a2166) (and maybe also macOS):
```
error: Undefined Behavior: calling a function with ABI C using caller ABI Rust
  --> src/main.rs:13:9
   |
13 |         foo();
   |         ^^^^^ calling a function with ABI C using caller ABI Rust
   |
   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavio
```
Output when targeting Windows:
```
error: Undefined Behavior: calling a function with ABI system using caller ABI C
  --> <anon>:13:9
   |
13 |         foo();
   |         ^^^^^ calling a function with ABI system using caller ABI C
   |
   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
```

However, to my knowledge, that's not UB -- it's just unsupported by Miri (and Miri can't assume the function has `"C"` or `"system"` ABI since Miri doesn't know about it). I believe that is because of the overzealous `check_abi()` call before the long `match` in `src/shims/{posix,windows}/foreign_items.rs`. The ABI is checked to match the system one (`"system"` on Windows, `"C"` otherwise) no matter the callee is recognized as a shim or an unsupported foreign function.

Therefore, this PR removes the `check_abi()` call before the `match` and inserts `check_abi()` calls to each non-wildcard match arm using a macro.