### PR TITLE
Improvements to the README item on `-Zmiri-track-raw-pointers`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,9 +252,10 @@ environment variable:
 * `-Zmiri-track-raw-pointers` makes Stacked Borrows track a pointer tag even for
   raw pointers. This can make valid code fail to pass the checks, but also can
   help identify latent aliasing issues in code that Miri accepts by default. You
-  can recognize false positives by "<untagged>" occurring in the message -- this
+  can recognize false positives by `<untagged>` occurring in the message -- this
   indicates a pointer that was cast from an integer, so Miri was unable to track
-  this pointer.
+  this pointer. It does not have false negatives; code that works with
+  `-Zmiri-track-raw-pointers` will work without `-Zmiri-track-raw-pointers`.
 
 Some native rustc `-Z` flags are also very relevant for Miri:
 

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ environment variable:
   indicates a pointer that was cast from an integer, so Miri was unable to track
   this pointer. Note that it is not currently guaranteed that code that works
   with `-Zmiri-track-raw-pointers` also works without
-  `-Zmiri-track-raw-pointers`.
+  `-Zmiri-track-raw-pointers`, but for the vast majority of code, this will be the case.
 
 Some native rustc `-Z` flags are also very relevant for Miri:
 

--- a/README.md
+++ b/README.md
@@ -254,8 +254,9 @@ environment variable:
   help identify latent aliasing issues in code that Miri accepts by default. You
   can recognize false positives by `<untagged>` occurring in the message -- this
   indicates a pointer that was cast from an integer, so Miri was unable to track
-  this pointer. It does not have false negatives; code that works with
-  `-Zmiri-track-raw-pointers` will work without `-Zmiri-track-raw-pointers`.
+  this pointer. Note that it is not currently guaranteed that code that works
+  with `-Zmiri-track-raw-pointers` also works without
+  `-Zmiri-track-raw-pointers`.
 
 Some native rustc `-Z` flags are also very relevant for Miri:
 


### PR DESCRIPTION
[Rendered](https://github.com/jrvanwhy/miri/tree/track-raw-pointers-doc)

Minor change: I changed the quotes around `<untagged>` into backticks, so they render correctly in markdown.

~~Significant change: I documented that `-Zmiri-track-raw-pointers` is a strictly more restrictive model that "normal" Stacked Borrows. **I am not confident this change is correct, please verify it.** If this change is not correct, let me know, and I'll update this PR to document that :-)~~

EDIT: I was wrong, `-Zmiri-track-raw-pointers` may not be strictly more restrictive. I added the following sentence to prevent others from making the same assumption that I did:

> Note that it is not currently guaranteed that code that works with `-Zmiri-track-raw-pointers` also works without `-Zmiri-track-raw-pointers`.