### PR TITLE
also test old getrandom

### DIFF
--- a/test-cargo-miri/Cargo.lock
+++ b/test-cargo-miri/Cargo.lock
@@ -14,7 +14,8 @@ version = "0.1.0"
 dependencies = [
  "byteorder",
  "cdylib",
- "getrandom",
+ "getrandom 0.1.16",
+ "getrandom 0.2.2",
  "issue_1567",
  "issue_1691",
  "issue_1705",
@@ -37,13 +38,24 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -141,7 +153,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -187,6 +199,12 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/test-cargo-miri/Cargo.toml
+++ b/test-cargo-miri/Cargo.toml
@@ -16,7 +16,8 @@ issue_1705 = { path = "issue-1705" }
 
 [dev-dependencies]
 rand = { version = "0.8", features = ["small_rng"] }
-getrandom = { version = "0.2" }
+getrandom_1 = { package = "getrandom", version = "0.1" }
+getrandom_2 = { package = "getrandom", version = "0.2" }
 serde_derive = "1.0" # not actually used, but exercises some unique code path (`--extern` .so file)
 
 [lib]

--- a/test-cargo-miri/tests/test.rs
+++ b/test-cargo-miri/tests/test.rs
@@ -24,9 +24,10 @@ fn does_not_work_on_miri() {
 
 #[test]
 fn entropy_rng() {
-    // Test `getrandom` directly.
+    // Test `getrandom` directly (in multiple different versions).
     let mut data = vec![0; 16];
-    getrandom::getrandom(&mut data).unwrap();
+    getrandom_1::getrandom(&mut data).unwrap();
+    getrandom_2::getrandom(&mut data).unwrap();
 
     // Try seeding with "real" entropy.
     let mut rng = SmallRng::from_entropy();


### PR DESCRIPTION
getrandom 0.1 is still in use, so let's make sure it also still works with Miri.