### PR TITLE
Don't use `MIRI_DEFAULT_ARGS` to compile host crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ You can pass arguments to Miri via `MIRIFLAGS`. For example,
 `MIRIFLAGS="-Zmiri-disable-stacked-borrows" cargo miri run` runs the program
 without checking the aliasing of references.
 
-When compiling code via `cargo miri`, the `cfg(miri)` config flag is set. You
-can use this to ignore test cases that fail under Miri because they do things
-Miri does not support:
+When compiling code via `cargo miri`, the `cfg(miri)` config flag is set for code
+that will be interpret under Miri. You can use this to ignore test cases that fail
+under Miri because they do things Miri does not support:
 
 ```rust
 #[test]
@@ -286,9 +286,11 @@ Moreover, Miri recognizes some environment variables:
 The following environment variables are internal, but used to communicate between
 different Miri binaries, and as such worth documenting:
 
-* `MIRI_BE_RUSTC` when set to any value tells the Miri driver to actually not
-  interpret the code but compile it like rustc would. This is useful to be sure
-  that the compiled `rlib`s are compatible with Miri.
+* `MIRI_BE_RUSTC` can be set to `host` or `target`. It tells the Miri driver to
+  actually not interpret the code but compile it like rustc would. With `target`, Miri sets
+  some compiler flags to prepare the code for interpretation; with `host`, this is not done.
+  This environment variable is useful to be sure that the compiled `rlib`s are compatible
+  with Miri.
   When set while running `cargo-miri`, it indicates that we are part of a sysroot
   build (for which some crates need special treatment).
 * `MIRI_CALLED_FROM_RUSTDOC` when set to any value tells `cargo-miri` that it is

--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -420,7 +420,7 @@ path = "lib.rs"
     } else {
         command.env("RUSTC", &cargo_miri_path);
     }
-    command.env("MIRI_BE_RUSTC", "1");
+    command.env("MIRI_BE_RUSTC", "target");
     // Make sure there are no other wrappers or flags getting in our way
     // (Cc https://github.com/rust-lang/miri/issues/1421).
     // This is consistent with normal `cargo build` that does not apply `RUSTFLAGS`
@@ -694,7 +694,7 @@ fn phase_cargo_rustc(mut args: env::Args) {
             }
 
             cmd.args(&env.args);
-            cmd.env("MIRI_BE_RUSTC", "1");
+            cmd.env("MIRI_BE_RUSTC", "target");
 
             if verbose {
                 eprintln!("[cargo-miri rustc] captured input:\n{}", std::str::from_utf8(&env.stdin).unwrap());
@@ -758,7 +758,9 @@ fn phase_cargo_rustc(mut args: env::Args) {
 
     // We want to compile, not interpret. We still use Miri to make sure the compiler version etc
     // are the exact same as what is used for interpretation.
-    cmd.env("MIRI_BE_RUSTC", "1");
+    // MIRI_DEFAULT_ARGS should not be used to build host crates, hence setting "target" or "host"
+    // as the value here to help Miri differentiate them.
+    cmd.env("MIRI_BE_RUSTC", if target_crate { "target" } else { "host" });
 
     // Run it.
     if verbose {

--- a/test-cargo-miri/Cargo.lock
+++ b/test-cargo-miri/Cargo.lock
@@ -19,6 +19,7 @@ dependencies = [
  "issue_1567",
  "issue_1691",
  "issue_1705",
+ "issue_1760",
  "rand",
  "serde_derive",
 ]
@@ -84,6 +85,10 @@ version = "0.1.0"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "issue_1760"
+version = "0.1.0"
 
 [[package]]
 name = "libc"

--- a/test-cargo-miri/Cargo.toml
+++ b/test-cargo-miri/Cargo.toml
@@ -13,6 +13,7 @@ cdylib = { path = "cdylib" }
 issue_1567 = { path = "issue-1567" }
 issue_1691 = { path = "issue-1691" }
 issue_1705 = { path = "issue-1705" }
+issue_1760 = { path = "issue-1760" }
 
 [dev-dependencies]
 rand = { version = "0.8", features = ["small_rng"] }

--- a/test-cargo-miri/build.rs
+++ b/test-cargo-miri/build.rs
@@ -1,5 +1,10 @@
 #![feature(llvm_asm)]
 
+use std::env;
+
+#[cfg(miri)]
+compile_error!("`miri` cfg should not be set in build script");
+
 fn not_in_miri() -> i32 {
     // Inline assembly definitely does not work in Miri.
     let dummy = 42;
@@ -11,6 +16,9 @@ fn not_in_miri() -> i32 {
 
 fn main() {
     not_in_miri();
+    // Cargo calls `miri --print=cfg` to populate the `CARGO_CFG_*` env vars.
+    // Make sure that the "miri" flag is set.
+    assert!(env::var_os("CARGO_CFG_MIRI").is_some());
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=MIRITESTVAR");
     println!("cargo:rustc-env=MIRITESTVAR=testval");

--- a/test-cargo-miri/issue-1760/Cargo.toml
+++ b/test-cargo-miri/issue-1760/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "issue_1760"
+version = "0.1.0"
+authors = ["Miri Team"]
+edition = "2018"
+
+[lib]
+proc-macro = true

--- a/test-cargo-miri/issue-1760/build.rs
+++ b/test-cargo-miri/issue-1760/build.rs
@@ -1,0 +1,10 @@
+use std::env;
+
+#[cfg(miri)]
+compile_error!("`miri` cfg should not be set in build script");
+
+fn main() {
+    // Cargo calls `miri --print=cfg` to populate the `CARGO_CFG_*` env vars.
+    // Make sure that the "miri" flag is not set since we are building a procedural macro crate.
+    assert!(env::var_os("CARGO_CFG_MIRI").is_none());
+}

--- a/test-cargo-miri/issue-1760/src/lib.rs
+++ b/test-cargo-miri/issue-1760/src/lib.rs
@@ -1,0 +1,9 @@
+use proc_macro::TokenStream;
+
+#[cfg(miri)]
+compile_error!("`miri` cfg should not be set in proc-macro");
+
+#[proc_macro]
+pub fn use_the_dependency(_: TokenStream) -> TokenStream {
+    TokenStream::new()
+}

--- a/test-cargo-miri/src/lib.rs
+++ b/test-cargo-miri/src/lib.rs
@@ -11,5 +11,6 @@
 pub fn make_true() -> bool {
     issue_1567::use_the_dependency();
     issue_1705::use_the_dependency();
+    issue_1760::use_the_dependency!();
     issue_1691::use_me()
 }

--- a/tests/run-pass/cfg_miri.rs
+++ b/tests/run-pass/cfg_miri.rs
@@ -1,0 +1,3 @@
+fn main() {
+    assert!(cfg!(miri));
+}


### PR DESCRIPTION
They (specifically, `--cfg=miri`) may cause procedural macros (and probably build scripts) to depend on Miri-only symbols, such as `miri_resolve_frame`.

This PR makes `miri` detect host crates inspecting the value of the `MIRI_BE_RUSTC` environment variable (`target` -> target crate, `host` -> host crate, other -> panic) and skip the insertion of `MIRI_DEFAULT_ARGS` if it's a host crate.

Fixes #1760