### PR TITLE
remove compatibility code for passing miri flags via cargo arguments

### DIFF
--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -521,46 +521,8 @@ fn phase_cargo_miri(mut args: env::Args) {
         &host
     };
 
-    // Forward all further arguments. We do some processing here because we want to
-    // detect people still using the old way of passing flags to Miri
-    // (`cargo miri -- -Zmiri-foo`).
-    while let Some(arg) = args.next() {
-        cmd.arg(&arg);
-        if arg == "--" {
-            // Check if the next argument starts with `-Zmiri`. If yes, we assume
-            // this is an old-style invocation.
-            if let Some(next_arg) = args.next() {
-                if next_arg.starts_with("-Zmiri") || next_arg == "--" {
-                    eprintln!(
-                        "WARNING: it seems like you are setting Miri's flags in `cargo miri` the old way,\n\
-                        i.e., by passing them after the first `--`. This style is deprecated; please set\n\
-                        the MIRIFLAGS environment variable instead. `cargo miri run/test` now interprets\n\
-                        arguments the exact same way as `cargo run/test`."
-                    );
-                    // Old-style invocation. Turn these into MIRIFLAGS, if there are any.
-                    if next_arg != "--" {
-                        let mut miriflags = env::var("MIRIFLAGS").unwrap_or_default();
-                        miriflags.push(' ');
-                        miriflags.push_str(&next_arg);
-                        while let Some(further_arg) = args.next() {
-                            if further_arg == "--" {
-                                // End of the Miri flags!
-                                break;
-                            }
-                            miriflags.push(' ');
-                            miriflags.push_str(&further_arg);
-                        }
-                        env::set_var("MIRIFLAGS", miriflags);
-                    }
-                    // Pass the remaining flags to cargo.
-                    cmd.args(args);
-                    break;
-                }
-                // Not a Miri argument after all, make sure we pass it to cargo.
-                cmd.arg(next_arg);
-            }
-        }
-    }
+    // Forward all further arguments to cargo.
+    cmd.args(args);
 
     // Set `RUSTC_WRAPPER` to ourselves.  Cargo will prepend that binary to its usual invocation,
     // i.e., the first argument is `rustc` -- which is what we use in `main` to distinguish


### PR DESCRIPTION
With https://github.com/rust-lang/miri/pull/1540, we deprecated `cargo miri test -- -Zmiri-disable-stacked-borrows` as a style of passing flags to Miri, introducing `MIRIFLAGS="-Zmiri-disable-stacked-borrows" cargo miri test` instead. This made `cargo miri` more compatible with `cargo`; both now behave the same in terms of argument parsing.

However, to avoid breaking things, I introduced some backwards compatibility hack such that the old way would still work. Six months later, I think it is time to remove that hack.