### PR TITLE
Use `harness = false` instead of `#![feature(custom_test_frameworks)]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,7 @@ colored = "2"
 # This crate uses #[feature(rustc_private)]. 
 # See https://github.com/rust-analyzer/rust-analyzer/pull/7891
 rustc_private = true
+
+[[test]]
+name = "compiletest"
+harness = false

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -1,7 +1,3 @@
-#![feature(custom_test_frameworks)]
-// Custom test runner, to avoid libtest being wrapped around compiletest which wraps libtest.
-#![test_runner(test_runner)]
-
 use std::env;
 use std::path::PathBuf;
 
@@ -83,7 +79,7 @@ fn get_target() -> String {
     env::var("MIRI_TEST_TARGET").unwrap_or_else(|_| get_host())
 }
 
-fn test_runner(_tests: &[&()]) {
+fn main() {
     // Add a test env var to do environment communication tests.
     env::set_var("MIRI_ENV_VAR_TEST", "0");
     // Let the tests know where to store temp files (they might run for a different target, which can make this hard to find).


### PR DESCRIPTION
Quoting from the comment in `tests/compiletest.rs`:
> Custom test runner, to avoid libtest being wrapped around compiletest which wraps libtest.

I believe `harness = false` is more suitable for that purpose.

I have verified that both `./miri test` and `LD_LIBRARY_PATH=$PWD/build/x86_64-unknown-linux-gnu/stage2/lib PATH=$PWD/build/bin:$PATH ./x.py test src/tools/miri` work well.