### PR TITLE
Throw UB if f*_fast intrinsic called with non-finite value

### DIFF
--- a/src/shims/intrinsics.rs
+++ b/src/shims/intrinsics.rs
@@ -173,35 +173,31 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                     "frem_fast" => mir::BinOp::Rem,
                     _ => bug!(),
                 };
-                let a_valid = match a.layout.ty.kind() {
-                    ty::Float(FloatTy::F32) => a.to_scalar()?.to_f32()?.is_finite(),
-                    ty::Float(FloatTy::F64) => a.to_scalar()?.to_f64()?.is_finite(),
-                    _ => bug!(
-                        "`{}` called with non-float input type {:?}",
-                        intrinsic_name,
-                        a.layout.ty
-                    ),
+                let float_finite = |x: ImmTy<'tcx, _>| -> InterpResult<'tcx, bool> {
+                    Ok(match x.layout.ty.kind() {
+                        ty::Float(FloatTy::F32) => x.to_scalar()?.to_f32()?.is_finite(),
+                        ty::Float(FloatTy::F64) => x.to_scalar()?.to_f64()?.is_finite(),
+                        _ => bug!(
+                            "`{}` called with non-float input type {:?}",
+                            intrinsic_name,
+                            x.layout.ty
+                        ),
+                    })
                 };
-                if !a_valid {
-                    throw_ub_format!(
+                match (float_finite(a)?, float_finite(b)?) {
+                    (false, false) => throw_ub_format!(
+                        "`{}` intrinsic called with non-finite value as both parameters",
+                        intrinsic_name,
+                    ),
+                    (false, _) => throw_ub_format!(
                         "`{}` intrinsic called with non-finite value as first parameter",
                         intrinsic_name,
-                    );
-                }
-                let b_valid = match b.layout.ty.kind() {
-                    ty::Float(FloatTy::F32) => b.to_scalar()?.to_f32()?.is_finite(),
-                    ty::Float(FloatTy::F64) => b.to_scalar()?.to_f64()?.is_finite(),
-                    _ => bug!(
-                        "`{}` called with non-float input type {:?}",
-                        intrinsic_name,
-                        b.layout.ty
                     ),
-                };
-                if !b_valid {
-                    throw_ub_format!(
+                    (_, false) => throw_ub_format!(
                         "`{}` intrinsic called with non-finite value as second parameter",
                         intrinsic_name,
-                    );
+                    ),
+                    _ => {}
                 }
                 this.binop_ignore_overflow(op, &a, &b, dest)?;
             }

--- a/tests/compile-fail/fast_math_both.rs
+++ b/tests/compile-fail/fast_math_both.rs
@@ -1,0 +1,7 @@
+#![feature(core_intrinsics)]
+
+fn main() {
+    unsafe {
+        let _x: f32 = core::intrinsics::frem_fast(f32::NAN, 3.2); //~ ERROR `frem_fast` intrinsic called with non-finite value as first parameter
+    }
+}

--- a/tests/compile-fail/fast_math_both.rs
+++ b/tests/compile-fail/fast_math_both.rs
@@ -2,6 +2,6 @@
 
 fn main() {
     unsafe {
-        let _x: f32 = core::intrinsics::frem_fast(f32::NAN, 3.2); //~ ERROR `frem_fast` intrinsic called with non-finite value as first parameter
+        let _x: f32 = core::intrinsics::fsub_fast(f32::NAN, f32::NAN); //~ ERROR `fsub_fast` intrinsic called with non-finite value as both parameters
     }
 }

--- a/tests/compile-fail/fast_math_first.rs
+++ b/tests/compile-fail/fast_math_first.rs
@@ -1,0 +1,7 @@
+#![feature(core_intrinsics)]
+
+fn main() {
+    unsafe {
+        let _x: f32 = core::intrinsics::fsub_fast(f32::NAN, f32::NAN); //~ ERROR `fsub_fast` intrinsic called with non-finite value as first parameter
+    }
+}

--- a/tests/compile-fail/fast_math_first.rs
+++ b/tests/compile-fail/fast_math_first.rs
@@ -2,6 +2,6 @@
 
 fn main() {
     unsafe {
-        let _x: f32 = core::intrinsics::fsub_fast(f32::NAN, f32::NAN); //~ ERROR `fsub_fast` intrinsic called with non-finite value as first parameter
+        let _x: f32 = core::intrinsics::frem_fast(f32::NAN, 3.2); //~ ERROR `frem_fast` intrinsic called with non-finite value as first parameter
     }
 }

--- a/tests/compile-fail/fast_math_second.rs
+++ b/tests/compile-fail/fast_math_second.rs
@@ -2,6 +2,6 @@
 
 fn main() {
     unsafe {
-        let _x: f32 = core::intrinsics::fmul_fast(3.4f32, f32::NAN); //~ ERROR `fmul_fast` intrinsic called with non-finite value as second parameter
+        let _x: f32 = core::intrinsics::fmul_fast(3.4f32, f32::INFINITY); //~ ERROR `fmul_fast` intrinsic called with non-finite value as second parameter
     }
 }

--- a/tests/compile-fail/fast_math_second.rs
+++ b/tests/compile-fail/fast_math_second.rs
@@ -1,0 +1,7 @@
+#![feature(core_intrinsics)]
+
+fn main() {
+    unsafe {
+        let _x: f32 = core::intrinsics::fmul_fast(3.4f32, f32::NAN); //~ ERROR `fmul_fast` intrinsic called with non-finite value as second parameter
+    }
+}


### PR DESCRIPTION
Calling these intrinsics with non-finite values is undefined behaviour, since they result in `f*` intrinsics in LLVM with the `fast` flag, and `fast` math on non-finite values results in `poison` values. (technically LLVM only considers it UB upon _using_ the value, but that shouldn't make much of a difference)