### PR TITLE
Add `measureme` integration for profiling the interpreted program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,8 +214,9 @@ dependencies = [
 
 [[package]]
 name = "measureme"
-version = "9.1.1"
-source = "git+https://github.com/rust-lang/measureme?rev=501d6a3c192beee5e633a6c5f79130bedfdadcb5#501d6a3c192beee5e633a6c5f79130bedfdadcb5"
+version = "9.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78f7a41bc6f856a2cf0e95094ad5121f82500e2d9a0f3c0171d98f6566d8117d"
 dependencies = [
  "log",
  "memmap2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "instant"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,6 +195,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56d855069fafbb9b344c0f962150cd2c1187975cb1c22c1522c240d8c4986714"
 
 [[package]]
+name = "lock_api"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3c91c24eae6777794bb1997ad98bbb87daf92890acab859f7eaa4320333176"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,10 +213,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "measureme"
+version = "9.1.1"
+source = "git+https://github.com/rust-lang/measureme?rev=501d6a3c192beee5e633a6c5f79130bedfdadcb5#501d6a3c192beee5e633a6c5f79130bedfdadcb5"
+dependencies = [
+ "log",
+ "memmap2",
+ "parking_lot",
+ "perf-event-open-sys",
+ "rustc-hash",
+ "smallvec",
+]
+
+[[package]]
 name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+
+[[package]]
+name = "memmap2"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "397d1a6d6d0563c0f5462bbdae662cf6c784edf5e828e40c7257f85d82bf56dd"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "miow"
@@ -220,6 +260,7 @@ dependencies = [
  "hex",
  "libc",
  "log",
+ "measureme",
  "rand",
  "rustc-workspace-hack",
  "rustc_version",
@@ -234,6 +275,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
+
+[[package]]
+name = "perf-event-open-sys"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce9bedf5da2c234fdf2391ede2b90fabf585355f33100689bc364a3ea558561a"
+dependencies = [
  "libc",
 ]
 
@@ -356,6 +431,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc-workspace-hack"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +474,12 @@ name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ test = false # we have no unit tests
 doctest = false # and no doc tests
 
 [dependencies]
-measureme = { git = "https://github.com/rust-lang/measureme", rev = "501d6a3c192beee5e633a6c5f79130bedfdadcb5" }
 getrandom = { version = "0.2", features = ["std"] }
 env_logger = "0.8"
 log = "0.4"
@@ -31,6 +30,7 @@ smallvec = "1.4.2"
 # See the `src/tools/rustc-workspace-hack/README.md` file in `rust-lang/rust`
 # for more information.
 rustc-workspace-hack = "1.0.0"
+measureme = "9.1.2"
 
 # Enable some feature flags that dev-dependencies need but dependencies
 # do not.  This makes `./miri install` after `./miri build` faster.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ test = false # we have no unit tests
 doctest = false # and no doc tests
 
 [dependencies]
+measureme = { git = "https://github.com/rust-lang/measureme", rev = "501d6a3c192beee5e633a6c5f79130bedfdadcb5" }
 getrandom = { version = "0.2", features = ["std"] }
 env_logger = "0.8"
 log = "0.4"

--- a/README.md
+++ b/README.md
@@ -258,6 +258,10 @@ environment variable:
   this pointer. Note that it is not currently guaranteed that code that works
   with `-Zmiri-track-raw-pointers` also works without
   `-Zmiri-track-raw-pointers`, but for the vast majority of code, this will be the case.
+* `-Zmiri-measureme=<name>` enables `measureme` profiling for the interpreted program.
+   This can be used to find which parts of your program are executing slowly under Miri.
+   The profile is written out to a file with the prefix `<name>`, and can be processed
+   using the tools in the repository https://github.com/rust-lang/measureme
 
 Some native rustc `-Z` flags are also very relevant for Miri:
 

--- a/README.md
+++ b/README.md
@@ -222,6 +222,10 @@ environment variable:
   times to exclude several variables.  On Windows, the `TERM` environment
   variable is excluded by default.
 * `-Zmiri-ignore-leaks` disables the memory leak checker.
+* `-Zmiri-measureme=<name>` enables `measureme` profiling for the interpreted program.
+   This can be used to find which parts of your program are executing slowly under Miri.
+   The profile is written out to a file with the prefix `<name>`, and can be processed
+   using the tools in the repository https://github.com/rust-lang/measureme.
 * `-Zmiri-seed=<hex>` configures the seed of the RNG that Miri uses to resolve
   non-determinism.  This RNG is used to pick base addresses for allocations.
   When isolation is enabled (the default), this is also used to emulate system
@@ -258,10 +262,6 @@ environment variable:
   this pointer. Note that it is not currently guaranteed that code that works
   with `-Zmiri-track-raw-pointers` also works without
   `-Zmiri-track-raw-pointers`, but for the vast majority of code, this will be the case.
-* `-Zmiri-measureme=<name>` enables `measureme` profiling for the interpreted program.
-   This can be used to find which parts of your program are executing slowly under Miri.
-   The profile is written out to a file with the prefix `<name>`, and can be processed
-   using the tools in the repository https://github.com/rust-lang/measureme
 
 Some native rustc `-Z` flags are also very relevant for Miri:
 

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -318,6 +318,10 @@ fn main() {
                     };
                     miri_config.cmpxchg_weak_failure_rate = rate;
                 }
+                arg if arg.starts_with("-Zmiri-measureme=") => {
+                    let measureme_out = arg.strip_prefix("-Zmiri-measureme=").unwrap();
+                    miri_config.measureme_out = Some(measureme_out.to_string());
+                }
                 _ => {
                     // Forward to rustc.
                     rustc_args.push(arg);

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -54,8 +54,8 @@ pub struct MiriConfig {
     /// Rate of spurious failures for compare_exchange_weak atomic operations,
     /// between 0.0 and 1.0, defaulting to 0.8 (80% chance of failure).
     pub cmpxchg_weak_failure_rate: f64,
-    /// If `Some`, enable the `measureme` profiler, writing results to the specified
-    /// directory.
+    /// If `Some`, enable the `measureme` profiler, writing results to a file
+    /// with the specified prefix.
     pub measureme_out: Option<String>,
 }
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -54,6 +54,9 @@ pub struct MiriConfig {
     /// Rate of spurious failures for compare_exchange_weak atomic operations,
     /// between 0.0 and 1.0, defaulting to 0.8 (80% chance of failure).
     pub cmpxchg_weak_failure_rate: f64,
+    /// If `Some`, enable the `measureme` profiler, writing results to the specified
+    /// directory.
+    pub measureme_out: Option<String>,
 }
 
 impl Default for MiriConfig {
@@ -73,6 +76,7 @@ impl Default for MiriConfig {
             track_raw: false,
             data_race_detector: true,
             cmpxchg_weak_failure_rate: 0.8,
+            measureme_out: None,
         }
     }
 }
@@ -92,7 +96,7 @@ pub fn create_ecx<'mir, 'tcx: 'mir>(
         tcx,
         rustc_span::source_map::DUMMY_SP,
         param_env,
-        Evaluator::new(config.communicate, config.validate, layout_cx),
+        Evaluator::new(&config, layout_cx),
         MemoryExtra::new(&config),
     );
     // Complete initialization.

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -51,6 +51,7 @@ pub struct FrameData<'tcx> {
 
 impl<'tcx> std::fmt::Debug for FrameData<'tcx> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Omitting `timing`, it does not support `Debug`.
         f.debug_struct("FrameData")
             .field("call_id", &self.call_id)
             .field("catch_unwind", &self.catch_unwind)

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -624,7 +624,7 @@ impl<'mir, 'tcx> Machine<'mir, 'tcx> for Evaluator<'mir, 'tcx> {
             Some(profiler.start_recording_interval_event_detached(
                 name,
                 EventId::from_label(name),
-                0
+                ecx.get_active_thread().to_u32()
             ))
         } else {
             None

--- a/src/shims/panic.rs
+++ b/src/shims/panic.rs
@@ -119,7 +119,6 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
     ) -> InterpResult<'tcx, StackPopJump> {
         let this = self.eval_context_mut();
 
-        trace!("handle_stack_pop(extra = {:?}, unwinding = {})", extra, unwinding);
         if let Some(stacked_borrows) = &this.memory.extra.stacked_borrows {
             stacked_borrows.borrow_mut().end_call(extra.call_id);
         }

--- a/src/shims/panic.rs
+++ b/src/shims/panic.rs
@@ -119,6 +119,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
     ) -> InterpResult<'tcx, StackPopJump> {
         let this = self.eval_context_mut();
 
+        trace!("handle_stack_pop(extra = {:?}, unwinding = {})", extra, unwinding);
         if let Some(stacked_borrows) = &this.memory.extra.stacked_borrows {
             stacked_borrows.borrow_mut().end_call(extra.call_id);
         }


### PR DESCRIPTION
This PR uses the `measureme` crate to profile the call stack of the
program being interpreted by Miri. This is accomplished by starting a
measureme 'event' when we enter a function call, and ending the event
when we exit the call. The `measureme` tooling can be used to produce a
call stack from the generated profile data.

Limitations:
* We currently record every single entry/exit. This might generate very
  large profile outputs for programs with a large number of function
  calls. In follow-up work, we might want to explore sampling (e.g. only
  recording every N function calls).
* This does not integrate very well with Miri's concurrency support.
  Each event we record starts when we push a frame, and ends when we pop
  a frame. As a result, the timing recorded for a particular frame will include all of the work Miri does before that frame completes, including executing another thread.

The `measureme` integration is off by default, and must be enabled via
`-Zmiri-measureme=<output_name>`