### PR TITLE
fix: avoid stopping machine upon running env operations in isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,13 @@ environment variable:
 * `-Zmiri-disable-isolation` disables host isolation.  As a consequence,
   the program has access to host resources such as environment variables, file
   systems, and randomness.
+* `-Zmiri-isolation-error=<action>` configures Miri's response to operations
+  requiring host access while isolation is enabled. `abort`, `hide`, `warn`,
+  and `warn-nobacktrace` are the supported actions. Default action is `abort`
+  which halts the machine. Rest of the actions configure it to return an error
+  code for the op and continue executing. `warn` prints backtrace that could
+  be used to trace the call. `warn-nobacktrace` is less verbose without
+  backtrace. `hide` hides the warning.
 * `-Zmiri-env-exclude=<var>` keeps the `var` environment variable isolated from
   the host so that it cannot be accessed by the program.  Can be used multiple
   times to exclude several variables.  On Windows, the `TERM` environment

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,9 @@ pub use crate::diagnostics::{
     register_diagnostic, report_error, EvalContextExt as DiagnosticsEvalContextExt,
     NonHaltingDiagnostic, TerminationInfo,
 };
-pub use crate::eval::{create_ecx, eval_main, AlignmentCheck, MiriConfig};
+pub use crate::eval::{
+    create_ecx, eval_main, AlignmentCheck, IsolatedOp, MiriConfig, RejectOpWith,
+};
 pub use crate::helpers::EvalContextExt as HelpersEvalContextExt;
 pub use crate::machine::{
     AllocExtra, Evaluator, FrameData, MemoryExtra, MiriEvalContext, MiriEvalContextExt,

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -263,9 +263,10 @@ pub struct Evaluator<'mir, 'tcx> {
     /// TLS state.
     pub(crate) tls: TlsData<'tcx>,
 
-    /// If enabled, the `env_vars` field is populated with the host env vars during initialization
-    /// and random number generation is delegated to the host.
-    pub(crate) communicate: bool,
+    /// What should Miri do when an op requires communicating with the host,
+    /// such as accessing host env vars, random number generation, and
+    /// file system access.
+    pub(crate) isolated_op: IsolatedOp,
 
     /// Whether to enforce the validity invariant.
     pub(crate) validate: bool,
@@ -314,7 +315,7 @@ impl<'mir, 'tcx> Evaluator<'mir, 'tcx> {
             argv: None,
             cmd_line: None,
             tls: TlsData::default(),
-            communicate: config.communicate,
+            isolated_op: config.isolated_op,
             validate: config.validate,
             enforce_abi: config.check_abi,
             file_handler: Default::default(),
@@ -327,6 +328,10 @@ impl<'mir, 'tcx> Evaluator<'mir, 'tcx> {
             string_cache: Default::default(),
             exported_symbols_cache: FxHashMap::default(),
         }
+    }
+
+    pub(crate) fn communicate(&self) -> bool {
+        self.isolated_op == IsolatedOp::Allow
     }
 }
 

--- a/src/shims/env.rs
+++ b/src/shims/env.rs
@@ -1,7 +1,7 @@
 use std::convert::TryFrom;
 use std::env;
 use std::ffi::{OsStr, OsString};
-use std::io::{Error, ErrorKind};
+use std::io::ErrorKind;
 
 use rustc_data_structures::fx::FxHashMap;
 use rustc_mir::interpret::Pointer;
@@ -324,8 +324,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
         if let IsolatedOp::Reject(reject_with) = this.machine.isolated_op {
             this.reject_in_isolation("getcwd", reject_with)?;
-            let err = Error::new(ErrorKind::NotFound, "rejected due to isolation");
-            this.set_last_error_from_io_error(err)?;
+            this.set_last_error_from_io_error(ErrorKind::NotFound)?;
             return Ok(Scalar::null_ptr(&*this.tcx));
         }
 
@@ -340,7 +339,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 let erange = this.eval_libc("ERANGE")?;
                 this.set_last_error(erange)?;
             }
-            Err(e) => this.set_last_error_from_io_error(e)?,
+            Err(e) => this.set_last_error_from_io_error(e.kind())?,
         }
 
         Ok(Scalar::null_ptr(&*this.tcx))
@@ -357,8 +356,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
         if let IsolatedOp::Reject(reject_with) = this.machine.isolated_op {
             this.reject_in_isolation("GetCurrentDirectoryW", reject_with)?;
-            let err = Error::new(ErrorKind::NotFound, "rejected due to isolation");
-            this.set_last_error_from_io_error(err)?;
+            this.set_last_error_from_io_error(ErrorKind::NotFound)?;
             return Ok(0);
         }
 
@@ -369,7 +367,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         match env::current_dir() {
             Ok(cwd) =>
                 return Ok(windows_check_buffer_size(this.write_path_to_wide_str(&cwd, buf, size)?)),
-            Err(e) => this.set_last_error_from_io_error(e)?,
+            Err(e) => this.set_last_error_from_io_error(e.kind())?,
         }
         Ok(0)
     }
@@ -384,8 +382,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
         if let IsolatedOp::Reject(reject_with) = this.machine.isolated_op {
             this.reject_in_isolation("chdir", reject_with)?;
-            let err = Error::new(ErrorKind::NotFound, "rejected due to isolation");
-            this.set_last_error_from_io_error(err)?;
+            this.set_last_error_from_io_error(ErrorKind::NotFound)?;
 
             return Ok(-1);
         }
@@ -395,7 +392,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         match env::set_current_dir(path) {
             Ok(()) => Ok(0),
             Err(e) => {
-                this.set_last_error_from_io_error(e)?;
+                this.set_last_error_from_io_error(e.kind())?;
                 Ok(-1)
             }
         }
@@ -413,8 +410,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
         if let IsolatedOp::Reject(reject_with) = this.machine.isolated_op {
             this.reject_in_isolation("SetCurrentDirectoryW", reject_with)?;
-            let err = Error::new(ErrorKind::NotFound, "rejected due to isolation");
-            this.set_last_error_from_io_error(err)?;
+            this.set_last_error_from_io_error(ErrorKind::NotFound)?;
 
             return Ok(0);
         }
@@ -424,7 +420,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         match env::set_current_dir(path) {
             Ok(()) => Ok(1),
             Err(e) => {
-                this.set_last_error_from_io_error(e)?;
+                this.set_last_error_from_io_error(e.kind())?;
                 Ok(0)
             }
         }

--- a/src/shims/posix/fs.rs
+++ b/src/shims/posix/fs.rs
@@ -634,7 +634,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                     match dup_result {
                         Ok(dup_fd) => Ok(fh.insert_fd_with_min_fd(dup_fd, start)),
                         Err(e) => {
-                            this.set_last_error_from_io_error(e)?;
+                            this.set_last_error_from_io_error(e.kind())?;
                             Ok(-1)
                         }
                     }
@@ -707,7 +707,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                     Ok(read_bytes)
                 }
                 Err(e) => {
-                    this.set_last_error_from_io_error(e)?;
+                    this.set_last_error_from_io_error(e.kind())?;
                     Ok(-1)
                 }
             }
@@ -1118,7 +1118,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 Ok(Scalar::from_machine_usize(id, this))
             }
             Err(e) => {
-                this.set_last_error_from_io_error(e)?;
+                this.set_last_error_from_io_error(e.kind())?;
                 Ok(Scalar::null_ptr(this))
             }
         }
@@ -1462,7 +1462,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 Ok(path_bytes.len().try_into().unwrap())
             }
             Err(e) => {
-                this.set_last_error_from_io_error(e)?;
+                this.set_last_error_from_io_error(e.kind())?;
                 Ok(-1)
             }
         }
@@ -1526,7 +1526,7 @@ impl FileMetadata {
         let metadata = match metadata {
             Ok(metadata) => metadata,
             Err(e) => {
-                ecx.set_last_error_from_io_error(e)?;
+                ecx.set_last_error_from_io_error(e.kind())?;
                 return Ok(None);
             }
         };

--- a/tests/run-pass/current_dir_with_isolation.rs
+++ b/tests/run-pass/current_dir_with_isolation.rs
@@ -1,0 +1,20 @@
+// compile-flags: -Zmiri-isolation-error=warn-nobacktrace
+// normalize-stderr-test "(getcwd|GetCurrentDirectoryW)" -> "$$GET"
+// normalize-stderr-test "(chdir|SetCurrentDirectoryW)" -> "$$SET"
+
+use std::env;
+use std::io::ErrorKind;
+
+fn main() {
+    // Test that current dir operations return a proper error instead
+    // of stopping the machine in isolation mode
+    assert_eq!(env::current_dir().unwrap_err().kind(), ErrorKind::NotFound);
+    for _i in 0..3 {
+        assert_eq!(env::current_dir().unwrap_err().kind(), ErrorKind::NotFound);
+    }
+
+    assert_eq!(env::set_current_dir("..").unwrap_err().kind(), ErrorKind::NotFound);
+    for _i in 0..3 {
+        assert_eq!(env::set_current_dir("..").unwrap_err().kind(), ErrorKind::NotFound);
+    }
+}

--- a/tests/run-pass/current_dir_with_isolation.stderr
+++ b/tests/run-pass/current_dir_with_isolation.stderr
@@ -1,0 +1,4 @@
+warning: `$GET` was made to return an error due to isolation
+
+warning: `$SET` was made to return an error due to isolation
+


### PR DESCRIPTION
get and set current dir operations used to halt the machine by
throwing an exception in isolation mode. This change updates them to
return a dummy `NotFound` error instead, and keep the machine running.

I started with a custom error using `ErrorKind::Other`, but since it
can't be mapped to a raw OS error, I dropped it. `NotFound` kind of make
sense for get operations, but not much for set operations. But that's
the only error supported for windows currently.

 