### PR TITLE
support building Miri outside a git repo

### DIFF
--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -6,6 +6,7 @@ use std::io::{self, BufRead, BufReader, BufWriter, Read, Write};
 use std::ops::Not;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::fmt::{Write as _};
 
 use serde::{Deserialize, Serialize};
 
@@ -90,12 +91,13 @@ fn show_help() {
 }
 
 fn show_version() {
-    println!(
-        "miri {} ({} {})",
-        env!("CARGO_PKG_VERSION"),
-        env!("VERGEN_GIT_SHA_SHORT"),
-        env!("VERGEN_GIT_COMMIT_DATE")
-    );
+    let mut version = format!("miri {}", env!("CARGO_PKG_VERSION"));
+    // Only use `option_env` on vergen variables to ensure the build succeeds
+    // when vergen failed to find the git info.
+    if let Some(sha) = option_env!("VERGEN_GIT_SHA_SHORT") {
+        write!(&mut version, " ({} {})", sha, option_env!("VERGEN_GIT_COMMIT_DATE").unwrap()).unwrap();
+    }
+    println!("{}", version);
 }
 
 fn show_error(msg: String) -> ! {

--- a/cargo-miri/build.rs
+++ b/cargo-miri/build.rs
@@ -7,5 +7,5 @@ fn main() {
     let mut gen_config = vergen::Config::default();
     *gen_config.git_mut().sha_kind_mut() = vergen::ShaKind::Short;
     *gen_config.git_mut().commit_timestamp_kind_mut() = vergen::TimestampKind::DateOnly;
-    vergen(gen_config).expect("Unable to generate vergen keys!");
+    vergen(gen_config).ok(); // Ignore failure (in case we are built outside a git repo)
 }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/84182

@semarie this should fix your problem... but I think any version of Miri actually shipped to users should have the proper git version information embedded, so I am not sure if this is the right fix. How do you do this for rustc proper? Even stable builds usually have a git version:
```
$ rustc +stable --version
rustc 1.51.0 (2fd73fabe 2021-03-23)
```