### PR TITLE
stop relying on c_str/wide_str helpers in rustc

### DIFF
--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -405,7 +405,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 check_abi(abi, Abi::C { unwind: false })?;
                 let &[ref ptr] = check_arg_count(args)?;
                 let ptr = this.read_scalar(ptr)?.check_init()?;
-                let n = this.memory.read_c_str(ptr)?.len();
+                let n = this.read_c_str(ptr)?.len();
                 this.write_scalar(Scalar::from_machine_usize(u64::try_from(n).unwrap(), this), dest)?;
             }
 

--- a/src/shims/posix/foreign_items.rs
+++ b/src/shims/posix/foreign_items.rs
@@ -187,7 +187,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 let &[ref handle, ref symbol] = check_arg_count(args)?;
                 this.read_scalar(handle)?.to_machine_usize(this)?;
                 let symbol = this.read_scalar(symbol)?.check_init()?;
-                let symbol_name = this.memory.read_c_str(symbol)?;
+                let symbol_name = this.read_c_str(symbol)?;
                 if let Some(dlsym) = Dlsym::from_str(symbol_name, &this.tcx.sess.target.os)? {
                     let ptr = this.memory.create_fn_alloc(FnVal::Other(dlsym));
                     this.write_scalar(Scalar::from(ptr), dest)?;

--- a/src/shims/posix/thread.rs
+++ b/src/shims/posix/thread.rs
@@ -111,7 +111,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         let option = this.read_scalar(option)?.to_i32()?;
         if option == this.eval_libc_i32("PR_SET_NAME")? {
             let address = this.read_scalar(arg2)?.check_init()?;
-            let mut name = this.memory.read_c_str(address)?.to_owned();
+            let mut name = this.read_c_str(address)?.to_owned();
             // The name should be no more than 16 bytes, including the null
             // byte. Since `read_c_str` returns the string without the null
             // byte, we need to truncate to 15.
@@ -134,7 +134,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         let this = self.eval_context_mut();
         this.assert_target_os("macos", "pthread_setname_np");
 
-        let name = this.memory.read_c_str(name)?.to_owned();
+        let name = this.read_c_str(name)?.to_owned();
         this.set_active_thread_name(name);
 
         Ok(())

--- a/src/shims/windows/foreign_items.rs
+++ b/src/shims/windows/foreign_items.rs
@@ -271,7 +271,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 #[allow(non_snake_case)]
                 let &[ref hModule, ref lpProcName] = check_arg_count(args)?;
                 this.read_scalar(hModule)?.to_machine_isize(this)?;
-                let name = this.memory.read_c_str(this.read_scalar(lpProcName)?.check_init()?)?;
+                let name = this.read_c_str(this.read_scalar(lpProcName)?.check_init()?)?;
                 if let Some(dlsym) = Dlsym::from_str(name, &this.tcx.sess.target.os)? {
                     let ptr = this.memory.create_fn_alloc(FnVal::Other(dlsym));
                     this.write_scalar(Scalar::from(ptr), dest)?;


### PR DESCRIPTION
This is a part of https://github.com/rust-lang/miri/pull/1804 that we can already do.