### PR TITLE
get rid of some `Rc`

### DIFF
--- a/src/data_race.rs
+++ b/src/data_race.rs
@@ -883,21 +883,19 @@ impl VClockAlloc {
     /// being created or if it is temporarily disabled during a racy read or write
     /// operation for which data-race detection is handled separately, for example
     /// atomic read operations.
-    pub fn read<'tcx>(&self, pointer: Pointer<Tag>, len: Size, global: &GlobalState) -> InterpResult<'tcx> {
+    pub fn read<'tcx>(
+        &self,
+        pointer: Pointer<Tag>,
+        len: Size,
+        global: &GlobalState,
+    ) -> InterpResult<'tcx> {
         if global.multi_threaded.get() {
             let (index, clocks) = global.current_thread_state();
             let mut alloc_ranges = self.alloc_ranges.borrow_mut();
             for (_, range) in alloc_ranges.iter_mut(pointer.offset, len) {
                 if let Err(DataRace) = range.read_race_detect(&*clocks, index) {
                     // Report data-race.
-                    return Self::report_data_race(
-                        global,
-                        range,
-                        "Read",
-                        false,
-                        pointer,
-                        len,
-                    );
+                    return Self::report_data_race(global, range, "Read", false, pointer, len);
                 }
             }
             Ok(())
@@ -939,7 +937,12 @@ impl VClockAlloc {
     /// data-race threads if `multi-threaded` is false, either due to no threads
     /// being created or if it is temporarily disabled during a racy read or write
     /// operation
-    pub fn write<'tcx>(&mut self, pointer: Pointer<Tag>, len: Size, global: &mut GlobalState) -> InterpResult<'tcx> {
+    pub fn write<'tcx>(
+        &mut self,
+        pointer: Pointer<Tag>,
+        len: Size,
+        global: &mut GlobalState,
+    ) -> InterpResult<'tcx> {
         self.unique_access(pointer, len, WriteType::Write, global)
     }
 
@@ -947,7 +950,12 @@ impl VClockAlloc {
     /// data-race threads if `multi-threaded` is false, either due to no threads
     /// being created or if it is temporarily disabled during a racy read or write
     /// operation
-    pub fn deallocate<'tcx>(&mut self, pointer: Pointer<Tag>, len: Size, global: &mut GlobalState) -> InterpResult<'tcx> {
+    pub fn deallocate<'tcx>(
+        &mut self,
+        pointer: Pointer<Tag>,
+        len: Size,
+        global: &mut GlobalState,
+    ) -> InterpResult<'tcx> {
         self.unique_access(pointer, len, WriteType::Deallocate, global)
     }
 }

--- a/src/data_race.rs
+++ b/src/data_race.rs
@@ -65,7 +65,6 @@ use std::{
     cell::{Cell, Ref, RefCell, RefMut},
     fmt::Debug,
     mem,
-    rc::Rc,
 };
 
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
@@ -80,7 +79,7 @@ use crate::{
 };
 
 pub type AllocExtra = VClockAlloc;
-pub type MemoryExtra = Rc<GlobalState>;
+pub type MemoryExtra = GlobalState;
 
 /// Valid atomic read-write operations, alias of atomic::Ordering (not non-exhaustive).
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
@@ -488,7 +487,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: MiriEvalContextExt<'mir, 'tcx> {
     ) -> InterpResult<'tcx, ScalarMaybeUninit<Tag>> {
         let this = self.eval_context_ref();
         let scalar = this.allow_data_races_ref(move |this| this.read_scalar(&place.into()))?;
-        self.validate_atomic_load(place, atomic)?;
+        this.validate_atomic_load(place, atomic)?;
         Ok(scalar)
     }
 
@@ -501,7 +500,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: MiriEvalContextExt<'mir, 'tcx> {
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
         this.allow_data_races_mut(move |this| this.write_scalar(val, &(*dest).into()))?;
-        self.validate_atomic_store(dest, atomic)
+        this.validate_atomic_store(dest, atomic)
     }
 
     /// Perform a atomic operation on a memory location.
@@ -733,9 +732,6 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: MiriEvalContextExt<'mir, 'tcx> {
 pub struct VClockAlloc {
     /// Assigning each byte a MemoryCellClocks.
     alloc_ranges: RefCell<RangeMap<MemoryCellClocks>>,
-
-    /// Pointer to global state.
-    global: MemoryExtra,
 }
 
 impl VClockAlloc {
@@ -767,7 +763,6 @@ impl VClockAlloc {
             | MemoryKind::Vtable => (0, VectorIdx::MAX_INDEX),
         };
         VClockAlloc {
-            global: Rc::clone(global),
             alloc_ranges: RefCell::new(RangeMap::new(
                 len,
                 MemoryCellClocks::new(alloc_timestamp, alloc_index),
@@ -888,15 +883,15 @@ impl VClockAlloc {
     /// being created or if it is temporarily disabled during a racy read or write
     /// operation for which data-race detection is handled separately, for example
     /// atomic read operations.
-    pub fn read<'tcx>(&self, pointer: Pointer<Tag>, len: Size) -> InterpResult<'tcx> {
-        if self.global.multi_threaded.get() {
-            let (index, clocks) = self.global.current_thread_state();
+    pub fn read<'tcx>(&self, pointer: Pointer<Tag>, len: Size, global: &GlobalState) -> InterpResult<'tcx> {
+        if global.multi_threaded.get() {
+            let (index, clocks) = global.current_thread_state();
             let mut alloc_ranges = self.alloc_ranges.borrow_mut();
             for (_, range) in alloc_ranges.iter_mut(pointer.offset, len) {
                 if let Err(DataRace) = range.read_race_detect(&*clocks, index) {
                     // Report data-race.
                     return Self::report_data_race(
-                        &self.global,
+                        global,
                         range,
                         "Read",
                         false,
@@ -917,14 +912,15 @@ impl VClockAlloc {
         pointer: Pointer<Tag>,
         len: Size,
         write_type: WriteType,
+        global: &mut GlobalState,
     ) -> InterpResult<'tcx> {
-        if self.global.multi_threaded.get() {
-            let (index, clocks) = self.global.current_thread_state();
+        if global.multi_threaded.get() {
+            let (index, clocks) = global.current_thread_state();
             for (_, range) in self.alloc_ranges.get_mut().iter_mut(pointer.offset, len) {
                 if let Err(DataRace) = range.write_race_detect(&*clocks, index, write_type) {
                     // Report data-race
                     return Self::report_data_race(
-                        &self.global,
+                        global,
                         range,
                         write_type.get_descriptor(),
                         false,
@@ -943,16 +939,16 @@ impl VClockAlloc {
     /// data-race threads if `multi-threaded` is false, either due to no threads
     /// being created or if it is temporarily disabled during a racy read or write
     /// operation
-    pub fn write<'tcx>(&mut self, pointer: Pointer<Tag>, len: Size) -> InterpResult<'tcx> {
-        self.unique_access(pointer, len, WriteType::Write)
+    pub fn write<'tcx>(&mut self, pointer: Pointer<Tag>, len: Size, global: &mut GlobalState) -> InterpResult<'tcx> {
+        self.unique_access(pointer, len, WriteType::Write, global)
     }
 
     /// Detect data-races for an unsynchronized deallocate operation, will not perform
     /// data-race threads if `multi-threaded` is false, either due to no threads
     /// being created or if it is temporarily disabled during a racy read or write
     /// operation
-    pub fn deallocate<'tcx>(&mut self, pointer: Pointer<Tag>, len: Size) -> InterpResult<'tcx> {
-        self.unique_access(pointer, len, WriteType::Deallocate)
+    pub fn deallocate<'tcx>(&mut self, pointer: Pointer<Tag>, len: Size, global: &mut GlobalState) -> InterpResult<'tcx> {
+        self.unique_access(pointer, len, WriteType::Deallocate, global)
     }
 }
 
@@ -1035,7 +1031,6 @@ trait EvalContextPrivExt<'mir, 'tcx: 'mir>: MiriEvalContextExt<'mir, 'tcx> {
                 );
 
                 // Perform the atomic operation.
-                let data_race = &alloc_meta.global;
                 data_race.maybe_perform_sync_operation(|index, mut clocks| {
                     for (_, range) in
                         alloc_meta.alloc_ranges.borrow_mut().iter_mut(place_ptr.offset, size)
@@ -1043,7 +1038,7 @@ trait EvalContextPrivExt<'mir, 'tcx: 'mir>: MiriEvalContextExt<'mir, 'tcx> {
                         if let Err(DataRace) = op(range, &mut *clocks, index, atomic) {
                             mem::drop(clocks);
                             return VClockAlloc::report_data_race(
-                                &alloc_meta.global,
+                                data_race,
                                 range,
                                 description,
                                 true,

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -151,11 +151,8 @@ impl MemoryExtra {
         } else {
             None
         };
-        let data_race = if config.data_race_detector {
-            Some(data_race::GlobalState::new())
-        } else {
-            None
-        };
+        let data_race =
+            if config.data_race_detector { Some(data_race::GlobalState::new()) } else { None };
         MemoryExtra {
             stacked_borrows,
             data_race,
@@ -532,7 +529,11 @@ impl<'mir, 'tcx> Machine<'mir, 'tcx> for Evaluator<'mir, 'tcx> {
             data_race.write(ptr, size, memory_extra.data_race.as_mut().unwrap())?;
         }
         if let Some(stacked_borrows) = &mut alloc_extra.stacked_borrows {
-            stacked_borrows.memory_written(ptr, size, memory_extra.stacked_borrows.as_mut().unwrap())
+            stacked_borrows.memory_written(
+                ptr,
+                size,
+                memory_extra.stacked_borrows.as_mut().unwrap(),
+            )
         } else {
             Ok(())
         }
@@ -552,7 +553,11 @@ impl<'mir, 'tcx> Machine<'mir, 'tcx> for Evaluator<'mir, 'tcx> {
             data_race.deallocate(ptr, size, memory_extra.data_race.as_mut().unwrap())?;
         }
         if let Some(stacked_borrows) = &mut alloc_extra.stacked_borrows {
-            stacked_borrows.memory_deallocated(ptr, size, memory_extra.stacked_borrows.as_mut().unwrap())
+            stacked_borrows.memory_deallocated(
+                ptr,
+                size,
+                memory_extra.stacked_borrows.as_mut().unwrap(),
+            )
         } else {
             Ok(())
         }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -436,10 +436,7 @@ impl<'mir, 'tcx: 'mir> ThreadManager<'mir, 'tcx> {
 
     /// Wakes up threads joining on the active one and deallocates thread-local statics.
     /// The `AllocId` that can now be freed is returned.
-    fn thread_terminated(
-        &mut self,
-        data_race: &Option<data_race::GlobalState>,
-    ) -> Vec<AllocId> {
+    fn thread_terminated(&mut self, data_race: &Option<data_race::GlobalState>) -> Vec<AllocId> {
         let mut free_tls_statics = Vec::new();
         {
             let mut thread_local_statics = self.thread_local_alloc_ids.borrow_mut();

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -4,7 +4,6 @@ use std::cell::RefCell;
 use std::collections::hash_map::Entry;
 use std::convert::TryFrom;
 use std::num::TryFromIntError;
-use std::rc::Rc;
 use std::time::{Duration, Instant, SystemTime};
 
 use log::trace;
@@ -333,7 +332,7 @@ impl<'mir, 'tcx: 'mir> ThreadManager<'mir, 'tcx> {
     fn join_thread(
         &mut self,
         joined_thread_id: ThreadId,
-        data_race: &Option<Rc<data_race::GlobalState>>,
+        data_race: &Option<data_race::GlobalState>,
     ) -> InterpResult<'tcx> {
         if self.threads[joined_thread_id].join_status != ThreadJoinStatus::Joinable {
             throw_ub_format!("trying to join a detached or already joined thread");
@@ -439,7 +438,7 @@ impl<'mir, 'tcx: 'mir> ThreadManager<'mir, 'tcx> {
     /// The `AllocId` that can now be freed is returned.
     fn thread_terminated(
         &mut self,
-        data_race: &Option<Rc<data_race::GlobalState>>,
+        data_race: &Option<data_race::GlobalState>,
     ) -> Vec<AllocId> {
         let mut free_tls_statics = Vec::new();
         {
@@ -481,7 +480,7 @@ impl<'mir, 'tcx: 'mir> ThreadManager<'mir, 'tcx> {
     /// blocked, terminated, or has explicitly asked to be preempted).
     fn schedule(
         &mut self,
-        data_race: &Option<Rc<data_race::GlobalState>>,
+        data_race: &Option<data_race::GlobalState>,
     ) -> InterpResult<'tcx, SchedulingAction> {
         // Check whether the thread has **just** terminated (`check_terminated`
         // checks whether the thread has popped all its stack and if yes, sets


### PR DESCRIPTION
Now that the memory access hooks get references to `MemoryExtra`, we can avoid refcounting for the global state of Stacked Borrows and the data race detector.