### PR TITLE
Skip doctests of `proc-macro` crates

### DIFF
--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -906,7 +906,7 @@ fn phase_rustdoc(fst_arg: &str, mut args: env::Args) {
     // Doc-tests of `proc-macro` crates (and their dependencies) are always built for the host,
     // so we are not able to run them in Miri.
     if ArgFlagValueIter::new("--crate-type").any(|crate_type| crate_type == "proc-macro") {
-        eprintln!("Running doc-tests of `proc-macro` crates is not currently supported by Miri.");
+        eprintln!("Running doctests of `proc-macro` crates is not currently supported by Miri.");
         return;
     }
 

--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -903,6 +903,13 @@ fn phase_rustdoc(fst_arg: &str, mut args: env::Args) {
         show_error(format!("cross-interpreting doc-tests is not currently supported by Miri."));
     }
 
+    // Doc-tests of `proc-macro` crates (and their dependencies) are always built for the host,
+    // so we are not able to run them in Miri.
+    if ArgFlagValueIter::new("--crate-type").any(|crate_type| crate_type == "proc-macro") {
+        eprintln!("Running doc-tests of `proc-macro` crates is not currently supported by Miri.");
+        return;
+    }
+
     // For each doc-test, rustdoc starts two child processes: first the test is compiled,
     // then the produced executable is invoked. We want to reroute both of these to cargo-miri,
     // such that the first time we'll enter phase_cargo_rustc, and phase_cargo_runner second.

--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -900,7 +900,7 @@ fn phase_rustdoc(fst_arg: &str, mut args: env::Args) {
     }
 
     if crossmode {
-        show_error(format!("cross-interpreting doc-tests is not currently supported by Miri."));
+        show_error(format!("cross-interpreting doctests is not currently supported by Miri."));
     }
 
     // Doctests of `proc-macro` crates (and their dependencies) are always built for the host,
@@ -910,7 +910,7 @@ fn phase_rustdoc(fst_arg: &str, mut args: env::Args) {
         return;
     }
 
-    // For each doc-test, rustdoc starts two child processes: first the test is compiled,
+    // For each doctest, rustdoc starts two child processes: first the test is compiled,
     // then the produced executable is invoked. We want to reroute both of these to cargo-miri,
     // such that the first time we'll enter phase_cargo_rustc, and phase_cargo_runner second.
     //

--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -903,7 +903,7 @@ fn phase_rustdoc(fst_arg: &str, mut args: env::Args) {
         show_error(format!("cross-interpreting doc-tests is not currently supported by Miri."));
     }
 
-    // Doc-tests of `proc-macro` crates (and their dependencies) are always built for the host,
+    // Doctests of `proc-macro` crates (and their dependencies) are always built for the host,
     // so we are not able to run them in Miri.
     if ArgFlagValueIter::new("--crate-type").any(|crate_type| crate_type == "proc-macro") {
         eprintln!("Running doctests of `proc-macro` crates is not currently supported by Miri.");

--- a/test-cargo-miri/run-test.py
+++ b/test-cargo-miri/run-test.py
@@ -140,6 +140,10 @@ def test_cargo_miri_test():
         "test.subcrate.stdout.ref", "test.stderr-proc-macro.ref",
         env={'MIRIFLAGS': "-Zmiri-disable-isolation"},
     )
+    test("`cargo miri test` (subcrate, doctests)",
+        cargo_miri("test") + ["-p", "subcrate", "--doc"],
+        "test.stdout-empty.ref", "test.stderr-proc-macro-doctest.ref",
+    )
 
 os.chdir(os.path.dirname(os.path.realpath(__file__)))
 os.environ["RUST_TEST_NOCAPTURE"] = "0" # this affects test output, so make sure it is not set

--- a/test-cargo-miri/subcrate/src/lib.rs
+++ b/test-cargo-miri/subcrate/src/lib.rs
@@ -1,5 +1,5 @@
 #[cfg(doctest)]
-use num_cpus as _;
+compile_error!("rustdoc should not touch me");
 
 #[cfg(test)]
 compile_error!("Miri should not touch me");

--- a/test-cargo-miri/subcrate/src/lib.rs
+++ b/test-cargo-miri/subcrate/src/lib.rs
@@ -1,2 +1,5 @@
+#[cfg(doctest)]
+use num_cpus as _;
+
 #[cfg(test)]
 compile_error!("Miri should not touch me");

--- a/test-cargo-miri/test.stderr-proc-macro-doctest.ref
+++ b/test-cargo-miri/test.stderr-proc-macro-doctest.ref
@@ -1,0 +1,1 @@
+Running doc-tests of `proc-macro` crates is not currently supported by Miri.

--- a/test-cargo-miri/test.stderr-proc-macro-doctest.ref
+++ b/test-cargo-miri/test.stderr-proc-macro-doctest.ref
@@ -1,1 +1,1 @@
-Running doc-tests of `proc-macro` crates is not currently supported by Miri.
+Running doctests of `proc-macro` crates is not currently supported by Miri.


### PR DESCRIPTION
Fixes #1813.

Verified that the newly added tests failed without the `cargo-miri` change and pass with normal `cargo test`.