### PR TITLE
Specify miri toolchain for CI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ nightly that *does* come with Miri:
 MIRI_NIGHTLY=nightly-$(curl -s https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)
 echo "Installing latest nightly with Miri: $MIRI_NIGHTLY"
 rustup set profile minimal
-rustup default "$MIRI_NIGHTLY"
+rustup override set "$MIRI_NIGHTLY"
 rustup component add miri
 
 cargo miri test


### PR DESCRIPTION
In particular current example doesn't work if you have a rust-toolchain file in the project.