### PR TITLE
isolated operations return EPERM; tweak isolation hint

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -84,7 +84,10 @@ pub fn report_error<'tcx, 'mir>(
             #[rustfmt::skip]
             let helps = match info {
                 UnsupportedInIsolation(_) =>
-                    vec![(None, format!("pass the flag `-Zmiri-disable-isolation` to disable isolation; or pass `-Zmiri-isolation-error=warn to configure Miri to return an error code from isolated operations and continue with a warning"))],
+                    vec![
+                        (None, format!("pass the flag `-Zmiri-disable-isolation` to disable isolation;")),
+                        (None, format!("or pass `-Zmiri-isolation-error=warn to configure Miri to return an error code from isolated operations (if supported for that operation) and continue with a warning")),
+                    ],
                 ExperimentalUb { url, .. } =>
                     vec![
                         (None, format!("this indicates a potential bug in the program: it performed an invalid operation, but the rules it violated are still experimental")),

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -485,7 +485,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 WouldBlock => "EWOULDBLOCK",
                 _ => {
                     throw_unsup_format!(
-                        "io error {:?} cannot be transformed into a raw os error",
+                        "io error {:?} cannot be translated into a raw os error",
                         err_kind
                     )
                 }
@@ -496,8 +496,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 "c",
                 match err_kind {
                     NotFound => "ERROR_FILE_NOT_FOUND",
+                    PermissionDenied => "ERROR_ACCESS_DENIED",
                     _ => throw_unsup_format!(
-                        "io error {:?} cannot be transformed into a raw os error",
+                        "io error {:?} cannot be translated into a raw os error",
                         err_kind
                     ),
                 },

--- a/src/shims/env.rs
+++ b/src/shims/env.rs
@@ -324,7 +324,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
         if let IsolatedOp::Reject(reject_with) = this.machine.isolated_op {
             this.reject_in_isolation("getcwd", reject_with)?;
-            this.set_last_error_from_io_error(ErrorKind::NotFound)?;
+            this.set_last_error_from_io_error(ErrorKind::PermissionDenied)?;
             return Ok(Scalar::null_ptr(&*this.tcx));
         }
 
@@ -356,7 +356,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
         if let IsolatedOp::Reject(reject_with) = this.machine.isolated_op {
             this.reject_in_isolation("GetCurrentDirectoryW", reject_with)?;
-            this.set_last_error_from_io_error(ErrorKind::NotFound)?;
+            this.set_last_error_from_io_error(ErrorKind::PermissionDenied)?;
             return Ok(0);
         }
 
@@ -382,7 +382,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
         if let IsolatedOp::Reject(reject_with) = this.machine.isolated_op {
             this.reject_in_isolation("chdir", reject_with)?;
-            this.set_last_error_from_io_error(ErrorKind::NotFound)?;
+            this.set_last_error_from_io_error(ErrorKind::PermissionDenied)?;
 
             return Ok(-1);
         }
@@ -410,7 +410,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
         if let IsolatedOp::Reject(reject_with) = this.machine.isolated_op {
             this.reject_in_isolation("SetCurrentDirectoryW", reject_with)?;
-            this.set_last_error_from_io_error(ErrorKind::NotFound)?;
+            this.set_last_error_from_io_error(ErrorKind::PermissionDenied)?;
 
             return Ok(0);
         }

--- a/tests/run-pass/current_dir_with_isolation.rs
+++ b/tests/run-pass/current_dir_with_isolation.rs
@@ -1,6 +1,6 @@
 // compile-flags: -Zmiri-isolation-error=warn-nobacktrace
-// normalize-stderr-test "(getcwd|GetCurrentDirectoryW)" -> "$$GET"
-// normalize-stderr-test "(chdir|SetCurrentDirectoryW)" -> "$$SET"
+// normalize-stderr-test "(getcwd|GetCurrentDirectoryW)" -> "$$GETCWD"
+// normalize-stderr-test "(chdir|SetCurrentDirectoryW)" -> "$$SETCWD"
 
 use std::env;
 use std::io::ErrorKind;
@@ -8,13 +8,14 @@ use std::io::ErrorKind;
 fn main() {
     // Test that current dir operations return a proper error instead
     // of stopping the machine in isolation mode
-    assert_eq!(env::current_dir().unwrap_err().kind(), ErrorKind::NotFound);
+    assert_eq!(env::current_dir().unwrap_err().kind(), ErrorKind::PermissionDenied);
     for _i in 0..3 {
-        assert_eq!(env::current_dir().unwrap_err().kind(), ErrorKind::NotFound);
+        // Ensure we get no repeated warnings when doing this multiple times.
+        assert_eq!(env::current_dir().unwrap_err().kind(), ErrorKind::PermissionDenied);
     }
 
-    assert_eq!(env::set_current_dir("..").unwrap_err().kind(), ErrorKind::NotFound);
+    assert_eq!(env::set_current_dir("..").unwrap_err().kind(), ErrorKind::PermissionDenied);
     for _i in 0..3 {
-        assert_eq!(env::set_current_dir("..").unwrap_err().kind(), ErrorKind::NotFound);
+        assert_eq!(env::set_current_dir("..").unwrap_err().kind(), ErrorKind::PermissionDenied);
     }
 }

--- a/tests/run-pass/current_dir_with_isolation.stderr
+++ b/tests/run-pass/current_dir_with_isolation.stderr
@@ -1,4 +1,4 @@
-warning: `$GET` was made to return an error due to isolation
+warning: `$GETCWD` was made to return an error due to isolation
 
-warning: `$SET` was made to return an error due to isolation
+warning: `$SETCWD` was made to return an error due to isolation
 


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/miri/pull/1797