### PR TITLE
Fix the wrong `EmulateByNameResult::NotSupported` in `syscall` shim

### DIFF
--- a/src/shims/posix/linux/foreign_items.rs
+++ b/src/shims/posix/linux/foreign_items.rs
@@ -185,7 +185,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                     }
                     id => {
                         this.handle_unsupported(format!("can't execute syscall with ID {}", id))?;
-                        return Ok(EmulateByNameResult::NotSupported);
+                        return Ok(EmulateByNameResult::AlreadyJumped);
                     }
                 }
             }

--- a/tests/run-pass/panic/unsupported_syscall.rs
+++ b/tests/run-pass/panic/unsupported_syscall.rs
@@ -1,0 +1,12 @@
+// ignore-windows: No libc on Windows
+// ignore-macos: `syscall` is not supported on macOS
+// compile-flags: -Zmiri-panic-on-unsupported
+#![feature(rustc_private)]
+
+extern crate libc;
+
+fn main() {
+    unsafe {
+        libc::syscall(0);
+    }
+}

--- a/tests/run-pass/panic/unsupported_syscall.stderr
+++ b/tests/run-pass/panic/unsupported_syscall.stderr
@@ -1,0 +1,2 @@
+thread 'main' panicked at 'unsupported Miri functionality: can't execute syscall with ID 0', $DIR/unsupported_syscall.rs:10:9
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


### PR DESCRIPTION
Without the change, the newly added test will fail with:
```diff
-thread 'main' panicked at 'unsupported Miri functionality: can't execute syscall with ID 0', $DIR/unsupported_syscall.rs:10:9
+thread 'main' panicked at 'unsupported Miri functionality: can't call foreign function: syscall', $DIR/unsupported_syscall.rs:10:9
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
cc https://github.com/rust-lang/miri/pull/1818#discussion_r648868937