### PR TITLE
Use `miri` inside the target directory used by rustc as Miri's target directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
           else
             RUSTC_HASH=$(< rust-version)
           fi
+          # We need a nightly cargo for parts of the cargo miri test suite.
           rustup-toolchain-install-master \
             -f \
             -n master "$RUSTC_HASH" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,12 @@ jobs:
             --host ${{ matrix.host_target }}
           rustup default master
 
+      # We need a nightly Cargo to run tests that depend on unstable Cargo features.
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+
       - name: Show Rust version
         run: |
           rustup show

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,17 +77,12 @@ jobs:
           rustup-toolchain-install-master \
             -f \
             -n master "$RUSTC_HASH" \
+            -c cargo \
             -c rust-src \
             -c rustc-dev \
             -c llvm-tools \
             --host ${{ matrix.host_target }}
           rustup default master
-
-      # We need a nightly Cargo to run tests that depend on unstable Cargo features.
-      - name: Install latest nightly
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
 
       - name: Show Rust version
         run: |

--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -6,7 +6,7 @@ use std::io::{self, BufRead, BufReader, BufWriter, Read, Write};
 use std::iter::TakeWhile;
 use std::ops::Not;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{self, Command};
 
 use serde::{Deserialize, Serialize};
 
@@ -233,7 +233,7 @@ fn exec(mut cmd: Command) {
 /// If it fails, fail this process with the same exit code.
 /// Otherwise, continue.
 fn exec_with_pipe(mut cmd: Command, input: &[u8]) {
-    cmd.stdin(std::process::Stdio::piped());
+    cmd.stdin(process::Stdio::piped());
     let mut child = cmd.spawn().expect("failed to spawn process");
     {
         let stdin = child.stdin.as_mut().expect("failed to open stdin");
@@ -493,8 +493,8 @@ fn detect_target_dir() -> PathBuf {
         }
     }
     let mut child = cmd
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
+        .stdin(process::Stdio::null())
+        .stdout(process::Stdio::piped())
         .spawn()
         .expect("failed ro run `cargo metadata`");
     // Check this `Result` after `status.success()` is checked, so we don't print the error

--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -500,7 +500,7 @@ fn detect_target_dir() -> PathBuf {
     // Check this `Result` after `status.success()` is checked, so we don't print the error
     // to stderr if `cargo metadata` is also printing to stderr.
     let metadata: Result<Metadata, _> = serde_json::from_reader(child.stdout.take().unwrap());
-    let status = child.wait().expect("failed to wait `cargo metadata` to exit");
+    let status = child.wait().expect("failed to wait for `cargo metadata` to exit");
     if !status.success() {
         std::process::exit(status.code().unwrap_or(-1));
     }

--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -572,7 +572,12 @@ fn phase_cargo_miri(mut args: env::Args) {
     // Forward all arguments before `--` other than `--target-dir` and its value to Cargo.
     for arg in ArgSplitFlagValue::new(&mut args, "--target-dir") {
         match arg {
-            Ok(value) => target_dir = Some(value.into()),
+            Ok(value) => {
+                if target_dir.is_some() {
+                    show_error(format!("`--target-dir` is provided more than once"));
+                }
+                target_dir = Some(value.into());
+            }
             Err(arg) => drop(cmd.arg(arg)),
         }
     }

--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -578,7 +578,9 @@ fn phase_cargo_miri(mut args: env::Args) {
                 }
                 target_dir = Some(value.into());
             }
-            Err(arg) => drop(cmd.arg(arg)),
+            Err(arg) => {
+                cmd.arg(arg);
+            }
         }
     }
 

--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -113,7 +113,7 @@ fn has_arg_flag(name: &str) -> bool {
 }
 
 /// Yields all values of command line flag `name` as `Ok(arg)`, and all other arguments except
-/// the flag as `Err(arg)`.
+/// the flag as `Err(arg)`. (The flag `name` itself is not yielded at all, only its values are.)
 struct ArgSplitFlagValue<'a, I> {
     args: TakeWhile<I, fn(&String) -> bool>,
     name: &'a str,

--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -481,7 +481,7 @@ fn detect_target_dir() -> PathBuf {
     let mut cmd = cargo();
     // `-Zunstable-options` is required by `--config`.
     cmd.args(["metadata", "--no-deps", "--format-version=1", "-Zunstable-options"]);
-    // The `build.target-dir` config can by passed by `--config` flags, so forward them to
+    // The `build.target-dir` config can be passed by `--config` flags, so forward them to
     // `cargo metadata`.
     let config_flag = "--config";
     for arg in ArgSplitFlagValue::new(

--- a/rustup-toolchain
+++ b/rustup-toolchain
@@ -39,7 +39,7 @@ fi
 
 # Install and setup new toolchain.
 rustup toolchain uninstall miri
-rustup-toolchain-install-master -n miri -c rust-src -c rustc-dev -c llvm-tools -- "$NEW_COMMIT"
+rustup-toolchain-install-master -n miri -c cargo -c rust-src -c rustc-dev -c llvm-tools -- "$NEW_COMMIT"
 rustup override set miri
 
 # Cleanup.

--- a/test-cargo-miri/.gitignore
+++ b/test-cargo-miri/.gitignore
@@ -1,1 +1,4 @@
 *.real
+custom-run
+custom-test
+config-cli

--- a/test-cargo-miri/run-test.py
+++ b/test-cargo-miri/run-test.py
@@ -173,9 +173,11 @@ if not 'MIRI_SYSROOT' in os.environ:
     subprocess.run(cargo_miri("setup"), check=True)
 test_cargo_miri_run()
 test_cargo_miri_test()
+# Ensure we did not create anything outside the expected target dir.
 for target_dir in ["target", "custom-run", "custom-test", "config-cli"]:
     if os.listdir(target_dir) != ["miri"]:
         fail(f"`{target_dir}` contains unexpected files")
+    # Ensure something exists inside that target dir.
     os.access(os.path.join(target_dir, "miri", "debug", "deps"), os.F_OK)
 
 print("\nTEST SUCCESSFUL!")

--- a/test-cargo-miri/run-test.py
+++ b/test-cargo-miri/run-test.py
@@ -101,6 +101,11 @@ def test_cargo_miri_run():
         "run.subcrate.stdout.ref", "run.subcrate.stderr.ref",
         env={'MIRIFLAGS': "-Zmiri-disable-isolation"},
     )
+    test("`cargo miri run` (custom target dir)",
+        # Attempt to confuse the argument parser.
+        cargo_miri("run") + ["--target-dir=custom-run", "--", "--target-dir=target/custom-run"],
+        "run.args.stdout.ref", "run.custom-target-dir.stderr.ref",
+    )
 
 def test_cargo_miri_test():
     # rustdoc is not run on foreign targets
@@ -144,8 +149,18 @@ def test_cargo_miri_test():
         cargo_miri("test") + ["-p", "subcrate", "--doc"],
         "test.stdout-empty.ref", "test.stderr-proc-macro-doctest.ref",
     )
+    test("`cargo miri test` (custom target dir)",
+        cargo_miri("test") + ["--target-dir=custom-test"],
+        default_ref, "test.stderr-empty.ref",
+    )
+    del os.environ["CARGO_TARGET_DIR"] # this overrides `build.target-dir` passed by `--config`, so unset it
+    test("`cargo miri test` (config-cli)",
+        cargo_miri("test") + ["--config=build.target-dir=\"config-cli\"", "-Zunstable-options"],
+        default_ref, "test.stderr-empty.ref",
+    )
 
 os.chdir(os.path.dirname(os.path.realpath(__file__)))
+os.environ["CARGO_TARGET_DIR"] = "target" # this affects the location of the target directory that we need to check
 os.environ["RUST_TEST_NOCAPTURE"] = "0" # this affects test output, so make sure it is not set
 os.environ["RUST_TEST_THREADS"] = "1" # avoid non-deterministic output due to concurrent test runs
 
@@ -158,6 +173,10 @@ if not 'MIRI_SYSROOT' in os.environ:
     subprocess.run(cargo_miri("setup"), check=True)
 test_cargo_miri_run()
 test_cargo_miri_test()
+for target_dir in ["target", "custom-run", "custom-test", "config-cli"]:
+    if os.listdir(target_dir) != ["miri"]:
+        fail(f"`{target_dir}` contains unexpected files")
+    os.access(os.path.join(target_dir, "miri", "debug", "deps"), os.F_OK)
 
 print("\nTEST SUCCESSFUL!")
 sys.exit(0)

--- a/test-cargo-miri/run.custom-target-dir.stderr.ref
+++ b/test-cargo-miri/run.custom-target-dir.stderr.ref
@@ -1,0 +1,2 @@
+main
+--target-dir=target/custom-run


### PR DESCRIPTION
Resolves #1311.

This PR makes Miri use `miri` inside the rustc target directory as its target directory, by letting `cargo-miri` get the rustc target directory by calling `cargo metadata`, append `miri` to it, and pass it with `--target-dir` to Cargo.

Getting the rustc target directory accurately requires calling `cargo metadata` as far as I know, because the `target-dir` can be set in config files in various places that are hard for `cargo-miri` to find.

I also considered https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#custom-named-profiles, but it looks like that requires adding `cargo-features = ["named-profiles"]` to **`Cargo.toml`**, which would be tricky for `cargo-miri`:
```
$ cargo +nightly-2021-06-23 test --config 'profile.miri.inherits="release"' --profile=miri -Z named-profiles -Z unstable-options
error: config profile `miri` is not valid (defined in `--config cli option`)

Caused by:
  feature `named-profiles` is required

  consider adding `cargo-features = ["named-profiles"]` to the manifest
```