### PR TITLE
also treat CallerLocation and Machine memory as properly tagged

### DIFF
--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -194,7 +194,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
         let instance = instance_and_crate.map(|ic| ic.0);
         // Cache it and load its MIR, if found.
-        this.machine.exported_symbols_cache.insert(link_name, instance);
+        this.machine.exported_symbols_cache.try_insert(link_name, instance).unwrap();
         instance.map(|instance| this.load_mir(instance.def, None)).transpose()
     }
 

--- a/src/stacked_borrows.rs
+++ b/src/stacked_borrows.rs
@@ -504,22 +504,23 @@ impl Stacks {
             // `Global` memory can be referenced by global pointers from `tcx`.
             // Thus we call `global_base_ptr` such that the global pointers get the same tag
             // as what we use here.
-            // `ExternStatic` is used for extern statics, and thus must also be listed here.
-            // `Env` we list because we can get away with precise tracking there.
+            // `ExternStatic` is used for extern statics, so the same reasoning applies.
+            // The others are various forms of machine-managed special global memory, and we can get
+            // away with precise tracking there.
             // The base pointer is not unique, so the base permission is `SharedReadWrite`.
-            MemoryKind::Machine(
+            MemoryKind::CallerLocation
+            | MemoryKind::Machine(
                 MiriMemoryKind::Global
                 | MiriMemoryKind::ExternStatic
                 | MiriMemoryKind::Tls
-                | MiriMemoryKind::Env,
+                | MiriMemoryKind::Env
+                | MiriMemoryKind::Machine,
             ) => (extra.global_base_ptr(id), Permission::SharedReadWrite),
-            // Everything else we only track precisely when raw pointers are tagged, for now.
-            MemoryKind::CallerLocation
-            | MemoryKind::Machine(
+            // Heap allocations we only track precisely when raw pointers are tagged, for now.
+            MemoryKind::Machine(
                 MiriMemoryKind::Rust
                 | MiriMemoryKind::C
-                | MiriMemoryKind::WinHeap
-                | MiriMemoryKind::Machine,
+                | MiriMemoryKind::WinHeap,
             ) => {
                 let tag =
                     if extra.track_raw { Tag::Tagged(extra.new_ptr()) } else { Tag::Untagged };

--- a/src/stacked_borrows.rs
+++ b/src/stacked_borrows.rs
@@ -513,8 +513,14 @@ impl Stacks {
                 | MiriMemoryKind::Tls
                 | MiriMemoryKind::Env,
             ) => (extra.global_base_ptr(id), Permission::SharedReadWrite),
-            // Everything else we handle like raw pointers for now.
-            _ => {
+            // Everything else we only track precisely when raw pointers are tagged, for now.
+            MemoryKind::CallerLocation
+            | MemoryKind::Machine(
+                MiriMemoryKind::Rust
+                | MiriMemoryKind::C
+                | MiriMemoryKind::WinHeap
+                | MiriMemoryKind::Machine,
+            ) => {
                 let tag =
                     if extra.track_raw { Tag::Tagged(extra.new_ptr()) } else { Tag::Untagged };
                 (tag, Permission::SharedReadWrite)

--- a/src/stacked_borrows.rs
+++ b/src/stacked_borrows.rs
@@ -518,9 +518,7 @@ impl Stacks {
             ) => (extra.global_base_ptr(id), Permission::SharedReadWrite),
             // Heap allocations we only track precisely when raw pointers are tagged, for now.
             MemoryKind::Machine(
-                MiriMemoryKind::Rust
-                | MiriMemoryKind::C
-                | MiriMemoryKind::WinHeap,
+                MiriMemoryKind::Rust | MiriMemoryKind::C | MiriMemoryKind::WinHeap,
             ) => {
                 let tag =
                     if extra.track_raw { Tag::Tagged(extra.new_ptr()) } else { Tag::Untagged };


### PR DESCRIPTION
Only heap allocations need an exception.