### PR TITLE
fmt: set force_multiline_blocks=true

### DIFF
--- a/benches/helpers/miri_helper.rs
+++ b/benches/helpers/miri_helper.rs
@@ -40,9 +40,10 @@ fn find_sysroot() -> String {
     let toolchain = option_env!("RUSTUP_TOOLCHAIN").or(option_env!("MULTIRUST_TOOLCHAIN"));
     match (home, toolchain) {
         (Some(home), Some(toolchain)) => format!("{}/toolchains/{}", home, toolchain),
-        _ => option_env!("RUST_SYSROOT")
-            .expect("need to specify RUST_SYSROOT env var or use rustup or multirust")
-            .to_owned(),
+        _ =>
+            option_env!("RUST_SYSROOT")
+                .expect("need to specify RUST_SYSROOT env var or use rustup or multirust")
+                .to_owned(),
     }
 }
 

--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -528,9 +528,10 @@ fn phase_cargo_miri(mut args: env::Args) {
         Some("run") => MiriCommand::Run,
         Some("setup") => MiriCommand::Setup,
         // Invalid command.
-        _ => show_error(format!(
-            "`cargo miri` supports the following subcommands: `run`, `test`, and `setup`."
-        )),
+        _ =>
+            show_error(format!(
+                "`cargo miri` supports the following subcommands: `run`, `test`, and `setup`."
+            )),
     };
     let verbose = has_arg_flag("-v");
 
@@ -1086,8 +1087,9 @@ fn main() {
                 ));
             }
         }
-        _ => show_error(format!(
-            "`cargo-miri` called without first argument; please only invoke this binary through `cargo miri`"
-        )),
+        _ =>
+            show_error(format!(
+                "`cargo-miri` called without first argument; please only invoke this binary through `cargo miri`"
+            )),
     }
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,3 +2,4 @@ version = "Two"
 use_small_heuristics = "Max"
 match_arm_blocks = false
 match_arm_leading_pipes = "Preserve"
+force_multiline_blocks = true

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -203,9 +203,12 @@ fn compile_time_sysroot() -> Option<String> {
     let toolchain = option_env!("RUSTUP_TOOLCHAIN").or(option_env!("MULTIRUST_TOOLCHAIN"));
     Some(match (home, toolchain) {
         (Some(home), Some(toolchain)) => format!("{}/toolchains/{}", home, toolchain),
-        _ => option_env!("RUST_SYSROOT")
-            .expect("To build Miri without rustup, set the `RUST_SYSROOT` env var at build time")
-            .to_owned(),
+        _ =>
+            option_env!("RUST_SYSROOT")
+                .expect(
+                    "To build Miri without rustup, set the `RUST_SYSROOT` env var at build time",
+                )
+                .to_owned(),
     })
 }
 
@@ -336,9 +339,10 @@ fn main() {
                         "warn" => miri::IsolatedOp::Reject(miri::RejectOpWith::Warning),
                         "warn-nobacktrace" =>
                             miri::IsolatedOp::Reject(miri::RejectOpWith::WarningWithoutBacktrace),
-                        _ => panic!(
-                            "-Zmiri-isolation-error must be `abort`, `hide`, `warn`, or `warn-nobacktrace`"
-                        ),
+                        _ =>
+                            panic!(
+                                "-Zmiri-isolation-error must be `abort`, `hide`, `warn`, or `warn-nobacktrace`"
+                            ),
                     };
                 }
                 "-Zmiri-ignore-leaks" => {
@@ -383,10 +387,11 @@ fn main() {
                     let id: u64 =
                         match arg.strip_prefix("-Zmiri-track-pointer-tag=").unwrap().parse() {
                             Ok(id) => id,
-                            Err(err) => panic!(
-                                "-Zmiri-track-pointer-tag requires a valid `u64` argument: {}",
-                                err
-                            ),
+                            Err(err) =>
+                                panic!(
+                                    "-Zmiri-track-pointer-tag requires a valid `u64` argument: {}",
+                                    err
+                                ),
                         };
                     if let Some(id) = miri::PtrId::new(id) {
                         miri_config.tracked_pointer_tag = Some(id);
@@ -422,13 +427,15 @@ fn main() {
                         .parse::<f64>()
                     {
                         Ok(rate) if rate >= 0.0 && rate <= 1.0 => rate,
-                        Ok(_) => panic!(
-                            "-Zmiri-compare-exchange-weak-failure-rate must be between `0.0` and `1.0`"
-                        ),
-                        Err(err) => panic!(
-                            "-Zmiri-compare-exchange-weak-failure-rate requires a `f64` between `0.0` and `1.0`: {}",
-                            err
-                        ),
+                        Ok(_) =>
+                            panic!(
+                                "-Zmiri-compare-exchange-weak-failure-rate must be between `0.0` and `1.0`"
+                            ),
+                        Err(err) =>
+                            panic!(
+                                "-Zmiri-compare-exchange-weak-failure-rate requires a `f64` between `0.0` and `1.0`: {}",
+                                err
+                            ),
                     };
                     miri_config.cmpxchg_weak_failure_rate = rate;
                 }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -43,11 +43,12 @@ impl fmt::Display for TerminationInfo {
             Deadlock => write!(f, "the evaluated program deadlocked"),
             MultipleSymbolDefinitions { link_name, .. } =>
                 write!(f, "multiple definitions of symbol `{}`", link_name),
-            SymbolShimClashing { link_name, .. } => write!(
-                f,
-                "found `{}` symbol definition that clashes with a built-in shim",
-                link_name
-            ),
+            SymbolShimClashing { link_name, .. } =>
+                write!(
+                    f,
+                    "found `{}` symbol definition that clashes with a built-in shim",
+                    link_name
+                ),
         }
     }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -498,10 +498,11 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 match err_kind {
                     NotFound => "ERROR_FILE_NOT_FOUND",
                     PermissionDenied => "ERROR_ACCESS_DENIED",
-                    _ => throw_unsup_format!(
-                        "io error {:?} cannot be translated into a raw os error",
-                        err_kind
-                    ),
+                    _ =>
+                        throw_unsup_format!(
+                            "io error {:?} cannot be translated into a raw os error",
+                            err_kind
+                        ),
                 },
             )?
         } else {

--- a/src/shims/env.rs
+++ b/src/shims/env.rs
@@ -53,10 +53,11 @@ impl<'tcx> EnvVars<'tcx> {
                         "linux" | "macos" =>
                             alloc_env_var_as_c_str(name.as_ref(), value.as_ref(), ecx)?,
                         "windows" => alloc_env_var_as_wide_str(name.as_ref(), value.as_ref(), ecx)?,
-                        unsupported => throw_unsup_format!(
-                            "environment support for target OS `{}` not yet available",
-                            unsupported
-                        ),
+                        unsupported =>
+                            throw_unsup_format!(
+                                "environment support for target OS `{}` not yet available",
+                                unsupported
+                            ),
                     };
                     ecx.machine.env_vars.map.insert(OsString::from(name), var_ptr);
                 }

--- a/src/shims/intrinsics.rs
+++ b/src/shims/intrinsics.rs
@@ -295,10 +295,11 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                         this.float_to_int_unchecked(val.to_scalar()?.to_f32()?, dest.layout.ty)?,
                     ty::Float(FloatTy::F64) =>
                         this.float_to_int_unchecked(val.to_scalar()?.to_f64()?, dest.layout.ty)?,
-                    _ => bug!(
-                        "`float_to_int_unchecked` called with non-float input type {:?}",
-                        val.layout.ty
-                    ),
+                    _ =>
+                        bug!(
+                            "`float_to_int_unchecked` called with non-float input type {:?}",
+                            val.layout.ty
+                        ),
                 };
 
                 this.write_scalar(res, dest)?;

--- a/src/shims/posix/fs.rs
+++ b/src/shims/posix/fs.rs
@@ -434,10 +434,11 @@ trait EvalContextExtPrivate<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, '
             Err(e) =>
                 return match e.raw_os_error() {
                     Some(error) => Ok(error),
-                    None => throw_unsup_format!(
-                        "the error {} couldn't be converted to a return value",
-                        e
-                    ),
+                    None =>
+                        throw_unsup_format!(
+                            "the error {} couldn't be converted to a return value",
+                            e
+                        ),
                 },
         }
     }
@@ -1203,13 +1204,17 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_null(&this.deref_operand(result_op)?.into())?;
                 Ok(0)
             }
-            Some(Err(e)) => match e.raw_os_error() {
-                // return positive error number on error
-                Some(error) => Ok(error),
-                None => {
-                    throw_unsup_format!("the error {} couldn't be converted to a return value", e)
-                }
-            },
+            Some(Err(e)) =>
+                match e.raw_os_error() {
+                    // return positive error number on error
+                    Some(error) => Ok(error),
+                    None => {
+                        throw_unsup_format!(
+                            "the error {} couldn't be converted to a return value",
+                            e
+                        )
+                    }
+                },
         }
     }
 
@@ -1294,13 +1299,17 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_null(&this.deref_operand(result_op)?.into())?;
                 Ok(0)
             }
-            Some(Err(e)) => match e.raw_os_error() {
-                // return positive error number on error
-                Some(error) => Ok(error),
-                None => {
-                    throw_unsup_format!("the error {} couldn't be converted to a return value", e)
-                }
-            },
+            Some(Err(e)) =>
+                match e.raw_os_error() {
+                    // return positive error number on error
+                    Some(error) => Ok(error),
+                    None => {
+                        throw_unsup_format!(
+                            "the error {} couldn't be converted to a return value",
+                            e
+                        )
+                    }
+                },
         }
     }
 

--- a/src/stacked_borrows.rs
+++ b/src/stacked_borrows.rs
@@ -699,10 +699,11 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         fn qualify(ty: ty::Ty<'_>, kind: RetagKind) -> Option<(RefKind, bool)> {
             match ty.kind() {
                 // References are simple.
-                ty::Ref(_, _, Mutability::Mut) => Some((
-                    RefKind::Unique { two_phase: kind == RetagKind::TwoPhase },
-                    kind == RetagKind::FnEntry,
-                )),
+                ty::Ref(_, _, Mutability::Mut) =>
+                    Some((
+                        RefKind::Unique { two_phase: kind == RetagKind::TwoPhase },
+                        kind == RetagKind::FnEntry,
+                    )),
                 ty::Ref(_, _, Mutability::Not) =>
                     Some((RefKind::Shared, kind == RetagKind::FnEntry)),
                 // Raw pointers need to be enabled.

--- a/src/vector_clock.rs
+++ b/src/vector_clock.rs
@@ -186,16 +186,18 @@ impl PartialOrd for VClock {
             Ordering::Equal => Some(order),
             // Right has at least 1 element > than the implicit 0,
             // so the only valid values are Ordering::Less or None.
-            Ordering::Less => match order {
-                Ordering::Less | Ordering::Equal => Some(Ordering::Less),
-                Ordering::Greater => None,
-            },
+            Ordering::Less =>
+                match order {
+                    Ordering::Less | Ordering::Equal => Some(Ordering::Less),
+                    Ordering::Greater => None,
+                },
             // Left has at least 1 element > than the implicit 0,
             // so the only valid values are Ordering::Greater or None.
-            Ordering::Greater => match order {
-                Ordering::Greater | Ordering::Equal => Some(Ordering::Greater),
-                Ordering::Less => None,
-            },
+            Ordering::Greater =>
+                match order {
+                    Ordering::Greater | Ordering::Equal => Some(Ordering::Greater),
+                    Ordering::Less => None,
+                },
         }
     }
 


### PR DESCRIPTION
This is an experiment, I am not yet sure if I like it... but it does prevent rustfmt from putting stuff after the `=>` in a `match` (unless the entire arm fits there), which IMO is a big plus. What do others think?
(I also tried setting `match_arm_blocks` back to its default of `true`, but that adds too many braces for my taste.)

Btw, @calebcartwright is the interaction of `match_arm_blocks = false` and `force_multiline_blocks = true` as can be seen here expected? I think I like it, but it it is not at all what I expected from the docs which describe `force_multiline_blocks = true` as "Force multiline closure and match arm bodies to be wrapped in a block" -- but here that is not the effect it has, there are no new blocks being added.