### PR TITLE
also ignore 'thread leaks' with -Zmiri-ignore-leaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,8 @@ environment variable:
   the host so that it cannot be accessed by the program.  Can be used multiple
   times to exclude several variables.  On Windows, the `TERM` environment
   variable is excluded by default.
-* `-Zmiri-ignore-leaks` disables the memory leak checker.
+* `-Zmiri-ignore-leaks` disables the memory leak checker, and also allows some
+  remaining threads to exist when the main thread exits.
 * `-Zmiri-measureme=<name>` enables `measureme` profiling for the interpreted program.
    This can be used to find which parts of your program are executing slowly under Miri.
    The profile is written out to a file with the prefix `<name>`, and can be processed

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -300,6 +300,12 @@ pub fn eval_main<'tcx>(tcx: TyCtxt<'tcx>, main_id: DefId, config: MiriConfig) ->
     match res {
         Ok(return_code) => {
             if !ignore_leaks {
+                // Check for thread leaks.
+                if !ecx.have_all_terminated() {
+                    tcx.sess.err("the main thread terminated without waiting for all remaining threads");
+                    return None;
+                }
+                // Check for memory leaks.
                 info!("Additonal static roots: {:?}", ecx.machine.static_roots);
                 let leaks = ecx.memory.leak_report(&ecx.machine.static_roots);
                 if leaks != 0 {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -302,7 +302,10 @@ pub fn eval_main<'tcx>(tcx: TyCtxt<'tcx>, main_id: DefId, config: MiriConfig) ->
             if !ignore_leaks {
                 // Check for thread leaks.
                 if !ecx.have_all_terminated() {
-                    tcx.sess.err("the main thread terminated without waiting for all remaining threads");
+                    tcx.sess.err(
+                        "the main thread terminated without waiting for all remaining threads",
+                    );
+                    tcx.sess.note_without_error("pass `-Zmiri-ignore-leaks` to disable this check");
                     return None;
                 }
                 // Check for memory leaks.
@@ -310,6 +313,7 @@ pub fn eval_main<'tcx>(tcx: TyCtxt<'tcx>, main_id: DefId, config: MiriConfig) ->
                 let leaks = ecx.memory.leak_report(&ecx.machine.static_roots);
                 if leaks != 0 {
                     tcx.sess.err("the evaluated program leaked memory");
+                    tcx.sess.note_without_error("pass `-Zmiri-ignore-leaks` to disable this check");
                     // Ignore the provided return code - let the reported error
                     // determine the return code.
                     return None;

--- a/tests/compile-fail/concurrency/libc_pthread_create_main_terminate.rs
+++ b/tests/compile-fail/concurrency/libc_pthread_create_main_terminate.rs
@@ -1,5 +1,5 @@
 // ignore-windows: No libc on Windows
-// error-pattern: unsupported operation: the main thread terminated without waiting for other threads
+// error-pattern: the main thread terminated without waiting for all remaining threads
 
 // Check that we terminate the program when the main thread terminates.
 
@@ -10,7 +10,7 @@ extern crate libc;
 use std::{mem, ptr};
 
 extern "C" fn thread_start(_null: *mut libc::c_void) -> *mut libc::c_void {
-    ptr::null_mut()
+    loop {}
 }
 
 fn main() {

--- a/tests/run-pass/threadleak_ignored.rs
+++ b/tests/run-pass/threadleak_ignored.rs
@@ -1,0 +1,24 @@
+// compile-flags: -Zmiri-ignore-leaks
+
+//! Test that leaking threads works, and that their destructors are not executed.
+
+use std::cell::RefCell;
+
+struct LoudDrop(i32);
+impl Drop for LoudDrop {
+    fn drop(&mut self) {
+        eprintln!("Dropping {}", self.0);
+    }
+}
+
+thread_local! {
+    static X: RefCell<Option<LoudDrop>> = RefCell::new(None);
+}
+
+fn main() {
+    X.with(|x| *x.borrow_mut() = Some(LoudDrop(0)));
+    
+    let _detached = std::thread::spawn(|| {
+        X.with(|x| *x.borrow_mut() = Some(LoudDrop(1)));
+    });
+}

--- a/tests/run-pass/threadleak_ignored.rs
+++ b/tests/run-pass/threadleak_ignored.rs
@@ -1,3 +1,4 @@
+// ignore-windows: Concurrency on Windows is not supported yet.
 // compile-flags: -Zmiri-ignore-leaks
 
 //! Test that leaking threads works, and that their destructors are not executed.

--- a/tests/run-pass/threadleak_ignored.rs
+++ b/tests/run-pass/threadleak_ignored.rs
@@ -21,5 +21,6 @@ fn main() {
     
     let _detached = std::thread::spawn(|| {
         X.with(|x| *x.borrow_mut() = Some(LoudDrop(1)));
+        loop {}
     });
 }

--- a/tests/run-pass/threadleak_ignored.stderr
+++ b/tests/run-pass/threadleak_ignored.stderr
@@ -1,0 +1,3 @@
+warning: thread support is experimental and incomplete: weak memory effects are not emulated.
+
+Dropping 0


### PR DESCRIPTION
This is a step towards https://github.com/rust-lang/miri/issues/1371. The remaining hard part would be supporting checking for memory leaks when there are threads still running. For now we elegantly avoid this problem by using the same flag to control both of these checks. :)