### PR TITLE
Use `Lrc` instead of `Rc` in `MiriCompilerCalls::config()`

### DIFF
--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -1,5 +1,6 @@
 #![feature(rustc_private, bool_to_option, stmt_expr_attributes)]
 
+extern crate rustc_data_structures;
 extern crate rustc_driver;
 extern crate rustc_errors;
 extern crate rustc_hir;
@@ -12,12 +13,12 @@ use std::convert::TryFrom;
 use std::env;
 use std::num::NonZeroU64;
 use std::path::PathBuf;
-use std::rc::Rc;
 use std::str::FromStr;
 
 use hex::FromHexError;
 use log::debug;
 
+use rustc_data_structures::sync::Lrc;
 use rustc_driver::Compilation;
 use rustc_errors::emitter::{ColorConfig, HumanReadableErrorType};
 use rustc_hir::{self as hir, def_id::LOCAL_CRATE, Node};
@@ -42,7 +43,7 @@ impl rustc_driver::Callbacks for MiriCompilerCalls {
                 // HACK: rustc will emit "crate ... required to be available in rlib format, but
                 // was not found in this form" errors once we use `tcx.dependency_formats()` if
                 // there's no rlib provided, so setting a dummy path here to workaround those errors.
-                Rc::make_mut(&mut crate_source).rlib = Some((PathBuf::new(), PathKind::All));
+                Lrc::make_mut(&mut crate_source).rlib = Some((PathBuf::new(), PathKind::All));
                 crate_source
             };
         });


### PR DESCRIPTION
The `used_crate_source` query defines its return type as [`Lrc<CrateSource>`](https://github.com/rust-lang/rust/blob/1195bea5a7b73e079fa14b37ac7e375fc77d368a/compiler/rustc_middle/src/query/mod.rs#L1418), which would be `Arc` when `parallel-compiler = true`.

I assume this fixes rust-lang/rust#87623. I didn't test that locally -- I'm not interested in `parallel-compiler = true` enough to be willing to recompile rustc with that configuration to test it, but I'm submitting this in case it might be useful for `parallel-compiler = true` users.