### PR TITLE
Update tests for `#[no_mangle]` on associated functions

### DIFF
--- a/test-cargo-miri/exported-symbol-dep/src/lib.rs
+++ b/test-cargo-miri/exported-symbol-dep/src/lib.rs
@@ -3,11 +3,11 @@ fn exported_symbol() -> i32 {
     123456
 }
 
-pub struct AssocFn;
+struct AssocFn;
 
 impl AssocFn {
     #[no_mangle]
-    pub fn assoc_fn_as_exported_symbol() -> i32 {
+    fn assoc_fn_as_exported_symbol() -> i32 {
         -123456
     }
 }

--- a/tests/run-pass/function_calls/exported_symbol.rs
+++ b/tests/run-pass/function_calls/exported_symbol.rs
@@ -15,6 +15,16 @@ fn baz() -> i32 {
     -3
 }
 
+struct AssocFn;
+
+impl AssocFn {
+    #[no_mangle]
+    fn qux() -> i32 {
+        -4
+    }
+}
+
+
 fn main() {
     // Repeat calls to make sure the `Instance` cache is not broken.
     for _ in 0..3 {
@@ -32,10 +42,12 @@ fn main() {
         extern "Rust" {
             fn bar() -> i32;
             fn baz() -> i32;
+            fn qux() -> i32;
         }
 
         assert_eq!(unsafe { bar() }, -2);
         assert_eq!(unsafe { baz() }, -3);
+        assert_eq!(unsafe { qux() }, -4);
 
         #[allow(clashing_extern_declarations)]
         {
@@ -53,6 +65,7 @@ fn main() {
             extern "C" {
                 fn bar() -> i32;
                 fn baz() -> i32;
+                fn qux() -> i32;
             }
 
             unsafe {
@@ -61,6 +74,7 @@ fn main() {
                 };
                 assert_eq!(transmute(bar)(), -2);
                 assert_eq!(transmute(baz)(), -3);
+                assert_eq!(transmute(qux)(), -4);
             }
         }
     }


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/86492 has landed:
- The code in https://github.com/rust-lang/miri/issues/1837 starts to work (even without `AssocFn::foo();` at line 12) in Miri.
- `pub` is not necessary for `#[no_mangle]` associated functions in `test-cargo-miri/exported-symbol-dep/src/lib.rs` anymore.

Closes https://github.com/rust-lang/miri/issues/1837.