### PR TITLE
Try out gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,9 @@
+image: ubuntu:latest
+
+tasks:
+  - before: echo "..."
+    init: |
+      cargo install rustup-toolchain-install-master
+      ./rustup-toolchain
+      ./miri build
+    command: echo "Run tests with ./miri test"


### PR DESCRIPTION
At https://gitpod.io/#https://github.com/rust-lang/miri one can edit miri in the browser and run it and everything.

I'm experimenting with this here as a low-impact version of trying it out on the whole rustc repo. This .gitpod file should cause the user to land in a shell that can run ./miri test immediately without any additional prep