### PR TITLE
Update compiletest_rs dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,9 +53,9 @@ dependencies = [
 
 [[package]]
 name = "compiletest_rs"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0086d6ad78cf409c3061618cd98e2789d5c9ce598fc9651611cf62eae0a599cb"
+checksum = "64698e5e2435db061a85e6320af12c30c5fd88eb84b35d2c1e03ce4f143255ca"
 dependencies = [
  "diff",
  "filetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ measureme = "9.1.2"
 libc = "0.2"
 
 [dev-dependencies]
-compiletest_rs = { version = "0.6", features = ["tmp"] }
+compiletest_rs = { version = "0.7", features = ["tmp"] }
 rustc_version = "0.3"
 colored = "2"
 


### PR DESCRIPTION
Hello. I am trying to [update some Clippy dependencies](https://github.com/rust-lang/rust/pull/88517) in the rust repo. To help keep the overall number of dependencies down, I was asked to submit a PR here to update `compiletest_rs` to from `0.6.0` to  `0.7.0`. I ran CI on my fork and the update didn't seem to cause any problems.