### PR TITLE
add support for `#[start]`

### DIFF
--- a/benches/helpers/miri_helper.rs
+++ b/benches/helpers/miri_helper.rs
@@ -20,11 +20,12 @@ impl rustc_driver::Callbacks for MiriCompilerCalls<'_> {
         compiler.session().abort_if_errors();
 
         queries.global_ctxt().unwrap().peek_mut().enter(|tcx| {
-            let (entry_def_id, _) = tcx.entry_fn(()).expect("no main or start function found");
+            let (entry_def_id, entry_type) =
+                tcx.entry_fn(()).expect("no main or start function found");
 
             self.bencher.iter(|| {
                 let config = miri::MiriConfig::default();
-                miri::eval_main(tcx, entry_def_id, config);
+                miri::eval_entry(tcx, entry_def_id, entry_type, config);
             });
         });
 

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -58,8 +58,8 @@ impl rustc_driver::Callbacks for MiriCompilerCalls {
 
         queries.global_ctxt().unwrap().peek_mut().enter(|tcx| {
             init_late_loggers(tcx);
-            let (entry_def_id, _) = if let Some((entry_def, x)) = tcx.entry_fn(()) {
-                (entry_def, x)
+            let (entry_def_id, entry_type) = if let Some(entry_def) = tcx.entry_fn(()) {
+                entry_def
             } else {
                 let output_ty = ErrorOutputType::HumanReadable(HumanReadableErrorType::Default(
                     ColorConfig::Auto,
@@ -79,7 +79,7 @@ impl rustc_driver::Callbacks for MiriCompilerCalls {
                 env::set_current_dir(cwd).unwrap();
             }
 
-            if let Some(return_code) = miri::eval_main(tcx, entry_def_id, config) {
+            if let Some(return_code) = miri::eval_entry(tcx, entry_def_id, entry_type, config) {
                 std::process::exit(
                     i32::try_from(return_code).expect("Return value was too large!"),
                 );

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -149,10 +149,6 @@ pub fn create_ecx<'mir, 'tcx: 'mir>(
 
     // Setup first stack-frame
     let entry_instance = ty::Instance::mono(tcx, entry_id);
-    /*let entry_mir = ecx.load_mir(entry_instance.def, None)?;
-    if main_mir.arg_count != 0 {
-        bug!("main function must not take any arguments");
-    }*/
 
     // First argument is constructed later, because its skipped if the entry function uses #[start]
 
@@ -227,16 +223,6 @@ pub fn create_ecx<'mir, 'tcx: 'mir>(
         }
         argv
     };
-
-    /*let args: &[_] = match entry_type {
-        EntryFnType::Main => {
-            // First argument: pointer to `main()`.
-            let main_ptr = ecx.memory.create_fn_alloc(FnVal::Instance(main_instance));
-
-            &[Scalar::from_pointer(main_ptr, &ecx).into(), argc.into(), argv]
-        }
-        EntryFnType::Start => &[argc.into(), argv],
-    };*/
 
     // Return place (in static memory so that it does not count as leak).
     let ret_place = ecx.allocate(ecx.machine.layouts.isize, MiriMemoryKind::Machine.into())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub use crate::diagnostics::{
     NonHaltingDiagnostic, TerminationInfo,
 };
 pub use crate::eval::{
-    create_ecx, eval_main, AlignmentCheck, IsolatedOp, MiriConfig, RejectOpWith,
+    create_ecx, eval_entry, AlignmentCheck, IsolatedOp, MiriConfig, RejectOpWith,
 };
 pub use crate::helpers::EvalContextExt as HelpersEvalContextExt;
 pub use crate::machine::{

--- a/tests/run-pass/start.rs
+++ b/tests/run-pass/start.rs
@@ -1,0 +1,8 @@
+#![feature(start)]
+
+#[start]
+fn start(_: isize, _: *const *const u8) -> isize {
+    println!("Hello from start!");
+
+    0
+}

--- a/tests/run-pass/start.stdout
+++ b/tests/run-pass/start.stdout
@@ -1,0 +1,1 @@
+Hello from start!


### PR DESCRIPTION
This PR adds support for the `#[start]` attribute and fixes #1825.

It also renames `eval_main` to `eval_entry` to reflect that it can evaluate any entry function.