### PR TITLE
add support for `#[global_allocator]`

### DIFF
--- a/src/shims/posix/foreign_items.rs
+++ b/src/shims/posix/foreign_items.rs
@@ -21,7 +21,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         args: &[OpTy<'tcx, Tag>],
         dest: &PlaceTy<'tcx, Tag>,
         ret: mir::BasicBlock,
-    ) -> InterpResult<'tcx, EmulateByNameResult> {
+    ) -> InterpResult<'tcx, EmulateByNameResult<'mir, 'tcx>> {
         let this = self.eval_context_mut();
 
         match &*link_name.as_str() {

--- a/src/shims/posix/linux/foreign_items.rs
+++ b/src/shims/posix/linux/foreign_items.rs
@@ -18,7 +18,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         args: &[OpTy<'tcx, Tag>],
         dest: &PlaceTy<'tcx, Tag>,
         _ret: mir::BasicBlock,
-    ) -> InterpResult<'tcx, EmulateByNameResult> {
+    ) -> InterpResult<'tcx, EmulateByNameResult<'mir, 'tcx>> {
         let this = self.eval_context_mut();
 
         match &*link_name.as_str() {

--- a/src/shims/posix/macos/foreign_items.rs
+++ b/src/shims/posix/macos/foreign_items.rs
@@ -16,7 +16,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         args: &[OpTy<'tcx, Tag>],
         dest: &PlaceTy<'tcx, Tag>,
         _ret: mir::BasicBlock,
-    ) -> InterpResult<'tcx, EmulateByNameResult> {
+    ) -> InterpResult<'tcx, EmulateByNameResult<'mir, 'tcx>> {
         let this = self.eval_context_mut();
 
         match &*link_name.as_str() {

--- a/src/shims/windows/foreign_items.rs
+++ b/src/shims/windows/foreign_items.rs
@@ -18,7 +18,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         args: &[OpTy<'tcx, Tag>],
         dest: &PlaceTy<'tcx, Tag>,
         _ret: mir::BasicBlock,
-    ) -> InterpResult<'tcx, EmulateByNameResult> {
+    ) -> InterpResult<'tcx, EmulateByNameResult<'mir, 'tcx>> {
         let this = self.eval_context_mut();
 
         // Windows API stubs.

--- a/tests/compile-fail/alloc/no_global_allocator.rs
+++ b/tests/compile-fail/alloc/no_global_allocator.rs
@@ -1,0 +1,25 @@
+// Make sure we pretend the allocation symbols don't exist when there is no allocator
+
+#![feature(lang_items, start)]
+#![no_std]
+
+extern "Rust" {
+    fn __rust_alloc(size: usize, align: usize) -> *mut u8;
+}
+
+#[start]
+fn start(_: isize, _: *const *const u8) -> isize {
+    unsafe {
+        __rust_alloc(1, 1); //~ERROR: unsupported operation: can't call foreign function: __rust_alloc
+    }
+
+    0
+}
+
+#[panic_handler]
+fn panic_handler(_: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+#[lang = "eh_personality"]
+fn eh_personality() {}

--- a/tests/run-pass/global_allocator.rs
+++ b/tests/run-pass/global_allocator.rs
@@ -1,0 +1,41 @@
+#![feature(allocator_api, slice_ptr_get)]
+
+use std::alloc::{Allocator as _, Global, GlobalAlloc, Layout, System};
+
+#[global_allocator]
+static ALLOCATOR: Allocator = Allocator;
+
+struct Allocator;
+
+unsafe impl GlobalAlloc for Allocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // use specific size to avoid getting triggered by rt
+        if layout.size() == 123 {
+            println!("Allocated!")
+        }
+
+        System.alloc(layout)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if layout.size() == 123 {
+            println!("Dellocated!")
+        }
+
+        System.dealloc(ptr, layout)
+    }
+}
+
+fn main() {
+    // Only okay because we explicitly set a global allocator that uses the system allocator!
+    let l = Layout::from_size_align(123, 1).unwrap();
+    let ptr = Global.allocate(l).unwrap().as_non_null_ptr(); // allocating with Global...
+    unsafe {
+        System.deallocate(ptr, l);
+    } // ... and deallocating with System.
+
+    let ptr = System.allocate(l).unwrap().as_non_null_ptr(); // allocating with System...
+    unsafe {
+        Global.deallocate(ptr, l);
+    } // ... and deallocating with Global.
+}

--- a/tests/run-pass/global_allocator.stdout
+++ b/tests/run-pass/global_allocator.stdout
@@ -1,0 +1,2 @@
+Allocated!
+Dellocated!


### PR DESCRIPTION
This PR adds support for custom global allocators. Unfortunately, the code given in #1207 still causes errors when used with box. I believe this is because Box is special-cased in miri and stacked borrows.