### PR TITLE
One character aliases for cargo-miri run/test

### DIFF
--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -20,8 +20,8 @@ Usage:
     cargo miri [subcommand] [<cargo options>...] [--] [<program/test suite options>...]
 
 Subcommands:
-    run                      Run binaries
-    test                     Run tests
+    run, r                   Run binaries
+    test, t                  Run tests
     setup                    Only perform automatic setup, but without asking questions (for getting a proper libstd)
 
 The cargo options are exactly the same as for `cargo run` and `cargo test`, respectively.
@@ -524,8 +524,8 @@ fn phase_cargo_miri(mut args: env::Args) {
     // We cannot know which of those flags take arguments and which do not,
     // so we cannot detect subcommands later.
     let subcommand = match args.next().as_deref() {
-        Some("test") => MiriCommand::Test,
-        Some("run") => MiriCommand::Run,
+        Some("test" | "t") => MiriCommand::Test,
+        Some("run" | "r") => MiriCommand::Run,
         Some("setup") => MiriCommand::Setup,
         // Invalid command.
         _ =>

--- a/test-cargo-miri/run-test.py
+++ b/test-cargo-miri/run-test.py
@@ -102,6 +102,11 @@ def test_cargo_miri_run():
         "run.subcrate.stdout.ref", "run.subcrate.stderr.ref",
         env={'MIRIFLAGS': "-Zmiri-disable-isolation"},
     )
+    test("`cargo miri r` (subcrate, no ioslation)",
+        cargo_miri("r") + ["-p", "subcrate"],
+        "run.subcrate.stdout.ref", "run.subcrate.stderr.ref",
+        env={'MIRIFLAGS': "-Zmiri-disable-isolation"},
+    )
     test("`cargo miri run` (custom target dir)",
         # Attempt to confuse the argument parser.
         cargo_miri("run") + ["--target-dir=custom-run", "--", "--target-dir=target/custom-run"],
@@ -143,6 +148,11 @@ def test_cargo_miri_test():
     )
     test("`cargo miri test` (subcrate, no isolation)",
         cargo_miri("test") + ["-p", "subcrate"],
+        "test.subcrate.stdout.ref", "test.stderr-proc-macro.ref",
+        env={'MIRIFLAGS': "-Zmiri-disable-isolation"},
+    )
+    test("`cargo miri t` (subcrate, no isolation)",
+        cargo_miri("t") + ["-p", "subcrate"],
         "test.subcrate.stdout.ref", "test.stderr-proc-macro.ref",
         env={'MIRIFLAGS': "-Zmiri-disable-isolation"},
     )

--- a/test-cargo-miri/run-test.py
+++ b/test-cargo-miri/run-test.py
@@ -97,12 +97,7 @@ def test_cargo_miri_run():
         cargo_miri("run") + ["--bin", "cargo-miri-test", "--", "hello world", '"hello world"'],
         "run.args.stdout.ref", "run.args.stderr.ref",
     )
-    test("`cargo miri run` (subcrate, no ioslation)",
-        cargo_miri("run") + ["-p", "subcrate"],
-        "run.subcrate.stdout.ref", "run.subcrate.stderr.ref",
-        env={'MIRIFLAGS': "-Zmiri-disable-isolation"},
-    )
-    test("`cargo miri r` (subcrate, no ioslation)",
+    test("`cargo miri r` (subcrate, no isolation)",
         cargo_miri("r") + ["-p", "subcrate"],
         "run.subcrate.stdout.ref", "run.subcrate.stderr.ref",
         env={'MIRIFLAGS': "-Zmiri-disable-isolation"},
@@ -145,11 +140,6 @@ def test_cargo_miri_test():
     test("`cargo miri test` (bin target)",
         cargo_miri("test") + ["--bin", "cargo-miri-test", "--", "--format=pretty"],
         "test.bin-target.stdout.ref", "test.stderr-empty.ref",
-    )
-    test("`cargo miri test` (subcrate, no isolation)",
-        cargo_miri("test") + ["-p", "subcrate"],
-        "test.subcrate.stdout.ref", "test.stderr-proc-macro.ref",
-        env={'MIRIFLAGS': "-Zmiri-disable-isolation"},
     )
     test("`cargo miri t` (subcrate, no isolation)",
         cargo_miri("t") + ["-p", "subcrate"],


### PR DESCRIPTION
The main `cargo` command supports `cargo r` as an alias for `cargo run`, and `cargo t` as an alias for `cargo test`. This adds support to them in `cargo-miri` for consistency.