### PR TITLE
Document threading support a bit more

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ in your program, and cannot run all programs:
   emulated and spin loops (without syscalls) just loop forever. There is no
   threading support on Windows.
 
-Consider looking into GitHub isues for more information about the limitations.
-
 [rust]: https://www.rust-lang.org/
 [mir]: https://github.com/rust-lang/rfcs/blob/master/text/1211-mir.md
 [`unreachable_unchecked`]: https://doc.rust-lang.org/stable/std/hint/fn.unreachable_unchecked.html


### PR DESCRIPTION
This adds a few known limitations around threading to the README and suggests the users to look into GitHub issues to learn more.

Addresses https://github.com/rust-lang/miri/issues/1388#issuecomment-939317828