### PR TITLE
rename track-raw-pointers flag to tag-raw-pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,14 +276,13 @@ environment variable:
   is popped from a borrow stack (which is where the tag becomes invalid and any
   future use of it will error).  This helps you in finding out why UB is
   happening and where in your code would be a good place to look for it.
-* `-Zmiri-track-raw-pointers` makes Stacked Borrows track a pointer tag even for
-  raw pointers. This can make valid code fail to pass the checks, but also can
-  help identify latent aliasing issues in code that Miri accepts by default. You
-  can recognize false positives by `<untagged>` occurring in the message -- this
-  indicates a pointer that was cast from an integer, so Miri was unable to track
-  this pointer. Note that it is not currently guaranteed that code that works
-  with `-Zmiri-track-raw-pointers` also works without
-  `-Zmiri-track-raw-pointers`, but for the vast majority of code, this will be the case.
+* `-Zmiri-tag-raw-pointers` makes Stacked Borrows assign proper tags even for raw pointers. This can
+  make valid code using int-to-ptr casts fail to pass the checks, but also can help identify latent
+  aliasing issues in code that Miri accepts by default. You can recognize false positives by
+  `<untagged>` occurring in the message -- this indicates a pointer that was cast from an integer,
+  so Miri was unable to track this pointer. Note that it is not currently guaranteed that code that
+  works with `-Zmiri-tag-raw-pointers` also works without `-Zmiri-tag-raw-pointers`, but for the
+  vast majority of code, this will be the case.
 
 [function ABI]: https://doc.rust-lang.org/reference/items/functions.html#extern-function-qualifier
 

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -359,8 +359,14 @@ fn main() {
                 "-Zmiri-panic-on-unsupported" => {
                     miri_config.panic_on_unsupported = true;
                 }
+                "-Zmiri-tag-raw-pointers" => {
+                    miri_config.tag_raw = true;
+                }
                 "-Zmiri-track-raw-pointers" => {
-                    miri_config.track_raw = true;
+                    eprintln!(
+                        "WARNING: -Zmiri-track-raw-pointers has been renamed to -Zmiri-tag-raw-pointers, the old name is deprecated."
+                    );
+                    miri_config.tag_raw = true;
                 }
                 "--" => {
                     after_dashdash = true;

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -87,7 +87,7 @@ pub struct MiriConfig {
     /// The allocation id to report about.
     pub tracked_alloc_id: Option<AllocId>,
     /// Whether to track raw pointers in stacked borrows.
-    pub track_raw: bool,
+    pub tag_raw: bool,
     /// Determine if data race detection should be enabled
     pub data_race_detector: bool,
     /// Rate of spurious failures for compare_exchange_weak atomic operations,
@@ -116,7 +116,7 @@ impl Default for MiriConfig {
             tracked_pointer_tag: None,
             tracked_call_id: None,
             tracked_alloc_id: None,
-            track_raw: false,
+            tag_raw: false,
             data_race_detector: true,
             cmpxchg_weak_failure_rate: 0.8,
             measureme_out: None,

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -194,7 +194,7 @@ impl MemoryExtra {
             Some(RefCell::new(stacked_borrows::GlobalState::new(
                 config.tracked_pointer_tag,
                 config.tracked_call_id,
-                config.track_raw,
+                config.tag_raw,
             )))
         } else {
             None

--- a/test-cargo-miri/run-test.py
+++ b/test-cargo-miri/run-test.py
@@ -127,7 +127,7 @@ def test_cargo_miri_test():
     test("`cargo miri test` (raw-ptr tracking)",
         cargo_miri("test"),
         default_ref, "test.stderr-empty.ref",
-        env={'MIRIFLAGS': "-Zmiri-track-raw-pointers"},
+        env={'MIRIFLAGS': "-Zmiri-tag-raw-pointers"},
     )
     test("`cargo miri test` (with filter)",
         cargo_miri("test") + ["--", "--format=pretty", "le1"],

--- a/tests/compile-fail/box-cell-alias.rs
+++ b/tests/compile-fail/box-cell-alias.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-track-raw-pointers
+// compile-flags: -Zmiri-tag-raw-pointers
 
 // Taken from <https://github.com/rust-lang/unsafe-code-guidelines/issues/194#issuecomment-520934222>.
 

--- a/tests/compile-fail/stacked_borrows/raw_tracking.rs
+++ b/tests/compile-fail/stacked_borrows/raw_tracking.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-track-raw-pointers
+// compile-flags: -Zmiri-tag-raw-pointers
 //! This demonstrates a provenance problem that requires tracking of raw pointers to be detected.
 
 fn main() {

--- a/tests/compile-fail/stacked_borrows/zst_slice.rs
+++ b/tests/compile-fail/stacked_borrows/zst_slice.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-track-raw-pointers
+// compile-flags: -Zmiri-tag-raw-pointers
 // error-pattern: does not have an appropriate item in the borrow stack
 
 fn main() {

--- a/tests/run-pass/btreemap.rs
+++ b/tests/run-pass/btreemap.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-track-raw-pointers
+// compile-flags: -Zmiri-tag-raw-pointers
 #![feature(btree_drain_filter)]
 use std::collections::{BTreeMap, BTreeSet};
 use std::mem;

--- a/tests/run-pass/concurrency/tls_lib_drop_single_thread.rs
+++ b/tests/run-pass/concurrency/tls_lib_drop_single_thread.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-track-raw-pointers
+// compile-flags: -Zmiri-tag-raw-pointers
 //! Check that destructors of the thread locals are executed on all OSes.
 #![feature(thread_local_const_init)]
 

--- a/tests/run-pass/rc.rs
+++ b/tests/run-pass/rc.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-track-raw-pointers
+// compile-flags: -Zmiri-tag-raw-pointers
 #![feature(new_uninit)]
 #![feature(get_mut_unchecked)]
 

--- a/tests/run-pass/slices.rs
+++ b/tests/run-pass/slices.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-track-raw-pointers
+// compile-flags: -Zmiri-tag-raw-pointers
 #![feature(new_uninit)]
 #![feature(slice_as_chunks)]
 #![feature(slice_partition_dedup)]

--- a/tests/run-pass/stacked-borrows/stacked-borrows.rs
+++ b/tests/run-pass/stacked-borrows/stacked-borrows.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-track-raw-pointers
+// compile-flags: -Zmiri-tag-raw-pointers
 use std::ptr;
     
 // Test various stacked-borrows-related things.

--- a/tests/run-pass/strings.rs
+++ b/tests/run-pass/strings.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-track-raw-pointers
+// compile-flags: -Zmiri-tag-raw-pointers
 
 fn empty() -> &'static str {
     ""

--- a/tests/run-pass/vec.rs
+++ b/tests/run-pass/vec.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-track-raw-pointers
+// compile-flags: -Zmiri-tag-raw-pointers
 // Gather all references from a mutable iterator and make sure Miri notices if
 // using them is dangerous.
 fn test_all_refs<'a, T: 'a>(dummy: &mut T, iter: impl Iterator<Item = &'a mut T>) {

--- a/tests/run-pass/vecdeque.rs
+++ b/tests/run-pass/vecdeque.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-track-raw-pointers
+// compile-flags: -Zmiri-tag-raw-pointers
 use std::collections::VecDeque;
 
 fn test_all_refs<'a, T: 'a>(dummy: &mut T, iter: impl Iterator<Item = &'a mut T>) {


### PR DESCRIPTION
The old flag name sounds too similar to `-Zmiri-track-pointer-tag`, which is a totally different kind of 'tracking'. This has lead to confusion in https://github.com/rust-lang/miri/issues/1907.