### PR TITLE
run rustdoc with the miri cfg flag

### DIFF
--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -1008,6 +1008,8 @@ fn phase_rustdoc(fst_arg: &str, mut args: env::Args) {
 
     // rustdoc needs to know the right sysroot.
     forward_miri_sysroot(&mut cmd);
+    // make sure the 'miri' flag is set for rustdoc
+    cmd.arg("--cfg").arg("miri");
 
     // Make rustdoc call us back.
     let cargo_miri_path = std::env::current_exe().expect("current executable path invalid");

--- a/test-cargo-miri/src/lib.rs
+++ b/test-cargo-miri/src/lib.rs
@@ -16,6 +16,12 @@ pub fn make_true() -> bool {
     issue_1691::use_me()
 }
 
+/// ```rust
+/// cargo_miri_test::miri_only_fn();
+/// ```
+#[cfg(miri)]
+pub fn miri_only_fn() {}
+
 pub fn main() {
     println!("imported main");
 }

--- a/test-cargo-miri/test.default.stdout.ref
+++ b/test-cargo-miri/test.default.stdout.ref
@@ -10,7 +10,7 @@ running 7 tests
 test result: ok. 6 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
 
 
-running 3 tests
-...
-test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+running 4 tests
+....
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/test-cargo-miri/test.filter.stdout.ref
+++ b/test-cargo-miri/test.filter.stdout.ref
@@ -13,5 +13,5 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out
 
 running 0 tests
 
-test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in $TIME
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in $TIME
 


### PR DESCRIPTION
This is important to be able to control which doctests run with `cargo miri test`. In particular, this is required for https://github.com/rust-lang/rust/pull/90909 to work as intended.