### PR TITLE
tweak cron job time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,7 @@ on:
     branches:
       - 'master'
   schedule:
-    # Use <https://crontab.guru> to conveniently edit cron schedule.
-    - cron: '0 7 * * *' # At 07:00 UTC every day.
+    - cron: '5 15 * * *' # At 15:05 UTC every day.
 
 jobs:
   build:


### PR DESCRIPTION
15:00 UTC is 16:00 in Europe and 10:00 on the US East Coast (during winter time, and 1h later during summer time), so a good time in both places to see the email and react quickly. No need to run this in the middle of the night if nobody will fix the problem anyway.

Move it 5min past the full hour to avoid what is probably a rush of cronjobs on the full hour.