### PR TITLE
hack to work around RA quirk

### DIFF
--- a/cargo-miri/miri
+++ b/cargo-miri/miri
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Hack to work around https://github.com/rust-analyzer/rust-analyzer/issues/10793.
+exec "$(dirname "$0")"/../miri "$@"

--- a/miri
+++ b/miri
@@ -39,10 +39,11 @@ EOF
 TARGET=$(rustc --version --verbose | grep "^host:" | cut -d ' ' -f 2)
 SYSROOT=$(rustc --print sysroot)
 LIBDIR=$SYSROOT/lib/rustlib/$TARGET/lib
-MIRIDIR=$(dirname "$0")
 if readlink -e . &>/dev/null; then
     # This platform supports `readlink -e`.
-    MIRIDIR=$(readlink -e "$MIRIDIR")
+    MIRIDIR=$(dirname "$(readlink -e "$0")")
+else
+    MIRIDIR=$(dirname "$0")
 fi
 if ! test -d "$LIBDIR"; then
     echo "Something went wrong determining the library dir."


### PR DESCRIPTION
This is a gross hack to work around https://github.com/rust-analyzer/rust-analyzer/issues/10793: calling `cargo-miri/miri` does the same thing as calling `./miri`.

@oli-obk this is the best I could come up with... not sure if we want to have this in the repo. I am also okay with carrying `cargo-miri/miri` locally.