### PR TITLE
intptrcast: Never allocate two objects directly adjecent

### DIFF
--- a/src/intptrcast.rs
+++ b/src/intptrcast.rs
@@ -108,9 +108,9 @@ impl<'mir, 'tcx> GlobalState {
 
                 // Remember next base address.  Leave a gap of at least 1 to avoid two zero-sized allocations
                 // having the same base address, and to avoid ambiguous provenance for the address between two
-                // allocations.
-                let bytes = size.bytes().checked_add(1).unwrap();
-                global_state.next_base_addr = base_addr.checked_add(bytes).unwrap();
+                // allocations (also see https://github.com/rust-lang/unsafe-code-guidelines/issues/313).
+                let size_plus_1 = size.bytes().checked_add(1).unwrap();
+                global_state.next_base_addr = base_addr.checked_add(size_plus_1).unwrap();
                 // Given that `next_base_addr` increases in each allocation, pushing the
                 // corresponding tuple keeps `int_to_ptr_map` sorted
                 global_state.int_to_ptr_map.push((base_addr, alloc_id));

--- a/tests/run-pass/adjacent-allocs.rs
+++ b/tests/run-pass/adjacent-allocs.rs
@@ -16,6 +16,7 @@ fn main() {
 
         let iptr = ptr as usize;
         let zst = (iptr + 8) as *const ();
+        // This is a ZST ptr just at the end of `n`, so it should be valid to deref.
         unsafe { *zst }
     }
 }

--- a/tests/run-pass/adjacent-allocs.rs
+++ b/tests/run-pass/adjacent-allocs.rs
@@ -1,0 +1,21 @@
+fn main() {
+    // The slack between allocations is random.
+    // Loop a few times to hit the zero-slack case.
+    for _ in 0..1024 {
+        let n = 0u64;
+        let ptr: *const u64 = &n;
+
+        // Allocate a new stack variable whose lifetime quickly ends.
+        // If there's a chance that &m == ptr.add(1), then an int-to-ptr cast of
+        // that value will have ambiguous provenance between n and m.
+        // See https://github.com/rust-lang/miri/issues/1866#issuecomment-985770125
+        {
+            let m = 0u64;
+            let _ = &m as *const u64;
+        }
+
+        let iptr = ptr as usize;
+        let zst = (iptr + 8) as *const ();
+        unsafe { *zst }
+    }
+}


### PR DESCRIPTION
When two objects directly follow each other in memory, what is the
provenance of an integer cast to a pointer that points directly between
them?  For a zero-size region, it could point into the end of the first
object, or the start of the second.

We can avoid answering this difficult question by simply never
allocating two objects directly beside each other.  This fixes some of
the false positives from #1866.
