### PR TITLE
add and document MIRI_LIB_SRC env var to set the source from which Miri builds the standard library

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,16 @@ There's a test for the cargo wrapper in the `test-cargo-miri` directory; run
 `./run-test.py` in there to execute it. Like `./miri test`, this respects the
 `MIRI_TEST_TARGET` environment variable to execute the test for another target.
 
+### Using a modified standard library
+
+Miri re-builds the standard library into a custom sysroot, so it is fairly easy
+to test Miri against a modified standard library -- you do not even have to
+build Miri yourself, the Miri shipped by `rustup` will work. All you have to do
+is set the `MIRI_LIB_SRC` environment variable to the `library` folder of a
+`rust-lang/rust` repository checkout. Note that changing files in that directory
+does not automatically trigger a re-build of the standard library; you have to
+clear the Miri build cache manually (on Linux, `rm -rf ~/.cache/miri`).
+
 ## Configuring `rust-analyzer`
 
 To configure `rust-analyzer` and VS Code for working on Miri, save the following

--- a/README.md
+++ b/README.md
@@ -306,6 +306,12 @@ Moreover, Miri recognizes some environment variables:
   Miri executions, also [see "Testing the Miri driver" in `CONTRIBUTING.md`][testing-miri].
 * `MIRIFLAGS` (recognized by `cargo miri` and the test suite) defines extra
   flags to be passed to Miri.
+* `MIRI_LIB_SRC` defines the directory where Miri expects the sources of the
+  standard library that it will build and use for interpretation. This directory
+  must point to the `library` subdirectory of a `rust-lang/rust` repository
+  checkout. Note that changing files in that directory does not automatically
+  trigger a re-build of the standard library; you have to clear the Miri build
+  cache manually (on Linux, `rm -rf ~/.cache/miri`).
 * `MIRI_SYSROOT` (recognized by `cargo miri` and the test suite)
   indicates the sysroot to use.  To do the same thing with `miri`
   directly, use the `--sysroot` flag.


### PR DESCRIPTION
This is just an alias of `XARGO_RUST_SRC`, but avoids exposing how exactly we use xargo.