### PR TITLE
exclude mutable references to !Unpin types from uniqueness guarantees

### DIFF
--- a/tests/run-pass/stacked-borrows/generators-self-referential.rs
+++ b/tests/run-pass/stacked-borrows/generators-self-referential.rs
@@ -1,0 +1,34 @@
+// See https://github.com/rust-lang/unsafe-code-guidelines/issues/148:
+// this fails when Stacked Borrows is strictly applied even to `!Unpin` types.
+#![feature(generators, generator_trait)]
+
+use std::{
+    ops::{Generator, GeneratorState},
+    pin::Pin,
+};
+
+fn firstn() -> impl Generator<Yield = u64, Return = ()> {
+    static move || {
+        let mut num = 0;
+        let num = &mut num;
+
+        yield *num;
+        *num += 1; //~ ERROR: borrow stack
+
+        yield *num;
+        *num += 1;
+
+        yield *num;
+        *num += 1;
+    }
+}
+
+fn main() {
+    let mut generator_iterator = firstn();
+    let mut pin = unsafe { Pin::new_unchecked(&mut generator_iterator) };
+    let mut sum = 0;
+    while let GeneratorState::Yielded(x) = pin.as_mut().resume(()) {
+        sum += x;
+    }
+    assert_eq!(sum, 3);
+}


### PR DESCRIPTION
This basically works around https://github.com/rust-lang/unsafe-code-guidelines/issues/148 by not requiring uniqueness any more for mutable references to self-referential generators. That corresponds to [the same work-around that was applied in rustc itself](https://github.com/rust-lang/rust/blob/b81553267437627af63c79c1a20c73af865a842a/compiler/rustc_middle/src/ty/layout.rs#L2482).

I am not entirely sure if this is a good idea since it might hide too many errors in case types are "accidentally" `!Unpin`. OTOH, our test suite still passes, and to my knowledge the vast majority of types is `Unpin`. (`place.layout.ty` is monomorphic, we should always exactly know which type this is.)