### PR TITLE
Allow varargs for libc::open when it is allowed by the second argument

### DIFF
--- a/src/shims/posix/foreign_items.rs
+++ b/src/shims/posix/foreign_items.rs
@@ -55,8 +55,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
             // File related shims
             "open" | "open64" => {
-                let &[ref path, ref flag, ref mode] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
-                let result = this.open(path, flag, mode)?;
+                // `open` is variadic, the third argument is only present when the second argument has O_CREAT (or on linux O_TMPFILE, but miri doesn't support that) set
+                this.check_abi_and_shim_symbol_clash(abi, Abi::C { unwind: false }, link_name)?;
+                let result = this.open(args)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "fcntl" => {

--- a/tests/compile-fail/fs/unix_open_missing_required_mode.rs
+++ b/tests/compile-fail/fs/unix_open_missing_required_mode.rs
@@ -1,0 +1,16 @@
+// ignore-windows: No libc on Windows
+// compile-flags: -Zmiri-disable-isolation
+
+#![feature(rustc_private)]
+
+extern crate libc;
+
+fn main() {
+    test_file_open_missing_needed_mode();
+}
+
+fn test_file_open_missing_needed_mode() {
+    let name = b"missing_arg.txt\0";
+    let name_ptr = name.as_ptr().cast::<libc::c_char>();
+    let _fd = unsafe { libc::open(name_ptr, libc::O_CREAT) }; //~ ERROR Undefined Behavior: incorrect number of arguments for `open` with `O_CREAT`: got 2, expected 3
+}

--- a/tests/compile-fail/fs/unix_open_too_many_args.rs
+++ b/tests/compile-fail/fs/unix_open_too_many_args.rs
@@ -1,0 +1,16 @@
+// ignore-windows: No libc on Windows
+// compile-flags: -Zmiri-disable-isolation
+
+#![feature(rustc_private)]
+
+extern crate libc;
+
+fn main() {
+    test_open_too_many_args();
+}
+
+fn test_open_too_many_args() {
+    let name = b"too_many_args.txt\0";
+    let name_ptr = name.as_ptr().cast::<libc::c_char>();
+    let _fd = unsafe { libc::open(name_ptr, libc::O_RDONLY, 0, 0) }; //~ ERROR Undefined Behavior: incorrect number of arguments for `open`: got 4, expected 2 or 3
+}


### PR DESCRIPTION
This PR allows `libc::open` to be called using two or three arguments as defined in https://man7.org/linux/man-pages/man2/open.2.html

The presence of the third argument depends on the value of the second argument.  If the second argument dictates that the third argument is *required* miri will emit an error if the argument is missing.  If the second argument does *not* require a third argument, then the argument is ignored and passed as 0 internally (it would be ignored by libc anyway)