### PR TITLE
Add a lot more information to SB fatal errors

### DIFF
--- a/tests/compile-fail/box-cell-alias.rs
+++ b/tests/compile-fail/box-cell-alias.rs
@@ -6,7 +6,7 @@ use std::cell::Cell;
 
 fn helper(val: Box<Cell<u8>>, ptr: *const Cell<u8>) -> u8 {
     val.set(10);
-    unsafe { (*ptr).set(20); } //~ ERROR does not have an appropriate item in the borrow stack
+    unsafe { (*ptr).set(20); } //~ ERROR does not exist in the borrow stack
     val.get()
 }
 

--- a/tests/compile-fail/stacked_borrows/illegal_write3.rs
+++ b/tests/compile-fail/stacked_borrows/illegal_write3.rs
@@ -3,6 +3,6 @@ fn main() {
     // Make sure raw ptr with raw tag cannot mutate frozen location without breaking the shared ref.
     let r#ref = &target; // freeze
     let ptr = r#ref as *const _ as *mut _; // raw ptr, with raw tag
-    unsafe { *ptr = 42; } //~ ERROR borrow stack
+    unsafe { *ptr = 42; } //~ ERROR only grants SharedReadOnly permission
     let _val = *r#ref;
 }

--- a/tests/compile-fail/stacked_borrows/raw_tracking.rs
+++ b/tests/compile-fail/stacked_borrows/raw_tracking.rs
@@ -7,6 +7,6 @@ fn main() {
     let raw2 = &mut l as *mut _; // invalidates raw1
     // Without raw pointer tracking, Stacked Borrows cannot distinguish raw1 and raw2, and thus
     // fails to realize that raw1 should not be used any more.
-    unsafe { *raw1 = 13; } //~ ERROR no item granting write access to tag
+    unsafe { *raw1 = 13; } //~ ERROR does not exist in the borrow stack
     unsafe { *raw2 = 13; }
 }

--- a/tests/compile-fail/stacked_borrows/shr_frozen_violation1.rs
+++ b/tests/compile-fail/stacked_borrows/shr_frozen_violation1.rs
@@ -9,5 +9,5 @@ fn main() {
 }
 
 fn unknown_code(x: &i32) {
-    unsafe { *(x as *const i32 as *mut i32) = 7; } //~ ERROR borrow stack
+    unsafe { *(x as *const i32 as *mut i32) = 7; } //~ ERROR only grants SharedReadOnly permission
 }

--- a/tests/compile-fail/stacked_borrows/zst_slice.rs
+++ b/tests/compile-fail/stacked_borrows/zst_slice.rs
@@ -1,5 +1,5 @@
 // compile-flags: -Zmiri-tag-raw-pointers
-// error-pattern: does not have an appropriate item in the borrow stack
+// error-pattern: does not exist in the borrow stack
 
 fn main() {
     unsafe {


### PR DESCRIPTION
In fatal errors, this clarifies the difference between a tag not being present in the borrow stack at all, and the tag being present but granting SRO. It also introduces a little notation for memory ranges so we can mention to the user that the span may point to code that operates on multiple memory locations, but we are reporting an error at a particular offset.

This also gets rid of the unqualified phrase "the borrow stack" in errors, and clarifies that it is the borrow stack _for some location_.

The crate `pdqselect` v0.1.1:
Before:
```
2103 |     unsafe { copy_nonoverlapping(src, dst, count) }
     |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no item granting read access to tag <2357> at alloc1029 found in borrow stack.
```
After:
```
2103 |     unsafe { copy_nonoverlapping(src, dst, count) }
     |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |              |
     |              attempting a read access using <2357> at alloc1029[0x0], but that tag does not exist in the borrow stack for this location
     |              this error occurs as part of an access at alloc1029[0x0..0x4]
```

And the crate `half` v1.8.2
Before:
```
131 |     unsafe { &mut *ptr::slice_from_raw_parts_mut(data, len) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trying to reborrow for Unique at alloc1051, but parent tag <2091> does not have an appropriate item in the borrow stack
```
After:
```
131 |     unsafe { &mut *ptr::slice_from_raw_parts_mut(data, len) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |              |
    |              trying to reborrow <2091> for Unique permission at alloc1051[0x0], but that tag only grants SharedReadOnly permission for this location
    |              this error occurs as part of a reborrow at alloc1051[0x0..0x6]
```