### PR TITLE
Catch more misaligned pointers via careful padding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(never_type)]
 #![feature(try_blocks)]
 #![feature(bool_to_option)]
+#![feature(int_log)]
 #![warn(rust_2018_idioms)]
 #![allow(clippy::cast_lossless)]
 


### PR DESCRIPTION
The current pointer alignment adds a random amount of padding between allocations (possibly). That has at best a 50% chance of detecting a failure to check alignment between types whose alignment only differs by a factor of 2, and because it is random, crates with a small number of tests can slip by entirely.

This changes to a deterministic algorithm which always detects an unchecked access of a pointer to T as a pointer to another type with twice T's alignment.

This was inspired by running `cargo miri test` on the crate `safe-transmute` version 0.11.2. With no flags, these errors are detected:
```
failures:
    src/lib.rs - (line 101)

test result: FAILED. 58 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.34s
```
Based on this, one could _start_ unraveling the alignment problems in this crate. But with this PR, we get this summary:
```
failures:
    src/base.rs - base::from_bytes (line 38)
    src/base.rs - base::from_bytes_pedantic (line 77)
    src/base.rs - base::transmute_many (line 121)
    src/base.rs - base::transmute_many_mut (line 166)
    src/base.rs - base::transmute_many_permissive (line 208)
    src/full.rs - full::transmute_many (line 101)
    src/full.rs - full::transmute_many_mut (line 184)
    src/full.rs - full::transmute_many_pedantic (line 156)
    src/full.rs - full::transmute_many_pedantic_mut (line 240)
    src/full.rs - full::transmute_one (line 41)
    src/full.rs - full::transmute_one_pedantic (line 72)
    src/lib.rs - (line 101)
    src/lib.rs - (line 125)
    src/trivial.rs - trivial::transmute_trivial (line 182)
    src/trivial.rs - trivial::transmute_trivial_many (line 255)
    src/trivial.rs - trivial::transmute_trivial_many_mut (line 292)
    src/trivial.rs - trivial::transmute_trivial_pedantic (line 220)

test result: FAILED. 42 passed; 17 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.34s
```
This is the same output as we get with `-Zmiri-symbolic-alignment-check`.

@RalfJung Do you have any interesting test inputs for this? I have two proposals for ways to improve alignment detection in here, the one that is commented-out costs more memory (though it could be tuned to be less sever) with the potential upside of detecting more patterns. But I don't have a codebase on hand at the moment which demonstrates that setting more bits to 1 actually finds bugs that people write.