### PR TITLE
Make sure we notice when a u16 is loaded at offset 1 into a u8 allocation

### DIFF
--- a/tests/compile-fail/unaligned_pointers/unaligned_ptr4.rs
+++ b/tests/compile-fail/unaligned_pointers/unaligned_ptr4.rs
@@ -1,0 +1,12 @@
+// This should fail even without validation or Stacked Borrows.
+// compile-flags: -Zmiri-disable-validation -Zmiri-disable-stacked-borrows
+
+fn main() {
+    // Make sure we notice when a u16 is loaded at offset 1 into a u8 allocation.
+    // (This would be missed if u8 allocations are *always* at odd addresses.)
+    for _ in 0..10 { // Try many times as this might work by chance.
+        let x = [0u8; 4];
+        let ptr = x.as_ptr().wrapping_offset(1).cast::<u16>();
+        let _val = unsafe { *ptr }; //~ERROR but alignment
+    }
+}


### PR DESCRIPTION
Cc https://github.com/rust-lang/miri/pull/1990 which would have changed the integer address logic in a way that this bug could not be found any more.