### PR TITLE
add basic support for android targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,9 @@ degree documented below):
   supported on Windows. We also test `i686-pc-windows-msvc`, with the same
   reduced feature set. We might ship Miri with a nightly even when some features
   on these targets regress.
+- `aarch64-linux-android` has basic support and should work for simple targets.
+  Some concurrency and filesystem operations are not supported and will fail at
+  runtime.
 
 ### Common Problems
 

--- a/ci.sh
+++ b/ci.sh
@@ -51,7 +51,8 @@ case $HOST_TARGET in
     MIRI_TEST_TARGET=i686-unknown-linux-gnu run_tests
     MIRI_TEST_TARGET=aarch64-apple-darwin run_tests
     MIRI_TEST_TARGET=i686-pc-windows-msvc run_tests
-    MIRI_TEST_TARGET=aarch64-linux-android run_tests
+    # TODO: Enable once https://github.com/rust-lang/rust/pull/94813 lands
+    # MIRI_TEST_TARGET=aarch64-linux-android run_tests
     ;;
   x86_64-apple-darwin)
     MIRI_TEST_TARGET=mips64-unknown-linux-gnuabi64 run_tests # big-endian architecture

--- a/ci.sh
+++ b/ci.sh
@@ -21,6 +21,7 @@ function run_tests {
   fi
 
   ./miri test --locked
+
   if [ -z "${MIRI_TEST_TARGET+exists}" ]; then
     # Only for host architecture: tests with optimizations (`-O` is what cargo passes, but crank MIR
     # optimizations up all the way).
@@ -50,6 +51,7 @@ case $HOST_TARGET in
     MIRI_TEST_TARGET=i686-unknown-linux-gnu run_tests
     MIRI_TEST_TARGET=aarch64-apple-darwin run_tests
     MIRI_TEST_TARGET=i686-pc-windows-msvc run_tests
+    MIRI_TEST_TARGET=aarch64-linux-android run_tests
     ;;
   x86_64-apple-darwin)
     MIRI_TEST_TARGET=mips64-unknown-linux-gnuabi64 run_tests # big-endian architecture

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -448,7 +448,7 @@ impl<'mir, 'tcx> Evaluator<'mir, 'tcx> {
                     Self::add_extern_static(this, name, place.ptr);
                 }
                 for symbol_name in &["signal", "bsd_signal"] {
-                    let layout = this.machine.layouts.usize;
+                    let layout = this.machine.layouts.mut_raw_ptr;
                     let dlsym = Dlsym::from_str(symbol_name.as_bytes(), &this.tcx.sess.target.os)?
                         .unwrap_or_else(|| {
                             panic!(

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -430,6 +430,41 @@ impl<'mir, 'tcx> Evaluator<'mir, 'tcx> {
                 this.write_scalar(Scalar::from_u8(0), &place.into())?;
                 Self::add_extern_static(this, "_tls_used", place.ptr);
             }
+            "android" => {
+                // "environ"
+                Self::add_extern_static(
+                    this,
+                    "environ",
+                    this.machine.env_vars.environ.unwrap().ptr,
+                );
+                // A couple zero-initialized pointer-sized extern statics.
+                // Most of them are for weak symbols, which we all set to null (indicating that the
+                // symbol is not supported, and triggering fallback code which ends up calling a
+                // syscall that we do support).
+                for name in &["__cxa_thread_atexit_impl", "getrandom", "statx"] {
+                    let layout = this.machine.layouts.usize;
+                    let place = this.allocate(layout, MiriMemoryKind::ExternStatic.into())?;
+                    this.write_scalar(Scalar::from_machine_usize(0, this), &place.into())?;
+                    Self::add_extern_static(this, name, place.ptr);
+                }
+                for symbol_name in &["signal", "bsd_signal"] {
+                    let layout = this.machine.layouts.usize;
+                    let dlsym = Dlsym::from_str(symbol_name.as_bytes(), &this.tcx.sess.target.os)?
+                        .unwrap_or_else(|| {
+                            panic!(
+                                "hardcoded `extern static` symbol {} has no dlsym handler",
+                                symbol_name
+                            )
+                        });
+                    let ecx = this.eval_context_mut();
+                    let ptr = ecx.create_fn_alloc_ptr(FnVal::Other(dlsym));
+
+                    let place = this.allocate(layout, MiriMemoryKind::ExternStatic.into())?;
+                    this.write_pointer(ptr, &place.into())?;
+
+                    Self::add_extern_static(this, symbol_name, place.ptr);
+                }
+            }
             _ => {} // No "extern statics" supported on this target
         }
         Ok(())

--- a/src/shims/dlsym.rs
+++ b/src/shims/dlsym.rs
@@ -1,6 +1,7 @@
 use rustc_middle::mir;
 use rustc_target::spec::abi::Abi;
 
+use crate::helpers::target_os_is_unix;
 use crate::*;
 use shims::posix::dlsym as posix;
 use shims::windows::dlsym as windows;
@@ -18,7 +19,8 @@ impl Dlsym {
     pub fn from_str<'tcx>(name: &[u8], target_os: &str) -> InterpResult<'tcx, Option<Dlsym>> {
         let name = &*String::from_utf8_lossy(name);
         Ok(match target_os {
-            "linux" | "macos" => posix::Dlsym::from_str(name, target_os)?.map(Dlsym::Posix),
+            target if target_os_is_unix(target) =>
+                posix::Dlsym::from_str(name, target_os)?.map(Dlsym::Posix),
             "windows" => windows::Dlsym::from_str(name)?.map(Dlsym::Windows),
             os => bug!("dlsym not implemented for target_os {}", os),
         })

--- a/src/shims/env.rs
+++ b/src/shims/env.rs
@@ -8,6 +8,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_middle::ty::layout::LayoutOf;
 use rustc_target::abi::Size;
 
+use crate::helpers::target_os_is_unix;
 use crate::*;
 
 /// Check whether an operation that writes to a target buffer was successful.
@@ -55,7 +56,7 @@ impl<'tcx> EnvVars<'tcx> {
                 };
                 if forward {
                     let var_ptr = match target_os {
-                        "linux" | "macos" =>
+                        target if target_os_is_unix(target) =>
                             alloc_env_var_as_c_str(name.as_ref(), value.as_ref(), ecx)?,
                         "windows" => alloc_env_var_as_wide_str(name.as_ref(), value.as_ref(), ecx)?,
                         unsupported =>
@@ -113,11 +114,7 @@ impl<'mir, 'tcx: 'mir> EvalContextExt<'mir, 'tcx> for crate::MiriEvalContext<'mi
 pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx> {
     fn getenv(&mut self, name_op: &OpTy<'tcx, Tag>) -> InterpResult<'tcx, Pointer<Option<Tag>>> {
         let this = self.eval_context_mut();
-        let target_os = &this.tcx.sess.target.os;
-        assert!(
-            target_os == "linux" || target_os == "macos",
-            "`getenv` is only available for the UNIX target family"
-        );
+        this.assert_target_os_is_unix("getenv");
 
         let name_ptr = this.read_pointer(name_op)?;
         let name = this.read_os_str_from_c_str(name_ptr)?;
@@ -211,11 +208,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         value_op: &OpTy<'tcx, Tag>,
     ) -> InterpResult<'tcx, i32> {
         let this = self.eval_context_mut();
-        let target_os = &this.tcx.sess.target.os;
-        assert!(
-            target_os == "linux" || target_os == "macos",
-            "`setenv` is only available for the UNIX target family"
-        );
+        this.assert_target_os_is_unix("setenv");
 
         let name_ptr = this.read_pointer(name_op)?;
         let value_ptr = this.read_pointer(value_op)?;
@@ -285,11 +278,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
     fn unsetenv(&mut self, name_op: &OpTy<'tcx, Tag>) -> InterpResult<'tcx, i32> {
         let this = self.eval_context_mut();
-        let target_os = &this.tcx.sess.target.os;
-        assert!(
-            target_os == "linux" || target_os == "macos",
-            "`unsetenv` is only available for the UNIX target family"
-        );
+        this.assert_target_os_is_unix("unsetenv");
 
         let name_ptr = this.read_pointer(name_op)?;
         let mut success = None;
@@ -319,11 +308,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         size_op: &OpTy<'tcx, Tag>,
     ) -> InterpResult<'tcx, Pointer<Option<Tag>>> {
         let this = self.eval_context_mut();
-        let target_os = &this.tcx.sess.target.os;
-        assert!(
-            target_os == "linux" || target_os == "macos",
-            "`getcwd` is only available for the UNIX target family"
-        );
+        this.assert_target_os_is_unix("getcwd");
 
         let buf = this.read_pointer(buf_op)?;
         let size = this.read_scalar(size_op)?.to_machine_usize(&*this.tcx)?;
@@ -378,11 +363,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
     fn chdir(&mut self, path_op: &OpTy<'tcx, Tag>) -> InterpResult<'tcx, i32> {
         let this = self.eval_context_mut();
-        let target_os = &this.tcx.sess.target.os;
-        assert!(
-            target_os == "linux" || target_os == "macos",
-            "`getcwd` is only available for the UNIX target family"
-        );
+        this.assert_target_os_is_unix("chdir");
 
         let path = this.read_path_from_c_str(this.read_pointer(path_op)?)?;
 

--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -23,6 +23,7 @@ use rustc_target::{
 
 use super::backtrace::EvalContextExt as _;
 use crate::helpers::convert::Truncate;
+use crate::helpers::target_os_is_unix;
 use crate::*;
 
 /// Returned by `emulate_foreign_item_by_name`.
@@ -700,9 +701,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 }
             }
 
-            // Platform-specific shims
             _ => match this.tcx.sess.target.os.as_ref() {
-                "linux" | "macos" => return shims::posix::foreign_items::EvalContextExt::emulate_foreign_item_by_name(this, link_name, abi, args, dest, ret),
+                target if target_os_is_unix(target) => return shims::posix::foreign_items::EvalContextExt::emulate_foreign_item_by_name(this, link_name, abi, args, dest, ret),
                 "windows" => return shims::windows::foreign_items::EvalContextExt::emulate_foreign_item_by_name(this, link_name, abi, args, dest, ret),
                 target => throw_unsup_format!("the target `{}` is not supported", target),
             }

--- a/src/shims/posix/android/dlsym.rs
+++ b/src/shims/posix/android/dlsym.rs
@@ -1,0 +1,53 @@
+use helpers::check_arg_count;
+use log::trace;
+use rustc_middle::mir;
+
+use crate::*;
+
+#[derive(Debug, Copy, Clone)]
+#[allow(non_camel_case_types)]
+pub enum Dlsym {
+    signal,
+}
+
+impl Dlsym {
+    // Returns an error for unsupported symbols, and None if this symbol
+    // should become a NULL pointer (pretend it does not exist).
+    pub fn from_str<'tcx>(name: &str) -> InterpResult<'tcx, Option<Dlsym>> {
+        Ok(match &*name {
+            "__pthread_get_minstack" => None,
+            "getrandom" => None, // std falls back to syscall(SYS_getrandom, ...) when this is NULL.
+            "statx" => None,     // std falls back to syscall(SYS_statx, ...) when this is NULL.
+            "signal" | "bsd_signal" => Some(Dlsym::signal), // these have the same signature/implementation
+            "android_set_abort_message" => None, // std falls back to just not doing anything when this is NULL.
+            _ => throw_unsup_format!("unsupported Android dlsym: {}", name),
+        })
+    }
+}
+
+impl<'mir, 'tcx: 'mir> EvalContextExt<'mir, 'tcx> for crate::MiriEvalContext<'mir, 'tcx> {}
+pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx> {
+    fn call_dlsym(
+        &mut self,
+        dlsym: Dlsym,
+        args: &[OpTy<'tcx, Tag>],
+        dest: &PlaceTy<'tcx, Tag>,
+        ret: Option<mir::BasicBlock>,
+    ) -> InterpResult<'tcx> {
+        let this = self.eval_context_mut();
+        assert!(this.tcx.sess.target.os == "android");
+
+        let ret = ret.expect("we don't support any diverging dlsym");
+
+        match dlsym {
+            Dlsym::signal => {
+                let &[ref _sig, ref _func] = check_arg_count(args)?;
+                this.write_null(dest)?;
+            }
+        }
+
+        trace!("{:?}", this.dump_place(**dest));
+        this.go_to_block(ret);
+        Ok(())
+    }
+}

--- a/src/shims/posix/android/foreign_items.rs
+++ b/src/shims/posix/android/foreign_items.rs
@@ -1,0 +1,28 @@
+use rustc_middle::mir;
+use rustc_span::Symbol;
+use rustc_target::spec::abi::Abi;
+
+use crate::*;
+use shims::foreign_items::EmulateByNameResult;
+
+impl<'mir, 'tcx: 'mir> EvalContextExt<'mir, 'tcx> for crate::MiriEvalContext<'mir, 'tcx> {}
+pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx> {
+    fn emulate_foreign_item_by_name(
+        &mut self,
+        link_name: Symbol,
+        abi: Abi,
+        args: &[OpTy<'tcx, Tag>],
+        dest: &PlaceTy<'tcx, Tag>,
+        ret: mir::BasicBlock,
+    ) -> InterpResult<'tcx, EmulateByNameResult<'mir, 'tcx>> {
+        let this = self.eval_context_mut();
+
+        match &*link_name.as_str() {
+            _ => {
+                // By default we piggyback off the items emulated for Linux. For now this functions
+                // serves to make adding android-specific syscalls easy
+                return shims::posix::linux::foreign_items::EvalContextExt::emulate_foreign_item_by_name(this, link_name, abi, args, dest, ret);
+            }
+        }
+    }
+}

--- a/src/shims/posix/android/mod.rs
+++ b/src/shims/posix/android/mod.rs
@@ -1,0 +1,2 @@
+pub mod dlsym;
+pub mod foreign_items;

--- a/src/shims/posix/dlsym.rs
+++ b/src/shims/posix/dlsym.rs
@@ -2,6 +2,7 @@ use rustc_middle::mir;
 use rustc_target::spec::abi::Abi;
 
 use crate::*;
+use shims::posix::android::dlsym as android;
 use shims::posix::linux::dlsym as linux;
 use shims::posix::macos::dlsym as macos;
 
@@ -9,6 +10,7 @@ use shims::posix::macos::dlsym as macos;
 pub enum Dlsym {
     Linux(linux::Dlsym),
     MacOs(macos::Dlsym),
+    Android(android::Dlsym),
 }
 
 impl Dlsym {
@@ -18,6 +20,7 @@ impl Dlsym {
         Ok(match target_os {
             "linux" => linux::Dlsym::from_str(name)?.map(Dlsym::Linux),
             "macos" => macos::Dlsym::from_str(name)?.map(Dlsym::MacOs),
+            "android" => android::Dlsym::from_str(name)?.map(Dlsym::Android),
             _ => unreachable!(),
         })
     }
@@ -40,6 +43,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         match dlsym {
             Dlsym::Linux(dlsym) => linux::EvalContextExt::call_dlsym(this, dlsym, args, dest, ret),
             Dlsym::MacOs(dlsym) => macos::EvalContextExt::call_dlsym(this, dlsym, args, dest, ret),
+            Dlsym::Android(dlsym) => android::EvalContextExt::call_dlsym(this, dlsym, args, dest, ret),
         }
     }
 }

--- a/src/shims/posix/dlsym.rs
+++ b/src/shims/posix/dlsym.rs
@@ -43,7 +43,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         match dlsym {
             Dlsym::Linux(dlsym) => linux::EvalContextExt::call_dlsym(this, dlsym, args, dest, ret),
             Dlsym::MacOs(dlsym) => macos::EvalContextExt::call_dlsym(this, dlsym, args, dest, ret),
-            Dlsym::Android(dlsym) => android::EvalContextExt::call_dlsym(this, dlsym, args, dest, ret),
+            Dlsym::Android(dlsym) =>
+                android::EvalContextExt::call_dlsym(this, dlsym, args, dest, ret),
         }
     }
 }

--- a/src/shims/posix/fs.rs
+++ b/src/shims/posix/fs.rs
@@ -976,7 +976,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
     ) -> InterpResult<'tcx, i32> {
         let this = self.eval_context_mut();
 
-        this.assert_target_os("linux", "statx");
+        this.assert_target_os_is_linux_based("statx");
 
         let dirfd = this.read_scalar(dirfd_op)?.to_i32()?;
         let pathname_ptr = this.read_pointer(pathname_op)?;
@@ -1278,7 +1278,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
     fn linux_readdir64(&mut self, dirp_op: &OpTy<'tcx, Tag>) -> InterpResult<'tcx, Scalar<Tag>> {
         let this = self.eval_context_mut();
 
-        this.assert_target_os("linux", "readdir64");
+        this.assert_target_os_is_linux_based("readdir64");
 
         let dirp = this.read_scalar(dirp_op)?.to_machine_usize(this)?;
 

--- a/src/shims/posix/mod.rs
+++ b/src/shims/posix/mod.rs
@@ -5,6 +5,7 @@ mod fs;
 mod sync;
 mod thread;
 
+mod android;
 mod linux;
 mod macos;
 

--- a/src/shims/posix/thread.rs
+++ b/src/shims/posix/thread.rs
@@ -97,7 +97,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
     fn prctl(&mut self, args: &[OpTy<'tcx, Tag>]) -> InterpResult<'tcx, i32> {
         let this = self.eval_context_mut();
-        this.assert_target_os("linux", "prctl");
+        this.assert_target_os_is_linux_based("prctl");
 
         if args.is_empty() {
             throw_ub_format!(

--- a/src/shims/time.rs
+++ b/src/shims/time.rs
@@ -22,7 +22,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
         let this = self.eval_context_mut();
 
-        this.assert_target_os("linux", "clock_gettime");
+        this.assert_target_os_is_linux_based("clock_gettime");
         this.check_no_isolation("`clock_gettime`")?;
 
         let clk_id = this.read_scalar(clk_id_op)?.to_i32()?;

--- a/tests/fail/environ-gets-deallocated.rs
+++ b/tests/fail/environ-gets-deallocated.rs
@@ -1,6 +1,6 @@
 // ignore-windows: Windows does not have a global environ list that the program can access directly
 
-#[cfg(target_os="linux")]
+#[cfg(any(target_os="linux", target_os="android"))]
 fn get_environ() -> *const *const u8 {
   extern "C" {
     static mut environ: *const *const u8;

--- a/tests/pass/concurrency/simple.rs
+++ b/tests/pass/concurrency/simple.rs
@@ -1,4 +1,5 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
+// ignore-android: `libc` crate does not support `PR_SET_NAME` on Android
 // compile-flags: -Zmiri-strict-provenance
 
 use std::thread;

--- a/tests/pass/concurrency/sync.rs
+++ b/tests/pass/concurrency/sync.rs
@@ -1,4 +1,5 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
+// ignore-android: `libc` crate does not support `gettimeofday()` on Android
 // compile-flags: -Zmiri-disable-isolation -Zmiri-strict-provenance
 
 use std::sync::{Arc, Barrier, Condvar, Mutex, Once, RwLock};

--- a/tests/pass/current_dir.rs
+++ b/tests/pass/current_dir.rs
@@ -1,3 +1,4 @@
+// ignore-android: No foreign function support for __errno yet
 // compile-flags: -Zmiri-disable-isolation
 use std::env;
 use std::io::ErrorKind;

--- a/tests/pass/current_dir_with_isolation.rs
+++ b/tests/pass/current_dir_with_isolation.rs
@@ -1,3 +1,4 @@
+// ignore-android: No foreign function support for __errno yet
 // compile-flags: -Zmiri-isolation-error=warn-nobacktrace
 // normalize-stderr-test: "(getcwd|GetCurrentDirectoryW)" -> "$$GETCWD"
 // normalize-stderr-test: "(chdir|SetCurrentDirectoryW)" -> "$$SETCWD"

--- a/tests/pass/fs.rs
+++ b/tests/pass/fs.rs
@@ -1,4 +1,5 @@
 // ignore-windows: File handling is not implemented yet
+// ignore-android: No foreign function support for __errno yet
 // compile-flags: -Zmiri-disable-isolation
 
 #![feature(rustc_private)]

--- a/tests/pass/fs_with_isolation.rs
+++ b/tests/pass/fs_with_isolation.rs
@@ -1,4 +1,5 @@
 // ignore-windows: File handling is not implemented yet
+// ignore-android: No foreign function support for __errno yet
 // compile-flags: -Zmiri-isolation-error=warn-nobacktrace
 // normalize-stderr-test: "(stat(x)?)" -> "$$STAT"
 

--- a/tests/pass/hashmap.rs
+++ b/tests/pass/hashmap.rs
@@ -1,3 +1,5 @@
+// ignore-android: libc for Android does not have `SYS_statx`
+
 use std::collections::HashMap;
 use std::hash::BuildHasher;
 

--- a/tests/pass/libc.rs
+++ b/tests/pass/libc.rs
@@ -1,4 +1,5 @@
 // ignore-windows: No libc on Windows
+// ignore-android: libc's Android target does not have support for __errno_location yet
 // compile-flags: -Zmiri-disable-isolation
 
 #![feature(rustc_private)]


### PR DESCRIPTION
This PR fixes #2010 by adding platform support for Android. This does a couple of things:

- Supports weak linking for `signal` and `bsd_signal` syscalls. This is handled similarly to `dlsym` (dynamically linked) items  where we call into the `Dlsym::from_str` for each weakly linked symbol, allocate a function for them, and write the pointer to the function at the slot for the weakly linked item.
- Adds `android` as a supported platform for `shims::posix::foreign_item` emulation
- Piggybacks off of the `shims::posix::linux::foreign_items` for foreign item emulation

This is marked as a draft until I figure out why my test (aka prod) application is hanging on one of its tests. I'm not sure if it's just really expensive and runs slow, or if one of the emulated syscalls works differently on Android.

Currently though this is enough support to run basic unit tests.

TODO:

- [x] Add tests? This may be a bigger change since we'd need to bring in the Android NDK for compiling stdlib
- [x] Add docs regarding platform support?
- [ ] https://github.com/rust-lang/rust/pull/94813