### PR TITLE
Avoid duplicating error message in title

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -215,7 +215,7 @@ pub fn report_error<'tcx, 'mir>(
     report_msg(
         *ecx.tcx,
         DiagLevel::Error,
-        &if let Some(title) = title { format!("{}: {}", title, msg) } else { msg.clone() },
+        &if let Some(title) = title { title.to_string() } else { msg.clone() },
         msg,
         helps,
         &stacktrace,


### PR DESCRIPTION
Error output currently repeats the full error message in the title as well as the span message:
```
error: Undefined Behavior: no item granting read access to tag <1997> at alloc994+0x1 found in borrow stack.
 --> src/main.rs:5:9
  |
5 |         dbg!(*ptr.add(1));
  |         ^^^^^^^^^^^^^^^^^ no item granting read access to tag <1997> at alloc994+0x1 found in borrow stack.
```
  
This gets noisy because messages are often quite long. This PR changes the title to a constant `Undefined Behavior`:
```
error: Undefined Behavior
 --> src/main.rs:5:9
  |
5 |         dbg!(*ptr.add(1));
  |         ^^^^^^^^^^^^^^^^^ no item granting read access to tag <1997> at alloc994+0x1 found in borrow stack.
```