### PR TITLE
exclude TERM env var by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,8 +254,9 @@ environment variable:
   `warn` prints a full backtrace when that happen; `warn-nobacktrace` is less
   verbose. `hide` hides the warning entirely.
 * `-Zmiri-env-exclude=<var>` keeps the `var` environment variable isolated from the host so that it
-  cannot be accessed by the program. Can be used multiple times to exclude several variables. On
-  Windows, the `TERM` environment variable is excluded by default. This has no effect unless
+  cannot be accessed by the program. Can be used multiple times to exclude several variables. The
+  `TERM` environment variable is excluded by default to [speed up the test
+  harness](https://github.com/rust-lang/miri/issues/1702). This has no effect unless
   `-Zmiri-disable-validation` is also set.
 * `-Zmiri-env-forward=<var>` forwards the `var` environment variable to the interpreted program. Can
   be used multiple times to forward several variables. This has no effect if

--- a/src/shims/env.rs
+++ b/src/shims/env.rs
@@ -42,11 +42,9 @@ impl<'tcx> EnvVars<'tcx> {
         forwarded_env_vars: Vec<String>,
     ) -> InterpResult<'tcx> {
         let target_os = ecx.tcx.sess.target.os.as_str();
-        if target_os == "windows" {
-            // Temporary hack: Exclude `TERM` var to avoid terminfo trying to open the termcap file.
-            // Can be removed once https://github.com/rust-lang/miri/issues/1013 is resolved.
-            excluded_env_vars.push("TERM".to_owned());
-        }
+        // HACK: Exclude `TERM` var to avoid terminfo trying to open the termcap file.
+        // This is (a) very slow and (b) does not work on Windows.
+        excluded_env_vars.push("TERM".to_owned());
 
         // Skip the loop entirely if we don't want to forward anything.
         if ecx.machine.communicate() || !forwarded_env_vars.is_empty() {


### PR DESCRIPTION
Fixes https://github.com/rust-lang/miri/issues/1702

r? @oli-obk 