### PR TITLE
Consider the cargo workspace when checking if a frame is local

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,9 +375,12 @@ binaries, and as such worth documenting:
   directory after loading all the source files, but before commencing
   interpretation. This is useful if the interpreted program wants a different
   working directory at run-time than at build-time.
+* `MIRI_LOCAL_CRATES` is set by `cargo-miri` to tell the Miri driver which
+  crates should be given special treatment in diagnostics, in addition to the
+  crate currently being compiled.
 * `MIRI_VERBOSE` when set to any value tells the various `cargo-miri` phases to
   perform verbose logging.
-  
+
 [testing-miri]: CONTRIBUTING.md#testing-the-miri-driver
 
 ## Miri `extern` functions


### PR DESCRIPTION
`DefId::is_local` returns a result which is technically correct, but doesn't match the user's intuition when running integration tests or doctests. This incorporates the workspace crates mentioned in `cargo metadata` into the check for whether a frame is local to match user intuition.

For example, here is the backtrace you get from `MIRIFLAGS=-Zmiri-tag-raw-pointers cargo miri test` in `bytes` 1.1.0:
```
   --> /home/ben/.rustup/toolchains/miri/lib/rustlib/src/rust/library/core/src/slice/raw.rs:131:14
    |
131 |     unsafe { &mut *ptr::slice_from_raw_parts_mut(data, len) }
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trying to reborrow for Unique at alloc67158, but parent tag <untagged> does not have an appropriate item in the borrow stack
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
            
    = note: inside `std::slice::from_raw_parts_mut::<u8>` at /home/ben/.rustup/toolchains/miri/lib/rustlib/src/rust/library/core/src/slice/raw.rs:131:14
    = note: inside `bytes::bytes::rebuild_boxed_slice` at /tmp/bytes-1.1.0/src/bytes.rs:938:19
    = note: inside closure at /tmp/bytes-1.1.0/src/bytes.rs:904:18
    = note: inside `<std::sync::atomic::AtomicPtr<()> as bytes::loom::sync::atomic::AtomicMut<()>>::with_mut::<[closure@bytes::bytes::promotable_even_drop::{closure#0}], ()>` at /tmp/bytes-1.1.0/src/loom.rs:17:17
    = note: inside `bytes::bytes::promotable_even_drop` at /tmp/bytes-1.1.0/src/bytes.rs:895:5
    = note: inside `<bytes::Bytes as std::ops::Drop>::drop` at /tmp/bytes-1.1.0/src/bytes.rs:515:18
    = note: inside `std::ptr::drop_in_place::<bytes::Bytes> - shim(Some(bytes::Bytes))` at /home/ben/.rustup/toolchains/miri/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:188:1
note: inside `copy_to_bytes_less` at tests/test_buf.rs:112:1
   --> tests/test_buf.rs:112:1
    |
112 | }
    | ^
note: inside closure at tests/test_buf.rs:106:1
   --> tests/test_buf.rs:106:1
    |
105 |   #[test]
    |   ------- in this procedural macro expansion
106 | / fn copy_to_bytes_less() {
107 | |     let mut buf = &b"hello world"[..];
108 | |
109 | |     let bytes = buf.copy_to_bytes(5);
110 | |     assert_eq!(bytes, &b"hello"[..]);
111 | |     assert_eq!(buf, &b" world"[..])
112 | | }
    | |_^
    = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
```
We get these because the integration tests are occurring in a crate called `test`, not the actual `bytes` crate. With this PR, we get this:
```
    = note: inside `std::slice::from_raw_parts_mut::<u8>` at /home/ben/.rustup/toolchains/miri/lib/rustlib/src/rust/library/core/src/slice/raw.rs:131:14
note: inside `bytes::bytes::rebuild_boxed_slice` at /tmp/bytes-1.1.0/src/bytes.rs:938:19
   --> /tmp/bytes-1.1.0/src/bytes.rs:938:19
    |
938 |     Box::from_raw(slice::from_raw_parts_mut(buf, cap))
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside closure at /tmp/bytes-1.1.0/src/bytes.rs:904:18
   --> /tmp/bytes-1.1.0/src/bytes.rs:904:18
    |
904 |             drop(rebuild_boxed_slice(buf, ptr, len));
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside `<std::sync::atomic::AtomicPtr<()> as bytes::loom::sync::atomic::AtomicMut<()>>::with_mut::<[closure@bytes::bytes::promotable_even_drop::{closure#0}], ()>` at /tmp/bytes-1.1.0/src/loom.rs:17:17
   --> /tmp/bytes-1.1.0/src/loom.rs:17:17
    |
17  |                 f(self.get_mut())
    |                 ^^^^^^^^^^^^^^^^^
note: inside `bytes::bytes::promotable_even_drop` at /tmp/bytes-1.1.0/src/bytes.rs:895:5
   --> /tmp/bytes-1.1.0/src/bytes.rs:895:5
    |
895 | /     data.with_mut(|shared| {
896 | |         let shared = *shared;
897 | |         let kind = shared as usize & KIND_MASK;
898 | |
...   |
905 | |         }
906 | |     });
    | |______^
note: inside `<bytes::Bytes as std::ops::Drop>::drop` at /tmp/bytes-1.1.0/src/bytes.rs:515:18
   --> /tmp/bytes-1.1.0/src/bytes.rs:515:18
    |
515 |         unsafe { (self.vtable.drop)(&mut self.data, self.ptr, self.len) }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: inside `std::ptr::drop_in_place::<bytes::Bytes> - shim(Some(bytes::Bytes))` at /home/ben/.rustup/toolchains/miri/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:188:1
note: inside `copy_to_bytes_less` at tests/test_buf.rs:112:1
   --> tests/test_buf.rs:112:1
    |
112 | }
    | ^
note: inside closure at tests/test_buf.rs:106:1
   --> tests/test_buf.rs:106:1
    |
105 |   #[test]
    |   ------- in this procedural macro expansion
106 | / fn copy_to_bytes_less() {
107 | |     let mut buf = &b"hello world"[..];
108 | |
109 | |     let bytes = buf.copy_to_bytes(5);
110 | |     assert_eq!(bytes, &b"hello"[..]);
111 | |     assert_eq!(buf, &b" world"[..])
112 | | }
    | |_^
    = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Note that this kind of inflation is rather rare to see. Most backtraces change not at all or only a tiny bit.

I originally implemented this to support another improvement to Miri diagnostics, but I think this is hairy enough to deserve its own PR, if somewhat poorly-motivated.