### PR TITLE
Print spans where tags are created and invalidated

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -165,10 +165,10 @@ pub fn report_error<'tcx, 'mir>(
                     ];
                     match history {
                         Some(TagHistory::Tagged {tag, created: (created_range, created_span), invalidated, protected }) => {
-                            let msg = format!("{:?} was created due to a retag at offsets {}", tag, HexRange(*created_range));
+                            let msg = format!("{:?} was created by a retag at offsets {}", tag, HexRange(*created_range));
                             helps.push((Some(created_span.clone()), msg));
                             if let Some((invalidated_range, invalidated_span)) = invalidated {
-                                let msg = format!("{:?} was later invalidated due to a retag at offsets {}", tag, HexRange(*invalidated_range));
+                                let msg = format!("{:?} was later invalidated at offsets {}", tag, HexRange(*invalidated_range));
                                 helps.push((Some(invalidated_span.clone()), msg));
                             }
                             if let Some((protecting_tag, protecting_tag_span, protection_span)) = protected {

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -8,7 +8,7 @@ use rustc_middle::ty;
 use rustc_span::{source_map::DUMMY_SP, Span, SpanData, Symbol};
 
 use crate::helpers::HexRange;
-use crate::stacked_borrows::{AccessKind, SbTag, TagHistory};
+use crate::stacked_borrows::{diagnostics::TagHistory, AccessKind, SbTag};
 use crate::*;
 
 /// Details of premature program termination.

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -15,7 +15,6 @@ use rustc_target::spec::abi::Abi;
 
 use rustc_session::config::EntryFnType;
 
-use rustc_span::DUMMY_SP;
 use std::collections::HashSet;
 
 use crate::*;
@@ -311,9 +310,6 @@ pub fn eval_entry<'tcx>(
             let info = ecx.preprocess_diagnostics();
             match ecx.schedule()? {
                 SchedulingAction::ExecuteStep => {
-                    if let Some(sb) = ecx.machine.stacked_borrows.as_mut() {
-                        sb.get_mut().current_span = DUMMY_SP;
-                    }
                     assert!(ecx.step()?, "a terminated thread was scheduled for execution");
                 }
                 SchedulingAction::ExecuteTimeoutCallback => {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -15,8 +15,8 @@ use rustc_target::spec::abi::Abi;
 
 use rustc_session::config::EntryFnType;
 
-use std::collections::HashSet;
 use rustc_span::DUMMY_SP;
+use std::collections::HashSet;
 
 use crate::*;
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -16,6 +16,7 @@ use rustc_target::spec::abi::Abi;
 use rustc_session::config::EntryFnType;
 
 use std::collections::HashSet;
+use rustc_span::DUMMY_SP;
 
 use crate::*;
 
@@ -283,24 +284,6 @@ pub fn create_ecx<'mir, 'tcx: 'mir>(
     Ok((ecx, ret_place))
 }
 
-// This is potentially a performance hazard.
-// Factoring it into its own function lets us keep an eye on how much it shows up in a profile.
-fn set_current_span<'mir, 'tcx: 'mir>(ecx: &mut MiriEvalContext<'mir, 'tcx>) {
-    let current_span = Machine::stack(&ecx)
-        .into_iter()
-        .rev()
-        .find(|frame| {
-            let info =
-                FrameInfo { instance: frame.instance, span: frame.current_span(), lint_root: None };
-            ecx.machine.is_local(&info)
-        })
-        .map(|frame| frame.current_span())
-        .unwrap_or(rustc_span::DUMMY_SP);
-    if let Some(sb) = ecx.machine.stacked_borrows.as_mut() {
-        sb.get_mut().current_span = current_span;
-    }
-}
-
 /// Evaluates the entry function specified by `entry_id`.
 /// Returns `Some(return_code)` if program executed completed.
 /// Returns `None` if an evaluation error occured.
@@ -328,8 +311,8 @@ pub fn eval_entry<'tcx>(
             let info = ecx.preprocess_diagnostics();
             match ecx.schedule()? {
                 SchedulingAction::ExecuteStep => {
-                    if ecx.machine.stacked_borrows.is_some() {
-                        set_current_span(&mut ecx);
+                    if let Some(sb) = ecx.machine.stacked_borrows.as_mut() {
+                        sb.get_mut().current_span = DUMMY_SP;
                     }
                     assert!(ecx.step()?, "a terminated thread was scheduled for execution");
                 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -813,3 +813,12 @@ pub fn get_local_crates(tcx: &TyCtxt<'_>) -> Vec<CrateNum> {
     }
     local_crates
 }
+
+/// Formats an AllocRange like [0x1..0x3], for use in diagnostics.
+pub struct HexRange(pub AllocRange);
+
+impl std::fmt::Display for HexRange {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{:#x}..{:#x}]", self.0.start.bytes(), self.0.end().bytes())
+    }
+}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,5 +1,6 @@
 use std::mem;
 use std::num::NonZeroUsize;
+use std::rc::Rc;
 use std::time::Duration;
 
 use log::trace;
@@ -797,7 +798,7 @@ pub fn isolation_abort_error(name: &str) -> InterpResult<'static> {
 
 /// Retrieve the list of local crates that should have been passed by cargo-miri in
 /// MIRI_LOCAL_CRATES and turn them into `CrateNum`s.
-pub fn get_local_crates(tcx: &TyCtxt<'_>) -> Vec<CrateNum> {
+pub fn get_local_crates(tcx: &TyCtxt<'_>) -> Rc<[CrateNum]> {
     // Convert the local crate names from the passed-in config into CrateNums so that they can
     // be looked up quickly during execution
     let local_crate_names = std::env::var("MIRI_LOCAL_CRATES")
@@ -811,7 +812,7 @@ pub fn get_local_crates(tcx: &TyCtxt<'_>) -> Vec<CrateNum> {
             local_crates.push(crate_num);
         }
     }
-    local_crates
+    Rc::from(local_crates.as_slice())
 }
 
 /// Formats an AllocRange like [0x1..0x3], for use in diagnostics.

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -6,6 +6,7 @@ use std::cell::RefCell;
 use std::collections::HashSet;
 use std::fmt;
 use std::num::NonZeroU64;
+use std::rc::Rc;
 use std::time::Instant;
 
 use rand::rngs::StdRng;
@@ -273,7 +274,7 @@ pub struct Evaluator<'mir, 'tcx> {
     pub(crate) backtrace_style: BacktraceStyle,
 
     /// Crates which are considered local for the purposes of error reporting.
-    pub(crate) local_crates: Vec<CrateNum>,
+    pub(crate) local_crates: Rc<[CrateNum]>,
 
     /// Mapping extern static names to their base pointer.
     extern_statics: FxHashMap<Symbol, Pointer<Tag>>,
@@ -307,7 +308,6 @@ impl<'mir, 'tcx> Evaluator<'mir, 'tcx> {
                 config.tracked_pointer_tags.clone(),
                 config.tracked_call_ids.clone(),
                 config.tag_raw,
-                local_crates.clone(),
             )))
         } else {
             None
@@ -575,6 +575,7 @@ impl<'mir, 'tcx> Machine<'mir, 'tcx> for Evaluator<'mir, 'tcx> {
                 stacked_borrows,
                 kind,
                 &ecx.machine.threads,
+                ecx.machine.local_crates.clone(),
             ))
         } else {
             None

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -776,6 +776,7 @@ impl<'mir, 'tcx> Machine<'mir, 'tcx> for Evaluator<'mir, 'tcx> {
 
 // This is potentially a performance hazard.
 // Factoring it into its own function lets us keep an eye on how much it shows up in a profile.
+///
 fn set_current_span<'mir, 'tcx: 'mir>(machine: &Evaluator<'mir, 'tcx>) {
     if let Some(sb) = machine.stacked_borrows.as_ref() {
         if sb.borrow().current_span != DUMMY_SP {

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -632,7 +632,7 @@ impl<'mir, 'tcx> Machine<'mir, 'tcx> for Evaluator<'mir, 'tcx> {
                 alloc_id,
                 tag,
                 range,
-                machine.stacked_borrows.as_ref().unwrap(),
+                 machine.stacked_borrows.as_ref().unwrap(),
             )
         } else {
             Ok(())
@@ -655,7 +655,7 @@ impl<'mir, 'tcx> Machine<'mir, 'tcx> for Evaluator<'mir, 'tcx> {
                 alloc_id,
                 tag,
                 range,
-                machine.stacked_borrows.as_mut().unwrap(),
+                machine.stacked_borrows.as_ref().unwrap(),
             )
         } else {
             Ok(())
@@ -681,7 +681,7 @@ impl<'mir, 'tcx> Machine<'mir, 'tcx> for Evaluator<'mir, 'tcx> {
                 alloc_id,
                 tag,
                 range,
-                machine.stacked_borrows.as_mut().unwrap(),
+                machine.stacked_borrows.as_ref().unwrap(),
             )
         } else {
             Ok(())

--- a/src/stacked_borrows.rs
+++ b/src/stacked_borrows.rs
@@ -14,13 +14,17 @@ use rustc_middle::ty::{
     self,
     layout::{HasParamEnv, LayoutOf},
 };
+use rustc_span::Span;
 use rustc_span::DUMMY_SP;
-use rustc_span::{Span, SpanData};
 use rustc_target::abi::Size;
 use std::collections::HashSet;
 
-use crate::helpers::HexRange;
 use crate::*;
+
+pub mod diagnostics;
+use diagnostics::{AllocHistory, GlobalStateExt, StackExt};
+
+use diagnostics::TagHistory;
 
 pub type PtrId = NonZeroU64;
 pub type CallId = NonZeroU64;
@@ -118,47 +122,6 @@ pub struct GlobalStateInner {
     extras: HashMap<AllocId, AllocHistory>,
     /// Current span
     pub(crate) current_span: Span,
-}
-
-#[derive(Debug, Default)]
-struct AllocHistory {
-    // The time tags can be compressed down to one bit per event, by just storing a Vec<u8>
-    // where each bit is set to indicate if the event was a creation or a retag
-    current_time: usize,
-    creations: smallvec::SmallVec<[Event; 2]>,
-    invalidations: smallvec::SmallVec<[Event; 1]>,
-    protectors: smallvec::SmallVec<[Protection; 1]>,
-}
-
-#[derive(Debug)]
-struct Protection {
-    orig_tag: SbTag,
-    tag: SbTag,
-    span: Span,
-}
-
-#[derive(Debug)]
-struct Event {
-    time: usize,
-    parent: Option<SbTag>,
-    tag: SbTag,
-    range: AllocRange,
-    span: Span,
-}
-
-pub enum TagHistory {
-    Tagged {
-        tag: SbTag,
-        created: (AllocRange, SpanData),
-        invalidated: Option<(AllocRange, SpanData)>,
-        protected: Option<(SbTag, SpanData, SpanData)>,
-    },
-    Untagged {
-        recently_created: Option<(AllocRange, SpanData)>,
-        recently_invalidated: Option<(AllocRange, SpanData)>,
-        matching_created: Option<(AllocRange, SpanData)>,
-        protected: Option<(SbTag, SpanData, SpanData)>,
-    },
 }
 
 /// We need interior mutable access to the global state.
@@ -269,144 +232,10 @@ impl GlobalStateInner {
         self.base_ptr_ids.try_insert(id, tag).unwrap();
         tag
     }
-
-    fn add_creation(
-        &mut self,
-        parent: Option<SbTag>,
-        tag: SbTag,
-        alloc: AllocId,
-        range: AllocRange,
-    ) {
-        let extras = self.extras.entry(alloc).or_default();
-        extras.creations.push(Event {
-            parent,
-            tag,
-            range,
-            span: self.current_span,
-            time: extras.current_time,
-        });
-        extras.current_time += 1;
-    }
-
-    fn add_invalidation(&mut self, tag: SbTag, alloc: AllocId, range: AllocRange) {
-        let extras = self.extras.entry(alloc).or_default();
-        extras.invalidations.push(Event {
-            parent: None,
-            tag,
-            range,
-            span: self.current_span,
-            time: extras.current_time,
-        });
-        extras.current_time += 1;
-    }
-
-    fn add_protector(&mut self, orig_tag: SbTag, tag: SbTag, alloc: AllocId) {
-        let extras = self.extras.entry(alloc).or_default();
-        extras.protectors.push(Protection { orig_tag, tag, span: self.current_span });
-        extras.current_time += 1;
-    }
-
-    fn get_stack_history(
-        &self,
-        tag: SbTag,
-        alloc: AllocId,
-        alloc_range: AllocRange,
-        offset: Size,
-        protector_tag: Option<SbTag>,
-    ) -> Option<TagHistory> {
-        let extras = self.extras.get(&alloc)?;
-        let protected = protector_tag
-            .and_then(|protector| {
-                extras.protectors.iter().find_map(|protection| {
-                    if protection.tag == protector {
-                        Some((protection.orig_tag, protection.span.data()))
-                    } else {
-                        None
-                    }
-                })
-            })
-            .and_then(|(tag, call_span)| {
-                extras.creations.iter().rev().find_map(|event| {
-                    if event.tag == tag {
-                        Some((event.parent?, event.span.data(), call_span))
-                    } else {
-                        None
-                    }
-                })
-            });
-        if let SbTag::Tagged(_) = tag {
-            let get_matching = |events: &[Event]| {
-                events.iter().rev().find_map(|event| {
-                    if event.tag == tag { Some((event.range, event.span.data())) } else { None }
-                })
-            };
-            Some(TagHistory::Tagged {
-                tag,
-                created: get_matching(&extras.creations)?,
-                invalidated: get_matching(&extras.invalidations),
-                protected,
-            })
-        } else {
-            let mut created_time = 0;
-            // Find the most recently created tag that satsfies this offset
-            let recently_created = extras.creations.iter().rev().find_map(|event| {
-                if event.tag == tag && offset >= event.range.start && offset < event.range.end() {
-                    created_time = event.time;
-                    Some((event.range, event.span.data()))
-                } else {
-                    None
-                }
-            });
-
-            // Find a different recently created tag that satisfies this whole operation, predates
-            // the recently created tag, and has a different span.
-            // We're trying to make a guess at which span the user wanted to provide the tag that
-            // they're using.
-            let matching_created = if let Some((_created_range, created_span)) = recently_created {
-                extras.creations.iter().rev().find_map(|event| {
-                    if event.tag == tag
-                        && alloc_range.start >= event.range.start
-                        && alloc_range.end() <= event.range.end()
-                        && event.span.data() != created_span
-                        && event.time != created_time
-                    {
-                        Some((event.range, event.span.data()))
-                    } else {
-                        None
-                    }
-                })
-            } else {
-                None
-            };
-
-            let recently_invalidated = if recently_created.is_some() {
-                // Find the most recent invalidation of this tag which post-dates the creation
-                let mut found = None;
-                for event in extras.invalidations.iter().rev() {
-                    if event.time < created_time {
-                        break;
-                    }
-                    if event.tag == tag && offset >= event.range.start && offset < event.range.end()
-                    {
-                        found = Some((event.range, event.span.data()))
-                    }
-                }
-                found
-            } else {
-                None
-            };
-            Some(TagHistory::Untagged {
-                recently_created,
-                matching_created,
-                recently_invalidated,
-                protected,
-            })
-        }
-    }
 }
 
 /// Error reporting
-fn err_sb_ub(
+pub fn err_sb_ub(
     msg: String,
     help: Option<String>,
     history: Option<TagHistory>,
@@ -498,7 +327,7 @@ impl<'tcx> Stack {
     /// `None` during a deallocation.
     fn check_protector(
         item: &Item,
-        provoking_access: Option<(SbTag, AllocId, AllocRange, Size)>, // just for debug printing amd error messages
+        provoking_access: Option<(SbTag, AllocId, AllocRange, Size)>, // just for debug printing and error messages
         global: &GlobalStateInner,
     ) -> InterpResult<'tcx> {
         if let SbTag::Tagged(id) = item.tag {
@@ -600,7 +429,7 @@ impl<'tcx> Stack {
     fn dealloc(
         &mut self,
         tag: SbTag,
-        (alloc_id, alloc_range, offset): (AllocId, AllocRange, Size), // just for debug printing amd error messages
+        (alloc_id, alloc_range, offset): (AllocId, AllocRange, Size), // just for debug printing and error messages
         global: &GlobalStateInner,
     ) -> InterpResult<'tcx> {
         // Step 1: Find granting item.
@@ -680,75 +509,6 @@ impl<'tcx> Stack {
         }
 
         Ok(())
-    }
-
-    /// Report a descriptive error when `new` could not be granted from `derived_from`.
-    fn grant_error(
-        &self,
-        derived_from: SbTag,
-        new: Item,
-        alloc_id: AllocId,
-        alloc_range: AllocRange,
-        error_offset: Size,
-        global: &GlobalStateInner,
-    ) -> InterpError<'static> {
-        let action = format!(
-            "trying to reborrow {:?} for {:?} permission at {}[{:#x}]",
-            derived_from,
-            new.perm,
-            alloc_id,
-            error_offset.bytes(),
-        );
-        err_sb_ub(
-            format!("{}{}", action, self.error_cause(derived_from)),
-            Some(Self::operation_summary("a reborrow", alloc_id, alloc_range)),
-            global.get_stack_history(derived_from, alloc_id, alloc_range, error_offset, None),
-        )
-    }
-
-    /// Report a descriptive error when `access` is not permitted based on `tag`.
-    fn access_error(
-        &self,
-        access: AccessKind,
-        tag: SbTag,
-        alloc_id: AllocId,
-        alloc_range: AllocRange,
-        error_offset: Size,
-        global: &GlobalStateInner,
-    ) -> InterpError<'static> {
-        let action = format!(
-            "attempting a {} using {:?} at {}[{:#x}]",
-            access,
-            tag,
-            alloc_id,
-            error_offset.bytes(),
-        );
-        err_sb_ub(
-            format!("{}{}", action, self.error_cause(tag)),
-            Some(Self::operation_summary("an access", alloc_id, alloc_range)),
-            global.get_stack_history(tag, alloc_id, alloc_range, error_offset, None),
-        )
-    }
-
-    fn operation_summary(
-        operation: &'static str,
-        alloc_id: AllocId,
-        alloc_range: AllocRange,
-    ) -> String {
-        format!(
-            "this error occurs as part of {} at {:?}{}",
-            operation,
-            alloc_id,
-            HexRange(alloc_range)
-        )
-    }
-
-    fn error_cause(&self, tag: SbTag) -> &'static str {
-        if self.borrows.iter().any(|item| item.tag == tag && item.perm != Permission::Disabled) {
-            ", but that tag only grants SharedReadOnly permission for this location"
-        } else {
-            ", but that tag does not exist in the borrow stack for this location"
-        }
     }
 }
 // # Stacked Borrows Core End

--- a/src/stacked_borrows/diagnostics.rs
+++ b/src/stacked_borrows/diagnostics.rs
@@ -1,0 +1,299 @@
+use rustc_middle::mir::interpret::{AllocId, AllocRange};
+use rustc_span::{Span, SpanData};
+use rustc_target::abi::Size;
+
+use crate::helpers::HexRange;
+use crate::stacked_borrows::{err_sb_ub, AccessKind, GlobalStateInner, Permission};
+use crate::Item;
+use crate::SbTag;
+use crate::Stack;
+
+use rustc_middle::mir::interpret::InterpError;
+
+#[derive(Debug, Default)]
+pub struct AllocHistory {
+    // The time tags can be compressed down to one bit per event, by just storing a Vec<u8>
+    // where each bit is set to indicate if the event was a creation or a retag
+    current_time: usize,
+    creations: smallvec::SmallVec<[Event; 2]>,
+    invalidations: smallvec::SmallVec<[Event; 1]>,
+    protectors: smallvec::SmallVec<[Protection; 1]>,
+}
+
+#[derive(Debug)]
+struct Protection {
+    orig_tag: SbTag,
+    tag: SbTag,
+    span: Span,
+}
+
+#[derive(Debug)]
+struct Event {
+    time: usize,
+    parent: Option<SbTag>,
+    tag: SbTag,
+    range: AllocRange,
+    span: Span,
+}
+
+pub enum TagHistory {
+    Tagged {
+        tag: SbTag,
+        created: (AllocRange, SpanData),
+        invalidated: Option<(AllocRange, SpanData)>,
+        protected: Option<(SbTag, SpanData, SpanData)>,
+    },
+    Untagged {
+        recently_created: Option<(AllocRange, SpanData)>,
+        recently_invalidated: Option<(AllocRange, SpanData)>,
+        matching_created: Option<(AllocRange, SpanData)>,
+        protected: Option<(SbTag, SpanData, SpanData)>,
+    },
+}
+
+pub trait GlobalStateExt {
+    fn add_creation(
+        &mut self,
+        parent: Option<SbTag>,
+        tag: SbTag,
+        alloc: AllocId,
+        range: AllocRange,
+    );
+
+    fn add_invalidation(&mut self, tag: SbTag, alloc: AllocId, range: AllocRange);
+
+    fn add_protector(&mut self, orig_tag: SbTag, tag: SbTag, alloc: AllocId);
+
+    fn get_stack_history(
+        &self,
+        tag: SbTag,
+        alloc: AllocId,
+        alloc_range: AllocRange,
+        offset: Size,
+        protector_tag: Option<SbTag>,
+    ) -> Option<TagHistory>;
+}
+
+impl GlobalStateExt for GlobalStateInner {
+    fn add_creation(
+        &mut self,
+        parent: Option<SbTag>,
+        tag: SbTag,
+        alloc: AllocId,
+        range: AllocRange,
+    ) {
+        let extras = self.extras.entry(alloc).or_default();
+        extras.creations.push(Event {
+            parent,
+            tag,
+            range,
+            span: self.current_span,
+            time: extras.current_time,
+        });
+        extras.current_time += 1;
+    }
+
+    fn add_invalidation(&mut self, tag: SbTag, alloc: AllocId, range: AllocRange) {
+        let extras = self.extras.entry(alloc).or_default();
+        extras.invalidations.push(Event {
+            parent: None,
+            tag,
+            range,
+            span: self.current_span,
+            time: extras.current_time,
+        });
+        extras.current_time += 1;
+    }
+
+    fn add_protector(&mut self, orig_tag: SbTag, tag: SbTag, alloc: AllocId) {
+        let extras = self.extras.entry(alloc).or_default();
+        extras.protectors.push(Protection { orig_tag, tag, span: self.current_span });
+        extras.current_time += 1;
+    }
+
+    fn get_stack_history(
+        &self,
+        tag: SbTag,
+        alloc: AllocId,
+        alloc_range: AllocRange,
+        offset: Size,
+        protector_tag: Option<SbTag>,
+    ) -> Option<TagHistory> {
+        let extras = self.extras.get(&alloc)?;
+        let protected = protector_tag
+            .and_then(|protector| {
+                extras.protectors.iter().find_map(|protection| {
+                    if protection.tag == protector {
+                        Some((protection.orig_tag, protection.span.data()))
+                    } else {
+                        None
+                    }
+                })
+            })
+            .and_then(|(tag, call_span)| {
+                extras.creations.iter().rev().find_map(|event| {
+                    if event.tag == tag {
+                        Some((event.parent?, event.span.data(), call_span))
+                    } else {
+                        None
+                    }
+                })
+            });
+        if let SbTag::Tagged(_) = tag {
+            let get_matching = |events: &[Event]| {
+                events.iter().rev().find_map(|event| {
+                    if event.tag == tag { Some((event.range, event.span.data())) } else { None }
+                })
+            };
+            Some(TagHistory::Tagged {
+                tag,
+                created: get_matching(&extras.creations)?,
+                invalidated: get_matching(&extras.invalidations),
+                protected,
+            })
+        } else {
+            let mut created_time = 0;
+            // Find the most recently created tag that satsfies this offset
+            let recently_created = extras.creations.iter().rev().find_map(|event| {
+                if event.tag == tag && offset >= event.range.start && offset < event.range.end() {
+                    created_time = event.time;
+                    Some((event.range, event.span.data()))
+                } else {
+                    None
+                }
+            });
+
+            // Find a different recently created tag that satisfies this whole operation, predates
+            // the recently created tag, and has a different span.
+            // We're trying to make a guess at which span the user wanted to provide the tag that
+            // they're using.
+            let matching_created = if let Some((_created_range, created_span)) = recently_created {
+                extras.creations.iter().rev().find_map(|event| {
+                    if event.tag == tag
+                        && alloc_range.start >= event.range.start
+                        && alloc_range.end() <= event.range.end()
+                        && event.span.data() != created_span
+                        && event.time != created_time
+                    {
+                        Some((event.range, event.span.data()))
+                    } else {
+                        None
+                    }
+                })
+            } else {
+                None
+            };
+
+            let recently_invalidated = if recently_created.is_some() {
+                // Find the most recent invalidation of this tag which post-dates the creation
+                let mut found = None;
+                for event in extras.invalidations.iter().rev() {
+                    if event.time < created_time {
+                        break;
+                    }
+                    if event.tag == tag && offset >= event.range.start && offset < event.range.end()
+                    {
+                        found = Some((event.range, event.span.data()))
+                    }
+                }
+                found
+            } else {
+                None
+            };
+            Some(TagHistory::Untagged {
+                recently_created,
+                matching_created,
+                recently_invalidated,
+                protected,
+            })
+        }
+    }
+}
+
+pub trait StackExt {
+    fn grant_error(
+        &self,
+        derived_from: SbTag,
+        new: Item,
+        alloc_id: AllocId,
+        alloc_range: AllocRange,
+        error_offset: Size,
+        global: &GlobalStateInner,
+    ) -> InterpError<'static>;
+
+    fn access_error(
+        &self,
+        access: AccessKind,
+        tag: SbTag,
+        alloc_id: AllocId,
+        alloc_range: AllocRange,
+        error_offset: Size,
+        global: &GlobalStateInner,
+    ) -> InterpError<'static>;
+}
+
+impl StackExt for Stack {
+    /// Report a descriptive error when `new` could not be granted from `derived_from`.
+    fn grant_error(
+        &self,
+        derived_from: SbTag,
+        new: Item,
+        alloc_id: AllocId,
+        alloc_range: AllocRange,
+        error_offset: Size,
+        global: &GlobalStateInner,
+    ) -> InterpError<'static> {
+        let action = format!(
+            "trying to reborrow {:?} for {:?} permission at {}[{:#x}]",
+            derived_from,
+            new.perm,
+            alloc_id,
+            error_offset.bytes(),
+        );
+        err_sb_ub(
+            format!("{}{}", action, error_cause(self, derived_from)),
+            Some(operation_summary("a reborrow", alloc_id, alloc_range)),
+            global.get_stack_history(derived_from, alloc_id, alloc_range, error_offset, None),
+        )
+    }
+
+    /// Report a descriptive error when `access` is not permitted based on `tag`.
+    fn access_error(
+        &self,
+        access: AccessKind,
+        tag: SbTag,
+        alloc_id: AllocId,
+        alloc_range: AllocRange,
+        error_offset: Size,
+        global: &GlobalStateInner,
+    ) -> InterpError<'static> {
+        let action = format!(
+            "attempting a {} using {:?} at {}[{:#x}]",
+            access,
+            tag,
+            alloc_id,
+            error_offset.bytes(),
+        );
+        err_sb_ub(
+            format!("{}{}", action, error_cause(self, tag)),
+            Some(operation_summary("an access", alloc_id, alloc_range)),
+            global.get_stack_history(tag, alloc_id, alloc_range, error_offset, None),
+        )
+    }
+}
+
+fn operation_summary(
+    operation: &'static str,
+    alloc_id: AllocId,
+    alloc_range: AllocRange,
+) -> String {
+    format!("this error occurs as part of {} at {:?}{}", operation, alloc_id, HexRange(alloc_range))
+}
+
+fn error_cause(stack: &Stack, tag: SbTag) -> &'static str {
+    if stack.borrows.iter().any(|item| item.tag == tag && item.perm != Permission::Disabled) {
+        ", but that tag only grants SharedReadOnly permission for this location"
+    } else {
+        ", but that tag does not exist in the borrow stack for this location"
+    }
+}

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -263,7 +263,7 @@ impl<'mir, 'tcx: 'mir> ThreadManager<'mir, 'tcx> {
     }
 
     /// Borrow the stack of the active thread.
-    fn active_thread_stack(&self) -> &[Frame<'mir, 'tcx, Tag, FrameData<'tcx>>] {
+    pub fn active_thread_stack(&self) -> &[Frame<'mir, 'tcx, Tag, FrameData<'tcx>>] {
         &self.threads[self.active_thread].stack
     }
 


### PR DESCRIPTION
5225225 called this "automatic tag tracking" and I think that may be a reasonable description, but I would like to kill tag tracking as a primary use of Miri if possible. Tag tracking isn't always possible; for example if the UB is only detected with isolation off and the failing tag is made unstable by removing isolation. (also it's bad UX to run the tool twice)

This is just one of the things we can do with https://github.com/rust-lang/miri/pull/2024

The memory usage of this is _shockingly_ low, I think because the memory usage of Miri is driven by allocations where each byte ends up with its own very large stack. The memory usage in this change is linear with the number of tags, not tags * bytes. If memory usage gets out of control we can cap the number of events we save per allocation, from experience we tend to only use the most recent few in diagnostics but of course there's no guarantee of that so if we can manage to keep everything that would be best.

In many cases now I can tell exactly what these codebases are doing wrong just from the new outputs here, which I think is extremely cool.

New helps generated with plain old `cargo miri test` on `rust-argon2` v1.0.0:
```
test argon2::tests::single_thread_verification_multi_lane_hash ... error: Undefined Behavior: trying to reborrow <1485898> for Unique permission at alloc110523[0x0], but that tag does not exist in the borrow stack for this location
   --> /home/ben/.rustup/toolchains/miri/lib/rustlib/src/rust/library/core/src/mem/manually_drop.rs:89:9
    |
89  |         slot.value
    |         ^^^^^^^^^^
    |         |
    |         trying to reborrow <1485898> for Unique permission at alloc110523[0x0], but that tag does not exist in the borrow stack for this location
    |         this error occurs as part of a reborrow at alloc110523[0x0..0x20]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
help: <1485898> was created by a retag at offsets [0x0..0x20]
   --> src/memory.rs:42:13
    |
42  |             vec.push(unsafe { &mut (*ptr) });
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
help: <1485898> was later invalidated at offsets [0x0..0x20]
   --> src/memory.rs:42:31
    |
42  |             vec.push(unsafe { &mut (*ptr) });
    |                               ^^^^^^^^^^^
```

And with `-Zmiri-tag-raw-pointers` on `slab` v0.4.5
```
error: Undefined Behavior: trying to reborrow <2915> for Unique permission at alloc1418[0x0], but that tag does not exist in the borrow stack for this location
   --> /tmp/slab-0.4.5/src/lib.rs:835:16
    |
835 |         match (&mut *ptr1, &mut *ptr2) {
    |                ^^^^^^^^^^
    |                |
    |                trying to reborrow <2915> for Unique permission at alloc1418[0x0], but that tag does not exist in the borrow stack for this location
    |                this error occurs as part of a reborrow at alloc1418[0x0..0x10]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
help: <2915> was created by a retag at offsets [0x0..0x10]
   --> /tmp/slab-0.4.5/src/lib.rs:833:20
    |
833 |         let ptr1 = self.entries.get_unchecked_mut(key1) as *mut Entry<T>;
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
help: <2915> was later invalidated at offsets [0x0..0x20]
   --> /tmp/slab-0.4.5/src/lib.rs:834:20
    |
834 |         let ptr2 = self.entries.get_unchecked_mut(key2) as *mut Entry<T>;
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

And without raw pointer tagging, `cargo miri test` on `half` v1.8.2
```
error: Undefined Behavior: trying to reborrow <untagged> for Unique permission at alloc1340[0x0], but that tag only grants SharedReadOnly permission for this location
   --> /home/ben/.rustup/toolchains/miri/lib/rustlib/src/rust/library/core/src/slice/raw.rs:141:9
    |
141 |         &mut *ptr::slice_from_raw_parts_mut(data, len)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
    |         trying to reborrow <untagged> for Unique permission at alloc1340[0x0], but that tag only grants SharedReadOnly permission for this location
    |         this error occurs as part of a reborrow at alloc1340[0x0..0x6]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
help: tag was most recently created at offsets [0x0..0x6]
   --> /tmp/half-1.8.2/src/slice.rs:309:22
    |
309 |         let length = self.len();
    |                      ^^^^^^^^^^
help: this tag was also created here at offsets [0x0..0x6]
   --> /tmp/half-1.8.2/src/slice.rs:308:23
    |
308 |         let pointer = self.as_ptr() as *mut u16;
    |                       ^^^^^^^^^^^^^
```
The second suggestion is close to guesswork, but from experience it tends to be correct (as in, it tends to locate the pointer the user wanted) more often that it doesn't.