### PR TITLE
add -Zmiri-strict-provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,10 @@ environment variable:
   entropy.  The default seed is 0.  **NOTE**: This entropy is not good enough
   for cryptographic use!  Do not generate secret keys in Miri or perform other
   kinds of cryptographic operations that rely on proper random numbers.
+* `-Zmiri-strict-provenance` enables [strict
+  provenance](https://github.com/rust-lang/rust/issues/95228) checking in Miri. This means that
+  casting an integer to a pointer yields a result with 'invalid' provenance, i.e., with provenance
+  that cannot be used for any memory access. Also implies `-Zmiri-tag-raw-pointers`.
 * `-Zmiri-symbolic-alignment-check` makes the alignment check more strict.  By
   default, alignment is checked by casting the pointer to an integer, and making
   sure that is a multiple of the alignment.  This can lead to cases where a

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -363,6 +363,10 @@ fn main() {
                 "-Zmiri-tag-raw-pointers" => {
                     miri_config.tag_raw = true;
                 }
+                "-Zmiri-strict-provenance" => {
+                    miri_config.strict_provenance = true;
+                    miri_config.tag_raw = true;
+                }
                 "-Zmiri-track-raw-pointers" => {
                     eprintln!(
                         "WARNING: -Zmiri-track-raw-pointers has been renamed to -Zmiri-tag-raw-pointers, the old name is deprecated."

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -108,9 +108,13 @@ pub struct MiriConfig {
     /// If `Some`, enable the `measureme` profiler, writing results to a file
     /// with the specified prefix.
     pub measureme_out: Option<String>,
-    /// Panic when unsupported functionality is encountered
+    /// Panic when unsupported functionality is encountered.
     pub panic_on_unsupported: bool,
+    /// Which style to use for printing backtraces.
     pub backtrace_style: BacktraceStyle,
+    /// Whether to enforce "strict provenance" rules. Enabling this means int2ptr casts return
+    /// pointers with an invalid provenance, i.e., not valid for any memory access.
+    pub strict_provenance: bool,
 }
 
 impl Default for MiriConfig {
@@ -136,6 +140,7 @@ impl Default for MiriConfig {
             measureme_out: None,
             panic_on_unsupported: false,
             backtrace_style: BacktraceStyle::Short,
+            strict_provenance: false,
         }
     }
 }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -205,7 +205,7 @@ impl MemoryExtra {
         MemoryExtra {
             stacked_borrows,
             data_race,
-            intptrcast: Default::default(),
+            intptrcast: RefCell::new(intptrcast::GlobalState::new(config)),
             extern_statics: FxHashMap::default(),
             rng: RefCell::new(rng),
             tracked_alloc_id: config.tracked_alloc_id,

--- a/tests/compile-fail/box-cell-alias.rs
+++ b/tests/compile-fail/box-cell-alias.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-tag-raw-pointers
+// compile-flags: -Zmiri-strict-provenance
 
 // Taken from <https://github.com/rust-lang/unsafe-code-guidelines/issues/194#issuecomment-520934222>.
 

--- a/tests/compile-fail/stacked_borrows/zst_slice.rs
+++ b/tests/compile-fail/stacked_borrows/zst_slice.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-tag-raw-pointers
+// compile-flags: -Zmiri-strict-provenance
 // error-pattern: does not exist in the borrow stack
 
 fn main() {

--- a/tests/compile-fail/strict-provenance-offset.rs
+++ b/tests/compile-fail/strict-provenance-offset.rs
@@ -1,0 +1,9 @@
+// compile-flags: -Zmiri-strict-provenance
+// error-pattern: not a valid pointer
+
+fn main() {
+    let x = 22;
+    let ptr = &x as *const _ as *const u8;
+    let roundtrip = ptr as usize as *const u8;
+    let _ = unsafe { roundtrip.offset(1) };
+}

--- a/tests/run-pass/btreemap.rs
+++ b/tests/run-pass/btreemap.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-tag-raw-pointers
+// compile-flags: -Zmiri-strict-provenance -Zmiri-check-number-validity
 #![feature(btree_drain_filter)]
 use std::collections::{BTreeMap, BTreeSet};
 use std::mem;

--- a/tests/run-pass/concurrency/channels.rs
+++ b/tests/run-pass/concurrency/channels.rs
@@ -1,5 +1,4 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-isolation
 
 use std::sync::mpsc::{channel, sync_channel};
 use std::thread;

--- a/tests/run-pass/concurrency/sync.rs
+++ b/tests/run-pass/concurrency/sync.rs
@@ -1,5 +1,5 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-isolation -Zmiri-check-number-validity
+// compile-flags: -Zmiri-disable-isolation -Zmiri-strict-provenance -Zmiri-check-number-validity
 
 use std::sync::{Arc, Barrier, Condvar, Mutex, Once, RwLock};
 use std::thread;

--- a/tests/run-pass/concurrency/thread_locals.rs
+++ b/tests/run-pass/concurrency/thread_locals.rs
@@ -1,5 +1,5 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-check-number-validity
+// compile-flags: -Zmiri-strict-provenance -Zmiri-check-number-validity
 
 //! The main purpose of this test is to check that if we take a pointer to
 //! thread's `t1` thread-local `A` and send it to another thread `t2`,

--- a/tests/run-pass/concurrency/tls_lib_drop_single_thread.rs
+++ b/tests/run-pass/concurrency/tls_lib_drop_single_thread.rs
@@ -1,4 +1,3 @@
-// compile-flags: -Zmiri-tag-raw-pointers
 //! Check that destructors of the thread locals are executed on all OSes.
 
 use std::cell::RefCell;

--- a/tests/run-pass/rc.rs
+++ b/tests/run-pass/rc.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-tag-raw-pointers
+// compile-flags: -Zmiri-strict-provenance -Zmiri-check-number-validity
 #![feature(new_uninit)]
 #![feature(get_mut_unchecked)]
 

--- a/tests/run-pass/slices.rs
+++ b/tests/run-pass/slices.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-tag-raw-pointers
+// compile-flags: -Zmiri-strict-provenance -Zmiri-check-number-validity
 #![feature(new_uninit)]
 #![feature(slice_as_chunks)]
 #![feature(slice_partition_dedup)]

--- a/tests/run-pass/strings.rs
+++ b/tests/run-pass/strings.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-tag-raw-pointers
+// compile-flags: -Zmiri-strict-provenance -Zmiri-check-number-validity
 
 fn empty() -> &'static str {
     ""

--- a/tests/run-pass/vec.rs
+++ b/tests/run-pass/vec.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-tag-raw-pointers -Zmiri-check-number-validity
+// compile-flags: -Zmiri-strict-provenance -Zmiri-check-number-validity
 // Gather all references from a mutable iterator and make sure Miri notices if
 // using them is dangerous.
 fn test_all_refs<'a, T: 'a>(dummy: &mut T, iter: impl Iterator<Item = &'a mut T>) {

--- a/tests/run-pass/vecdeque.rs
+++ b/tests/run-pass/vecdeque.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-tag-raw-pointers
+// compile-flags: -Zmiri-strict-provenance -Zmiri-check-number-validity
 use std::collections::VecDeque;
 
 fn test_all_refs<'a, T: 'a>(dummy: &mut T, iter: impl Iterator<Item = &'a mut T>) {


### PR DESCRIPTION
This implements [strict provenance](https://github.com/rust-lang/rust/issues/95228) in Miri. The only change is that casting an integer to a pointer does not even attempt to produce a good provenance for the given address; instead, it always uses the invalid provenance. This stricter than even `-Zmiri-tag-raw-pointers` in that it also rejects the following example (which does not even involve Stacked Borrows):
```rust
fn main() {
    let x = 22;
    let ptr = &x as *const _ as *const u8;
    let roundtrip = ptr as usize as *const u8;
    let _ = unsafe { roundtrip.offset(1) };
}
```
The new flag also implies `-Zmiri-tag-raw-pointers` since the only reason one would *not* want to tag raw pointers is to support ptr-int-ptr roundtrips.

Note that the flag does *not* check against ptr-to-int *transmutes*; that still requires `-Zmiri-check-number-validity`. You can also check for strict provenance *without* Stacked Borrows by adding `-Zmiri-disable-stacked-borrows`.

The new "Miri hard mode" flags for maximal checking are `-Zmiri-strict-provenance -Zmiri-check-number-validity`. (Add `-Zmiri-symbolic-alignment-check` if you feel extra spicy today.)