### PR TITLE
Initial work on Miri permissive-exposed-provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,17 @@ to Miri failing to detect cases of undefined behavior in a program.
   application instead of raising an error within the context of Miri (and halting
   execution). Note that code might not expect these operations to ever panic, so
   this flag can lead to strange (mis)behavior.
+* `-Zmiri-permissive-provenance` is **experimental**. This will make Miri do a
+  best-effort attempt to implement the semantics of
+  [`expose_addr`](https://doc.rust-lang.org/nightly/std/primitive.pointer.html#method.expose_addr)
+  and
+  [`ptr::from_exposed_addr`](https://doc.rust-lang.org/nightly/std/ptr/fn.from_exposed_addr.html)
+  for pointer-to-int and int-to-pointer casts, respectively. This will
+  necessarily miss some bugs as those semantics are not efficiently
+  implementable in a sanitizer, but it will only miss bugs that concerns
+  memory/pointers which is subject to these operations. Also note that this flag
+  is currently incompatible with Stacked Borrows, so you will have to also pass
+  `-Zmiri-disable-stacked-borrows` to use this.
 * `-Zmiri-seed=<hex>` configures the seed of the RNG that Miri uses to resolve
   non-determinism.  This RNG is used to pick base addresses for allocations.
   When isolation is enabled (the default), this is also used to emulate system

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -30,7 +30,7 @@ use rustc_middle::{
 };
 use rustc_session::{config::ErrorOutputType, search_paths::PathKind, CtfeBacktrace};
 
-use miri::BacktraceStyle;
+use miri::{BacktraceStyle, ProvenanceMode};
 
 struct MiriCompilerCalls {
     miri_config: miri::MiriConfig,
@@ -384,9 +384,13 @@ fn main() {
                     miri_config.tag_raw = true;
                 }
                 "-Zmiri-strict-provenance" => {
-                    miri_config.strict_provenance = true;
+                    miri_config.provenance_mode = ProvenanceMode::Strict;
                     miri_config.tag_raw = true;
                     miri_config.check_number_validity = true;
+                }
+                "-Zmiri-permissive-provenance" => {
+                    miri_config.provenance_mode = ProvenanceMode::Permissive;
+                    miri_config.tag_raw = true;
                 }
                 "-Zmiri-mute-stdout-stderr" => {
                     miri_config.mute_stdout_stderr = true;

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -113,9 +113,8 @@ pub struct MiriConfig {
     pub panic_on_unsupported: bool,
     /// Which style to use for printing backtraces.
     pub backtrace_style: BacktraceStyle,
-    /// Whether to enforce "strict provenance" rules. Enabling this means int2ptr casts return
-    /// pointers with an invalid provenance, i.e., not valid for any memory access.
-    pub strict_provenance: bool,
+    /// Which provenance to use for int2ptr casts
+    pub provenance_mode: ProvenanceMode,
     /// Whether to ignore any output by the program. This is helpful when debugging miri
     /// as its messages don't get intermingled with the program messages.
     pub mute_stdout_stderr: bool,
@@ -144,7 +143,7 @@ impl Default for MiriConfig {
             measureme_out: None,
             panic_on_unsupported: false,
             backtrace_style: BacktraceStyle::Short,
-            strict_provenance: false,
+            provenance_mode: ProvenanceMode::Legacy,
             mute_stdout_stderr: false,
         }
     }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -786,8 +786,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
     fn mark_immutable(&mut self, mplace: &MemPlace<Tag>) {
         let this = self.eval_context_mut();
         // This got just allocated, so there definitely is a pointer here.
-        this.alloc_mark_immutable(mplace.ptr.into_pointer_or_addr().unwrap().provenance.alloc_id)
-            .unwrap();
+        let provenance = mplace.ptr.into_pointer_or_addr().unwrap().provenance;
+        this.alloc_mark_immutable(provenance.get_alloc_id().unwrap()).unwrap();
     }
 
     fn item_link_name(&self, def_id: DefId) -> Symbol {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,9 +78,10 @@ pub use crate::eval::{
     create_ecx, eval_entry, AlignmentCheck, BacktraceStyle, IsolatedOp, MiriConfig, RejectOpWith,
 };
 pub use crate::helpers::{CurrentSpan, EvalContextExt as HelpersEvalContextExt};
+pub use crate::intptrcast::ProvenanceMode;
 pub use crate::machine::{
-    AllocExtra, Evaluator, FrameData, MiriEvalContext, MiriEvalContextExt, MiriMemoryKind, Tag,
-    NUM_CPUS, PAGE_SIZE, STACK_ADDR, STACK_SIZE,
+    AllocExtra, ConcreteTag, Evaluator, FrameData, MiriEvalContext, MiriEvalContextExt,
+    MiriMemoryKind, Tag, NUM_CPUS, PAGE_SIZE, STACK_ADDR, STACK_SIZE,
 };
 pub use crate::mono_hash_map::MonoHashMap;
 pub use crate::operator::EvalContextExt as OperatorEvalContextExt;

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -125,7 +125,13 @@ impl fmt::Display for MiriMemoryKind {
 
 /// Pointer provenance (tag).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct Tag {
+pub enum Tag {
+    Concrete(ConcreteTag),
+    Wildcard,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ConcreteTag {
     pub alloc_id: AllocId,
     /// Stacked Borrows tag.
     pub sb: SbTag,
@@ -133,8 +139,8 @@ pub struct Tag {
 
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
 static_assert_size!(Pointer<Tag>, 24);
-#[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
-static_assert_size!(Pointer<Option<Tag>>, 24);
+// #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
+// static_assert_size!(Pointer<Option<Tag>>, 24);
 #[cfg(all(target_arch = "x86_64", target_pointer_width = "64"))]
 static_assert_size!(ScalarMaybeUninit<Tag>, 32);
 
@@ -148,18 +154,31 @@ impl Provenance for Tag {
     fn fmt(ptr: &Pointer<Self>, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let (tag, addr) = ptr.into_parts(); // address is absolute
         write!(f, "0x{:x}", addr.bytes())?;
-        // Forward `alternate` flag to `alloc_id` printing.
-        if f.alternate() {
-            write!(f, "[{:#?}]", tag.alloc_id)?;
-        } else {
-            write!(f, "[{:?}]", tag.alloc_id)?;
+
+        match tag {
+            Tag::Concrete(tag) => {
+                // Forward `alternate` flag to `alloc_id` printing.
+                if f.alternate() {
+                    write!(f, "[{:#?}]", tag.alloc_id)?;
+                } else {
+                    write!(f, "[{:?}]", tag.alloc_id)?;
+                }
+                // Print Stacked Borrows tag.
+                write!(f, "{:?}", tag.sb)?;
+            }
+            Tag::Wildcard => {
+                write!(f, "[Wildcard]")?;
+            }
         }
-        // Print Stacked Borrows tag.
-        write!(f, "{:?}", tag.sb)
+
+        Ok(())
     }
 
     fn get_alloc_id(self) -> Option<AllocId> {
-        Some(self.alloc_id)
+        match self {
+            Tag::Concrete(concrete) => Some(concrete.alloc_id),
+            Tag::Wildcard => None,
+        }
     }
 }
 
@@ -611,7 +630,10 @@ impl<'mir, 'tcx> Machine<'mir, 'tcx> for Evaluator<'mir, 'tcx> {
         } else {
             SbTag::Untagged
         };
-        Pointer::new(Tag { alloc_id: ptr.provenance, sb: sb_tag }, Size::from_bytes(absolute_addr))
+        Pointer::new(
+            Tag::Concrete(ConcreteTag { alloc_id: ptr.provenance, sb: sb_tag }),
+            Size::from_bytes(absolute_addr),
+        )
     }
 
     #[inline(always)]
@@ -619,7 +641,7 @@ impl<'mir, 'tcx> Machine<'mir, 'tcx> for Evaluator<'mir, 'tcx> {
         ecx: &MiriEvalContext<'mir, 'tcx>,
         addr: u64,
     ) -> Pointer<Option<Self::PointerTag>> {
-        intptrcast::GlobalStateInner::ptr_from_addr(addr, ecx)
+        intptrcast::GlobalStateInner::ptr_from_addr_cast(ecx, addr)
     }
 
     #[inline(always)]
@@ -627,14 +649,22 @@ impl<'mir, 'tcx> Machine<'mir, 'tcx> for Evaluator<'mir, 'tcx> {
         ecx: &MiriEvalContext<'mir, 'tcx>,
         addr: u64,
     ) -> Pointer<Option<Self::PointerTag>> {
-        Self::ptr_from_addr_cast(ecx, addr)
+        intptrcast::GlobalStateInner::ptr_from_addr_transmute(ecx, addr)
     }
 
     #[inline(always)]
     fn expose_ptr(
-        _ecx: &mut InterpCx<'mir, 'tcx, Self>,
-        _ptr: Pointer<Self::PointerTag>,
+        ecx: &mut InterpCx<'mir, 'tcx, Self>,
+        ptr: Pointer<Self::PointerTag>,
     ) -> InterpResult<'tcx> {
+        let tag = ptr.provenance;
+
+        if let Tag::Concrete(concrete) = tag {
+            intptrcast::GlobalStateInner::expose_addr(ecx, concrete.alloc_id);
+        }
+
+        // No need to do anything for wildcard pointers as
+        // their provenances have already been previously exposed.
         Ok(())
     }
 
@@ -645,7 +675,13 @@ impl<'mir, 'tcx> Machine<'mir, 'tcx> for Evaluator<'mir, 'tcx> {
         ptr: Pointer<Self::PointerTag>,
     ) -> Option<(AllocId, Size, Self::TagExtra)> {
         let rel = intptrcast::GlobalStateInner::abs_ptr_to_rel(ecx, ptr);
-        Some((ptr.provenance.alloc_id, rel, ptr.provenance.sb))
+
+        let sb = match ptr.provenance {
+            Tag::Concrete(ConcreteTag { sb, .. }) => sb,
+            Tag::Wildcard => SbTag::Untagged,
+        };
+
+        rel.map(|(alloc_id, size)| (alloc_id, size, sb))
     }
 
     #[inline(always)]

--- a/src/stacked_borrows.rs
+++ b/src/stacked_borrows.rs
@@ -867,7 +867,16 @@ trait EvalContextPrivExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         this.reborrow(&place, size, kind, new_tag, protect)?;
 
         // Adjust pointer.
-        let new_place = place.map_provenance(|p| p.map(|t| Tag { sb: new_tag, ..t }));
+        let new_place = place.map_provenance(|p| {
+            p.map(|t| {
+                // TODO: Fix this eventually
+                if let Tag::Concrete(t) = t {
+                    Tag::Concrete(ConcreteTag { sb: new_tag, ..t })
+                } else {
+                    t
+                }
+            })
+        });
 
         // Return new pointer.
         Ok(ImmTy::from_immediate(new_place.to_ref(this), val.layout))

--- a/tests/compile-fail/ptr_int_unexposed.rs
+++ b/tests/compile-fail/ptr_int_unexposed.rs
@@ -1,0 +1,12 @@
+// compile-flags: -Zmiri-permissive-provenance -Zmiri-disable-stacked-borrows
+
+fn main() {
+    let x: i32 = 3;
+    let x_ptr = &x as *const i32;
+
+    // TODO: switch this to addr() once we intrinsify it
+    let x_usize: usize = unsafe { std::mem::transmute(x_ptr) };
+    // Cast back a pointer that did *not* get exposed.
+    let ptr = x_usize as *const i32;
+    assert_eq!(unsafe { *ptr }, 3); //~ ERROR Undefined Behavior: dereferencing pointer failed
+}

--- a/tests/compile-fail/ptr_legacy_provenance.rs
+++ b/tests/compile-fail/ptr_legacy_provenance.rs
@@ -1,0 +1,21 @@
+// compile-flags: -Zmiri-disable-stacked-borrows
+#![feature(strict_provenance)]
+
+use std::ptr;
+
+// Make sure that with legacy provenance, the allocation id of
+// a casted pointer is determined at cast-time
+fn main() {
+    let x: i32 = 0;
+    let y: i32 = 1;
+
+    let x_ptr = &x as *const i32;
+    let y_ptr = &y as *const i32;
+
+    let x_usize = x_ptr.expose_addr();
+    let y_usize = y_ptr.expose_addr();
+
+    let ptr = ptr::from_exposed_addr::<i32>(y_usize);
+    let ptr = ptr.with_addr(x_usize);
+    assert_eq!(unsafe { *ptr }, 0); //~ ERROR is out-of-bounds
+}

--- a/tests/run-pass/ptr_int_permissive_provenance.rs
+++ b/tests/run-pass/ptr_int_permissive_provenance.rs
@@ -1,0 +1,62 @@
+// compile-flags: -Zmiri-permissive-provenance -Zmiri-disable-stacked-borrows
+#![feature(strict_provenance)]
+
+use std::ptr;
+
+/// Ensure we can expose the address of a pointer that is out-of-bounds
+fn ptr_roundtrip_out_of_bounds() {
+    let x: i32 = 3;
+    let x_ptr = &x as *const i32;
+
+    let x_usize = x_ptr.wrapping_offset(128).expose_addr();
+
+    let ptr = ptr::from_exposed_addr::<i32>(x_usize).wrapping_offset(-128);
+    assert_eq!(unsafe { *ptr }, 3);
+}
+
+/// Ensure that we can move between allocations after casting back to a ptr
+fn ptr_roundtrip_confusion() {
+    let x: i32 = 0;
+    let y: i32 = 1;
+
+    let x_ptr = &x as *const i32;
+    let y_ptr = &y as *const i32;
+
+    let x_usize = x_ptr.expose_addr();
+    let y_usize = y_ptr.expose_addr();
+
+    let ptr = ptr::from_exposed_addr::<i32>(y_usize);
+    let ptr = ptr.with_addr(x_usize);
+    assert_eq!(unsafe { *ptr }, 0);
+}
+
+/// Ensure we can cast back a different integer than the one we got when exposing.
+fn ptr_roundtrip_imperfect() {
+    let x: u8 = 3;
+    let x_ptr = &x as *const u8;
+
+    let x_usize = x_ptr.expose_addr() + 128;
+
+    let ptr = ptr::from_exposed_addr::<u8>(x_usize).wrapping_offset(-128);
+    assert_eq!(unsafe { *ptr }, 3);
+}
+
+/// Ensure that we can roundtrip through a pointer with an address of 0
+fn ptr_roundtrip_null() {
+    let x = &42;
+    let x_ptr = x as *const i32;
+    let x_null_ptr = x_ptr.with_addr(0); // addr 0, but still the provenance of x
+    let null = x_null_ptr.expose_addr();
+    assert_eq!(null, 0);
+
+    let x_null_ptr_copy = ptr::from_exposed_addr::<i32>(null); // just a roundtrip, so has provenance of x (angelically)
+    let x_ptr_copy = x_null_ptr_copy.with_addr(x_ptr.addr()); // addr of x and provenance of x
+    assert_eq!(unsafe { *x_ptr_copy }, 42);
+}
+
+fn main() {
+    ptr_roundtrip_out_of_bounds();
+    ptr_roundtrip_confusion();
+    ptr_roundtrip_imperfect();
+    ptr_roundtrip_null();
+}


### PR DESCRIPTION
Miri portions of the changes for portions of a permissive ptr-to-int model for Miri. This is more restrictive than what we currently have so it will probably need a flag once I figure out how to hook that up.

> This implements a form of permissive exposed-address provenance, wherein the only way to expose the address is with a cast to usize (ideally expose_addr). This is more restrictive than C in that stuff like reading the representation bytes (via unions, type-punning, transmute) does not expose the address, only expose_addr. This is less restrictive than C in that a pointer casted from an integer has union provenance of all exposed pointers, not any udi stuff.

There's a few TODOs here, namely related to `fn memory_read` and friends. We pass it the maybe/unreified provenance before `ptr_get_alloc` reifies it into a concrete one, so it doesn't have the `AllocId` (or the SB tag, but that's getting ahead of ourselves). One way this could be fixed is changing `ptr_get_alloc` and (`ptr_try_get_alloc_id` on the rustc side) to return a pointer with the tag fixed up. We could also take in different arguments, but I'm not sure what works best.

The other TODOs here are how permissive this model could be. This currently does not enforce that a ptr-to-int cast happens before the corresponding int-to-ptr (colloquial meaning of happens before, not atomic meaning). Example:

```
let ptr = 0x2000 as *const i32;
let a: i32 = 5;
let a_ptr = &a as *const i32;

// value is 0x2000;
a_ptr as usize;

println!("{}", unsafe { *ptr }); // this is valid
```

We also allow the resulting pointer to dereference different non-contiguous allocations (the "not any udi stuff" mentioned above), which I'm not sure if is allowed by LLVM.

This is the Miri side of https://github.com/rust-lang/rust/pull/95826.