### PR TITLE
port Miri to edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ name = "miri"
 repository = "https://github.com/rust-lang/miri"
 version = "0.1.0"
 default-run = "miri"
-edition = "2018"
+edition = "2021"
 
 [lib]
 test = true # we have unit tests

--- a/cargo-miri/Cargo.toml
+++ b/cargo-miri/Cargo.toml
@@ -5,7 +5,7 @@ license = "MIT OR Apache-2.0"
 name = "cargo-miri"
 repository = "https://github.com/rust-lang/miri"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [[bin]]
 name = "cargo-miri"

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -9,7 +9,6 @@ extern crate rustc_metadata;
 extern crate rustc_middle;
 extern crate rustc_session;
 
-use std::convert::TryFrom;
 use std::env;
 use std::num::NonZeroU64;
 use std::path::PathBuf;

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -414,11 +414,11 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                                 )
                             }
                         },
-                    CreatedCallId(id) => format!("function call with id {}", id),
-                    CreatedAlloc(AllocId(id)) => format!("created allocation with id {}", id),
-                    FreedAlloc(AllocId(id)) => format!("freed allocation with id {}", id),
+                    CreatedCallId(id) => format!("function call with id {id}"),
+                    CreatedAlloc(AllocId(id)) => format!("created allocation with id {id}"),
+                    FreedAlloc(AllocId(id)) => format!("freed allocation with id {id}"),
                     RejectedIsolatedOp(ref op) =>
-                        format!("{} was made to return an error due to isolation", op),
+                        format!("{op} was made to return an error due to isolation"),
                 };
 
                 let (title, diag_level) = match e {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,6 +1,5 @@
 //! Main evaluator loop and setting up the initial stack frame.
 
-use std::convert::TryFrom;
 use std::ffi::OsStr;
 use std::iter;
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,4 +1,3 @@
-use std::convert::{TryFrom, TryInto};
 use std::mem;
 use std::num::NonZeroUsize;
 use std::time::Duration;

--- a/src/shims/backtrace.rs
+++ b/src/shims/backtrace.rs
@@ -4,7 +4,6 @@ use rustc_middle::ty::layout::LayoutOf as _;
 use rustc_middle::ty::{self, Instance};
 use rustc_span::{BytePos, Loc, Symbol};
 use rustc_target::{abi::Size, spec::abi::Abi};
-use std::convert::TryInto as _;
 
 impl<'mir, 'tcx: 'mir> EvalContextExt<'mir, 'tcx> for crate::MiriEvalContext<'mir, 'tcx> {}
 pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx> {

--- a/src/shims/env.rs
+++ b/src/shims/env.rs
@@ -1,4 +1,3 @@
-use std::convert::TryFrom;
 use std::env;
 use std::ffi::{OsStr, OsString};
 use std::io::ErrorKind;

--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::hash_map::Entry,
-    convert::{TryFrom, TryInto},
-    iter,
-};
+use std::{collections::hash_map::Entry, iter};
 
 use log::trace;
 

--- a/src/shims/intrinsics.rs
+++ b/src/shims/intrinsics.rs
@@ -1,4 +1,3 @@
-use std::convert::TryInto;
 use std::iter;
 
 use log::trace;

--- a/src/shims/os_str.rs
+++ b/src/shims/os_str.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::convert::TryFrom;
 use std::ffi::{OsStr, OsString};
 use std::iter;
 use std::path::{Path, PathBuf};

--- a/src/shims/posix/fs.rs
+++ b/src/shims/posix/fs.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 use std::collections::BTreeMap;
-use std::convert::{TryFrom, TryInto};
 use std::fs::{
     read_dir, remove_dir, remove_file, rename, DirBuilder, File, FileType, OpenOptions, ReadDir,
 };

--- a/src/shims/posix/thread.rs
+++ b/src/shims/posix/thread.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 use crate::*;
 use rustc_middle::ty::layout::LayoutOf;
 use rustc_target::spec::abi::Abi;

--- a/src/shims/time.rs
+++ b/src/shims/time.rs
@@ -1,4 +1,3 @@
-use std::convert::TryFrom;
 use std::time::{Duration, Instant, SystemTime};
 
 use crate::*;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,5 +1,4 @@
 use std::collections::{hash_map::Entry, HashMap, VecDeque};
-use std::convert::TryFrom;
 use std::num::NonZeroU32;
 use std::ops::Not;
 

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -2,7 +2,6 @@
 
 use std::cell::RefCell;
 use std::collections::hash_map::Entry;
-use std::convert::TryFrom;
 use std::num::TryFromIntError;
 use std::time::{Duration, Instant, SystemTime};
 

--- a/src/vector_clock.rs
+++ b/src/vector_clock.rs
@@ -1,6 +1,6 @@
 use rustc_index::vec::Idx;
 use smallvec::SmallVec;
-use std::{cmp::Ordering, convert::TryFrom, fmt::Debug, ops::Index};
+use std::{cmp::Ordering, fmt::Debug, ops::Index};
 
 /// A vector clock index, this is associated with a thread id
 /// but in some cases one vector index may be shared with


### PR DESCRIPTION
`cargo fix --edition` didn't change anything for either of these crates, so this looks like a very simple port. And then we can remove a bunch of annoying imports. :)

I thought this also unlocks the named format string stuff, but it seems that works on all editions except for that problem around `panic!`. Whatever. ;)