### PR TITLE
implement strerror_r

### DIFF
--- a/tests/run-pass/fs.rs
+++ b/tests/run-pass/fs.rs
@@ -335,6 +335,8 @@ fn test_errors() {
     // The following tests also check that the `__errno_location()` shim is working properly.
     // Opening a non-existing file should fail with a "not found" error.
     assert_eq!(ErrorKind::NotFound, File::open(&path).unwrap_err().kind());
+    // Make sure we can also format this.
+    format!("{0:?}: {0}", File::open(&path).unwrap_err());
     // Removing a non-existing file should fail with a "not found" error.
     assert_eq!(ErrorKind::NotFound, remove_file(&path).unwrap_err().kind());
     // Reading the metadata of a non-existing file should fail with a "not found" error.


### PR DESCRIPTION
This isn't perfect; we end up using [this match](https://github.com/rust-lang/rust/blob/72a25d05bf1a4b155d74139ef700ff93af6d8e22/library/std/src/io/error.rs#L380) rather than the platform-specific messages, but at least we show something -- this is mostly informational anyway.

Cc https://github.com/rust-lang/miri/issues/2057