### PR TITLE
do not consider thread-local allocations read-only

### DIFF
--- a/tests/run-pass/concurrency/thread_locals.rs
+++ b/tests/run-pass/concurrency/thread_locals.rs
@@ -16,6 +16,10 @@ static mut A: u8 = 0;
 static mut B: u8 = 0;
 static mut C: u8 = 0;
 
+// Regression test for https://github.com/rust-lang/rust/issues/96191.
+#[thread_local]
+static READ_ONLY: u8 = 42;
+
 unsafe fn get_a_ref() -> *mut u8 {
     &mut A
 }
@@ -25,6 +29,8 @@ struct Sender(*mut u8);
 unsafe impl Send for Sender {}
 
 fn main() {
+    let _val = READ_ONLY;
+
     let ptr = unsafe {
         let x = get_a_ref();
         *x = 5;


### PR DESCRIPTION
They are not in read-only memory the way regular `static`s are.

Fixes https://github.com/rust-lang/rust/issues/96191