### PR TITLE
Add a command line flag to avoid printing to stdout and stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,10 +265,6 @@ environment variable:
 * `-Zmiri-disable-isolation` disables host isolation.  As a consequence,
   the program has access to host resources such as environment variables, file
   systems, and randomness.
-* `-Zmiri-mute-stdout-stderr` silently ignores all writes to stdout and stderr,
-  but reports to the program that it did actually write. This is useful when you
-  are not interested in the actual program's messages, but only want to see miri's
-  errors and warnings.
 * `-Zmiri-isolation-error=<action>` configures Miri's response to operations
   requiring host access while isolation is enabled. `abort`, `hide`, `warn`,
   and `warn-nobacktrace` are the supported actions. The default is to `abort`,
@@ -290,6 +286,10 @@ environment variable:
    This can be used to find which parts of your program are executing slowly under Miri.
    The profile is written out to a file with the prefix `<name>`, and can be processed
    using the tools in the repository https://github.com/rust-lang/measureme.
+* `-Zmiri-mute-stdout-stderr` silently ignores all writes to stdout and stderr,
+  but reports to the program that it did actually write. This is useful when you
+  are not interested in the actual program's messages, but only want to see miri's
+  errors and warnings.
 * `-Zmiri-panic-on-unsupported` will makes some forms of unsupported functionality,
   such as FFI and unsupported syscalls, panic within the context of the emulated
   application instead of raising an error within the context of Miri (and halting

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ environment variable:
    using the tools in the repository https://github.com/rust-lang/measureme.
 * `-Zmiri-mute-stdout-stderr` silently ignores all writes to stdout and stderr,
   but reports to the program that it did actually write. This is useful when you
-  are not interested in the actual program's messages, but only want to see miri's
+  are not interested in the actual program's output, but only want to see miri's
   errors and warnings.
 * `-Zmiri-panic-on-unsupported` will makes some forms of unsupported functionality,
   such as FFI and unsupported syscalls, panic within the context of the emulated

--- a/README.md
+++ b/README.md
@@ -265,6 +265,10 @@ environment variable:
 * `-Zmiri-disable-isolation` disables host isolation.  As a consequence,
   the program has access to host resources such as environment variables, file
   systems, and randomness.
+* `-Zmiri-mute-stdout-stderr` silently ignores all writes to stdout and stderr,
+  but reports to the program that it did actually write. This is useful when you
+  are not interested in the actual program's messages, but only want to see miri's
+  errors and warnings.
 * `-Zmiri-isolation-error=<action>` configures Miri's response to operations
   requiring host access while isolation is enabled. `abort`, `hide`, `warn`,
   and `warn-nobacktrace` are the supported actions. The default is to `abort`,

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -374,8 +374,8 @@ fn main() {
                     miri_config.tag_raw = true;
                     miri_config.check_number_validity = true;
                 }
-                "-Zmiri-drop-stdout-stderr" => {
-                    miri_config.drop_stdout_stderr = true;
+                "-Zmiri-mute-stdout-stderr" => {
+                    miri_config.mute_stdout_stderr = true;
                 }
                 "-Zmiri-track-raw-pointers" => {
                     eprintln!(

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -374,6 +374,9 @@ fn main() {
                     miri_config.tag_raw = true;
                     miri_config.check_number_validity = true;
                 }
+                "-Zmiri-drop-stdout-stderr" => {
+                    miri_config.drop_stdout_stderr = true;
+                }
                 "-Zmiri-track-raw-pointers" => {
                     eprintln!(
                         "WARNING: -Zmiri-track-raw-pointers has been renamed to -Zmiri-tag-raw-pointers, the old name is deprecated."

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -116,6 +116,9 @@ pub struct MiriConfig {
     /// Whether to enforce "strict provenance" rules. Enabling this means int2ptr casts return
     /// pointers with an invalid provenance, i.e., not valid for any memory access.
     pub strict_provenance: bool,
+    /// Whether to ignore any output by the program. This is helpful when debugging miri
+    /// as its messages don't get intermingled with the program messages.
+    pub drop_stdout_stderr: bool,
 }
 
 impl Default for MiriConfig {
@@ -142,6 +145,7 @@ impl Default for MiriConfig {
             panic_on_unsupported: false,
             backtrace_style: BacktraceStyle::Short,
             strict_provenance: false,
+            drop_stdout_stderr: false,
         }
     }
 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -118,7 +118,7 @@ pub struct MiriConfig {
     pub strict_provenance: bool,
     /// Whether to ignore any output by the program. This is helpful when debugging miri
     /// as its messages don't get intermingled with the program messages.
-    pub drop_stdout_stderr: bool,
+    pub mute_stdout_stderr: bool,
 }
 
 impl Default for MiriConfig {
@@ -145,7 +145,7 @@ impl Default for MiriConfig {
             panic_on_unsupported: false,
             backtrace_style: BacktraceStyle::Short,
             strict_provenance: false,
-            drop_stdout_stderr: false,
+            mute_stdout_stderr: false,
         }
     }
 }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -291,6 +291,9 @@ pub struct Evaluator<'mir, 'tcx> {
 
     /// Failure rate of compare_exchange_weak, between 0.0 and 1.0
     pub(crate) cmpxchg_weak_failure_rate: f64,
+
+    /// Corresponds to -Zmiri-drop-stdout-stderr and doesn't write the output but acts as if it succeeded.
+    pub(crate) drop_stdout_stderr: bool,
 }
 
 impl<'mir, 'tcx> Evaluator<'mir, 'tcx> {
@@ -344,6 +347,7 @@ impl<'mir, 'tcx> Evaluator<'mir, 'tcx> {
             tracked_alloc_ids: config.tracked_alloc_ids.clone(),
             check_alignment: config.check_alignment,
             cmpxchg_weak_failure_rate: config.cmpxchg_weak_failure_rate,
+            drop_stdout_stderr: config.drop_stdout_stderr,
         }
     }
 

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -292,8 +292,8 @@ pub struct Evaluator<'mir, 'tcx> {
     /// Failure rate of compare_exchange_weak, between 0.0 and 1.0
     pub(crate) cmpxchg_weak_failure_rate: f64,
 
-    /// Corresponds to -Zmiri-drop-stdout-stderr and doesn't write the output but acts as if it succeeded.
-    pub(crate) drop_stdout_stderr: bool,
+    /// Corresponds to -Zmiri-mute-stdout-stderr and doesn't write the output but acts as if it succeeded.
+    pub(crate) mute_stdout_stderr: bool,
 }
 
 impl<'mir, 'tcx> Evaluator<'mir, 'tcx> {
@@ -330,7 +330,7 @@ impl<'mir, 'tcx> Evaluator<'mir, 'tcx> {
             validate: config.validate,
             enforce_number_validity: config.check_number_validity,
             enforce_abi: config.check_abi,
-            file_handler: FileHandler::new(config.drop_stdout_stderr),
+            file_handler: FileHandler::new(config.mute_stdout_stderr),
             dir_handler: Default::default(),
             time_anchor: Instant::now(),
             layouts,
@@ -347,7 +347,7 @@ impl<'mir, 'tcx> Evaluator<'mir, 'tcx> {
             tracked_alloc_ids: config.tracked_alloc_ids.clone(),
             check_alignment: config.check_alignment,
             cmpxchg_weak_failure_rate: config.cmpxchg_weak_failure_rate,
-            drop_stdout_stderr: config.drop_stdout_stderr,
+            mute_stdout_stderr: config.mute_stdout_stderr,
         }
     }
 

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -28,7 +28,7 @@ use rustc_span::symbol::{sym, Symbol};
 use rustc_target::abi::Size;
 use rustc_target::spec::abi::Abi;
 
-use crate::*;
+use crate::{*, shims::posix::FileHandler};
 
 // Some global facts about the emulated machine.
 pub const PAGE_SIZE: u64 = 4 * 1024; // FIXME: adjust to target architecture
@@ -327,7 +327,7 @@ impl<'mir, 'tcx> Evaluator<'mir, 'tcx> {
             validate: config.validate,
             enforce_number_validity: config.check_number_validity,
             enforce_abi: config.check_abi,
-            file_handler: Default::default(),
+            file_handler: FileHandler::new(config.drop_stdout_stderr),
             dir_handler: Default::default(),
             time_anchor: Instant::now(),
             layouts,

--- a/src/shims/posix/fs.rs
+++ b/src/shims/posix/fs.rs
@@ -252,21 +252,69 @@ impl FileDescriptor for io::Stderr {
 }
 
 #[derive(Debug)]
+struct DevNull;
+
+impl FileDescriptor for DevNull {
+    fn as_file_handle<'tcx>(&self) -> InterpResult<'tcx, &FileHandle> {
+        throw_unsup_format!("/dev/null cannot be used as FileHandle");
+    }
+
+    fn read<'tcx>(
+        &mut self,
+        _communicate_allowed: bool,
+        _bytes: &mut [u8],
+    ) -> InterpResult<'tcx, io::Result<usize>> {
+        throw_unsup_format!("cannot read from /dev/null");
+    }
+
+    fn write<'tcx>(
+        &self,
+        _communicate_allowed: bool,
+        bytes: &[u8],
+    ) -> InterpResult<'tcx, io::Result<usize>> {
+        // We just don't write anything
+        Ok(Ok(bytes.len()))
+    }
+
+    fn seek<'tcx>(
+        &mut self,
+        _communicate_allowed: bool,
+        _offset: SeekFrom,
+    ) -> InterpResult<'tcx, io::Result<u64>> {
+        throw_unsup_format!("cannot seek on /dev/null");
+    }
+
+    fn close<'tcx>(
+        self: Box<Self>,
+        _communicate_allowed: bool,
+    ) -> InterpResult<'tcx, io::Result<i32>> {
+        throw_unsup_format!("/dev/null cannot be closed");
+    }
+
+    fn dup<'tcx>(&mut self) -> io::Result<Box<dyn FileDescriptor>> {
+        Ok(Box::new(DevNull))
+    }
+}
+
+#[derive(Debug)]
 pub struct FileHandler {
     handles: BTreeMap<i32, Box<dyn FileDescriptor>>,
 }
 
-impl<'tcx> Default for FileHandler {
-    fn default() -> Self {
+impl<'tcx> FileHandler {
+    pub(crate) fn new(drop_stdout_stderr: bool) -> FileHandler {
         let mut handles: BTreeMap<_, Box<dyn FileDescriptor>> = BTreeMap::new();
-        handles.insert(0i32, Box::new(io::stdin()));
-        handles.insert(1i32, Box::new(io::stdout()));
+        if drop_stdout_stderr {
+            handles.insert(0i32, Box::new(DevNull));
+            handles.insert(1i32, Box::new(DevNull));
+        } else {
+            handles.insert(0i32, Box::new(io::stdin()));
+            handles.insert(1i32, Box::new(io::stdout()));
+        }
         handles.insert(2i32, Box::new(io::stderr()));
         FileHandler { handles }
     }
-}
 
-impl<'tcx> FileHandler {
     fn insert_fd(&mut self, file_handle: Box<dyn FileDescriptor>) -> i32 {
         self.insert_fd_with_min_fd(file_handle, 0)
     }

--- a/src/shims/windows/dlsym.rs
+++ b/src/shims/windows/dlsym.rs
@@ -75,7 +75,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                     use std::io::{self, Write};
 
                     let buf_cont = this.read_bytes_ptr(buf, Size::from_bytes(u64::from(n)))?;
-                    let res = if this.machine.drop_stdout_stderr {
+                    let res = if this.machine.mute_stdout_stderr {
                         Ok(buf_cont.len())
                     } else if handle == -11 {
                         io::stdout().write(buf_cont)

--- a/src/shims/windows/dlsym.rs
+++ b/src/shims/windows/dlsym.rs
@@ -75,7 +75,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                     use std::io::{self, Write};
 
                     let buf_cont = this.read_bytes_ptr(buf, Size::from_bytes(u64::from(n)))?;
-                    let res = if handle == -11 {
+                    let res = if this.machine.drop_stdout_stderr {
+                        Ok(buf_cont.len())
+                    } else if handle == -11 {
                         io::stdout().write(buf_cont)
                     } else {
                         io::stderr().write(buf_cont)

--- a/tests/run-pass/hide_stdout.rs
+++ b/tests/run-pass/hide_stdout.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-drop-stdout-stderr
+// compile-flags: -Zmiri-mute-stdout-stderr
 
 fn main() {
     println!("cake");

--- a/tests/run-pass/hide_stdout.rs
+++ b/tests/run-pass/hide_stdout.rs
@@ -1,0 +1,5 @@
+// compile-flags: -Zmiri-drop-stdout-stderr
+
+fn main() {
+    println!("cake");
+}


### PR DESCRIPTION
This is practical for tests that don't actually care about the output and thus don't want it intermingled with miri's warnings, errors or ICEs

fixes #2083