### PR TITLE
Resolve some clippy lints, ignore the rest

### DIFF
--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -1,4 +1,5 @@
 #![feature(rustc_private, bool_to_option, stmt_expr_attributes)]
+#![allow(clippy::manual_range_contains)]
 
 extern crate rustc_data_structures;
 extern crate rustc_driver;

--- a/src/data_race.rs
+++ b/src/data_race.rs
@@ -562,7 +562,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: MiriEvalContextExt<'mir, 'tcx> {
 
         this.allow_data_races_mut(|this| this.write_immediate(**new_val, &(*place).into()))?;
 
-        this.validate_atomic_rmw(&place, atomic)?;
+        this.validate_atomic_rmw(place, atomic)?;
 
         // Return the old value.
         Ok(old)
@@ -1410,7 +1410,7 @@ impl GlobalState {
     /// incremented.
     pub fn validate_lock_acquire(&self, lock: &VClock, thread: ThreadId) {
         let (_, mut clocks) = self.load_thread_state_mut(thread);
-        clocks.clock.join(&lock);
+        clocks.clock.join(lock);
     }
 
     /// Release a lock handle, express that this happens-before

--- a/src/data_race.rs
+++ b/src/data_race.rs
@@ -784,7 +784,7 @@ impl VClockAlloc {
                     None
                 }
             })
-            .map(|idx| VectorIdx::new(idx))
+            .map(VectorIdx::new)
     }
 
     /// Report a data-race found in the program.

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -296,7 +296,7 @@ fn report_msg<'mir, 'tcx>(
     // Show help messages.
     if !helps.is_empty() {
         // Add visual separator before backtrace.
-        helps.last_mut().unwrap().1.push_str("\n");
+        helps.last_mut().unwrap().1.push('\n');
         for (span_data, help) in helps {
             if let Some(span_data) = span_data {
                 err.span_help(span_data.span(), &help);

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -43,7 +43,7 @@ const UNIX_IO_ERROR_TABLE: &[(std::io::ErrorKind, &str)] = {
 };
 
 /// Gets an instance for a path.
-fn try_resolve_did<'mir, 'tcx>(tcx: TyCtxt<'tcx>, path: &[&str]) -> Option<DefId> {
+fn try_resolve_did<'tcx>(tcx: TyCtxt<'tcx>, path: &[&str]) -> Option<DefId> {
     tcx.crates(()).iter().find(|&&krate| tcx.crate_name(krate).as_str() == path[0]).and_then(
         |krate| {
             let krate = DefId { krate: *krate, index: CRATE_DEF_INDEX };

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -664,8 +664,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         loop {
             // FIXME: We are re-getting the allocation each time around the loop.
             // Would be nice if we could somehow "extend" an existing AllocRange.
-            let alloc =
-                this.get_ptr_alloc(ptr.offset(len, this)?.into(), size1, Align::ONE)?.unwrap(); // not a ZST, so we will get a result
+            let alloc = this.get_ptr_alloc(ptr.offset(len, this)?, size1, Align::ONE)?.unwrap(); // not a ZST, so we will get a result
             let byte = alloc.read_scalar(alloc_range(Size::ZERO, size1))?.to_u8()?;
             if byte == 0 {
                 break;
@@ -675,7 +674,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         }
 
         // Step 2: get the bytes.
-        this.read_bytes_ptr(ptr.into(), len)
+        this.read_bytes_ptr(ptr, len)
     }
 
     fn read_wide_str(&self, mut ptr: Pointer<Option<Tag>>) -> InterpResult<'tcx, Vec<u16>> {
@@ -687,7 +686,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         loop {
             // FIXME: We are re-getting the allocation each time around the loop.
             // Would be nice if we could somehow "extend" an existing AllocRange.
-            let alloc = this.get_ptr_alloc(ptr.into(), size2, align2)?.unwrap(); // not a ZST, so we will get a result
+            let alloc = this.get_ptr_alloc(ptr, size2, align2)?.unwrap(); // not a ZST, so we will get a result
             let wchar = alloc.read_scalar(alloc_range(Size::ZERO, size2))?.to_u16()?;
             if wchar == 0 {
                 break;

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -51,7 +51,7 @@ fn try_resolve_did<'tcx>(tcx: TyCtxt<'tcx>, path: &[&str]) -> Option<DefId> {
             let mut path_it = path.iter().skip(1).peekable();
 
             while let Some(segment) = path_it.next() {
-                for item in mem::replace(&mut items, Default::default()).iter() {
+                for item in mem::take(&mut items).iter() {
                     if item.ident.name.as_str() == *segment {
                         if path_it.peek().is_none() {
                             return Some(item.res.def_id());

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -323,7 +323,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                     trace!("unsafe_cell_action on {:?}", place.ptr);
                     // We need a size to go on.
                     let unsafe_cell_size = this
-                        .size_and_align_of_mplace(&place)?
+                        .size_and_align_of_mplace(place)?
                         .map(|(size, _)| size)
                         // for extern types, just cover what we can
                         .unwrap_or_else(|| place.layout.size);
@@ -362,7 +362,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
             #[inline(always)]
             fn ecx(&self) -> &MiriEvalContext<'mir, 'tcx> {
-                &self.ecx
+                self.ecx
             }
 
             // Hook to detect `UnsafeCell`.
@@ -631,10 +631,10 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
     /// `EINVAL` in this case.
     fn read_timespec(&mut self, tp: &MPlaceTy<'tcx, Tag>) -> InterpResult<'tcx, Option<Duration>> {
         let this = self.eval_context_mut();
-        let seconds_place = this.mplace_field(&tp, 0)?;
+        let seconds_place = this.mplace_field(tp, 0)?;
         let seconds_scalar = this.read_scalar(&seconds_place.into())?;
         let seconds = seconds_scalar.to_machine_isize(this)?;
-        let nanoseconds_place = this.mplace_field(&tp, 1)?;
+        let nanoseconds_place = this.mplace_field(tp, 1)?;
         let nanoseconds_scalar = this.read_scalar(&nanoseconds_place.into())?;
         let nanoseconds = nanoseconds_scalar.to_machine_isize(this)?;
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -83,7 +83,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         let cid = GlobalId { instance, promoted: None };
         let const_val = this.eval_to_allocation(cid)?;
         let const_val = this.read_scalar(&const_val.into())?;
-        return Ok(const_val.check_init()?);
+        const_val.check_init()
     }
 
     /// Helper function to get a `libc` constant as a `Scalar`.

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -802,7 +802,7 @@ pub fn get_local_crates(tcx: &TyCtxt<'_>) -> Vec<CrateNum> {
     // Convert the local crate names from the passed-in config into CrateNums so that they can
     // be looked up quickly during execution
     let local_crate_names = std::env::var("MIRI_LOCAL_CRATES")
-        .map(|crates| crates.split(",").map(|krate| krate.to_string()).collect::<Vec<_>>())
+        .map(|crates| crates.split(',').map(|krate| krate.to_string()).collect::<Vec<_>>())
         .unwrap_or_default();
     let mut local_crates = Vec::new();
     for &crate_num in tcx.crates(()) {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -196,7 +196,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
     /// Get the `Place` for a local
     fn local_place(&mut self, local: mir::Local) -> InterpResult<'tcx, PlaceTy<'tcx, Tag>> {
         let this = self.eval_context_mut();
-        let place = mir::Place { local: local, projection: List::empty() };
+        let place = mir::Place { local, projection: List::empty() };
         this.eval_place(place)
     }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -670,7 +670,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             if byte == 0 {
                 break;
             } else {
-                len = len + size1;
+                len += size1;
             }
         }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -731,7 +731,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             // message is slightly different here to make automated analysis easier
             let error_msg = format!("unsupported Miri functionality: {}", error_msg.as_ref());
             this.start_panic(error_msg.as_ref(), StackPopUnwind::Skip)?;
-            return Ok(());
+            Ok(())
         } else {
             throw_unsup_format!("{}", error_msg.as_ref());
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@
     clippy::needless_lifetimes,
     clippy::new_without_default,
     clippy::single_match,
-    clippy::unnecessary_mut_passed,
     clippy::useless_conversion,
     clippy::useless_format
 )]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@
     clippy::needless_lifetimes,
     clippy::new_without_default,
     clippy::single_match,
-    clippy::useless_conversion,
     clippy::useless_format
 )]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@
     clippy::manual_map,
     clippy::needless_lifetimes,
     clippy::new_without_default,
-    clippy::op_ref,
     clippy::redundant_closure,
     clippy::redundant_field_names,
     clippy::single_char_add_str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
 #![allow(clippy::cast_lossless)]
 // TODO: Uncategorized. Some of these we'll want to fix, some keep ignored.
 #![allow(
-    clippy::assign_op_pattern,
     clippy::clone_on_copy,
     clippy::collapsible_else_if,
     clippy::collapsible_if,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,36 @@
 #![feature(io_error_more)]
 #![warn(rust_2018_idioms)]
 #![allow(clippy::cast_lossless)]
+// TODO: Uncategorized. Some of these we'll want to fix, some keep ignored.
+#![allow(
+    clippy::assign_op_pattern,
+    clippy::clone_on_copy,
+    clippy::collapsible_else_if,
+    clippy::collapsible_if,
+    clippy::comparison_chain,
+    clippy::enum_variant_names,
+    clippy::extra_unused_lifetimes,
+    clippy::field_reassign_with_default,
+    clippy::from_over_into,
+    clippy::if_same_then_else,
+    clippy::len_zero,
+    clippy::manual_map,
+    clippy::mem_replace_with_default,
+    clippy::needless_borrow,
+    clippy::needless_lifetimes,
+    clippy::needless_question_mark,
+    clippy::needless_return,
+    clippy::new_without_default,
+    clippy::op_ref,
+    clippy::redundant_closure,
+    clippy::redundant_field_names,
+    clippy::single_char_add_str,
+    clippy::single_char_pattern,
+    clippy::single_match,
+    clippy::unnecessary_mut_passed,
+    clippy::useless_conversion,
+    clippy::useless_format
+)]
 
 extern crate rustc_apfloat;
 extern crate rustc_ast;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@
     clippy::manual_map,
     clippy::needless_lifetimes,
     clippy::new_without_default,
-    clippy::single_char_pattern,
     clippy::single_match,
     clippy::unnecessary_mut_passed,
     clippy::useless_conversion,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,6 @@
     clippy::collapsible_if,
     clippy::comparison_chain,
     clippy::enum_variant_names,
-    clippy::extra_unused_lifetimes,
     clippy::field_reassign_with_default,
     clippy::from_over_into,
     clippy::if_same_then_else,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@
     clippy::field_reassign_with_default,
     clippy::from_over_into,
     clippy::if_same_then_else,
-    clippy::len_zero,
     clippy::manual_map,
     clippy::mem_replace_with_default,
     clippy::needless_borrow,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,6 @@
     clippy::from_over_into,
     clippy::if_same_then_else,
     clippy::manual_map,
-    clippy::mem_replace_with_default,
     clippy::needless_borrow,
     clippy::needless_lifetimes,
     clippy::needless_question_mark,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,8 @@
 #![feature(bool_to_option)]
 #![feature(io_error_more)]
 #![warn(rust_2018_idioms)]
-#![allow(clippy::cast_lossless)]
-// TODO: Uncategorized. Some of these we'll want to fix, some keep ignored.
 #![allow(
+    clippy::cast_lossless,
     clippy::collapsible_else_if,
     clippy::collapsible_if,
     clippy::comparison_chain,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@
     clippy::manual_map,
     clippy::needless_lifetimes,
     clippy::new_without_default,
-    clippy::redundant_closure,
     clippy::redundant_field_names,
     clippy::single_char_add_str,
     clippy::single_char_pattern,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@
     clippy::manual_map,
     clippy::needless_lifetimes,
     clippy::new_without_default,
-    clippy::single_char_add_str,
     clippy::single_char_pattern,
     clippy::single_match,
     clippy::unnecessary_mut_passed,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,6 @@
     clippy::if_same_then_else,
     clippy::manual_map,
     clippy::needless_lifetimes,
-    clippy::needless_question_mark,
     clippy::needless_return,
     clippy::new_without_default,
     clippy::op_ref,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@
     clippy::manual_map,
     clippy::needless_lifetimes,
     clippy::new_without_default,
-    clippy::redundant_field_names,
     clippy::single_char_add_str,
     clippy::single_char_pattern,
     clippy::single_match,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
 #![allow(clippy::cast_lossless)]
 // TODO: Uncategorized. Some of these we'll want to fix, some keep ignored.
 #![allow(
-    clippy::clone_on_copy,
     clippy::collapsible_else_if,
     clippy::collapsible_if,
     clippy::comparison_chain,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,6 @@
     clippy::if_same_then_else,
     clippy::manual_map,
     clippy::needless_lifetimes,
-    clippy::needless_return,
     clippy::new_without_default,
     clippy::op_ref,
     clippy::redundant_closure,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,6 @@
     clippy::from_over_into,
     clippy::if_same_then_else,
     clippy::manual_map,
-    clippy::needless_borrow,
     clippy::needless_lifetimes,
     clippy::needless_question_mark,
     clippy::needless_return,

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -544,7 +544,7 @@ impl<'mir, 'tcx> Machine<'mir, 'tcx> for Evaluator<'mir, 'tcx> {
         def_id: DefId,
     ) -> InterpResult<'tcx, Pointer<Tag>> {
         let attrs = ecx.tcx.get_attrs(def_id);
-        let link_name = match ecx.tcx.sess.first_attr_value_str_by_name(&attrs, sym::link_name) {
+        let link_name = match ecx.tcx.sess.first_attr_value_str_by_name(attrs, sym::link_name) {
             Some(name) => name,
             None => ecx.tcx.item_name(def_id),
         };
@@ -573,7 +573,7 @@ impl<'mir, 'tcx> Machine<'mir, 'tcx> for Evaluator<'mir, 'tcx> {
             None
         };
         let race_alloc = if let Some(data_race) = &ecx.machine.data_race {
-            Some(data_race::AllocExtra::new_allocation(&data_race, alloc.size(), kind))
+            Some(data_race::AllocExtra::new_allocation(data_race, alloc.size(), kind))
         } else {
             None
         };

--- a/src/range_map.rs
+++ b/src/range_map.rs
@@ -63,7 +63,7 @@ impl<T> RangeMap<T> {
     /// through interior mutability.
     ///
     /// The iterator also provides the offset of the given element.
-    pub fn iter<'a>(&'a self, offset: Size, len: Size) -> impl Iterator<Item = (Size, &'a T)> + 'a {
+    pub fn iter(&self, offset: Size, len: Size) -> impl Iterator<Item = (Size, &T)> {
         let offset = offset.bytes();
         let len = len.bytes();
         // Compute a slice starting with the elements we care about.
@@ -83,7 +83,7 @@ impl<T> RangeMap<T> {
             .map(|elem| (Size::from_bytes(elem.range.start), &elem.data))
     }
 
-    pub fn iter_mut_all<'a>(&'a mut self) -> impl Iterator<Item = &'a mut T> + 'a {
+    pub fn iter_mut_all(&mut self) -> impl Iterator<Item = &mut T> {
         self.v.iter_mut().map(|elem| &mut elem.data)
     }
 
@@ -119,11 +119,7 @@ impl<T> RangeMap<T> {
     /// Moreover, this will opportunistically merge neighbouring equal blocks.
     ///
     /// The iterator also provides the offset of the given element.
-    pub fn iter_mut<'a>(
-        &'a mut self,
-        offset: Size,
-        len: Size,
-    ) -> impl Iterator<Item = (Size, &'a mut T)> + 'a
+    pub fn iter_mut(&mut self, offset: Size, len: Size) -> impl Iterator<Item = (Size, &mut T)>
     where
         T: Clone + PartialEq,
     {

--- a/src/range_map.rs
+++ b/src/range_map.rs
@@ -110,7 +110,7 @@ impl<T> RangeMap<T> {
         // Copy the data, and insert second element.
         let second = Elem { range: second_range, data: elem.data.clone() };
         self.v.insert(index + 1, second);
-        return true;
+        true
     }
 
     /// Provides mutable iteration over everything in the given range. As a side-effect,

--- a/src/shims/env.rs
+++ b/src/shims/env.rs
@@ -64,7 +64,7 @@ impl<'tcx> EnvVars<'tcx> {
                                 unsupported
                             ),
                     };
-                    ecx.machine.env_vars.map.insert(OsString::from(name), var_ptr);
+                    ecx.machine.env_vars.map.insert(name, var_ptr);
                 }
             }
         }

--- a/src/shims/env.rs
+++ b/src/shims/env.rs
@@ -50,8 +50,8 @@ impl<'tcx> EnvVars<'tcx> {
         if ecx.machine.communicate() || !config.forwarded_env_vars.is_empty() {
             for (name, value) in env::vars_os() {
                 let forward = match ecx.machine.communicate() {
-                    true => !excluded_env_vars.iter().any(|v| v.as_str() == &name),
-                    false => config.forwarded_env_vars.iter().any(|v| v.as_str() == &name),
+                    true => !excluded_env_vars.iter().any(|v| **v == name),
+                    false => config.forwarded_env_vars.iter().any(|v| **v == name),
                 };
                 if forward {
                     let var_ptr = match target_os {

--- a/src/shims/env.rs
+++ b/src/shims/env.rs
@@ -210,7 +210,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         name_op: &OpTy<'tcx, Tag>,
         value_op: &OpTy<'tcx, Tag>,
     ) -> InterpResult<'tcx, i32> {
-        let mut this = self.eval_context_mut();
+        let this = self.eval_context_mut();
         let target_os = &this.tcx.sess.target.os;
         assert!(
             target_os == "linux" || target_os == "macos",
@@ -229,7 +229,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             }
         }
         if let Some((name, value)) = new {
-            let var_ptr = alloc_env_var_as_c_str(&name, &value, &mut this)?;
+            let var_ptr = alloc_env_var_as_c_str(&name, &value, this)?;
             if let Some(var) = this.machine.env_vars.map.insert(name, var_ptr) {
                 this.deallocate_ptr(var, None, MiriMemoryKind::Runtime.into())?;
             }
@@ -249,7 +249,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         name_op: &OpTy<'tcx, Tag>,  // LPCWSTR
         value_op: &OpTy<'tcx, Tag>, // LPCWSTR
     ) -> InterpResult<'tcx, i32> {
-        let mut this = self.eval_context_mut();
+        let this = self.eval_context_mut();
         this.assert_target_os("windows", "SetEnvironmentVariableW");
 
         let name_ptr = this.read_pointer(name_op)?;
@@ -274,7 +274,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             Ok(1) // return non-zero on success
         } else {
             let value = this.read_os_str_from_wide_str(value_ptr)?;
-            let var_ptr = alloc_env_var_as_wide_str(&name, &value, &mut this)?;
+            let var_ptr = alloc_env_var_as_wide_str(&name, &value, this)?;
             if let Some(var) = this.machine.env_vars.map.insert(name, var_ptr) {
                 this.deallocate_ptr(var, None, MiriMemoryKind::Runtime.into())?;
             }
@@ -325,8 +325,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             "`getcwd` is only available for the UNIX target family"
         );
 
-        let buf = this.read_pointer(&buf_op)?;
-        let size = this.read_scalar(&size_op)?.to_machine_usize(&*this.tcx)?;
+        let buf = this.read_pointer(buf_op)?;
+        let size = this.read_scalar(size_op)?.to_machine_usize(&*this.tcx)?;
 
         if let IsolatedOp::Reject(reject_with) = this.machine.isolated_op {
             this.reject_in_isolation("`getcwd`", reject_with)?;

--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -238,7 +238,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         let link_name = this
             .tcx
             .sess
-            .first_attr_value_str_by_name(&attrs, sym::link_name)
+            .first_attr_value_str_by_name(attrs, sym::link_name)
             .unwrap_or_else(|| this.tcx.item_name(def_id));
         let tcx = this.tcx.tcx;
 

--- a/src/shims/intrinsics.rs
+++ b/src/shims/intrinsics.rs
@@ -775,7 +775,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
                 for i in 0..dest_len {
                     let src_index: u64 = this
-                        .read_immediate(&this.operand_index(index, i)?.into())?
+                        .read_immediate(&this.operand_index(index, i)?)?
                         .to_scalar()?
                         .to_u32()?
                         .into();

--- a/src/shims/intrinsics.rs
+++ b/src/shims/intrinsics.rs
@@ -775,7 +775,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
                 for i in 0..dest_len {
                     let src_index: u64 = this
-                        .read_immediate(&this.operand_index(&index, i)?.into())?
+                        .read_immediate(&this.operand_index(index, i)?.into())?
                         .to_scalar()?
                         .to_u32()?
                         .into();
@@ -1192,12 +1192,12 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         match atomic_op {
             AtomicOp::Min => {
                 let old = this.atomic_min_max_scalar(&place, rhs, true, atomic)?;
-                this.write_immediate(*old, &dest)?; // old value is returned
+                this.write_immediate(*old, dest)?; // old value is returned
                 Ok(())
             }
             AtomicOp::Max => {
                 let old = this.atomic_min_max_scalar(&place, rhs, false, atomic)?;
-                this.write_immediate(*old, &dest)?; // old value is returned
+                this.write_immediate(*old, dest)?; // old value is returned
                 Ok(())
             }
             AtomicOp::MirOp(op, neg) => {

--- a/src/shims/os_str.rs
+++ b/src/shims/os_str.rs
@@ -78,7 +78,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             Ok(OsString::from_wide(&u16_vec[..]))
         }
         #[cfg(not(windows))]
-        pub fn u16vec_to_osstring<'tcx, 'a>(u16_vec: Vec<u16>) -> InterpResult<'tcx, OsString> {
+        pub fn u16vec_to_osstring<'tcx>(u16_vec: Vec<u16>) -> InterpResult<'tcx, OsString> {
             let s = String::from_utf16(&u16_vec[..])
                 .map_err(|_| err_unsup_format!("{:?} is not a valid utf-16 string", u16_vec))?;
             Ok(s.into())

--- a/src/shims/panic.rs
+++ b/src/shims/panic.rs
@@ -59,7 +59,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
         // Jump to the unwind block to begin unwinding.
         this.unwind_to_block(unwind)?;
-        return Ok(());
+        Ok(())
     }
 
     /// Handles the `try` intrinsic, the underlying implementation of `std::panicking::try`.
@@ -112,7 +112,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 Some(CatchUnwindData { catch_fn, data, dest: *dest, ret });
         }
 
-        return Ok(());
+        Ok(())
     }
 
     fn handle_stack_pop(

--- a/src/shims/posix/fs.rs
+++ b/src/shims/posix/fs.rs
@@ -51,7 +51,7 @@ trait FileDescriptor: std::fmt::Debug {
 
 impl FileDescriptor for FileHandle {
     fn as_file_handle<'tcx>(&self) -> InterpResult<'tcx, &FileHandle> {
-        Ok(&self)
+        Ok(self)
     }
 
     fn read<'tcx>(
@@ -651,7 +651,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             if let Some(file_descriptor) = this.machine.file_handler.handles.get(&fd) {
                 // FIXME: Support fullfsync for all FDs
                 let FileHandle { file, writable } = file_descriptor.as_file_handle()?;
-                let io_result = maybe_sync_file(&file, *writable, File::sync_all);
+                let io_result = maybe_sync_file(file, *writable, File::sync_all);
                 this.try_unwrap_io_result(io_result)
             } else {
                 this.handle_not_found()
@@ -743,7 +743,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         if let Some(file_descriptor) = this.machine.file_handler.handles.get(&fd) {
             let bytes = this.read_bytes_ptr(buf, Size::from_bytes(count))?;
             let result =
-                file_descriptor.write(communicate, &bytes)?.map(|c| i64::try_from(c).unwrap());
+                file_descriptor.write(communicate, bytes)?.map(|c| i64::try_from(c).unwrap());
             this.try_unwrap_io_result(result)
         } else {
             this.handle_not_found()
@@ -1491,7 +1491,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         if let Some(file_descriptor) = this.machine.file_handler.handles.get(&fd) {
             // FIXME: Support fsync for all FDs
             let FileHandle { file, writable } = file_descriptor.as_file_handle()?;
-            let io_result = maybe_sync_file(&file, *writable, File::sync_all);
+            let io_result = maybe_sync_file(file, *writable, File::sync_all);
             this.try_unwrap_io_result(io_result)
         } else {
             this.handle_not_found()
@@ -1513,7 +1513,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         if let Some(file_descriptor) = this.machine.file_handler.handles.get(&fd) {
             // FIXME: Support fdatasync for all FDs
             let FileHandle { file, writable } = file_descriptor.as_file_handle()?;
-            let io_result = maybe_sync_file(&file, *writable, File::sync_data);
+            let io_result = maybe_sync_file(file, *writable, File::sync_data);
             this.try_unwrap_io_result(io_result)
         } else {
             this.handle_not_found()
@@ -1558,7 +1558,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         if let Some(file_descriptor) = this.machine.file_handler.handles.get(&fd) {
             // FIXME: Support sync_data_range for all FDs
             let FileHandle { file, writable } = file_descriptor.as_file_handle()?;
-            let io_result = maybe_sync_file(&file, *writable, File::sync_data);
+            let io_result = maybe_sync_file(file, *writable, File::sync_data);
             this.try_unwrap_io_result(io_result)
         } else {
             this.handle_not_found()

--- a/src/shims/posix/fs.rs
+++ b/src/shims/posix/fs.rs
@@ -645,7 +645,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                         }
                     }
                 }
-                None => return this.handle_not_found(),
+                None => this.handle_not_found(),
             }
         } else if this.tcx.sess.target.os == "macos" && cmd == this.eval_libc_i32("F_FULLFSYNC")? {
             if let Some(file_descriptor) = this.machine.file_handler.handles.get(&fd) {

--- a/src/shims/posix/fs.rs
+++ b/src/shims/posix/fs.rs
@@ -1168,7 +1168,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         #[cfg(unix)]
         {
             use std::os::unix::fs::DirBuilderExt;
-            builder.mode(mode.into());
+            builder.mode(mode);
         }
 
         let result = builder.create(path).map(|_| 0i32);

--- a/src/shims/posix/fs.rs
+++ b/src/shims/posix/fs.rs
@@ -46,7 +46,7 @@ trait FileDescriptor: std::fmt::Debug {
         _communicate_allowed: bool,
     ) -> InterpResult<'tcx, io::Result<i32>>;
 
-    fn dup<'tcx>(&mut self) -> io::Result<Box<dyn FileDescriptor>>;
+    fn dup(&mut self) -> io::Result<Box<dyn FileDescriptor>>;
 }
 
 impl FileDescriptor for FileHandle {
@@ -107,7 +107,7 @@ impl FileDescriptor for FileHandle {
         }
     }
 
-    fn dup<'tcx>(&mut self) -> io::Result<Box<dyn FileDescriptor>> {
+    fn dup(&mut self) -> io::Result<Box<dyn FileDescriptor>> {
         let duplicated = self.file.try_clone()?;
         Ok(Box::new(FileHandle { file: duplicated, writable: self.writable }))
     }
@@ -153,7 +153,7 @@ impl FileDescriptor for io::Stdin {
         throw_unsup_format!("stdin cannot be closed");
     }
 
-    fn dup<'tcx>(&mut self) -> io::Result<Box<dyn FileDescriptor>> {
+    fn dup(&mut self) -> io::Result<Box<dyn FileDescriptor>> {
         Ok(Box::new(io::stdin()))
     }
 }
@@ -203,7 +203,7 @@ impl FileDescriptor for io::Stdout {
         throw_unsup_format!("stdout cannot be closed");
     }
 
-    fn dup<'tcx>(&mut self) -> io::Result<Box<dyn FileDescriptor>> {
+    fn dup(&mut self) -> io::Result<Box<dyn FileDescriptor>> {
         Ok(Box::new(io::stdout()))
     }
 }
@@ -246,7 +246,7 @@ impl FileDescriptor for io::Stderr {
         throw_unsup_format!("stderr cannot be closed");
     }
 
-    fn dup<'tcx>(&mut self) -> io::Result<Box<dyn FileDescriptor>> {
+    fn dup(&mut self) -> io::Result<Box<dyn FileDescriptor>> {
         Ok(Box::new(io::stderr()))
     }
 }

--- a/src/shims/posix/thread.rs
+++ b/src/shims/posix/thread.rs
@@ -99,7 +99,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         let this = self.eval_context_mut();
         this.assert_target_os("linux", "prctl");
 
-        if args.len() < 1 {
+        if args.is_empty() {
             throw_ub_format!(
                 "incorrect number of arguments for `prctl`: got {}, expected at least 1",
                 args.len()

--- a/src/shims/tls.rs
+++ b/src/shims/tls.rs
@@ -99,7 +99,7 @@ impl<'tcx> TlsData<'tcx> {
             Some(TlsEntry { data, .. }) => {
                 let value = data.get(&thread_id).copied();
                 trace!("TLS key {} for thread {:?} loaded: {:?}", key, thread_id, value);
-                Ok(value.unwrap_or_else(|| Scalar::null_ptr(cx).into()))
+                Ok(value.unwrap_or_else(|| Scalar::null_ptr(cx)))
             }
             None => throw_ub_format!("loading from a non-existing TLS key: {}", key),
         }

--- a/src/shims/tls.rs
+++ b/src/shims/tls.rs
@@ -304,7 +304,7 @@ trait EvalContextPrivExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
         assert!(this.has_terminated(active_thread), "running TLS dtors for non-terminated thread");
         // Fetch next dtor after `key`.
-        let last_key = this.machine.tls.dtors_running[&active_thread].last_dtor_key.clone();
+        let last_key = this.machine.tls.dtors_running[&active_thread].last_dtor_key;
         let dtor = match this.machine.tls.fetch_tls_dtor(last_key, active_thread) {
             dtor @ Some(_) => dtor,
             // We ran each dtor once, start over from the beginning.

--- a/src/stacked_borrows.rs
+++ b/src/stacked_borrows.rs
@@ -314,7 +314,7 @@ impl<'tcx> Stack {
         if let SbTag::Tagged(id) = item.tag {
             if global.tracked_pointer_tags.contains(&id) {
                 register_diagnostic(NonHaltingDiagnostic::PoppedPointerTag(
-                    item.clone(),
+                    *item,
                     provoking_access,
                 ));
             }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -474,7 +474,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         }
         condvar.waiters.pop_front().map(|waiter| {
             if let Some(data_race) = data_race {
-                data_race.validate_lock_acquire(&mut condvar.data_race, waiter.thread);
+                data_race.validate_lock_acquire(&condvar.data_race, waiter.thread);
             }
             (waiter.thread, waiter.mutex)
         })

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -58,7 +58,7 @@ impl Idx for ThreadId {
 impl TryFrom<u64> for ThreadId {
     type Error = TryFromIntError;
     fn try_from(id: u64) -> Result<Self, Self::Error> {
-        u32::try_from(id).map(|id_u32| Self(id_u32))
+        u32::try_from(id).map(Self)
     }
 }
 

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -69,7 +69,7 @@ impl From<u32> for ThreadId {
 }
 
 impl ThreadId {
-    pub fn to_u32_scalar<'tcx>(&self) -> Scalar<Tag> {
+    pub fn to_u32_scalar(&self) -> Scalar<Tag> {
         Scalar::from_u32(u32::try_from(self.0).unwrap())
     }
 }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -70,7 +70,7 @@ impl From<u32> for ThreadId {
 
 impl ThreadId {
     pub fn to_u32_scalar(&self) -> Scalar<Tag> {
-        Scalar::from_u32(u32::try_from(self.0).unwrap())
+        Scalar::from_u32(self.0)
     }
 }
 

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -456,7 +456,7 @@ impl<'mir, 'tcx: 'mir> ThreadManager<'mir, 'tcx> {
                 // Delete this static from the map and from memory.
                 // We cannot free directly here as we cannot use `?` in this context.
                 free_tls_statics.push(alloc_id);
-                return false;
+                false
             });
         }
         // Set the thread into a terminated state in the data-race detector
@@ -474,7 +474,7 @@ impl<'mir, 'tcx: 'mir> ThreadManager<'mir, 'tcx> {
                 thread.state = ThreadState::Enabled;
             }
         }
-        return free_tls_statics;
+        free_tls_statics
     }
 
     /// Decide which action to take next and on which thread.

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -235,7 +235,7 @@ impl<'mir, 'tcx> Default for ThreadManager<'mir, 'tcx> {
         threads.push(main_thread);
         Self {
             active_thread: ThreadId::new(0),
-            threads: threads,
+            threads,
             sync: SynchronizationState::default(),
             thread_local_alloc_ids: Default::default(),
             yield_active_thread: false,


### PR DESCRIPTION
`cargo clippy` finishes cleanly after this. I stuck to only what I think are the least objectionable lints: cleaning up useless identity conversions that do `from`/`try_from`/`into` going from T-&gt;T, extraneous `&` on expressions that are already a reference, unused lifetime parameters, and similar.

Below in the \<details\> is the complete remaining output of `cargo clippy` with the `allow` attribute removed. I think all the lints left are fine to keep ignoring.

<details>
<summary><code>$ cargo clippy -- -Dclippy::all</code></summary>

```console
error: this `else { if .. }` block can be collapsed
   --> src/data_race.rs:559:16
    |
559 |           } else {
    |  ________________^
560 | |             if lt { &rhs } else { &old }
561 | |         };
    | |_________^ help: collapse nested if block: `if lt { &rhs } else { &old }`
    |
    = note: `-D clippy::collapsible-else-if` implied by `-D clippy::all`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_else_if

error: this `if` statement can be collapsed
   --> src/range_map.rs:166:17
    |
166 | /                 if successful_merge_count > 0 {
167 | |                     if done || self.v[end_idx].data != self.v[equal_since_idx].data {
168 | |                         // Everything in `equal_since..end` was equal. Make them just one element covering
169 | |                         // the entire range.
...   |
187 | |                     }
188 | |                 }
    | |_________________^
    |
    = note: `-D clippy::collapsible-if` implied by `-D clippy::all`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_if
help: collapse nested if block
    |
166 ~                 if successful_merge_count > 0 && (done || self.v[end_idx].data != self.v[equal_since_idx].data) {
167 +                     // Everything in `equal_since..end` was equal. Make them just one element covering
168 +                     // the entire range.
169 +                     let removed_elems = end_idx - equal_since_idx - 1; // number of elements that we would remove
170 +                     if removed_elems > 0 {
171 +                         // Adjust the range of the first element to cover all of them.
  ...

error: this `else { if .. }` block can be collapsed
   --> src/shims/foreign_items.rs:114:16
    |
114 |           } else {
    |  ________________^
115 | |             if new_size == 0 {
116 | |                 this.deallocate_ptr(old_ptr, None, kind.into())?;
117 | |                 Ok(Pointer::null())
...   |
127 | |             }
128 | |         }
    | |_________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_else_if
help: collapse nested if block
    |
114 ~         } else if new_size == 0 {
115 +             this.deallocate_ptr(old_ptr, None, kind.into())?;
116 +             Ok(Pointer::null())
117 +         } else {
118 +             let new_ptr = this.reallocate_ptr(
119 +                 old_ptr,
  ...

error: this `else { if .. }` block can be collapsed
   --> src/shims/posix/sync.rs:459:20
    |
459 |               } else {
    |  ____________________^
460 | |                 if is_mutex_kind_default(this, kind)?
461 | |                     || is_mutex_kind_normal(this, kind)?
462 | |                     || kind == this.eval_libc("PTHREAD_MUTEX_ERRORCHECK")?
...   |
472 | |                 }
473 | |             }
    | |_____________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_else_if
help: collapse nested if block
    |
459 ~             } else if is_mutex_kind_default(this, kind)?
460 +                 || is_mutex_kind_normal(this, kind)?
461 +                 || kind == this.eval_libc("PTHREAD_MUTEX_ERRORCHECK")?
462 +             {
463 +                 this.eval_libc_i32("EBUSY")
464 +             } else if kind == this.eval_libc("PTHREAD_MUTEX_RECURSIVE")? {
  ...

error: this `if` statement can be collapsed
   --> src/thread.rs:132:9
    |
132 | /         if self.state == ThreadState::Enabled {
133 | |             if self.stack.is_empty() {
134 | |                 self.state = ThreadState::Terminated;
135 | |                 return true;
136 | |             }
137 | |         }
    | |_________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_if
help: collapse nested if block
    |
132 ~         if self.state == ThreadState::Enabled && self.stack.is_empty() {
133 +             self.state = ThreadState::Terminated;
134 +             return true;
135 +         }
    |

error: this `if` statement can be collapsed
   --> src/thread.rs:523:13
    |
523 | /             if thread.state == ThreadState::Enabled {
524 | |                 if !self.yield_active_thread || id != self.active_thread {
525 | |                     self.active_thread = id;
526 | |                     if let Some(data_race) = data_race {
...   |
530 | |                 }
531 | |             }
    | |_____________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_if
help: collapse nested if block
    |
523 ~             if thread.state == ThreadState::Enabled && (!self.yield_active_thread || id != self.active_thread) {
524 +                 self.active_thread = id;
525 +                 if let Some(data_race) = data_race {
526 +                     data_race.thread_set_active(self.active_thread);
527 +                 }
528 +                 break;
  ...

error: you should consider adding a `Default` implementation for `GlobalState`
    --> src/data_race.rs:1132:5
     |
1132 | /     pub fn new() -> Self {
1133 | |         let mut global_state = GlobalState {
1134 | |             multi_threaded: Cell::new(false),
1135 | |             vector_clocks: RefCell::new(IndexVec::new()),
...    |
1155 | |         global_state
1156 | |     }
     | |_____^
     |
     = note: `-D clippy::new-without-default` implied by `-D clippy::all`
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#new_without_default
help: try adding this
     |
1129 + impl Default for GlobalState {
1130 +     fn default() -> Self {
1131 +         Self::new()
1132 +     }
1133 + }
     |

error: useless use of `format!`
   --> src/diagnostics.rs:155:32
    |
155 |                         (None, format!("pass the flag `-Zmiri-disable-isolation` to disable isolation;")),
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"pass the flag `-Zmiri-disable-isolation` to disable isolation;".to_string()`
    |
    = note: `-D clippy::useless-format` implied by `-D clippy::all`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_format

error: useless use of `format!`
   --> src/diagnostics.rs:156:32
    |
156 | ...e, format!("or pass `-Zmiri-isolation-error=warn` to configure Miri to return an error code from isolated operations (if supported for that operation) and continue with a warning"...
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"or pass `-Zmiri-isolation-error=warn` to configure Miri to return an error code from isolated operations (if supported for that operation) and continue with a warning".to_string()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_format

error: useless use of `format!`
   --> src/diagnostics.rs:161:32
    |
161 | ...e, format!("this indicates a potential bug in the program: it performed an invalid operation, but the rules it violated are still experimental"...
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"this indicates a potential bug in the program: it performed an invalid operation, but the rules it violated are still experimental".to_string()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_format

error: useless use of `format!`
   --> src/diagnostics.rs:197:33
    |
197 | ...e, format!("this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support")...
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support".to_string()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_format

error: useless use of `format!`
   --> src/diagnostics.rs:202:32
    |
202 | ...  (None, format!("this usually indicates that your program performed an invalid operation and caused Undefined Behavior")),
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"this usually indicates that your program performed an invalid operation and caused Undefined Behavior".to_string()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_format

error: useless use of `format!`
   --> src/diagnostics.rs:203:32
    |
203 |                         (None, format!("but due to `-Zmiri-symbolic-alignment-check`, alignment errors can also be false positives")),
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"but due to `-Zmiri-symbolic-alignment-check`, alignment errors can also be false positives".to_string()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_format

error: useless use of `format!`
   --> src/diagnostics.rs:207:32
    |
207 | ...  (None, format!("this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior")),
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior".to_string()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_format

error: useless use of `format!`
   --> src/diagnostics.rs:208:32
    |
208 | ...(None, format!("see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information")),
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information".to_string()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_format

error: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
   --> src/diagnostics.rs:247:5
    |
247 | /     match e.kind() {
248 | |         UndefinedBehavior(UndefinedBehaviorInfo::InvalidUninitBytes(Some((alloc_id, access)))) => {
249 | |             eprintln!(
250 | |                 "Uninitialized read occurred at offsets 0x{:x}..0x{:x} into this allocation:",
...   |
256 | |         _ => {}
257 | |     }
    | |_____^
    |
    = note: `-D clippy::single-match` implied by `-D clippy::all`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_match
help: try this
    |
247 ~     if let UndefinedBehavior(UndefinedBehaviorInfo::InvalidUninitBytes(Some((alloc_id, access)))) = e.kind() {
248 +         eprintln!(
249 +             "Uninitialized read occurred at offsets 0x{:x}..0x{:x} into this allocation:",
250 +             access.uninit_offset.bytes(),
251 +             access.uninit_offset.bytes() + access.uninit_size.bytes(),
252 +         );
  ...

error: an implementation of `From` is preferred since it gives you `Into<_>` for free where the reverse isn't true
  --> src/machine.rs:92:1
   |
92 | impl Into<MemoryKind<MiriMemoryKind>> for MiriMemoryKind {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `-D clippy::from-over-into` implied by `-D clippy::all`
   = help: consider to implement `From<machine::MiriMemoryKind>` instead
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#from_over_into

error: manual implementation of `Option::map`
   --> src/machine.rs:570:22
    |
570 |           let stacks = if let Some(stacked_borrows) = &ecx.machine.stacked_borrows {
    |  ______________________^
571 | |             Some(Stacks::new_allocation(id, alloc.size(), stacked_borrows, kind))
572 | |         } else {
573 | |             None
574 | |         };
    | |_________^ help: try this: `ecx.machine.stacked_borrows.as_ref().map(|stacked_borrows| Stacks::new_allocation(id, alloc.size(), stacked_borrows, kind))`
    |
    = note: `-D clippy::manual-map` implied by `-D clippy::all`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_map

error: manual implementation of `Option::map`
   --> src/machine.rs:575:26
    |
575 |           let race_alloc = if let Some(data_race) = &ecx.machine.data_race {
    |  __________________________^
576 | |             Some(data_race::AllocExtra::new_allocation(data_race, alloc.size(), kind))
577 | |         } else {
578 | |             None
579 | |         };
    | |_________^ help: try this: `ecx.machine.data_race.as_ref().map(|data_race| data_race::AllocExtra::new_allocation(data_race, alloc.size(), kind))`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_map

error: variant name ends with the enum's name
   --> src/shims/intrinsics.rs:354:21
    |
354 |                     MirOp(mir::UnOp),
    |                     ^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::enum-variant-names` implied by `-D clippy::all`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#enum_variant_names

error: variant name ends with the enum's name
   --> src/shims/intrinsics.rs:453:21
    |
453 |                     MirOp(BinOp),
    |                     ^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#enum_variant_names

error: variant name ends with the enum's name
   --> src/shims/intrinsics.rs:454:21
    |
454 |                     SaturatingOp(BinOp),
    |                     ^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#enum_variant_names

error: variant name ends with the enum's name
   --> src/shims/intrinsics.rs:580:21
    |
580 |                     MirOp(BinOp),
    |                     ^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#enum_variant_names

error: explicit lifetimes given in parameter types where they could be elided (or replaced with `'_` if needed by type declaration)
    --> src/shims/intrinsics.rs:1391:1
     |
1391 | fn simd_element_to_bool<'tcx>(elem: ImmTy<'tcx, Tag>) -> InterpResult<'tcx, bool> {
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: `-D clippy::needless-lifetimes` implied by `-D clippy::all`
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes

error: this `if` has identical blocks
   --> src/shims/posix/sync.rs:503:75
    |
503 |               } else if kind == this.eval_libc("PTHREAD_MUTEX_ERRORCHECK")? {
    |  ___________________________________________________________________________^
504 | |                 this.eval_libc_i32("EPERM")
505 | |             } else if kind == this.eval_libc("PTHREAD_MUTEX_RECURSIVE")? {
    | |_____________^
    |
    = note: `-D clippy::if-same-then-else` implied by `-D clippy::all`
note: same as this
   --> src/shims/posix/sync.rs:505:74
    |
505 |               } else if kind == this.eval_libc("PTHREAD_MUTEX_RECURSIVE")? {
    |  __________________________________________________________________________^
506 | |                 this.eval_libc_i32("EPERM")
507 | |             } else {
    | |_____________^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#if_same_then_else

error: this `if` has identical blocks
   --> src/shims/posix/sync.rs:610:57
    |
610 |           if this.rwlock_reader_unlock(id, active_thread) {
    |  _________________________________________________________^
611 | |             Ok(0)
612 | |         } else if this.rwlock_writer_unlock(id, active_thread) {
    | |_________^
    |
note: same as this
   --> src/shims/posix/sync.rs:612:64
    |
612 |           } else if this.rwlock_writer_unlock(id, active_thread) {
    |  ________________________________________________________________^
613 | |             Ok(0)
614 | |         } else {
    | |_________^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#if_same_then_else

error: useless use of `format!`
   --> src/stacked_borrows.rs:228:14
    |
228 |           url: format!(
    |  ______________^
229 | |             "https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md"
230 | |         ),
    | |_________^ help: consider using `.to_string()`: `"https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md".to_string()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_format

error: field assignment outside of initializer for an instance created with Default::default()
   --> src/thread.rs:234:9
    |
234 |         main_thread.join_status = ThreadJoinStatus::Detached;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::field-reassign-with-default` implied by `-D clippy::all`
note: consider initializing the variable with `Thread::<'_, '_> { join_status: ThreadJoinStatus::Detached, ..Default::default() }` and removing relevant reassignments
   --> src/thread.rs:232:9
    |
232 |         let mut main_thread = Thread::default();
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#field_reassign_with_default

error: `if` chain can be rewritten with `match`
   --> src/vector_clock.rs:224:17
    |
224 | /                 if l > r {
225 | |                     return false;
226 | |                 } else if l < r {
227 | |                     equal = false;
228 | |                 }
    | |_________________^
    |
    = note: `-D clippy::comparison-chain` implied by `-D clippy::all`
    = help: consider rewriting the `if` chain to use `cmp` and `match`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#comparison_chain

error: `if` chain can be rewritten with `match`
   --> src/vector_clock.rs:278:17
    |
278 | /                 if l < r {
279 | |                     return false;
280 | |                 } else if l > r {
281 | |                     equal = false;
282 | |                 }
    | |_________________^
    |
    = help: consider rewriting the `if` chain to use `cmp` and `match`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#comparison_chain

error: manual `RangeInclusive::contains` implementation
   --> src/bin/miri.rs:473:37
    |
473 |                         Ok(rate) if rate >= 0.0 && rate <= 1.0 => rate,
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `(0.0..=1.0).contains(&rate)`
    |
    = note: `-D clippy::manual-range-contains` implied by `-D clippy::all`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_range_contains
```
</details>