### PR TITLE
Update GitHub Actions actions/checkout@v2 to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
             os: windows-latest
             host_target: i686-pc-windows-msvc
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # We install gnu-tar because BSD tar is buggy on macOS builders of GHA.
       # See <https://github.com/actions/cache/issues/403>.
@@ -97,7 +97,7 @@ jobs:
     name: check formatting (ignored by bors)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Here is an example job for GitHub Actions:
     name: "Miri"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Miri
         run: |
           rustup toolchain install nightly --component miri


### PR DESCRIPTION
The v2 implementation uses Node 12, which is end-of-life on April 30, 2022. See https://nodejs.org/en/about/releases/. Update to v3, which is based on Node 16 whose support lasts until April 30, 2024.