### PR TITLE
gracefully handle type-too-large layout errors

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -182,10 +182,8 @@ pub fn report_error<'tcx, 'mir>(
                     "Undefined Behavior",
                 ResourceExhaustion(_) =>
                     "resource exhaustion",
-                InvalidProgram(InvalidProgramInfo::ReferencedConstant) =>
+                InvalidProgram(InvalidProgramInfo::AlreadyReported(_) | InvalidProgramInfo::Layout(..)) =>
                     "post-monomorphization error",
-                InvalidProgram(InvalidProgramInfo::AlreadyReported(_)) =>
-                    "error occurred",
                 kind =>
                     bug!("This error should be impossible in Miri: {:?}", kind),
             };

--- a/tests/compile-fail/erroneous_const.rs
+++ b/tests/compile-fail/erroneous_const.rs
@@ -12,7 +12,7 @@ impl<T> PrintName<T> {
 
 fn no_codegen<T>() {
     if false {
-        let _ = PrintName::<T>::VOID; //~ERROR error occurred: encountered constant
+        let _ = PrintName::<T>::VOID; //~ERROR post-monomorphization error
     }
 }
 fn main() {

--- a/tests/compile-fail/type-too-large.rs
+++ b/tests/compile-fail/type-too-large.rs
@@ -1,0 +1,6 @@
+// ignore-32bit
+
+fn main() {
+    let _fat: [u8; (1<<61)+(1<<31)] =
+        [0; (1u64<<61) as usize +(1u64<<31) as usize]; //~ ERROR post-monomorphization error
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/miri/issues/2088