### PR TITLE
Replace unneeded use of `ref` in favor of "match ergonomics"

### DIFF
--- a/src/shims/backtrace.rs
+++ b/src/shims/backtrace.rs
@@ -15,7 +15,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         dest: &PlaceTy<'tcx, Tag>,
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
-        let &[ref flags] = this.check_shim(abi, Abi::Rust, link_name, args)?;
+        let [flags] = this.check_shim(abi, Abi::Rust, link_name, args)?;
 
         let flags = this.read_scalar(flags)?.to_u64()?;
         if flags != 0 {
@@ -77,7 +77,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             // storage for pointers is allocated by miri
             // deallocating the slice is undefined behavior with a custom global allocator
             0 => {
-                let &[_flags] = this.check_shim(abi, Abi::Rust, link_name, args)?;
+                let [_flags] = this.check_shim(abi, Abi::Rust, link_name, args)?;
 
                 let alloc = this.allocate(array_layout, MiriMemoryKind::Rust.into())?;
 
@@ -95,7 +95,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             }
             // storage for pointers is allocated by the caller
             1 => {
-                let &[_flags, ref buf] = this.check_shim(abi, Abi::Rust, link_name, args)?;
+                let [_flags, buf] = this.check_shim(abi, Abi::Rust, link_name, args)?;
 
                 let buf_place = this.deref_operand(buf)?;
 
@@ -150,7 +150,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         dest: &PlaceTy<'tcx, Tag>,
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
-        let &[ref ptr, ref flags] = this.check_shim(abi, Abi::Rust, link_name, args)?;
+        let [ptr, flags] = this.check_shim(abi, Abi::Rust, link_name, args)?;
 
         let flags = this.read_scalar(flags)?.to_u64()?;
 
@@ -233,7 +233,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
 
-        let &[ref ptr, ref flags, ref name_ptr, ref filename_ptr] =
+        let [ptr, flags, name_ptr, filename_ptr] =
             this.check_shim(abi, Abi::Rust, link_name, args)?;
 
         let flags = this.read_scalar(flags)?.to_u64()?;

--- a/src/shims/intrinsics.rs
+++ b/src/shims/intrinsics.rs
@@ -43,13 +43,13 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         match intrinsic_name {
             // Miri overwriting CTFE intrinsics.
             "ptr_guaranteed_eq" => {
-                let &[ref left, ref right] = check_arg_count(args)?;
+                let [left, right] = check_arg_count(args)?;
                 let left = this.read_immediate(left)?;
                 let right = this.read_immediate(right)?;
                 this.binop_ignore_overflow(mir::BinOp::Eq, &left, &right, dest)?;
             }
             "ptr_guaranteed_ne" => {
-                let &[ref left, ref right] = check_arg_count(args)?;
+                let [left, right] = check_arg_count(args)?;
                 let left = this.read_immediate(left)?;
                 let right = this.read_immediate(right)?;
                 this.binop_ignore_overflow(mir::BinOp::Ne, &left, &right, dest)?;
@@ -65,18 +65,18 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
             // Raw memory accesses
             "volatile_load" => {
-                let &[ref place] = check_arg_count(args)?;
+                let [place] = check_arg_count(args)?;
                 let place = this.deref_operand(place)?;
                 this.copy_op(&place.into(), dest)?;
             }
             "volatile_store" => {
-                let &[ref place, ref dest] = check_arg_count(args)?;
+                let [place, dest] = check_arg_count(args)?;
                 let place = this.deref_operand(place)?;
                 this.copy_op(dest, &place.into())?;
             }
 
             "write_bytes" | "volatile_set_memory" => {
-                let &[ref ptr, ref val_byte, ref count] = check_arg_count(args)?;
+                let [ptr, val_byte, count] = check_arg_count(args)?;
                 let ty = instance.substs.type_at(0);
                 let ty_layout = this.layout_of(ty)?;
                 let val_byte = this.read_scalar(val_byte)?.to_u8()?;
@@ -95,13 +95,13 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
             // Floating-point operations
             "fabsf32" => {
-                let &[ref f] = check_arg_count(args)?;
+                let [f] = check_arg_count(args)?;
                 let f = this.read_scalar(f)?.to_f32()?;
                 // Can be implemented in soft-floats.
                 this.write_scalar(Scalar::from_f32(f.abs()), dest)?;
             }
             "fabsf64" => {
-                let &[ref f] = check_arg_count(args)?;
+                let [f] = check_arg_count(args)?;
                 let f = this.read_scalar(f)?.to_f64()?;
                 // Can be implemented in soft-floats.
                 this.write_scalar(Scalar::from_f64(f.abs()), dest)?;
@@ -120,7 +120,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             | "truncf32"
             | "roundf32"
             => {
-                let &[ref f] = check_arg_count(args)?;
+                let [f] = check_arg_count(args)?;
                 // FIXME: Using host floats.
                 let f = f32::from_bits(this.read_scalar(f)?.to_u32()?);
                 let f = match intrinsic_name {
@@ -155,7 +155,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             | "truncf64"
             | "roundf64"
             => {
-                let &[ref f] = check_arg_count(args)?;
+                let [f] = check_arg_count(args)?;
                 // FIXME: Using host floats.
                 let f = f64::from_bits(this.read_scalar(f)?.to_u64()?);
                 let f = match intrinsic_name {
@@ -183,7 +183,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             | "fdiv_fast"
             | "frem_fast"
             => {
-                let &[ref a, ref b] = check_arg_count(args)?;
+                let [a, b] = check_arg_count(args)?;
                 let a = this.read_immediate(a)?;
                 let b = this.read_immediate(b)?;
                 let op = match intrinsic_name {
@@ -228,7 +228,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             | "maxnumf32"
             | "copysignf32"
             => {
-                let &[ref a, ref b] = check_arg_count(args)?;
+                let [a, b] = check_arg_count(args)?;
                 let a = this.read_scalar(a)?.to_f32()?;
                 let b = this.read_scalar(b)?.to_f32()?;
                 let res = match intrinsic_name {
@@ -245,7 +245,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             | "maxnumf64"
             | "copysignf64"
             => {
-                let &[ref a, ref b] = check_arg_count(args)?;
+                let [a, b] = check_arg_count(args)?;
                 let a = this.read_scalar(a)?.to_f64()?;
                 let b = this.read_scalar(b)?.to_f64()?;
                 let res = match intrinsic_name {
@@ -258,7 +258,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             }
 
             "powf32" => {
-                let &[ref f, ref f2] = check_arg_count(args)?;
+                let [f, f2] = check_arg_count(args)?;
                 // FIXME: Using host floats.
                 let f = f32::from_bits(this.read_scalar(f)?.to_u32()?);
                 let f2 = f32::from_bits(this.read_scalar(f2)?.to_u32()?);
@@ -266,7 +266,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             }
 
             "powf64" => {
-                let &[ref f, ref f2] = check_arg_count(args)?;
+                let [f, f2] = check_arg_count(args)?;
                 // FIXME: Using host floats.
                 let f = f64::from_bits(this.read_scalar(f)?.to_u64()?);
                 let f2 = f64::from_bits(this.read_scalar(f2)?.to_u64()?);
@@ -274,7 +274,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             }
 
             "fmaf32" => {
-                let &[ref a, ref b, ref c] = check_arg_count(args)?;
+                let [a, b, c] = check_arg_count(args)?;
                 let a = this.read_scalar(a)?.to_f32()?;
                 let b = this.read_scalar(b)?.to_f32()?;
                 let c = this.read_scalar(c)?.to_f32()?;
@@ -283,7 +283,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             }
 
             "fmaf64" => {
-                let &[ref a, ref b, ref c] = check_arg_count(args)?;
+                let [a, b, c] = check_arg_count(args)?;
                 let a = this.read_scalar(a)?.to_f64()?;
                 let b = this.read_scalar(b)?.to_f64()?;
                 let c = this.read_scalar(c)?.to_f64()?;
@@ -292,7 +292,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             }
 
             "powif32" => {
-                let &[ref f, ref i] = check_arg_count(args)?;
+                let [f, i] = check_arg_count(args)?;
                 // FIXME: Using host floats.
                 let f = f32::from_bits(this.read_scalar(f)?.to_u32()?);
                 let i = this.read_scalar(i)?.to_i32()?;
@@ -300,7 +300,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             }
 
             "powif64" => {
-                let &[ref f, ref i] = check_arg_count(args)?;
+                let [f, i] = check_arg_count(args)?;
                 // FIXME: Using host floats.
                 let f = f64::from_bits(this.read_scalar(f)?.to_u64()?);
                 let i = this.read_scalar(i)?.to_i32()?;
@@ -308,7 +308,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             }
 
             "float_to_int_unchecked" => {
-                let &[ref val] = check_arg_count(args)?;
+                let [val] = check_arg_count(args)?;
                 let val = this.read_immediate(val)?;
 
                 let res = match val.layout.ty.kind() {
@@ -335,7 +335,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             | "simd_round"
             | "simd_trunc"
             | "simd_fsqrt" => {
-                let &[ref op] = check_arg_count(args)?;
+                let [op] = check_arg_count(args)?;
                 let (op, op_len) = this.operand_to_simd(op)?;
                 let (dest, dest_len) = this.place_to_simd(dest)?;
 
@@ -441,7 +441,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             | "simd_arith_offset" => {
                 use mir::BinOp;
 
-                let &[ref left, ref right] = check_arg_count(args)?;
+                let [left, right] = check_arg_count(args)?;
                 let (left, left_len) = this.operand_to_simd(left)?;
                 let (right, right_len) = this.operand_to_simd(right)?;
                 let (dest, dest_len) = this.place_to_simd(dest)?;
@@ -531,7 +531,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 }
             }
             "simd_fma" => {
-                let &[ref a, ref b, ref c] = check_arg_count(args)?;
+                let [a, b, c] = check_arg_count(args)?;
                 let (a, a_len) = this.operand_to_simd(a)?;
                 let (b, b_len) = this.operand_to_simd(b)?;
                 let (c, c_len) = this.operand_to_simd(c)?;
@@ -570,7 +570,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             | "simd_reduce_min" => {
                 use mir::BinOp;
 
-                let &[ref op] = check_arg_count(args)?;
+                let [op] = check_arg_count(args)?;
                 let (op, op_len) = this.operand_to_simd(op)?;
 
                 let imm_from_bool =
@@ -642,7 +642,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             | "simd_reduce_mul_ordered" => {
                 use mir::BinOp;
 
-                let &[ref op, ref init] = check_arg_count(args)?;
+                let [op, init] = check_arg_count(args)?;
                 let (op, op_len) = this.operand_to_simd(op)?;
                 let init = this.read_immediate(init)?;
 
@@ -660,7 +660,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_immediate(*res, dest)?;
             }
             "simd_select" => {
-                let &[ref mask, ref yes, ref no] = check_arg_count(args)?;
+                let [mask, yes, no] = check_arg_count(args)?;
                 let (mask, mask_len) = this.operand_to_simd(mask)?;
                 let (yes, yes_len) = this.operand_to_simd(yes)?;
                 let (no, no_len) = this.operand_to_simd(no)?;
@@ -681,7 +681,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 }
             }
             "simd_select_bitmask" => {
-                let &[ref mask, ref yes, ref no] = check_arg_count(args)?;
+                let [mask, yes, no] = check_arg_count(args)?;
                 let (yes, yes_len) = this.operand_to_simd(yes)?;
                 let (no, no_len) = this.operand_to_simd(no)?;
                 let (dest, dest_len) = this.place_to_simd(dest)?;
@@ -721,7 +721,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             }
             #[rustfmt::skip]
             "simd_cast" | "simd_as" => {
-                let &[ref op] = check_arg_count(args)?;
+                let [op] = check_arg_count(args)?;
                 let (op, op_len) = this.operand_to_simd(op)?;
                 let (dest, dest_len) = this.place_to_simd(dest)?;
 
@@ -759,7 +759,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 }
             }
             "simd_shuffle" => {
-                let &[ref left, ref right, ref index] = check_arg_count(args)?;
+                let [left, right, index] = check_arg_count(args)?;
                 let (left, left_len) = this.operand_to_simd(left)?;
                 let (right, right_len) = this.operand_to_simd(right)?;
                 let (dest, dest_len) = this.place_to_simd(dest)?;
@@ -798,7 +798,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 }
             }
             "simd_gather" => {
-                let &[ref passthru, ref ptrs, ref mask] = check_arg_count(args)?;
+                let [passthru, ptrs, mask] = check_arg_count(args)?;
                 let (passthru, passthru_len) = this.operand_to_simd(passthru)?;
                 let (ptrs, ptrs_len) = this.operand_to_simd(ptrs)?;
                 let (mask, mask_len) = this.operand_to_simd(mask)?;
@@ -824,7 +824,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 }
             }
             "simd_scatter" => {
-                let &[ref value, ref ptrs, ref mask] = check_arg_count(args)?;
+                let [value, ptrs, mask] = check_arg_count(args)?;
                 let (value, value_len) = this.operand_to_simd(value)?;
                 let (ptrs, ptrs_len) = this.operand_to_simd(ptrs)?;
                 let (mask, mask_len) = this.operand_to_simd(mask)?;
@@ -844,7 +844,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 }
             }
             "simd_bitmask" => {
-                let &[ref op] = check_arg_count(args)?;
+                let [op] = check_arg_count(args)?;
                 let (op, op_len) = this.operand_to_simd(op)?;
                 let bitmask_len = op_len.max(8);
 
@@ -1063,14 +1063,14 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
             // Other
             "exact_div" => {
-                let &[ref num, ref denom] = check_arg_count(args)?;
+                let [num, denom] = check_arg_count(args)?;
                 this.exact_div(&this.read_immediate(num)?, &this.read_immediate(denom)?, dest)?;
             }
 
             "try" => return this.handle_try(args, dest, ret),
 
             "breakpoint" => {
-                let &[] = check_arg_count(args)?;
+                let [] = check_arg_count(args)?;
                 // normally this would raise a SIGTRAP, which aborts if no debugger is connected
                 throw_machine_stop!(TerminationInfo::Abort("Trace/breakpoint trap".to_string()))
             }
@@ -1091,7 +1091,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
 
-        let &[ref place] = check_arg_count(args)?;
+        let [place] = check_arg_count(args)?;
         let place = this.deref_operand(place)?;
 
         // make sure it fits into a scalar; otherwise it cannot be atomic
@@ -1119,7 +1119,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
 
-        let &[ref place, ref val] = check_arg_count(args)?;
+        let [place, val] = check_arg_count(args)?;
         let place = this.deref_operand(place)?;
         let val = this.read_scalar(val)?; // make sure it fits into a scalar; otherwise it cannot be atomic
 
@@ -1144,7 +1144,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         args: &[OpTy<'tcx, Tag>],
         atomic: AtomicFenceOp,
     ) -> InterpResult<'tcx> {
-        let &[] = check_arg_count(args)?;
+        let [] = check_arg_count(args)?;
         let _ = atomic;
         //FIXME: compiler fences are currently ignored
         Ok(())
@@ -1156,7 +1156,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         atomic: AtomicFenceOp,
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
-        let &[] = check_arg_count(args)?;
+        let [] = check_arg_count(args)?;
         this.validate_atomic_fence(atomic)?;
         Ok(())
     }
@@ -1170,7 +1170,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
 
-        let &[ref place, ref rhs] = check_arg_count(args)?;
+        let [place, rhs] = check_arg_count(args)?;
         let place = this.deref_operand(place)?;
 
         if !place.layout.ty.is_integral() {
@@ -1216,7 +1216,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
 
-        let &[ref place, ref new] = check_arg_count(args)?;
+        let [place, new] = check_arg_count(args)?;
         let place = this.deref_operand(place)?;
         let new = this.read_scalar(new)?;
 
@@ -1246,7 +1246,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
 
-        let &[ref place, ref expect_old, ref new] = check_arg_count(args)?;
+        let [place, expect_old, new] = check_arg_count(args)?;
         let place = this.deref_operand(place)?;
         let expect_old = this.read_immediate(expect_old)?; // read as immediate for the sake of `binary_op()`
         let new = this.read_scalar(new)?;

--- a/src/shims/mod.rs
+++ b/src/shims/mod.rs
@@ -36,7 +36,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
         // There are some more lang items we want to hook that CTFE does not hook (yet).
         if this.tcx.lang_items().align_offset_fn() == Some(instance.def.def_id()) {
-            let &[ref ptr, ref align] = check_arg_count(args)?;
+            let [ptr, align] = check_arg_count(args)?;
             if this.align_offset(ptr, align, ret, unwind)? {
                 return Ok(None);
             }

--- a/src/shims/panic.rs
+++ b/src/shims/panic.rs
@@ -51,7 +51,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         trace!("miri_start_panic: {:?}", this.frame().instance);
 
         // Get the raw pointer stored in arg[0] (the panic payload).
-        let &[ref payload] = this.check_shim(abi, Abi::Rust, link_name, args)?;
+        let [payload] = this.check_shim(abi, Abi::Rust, link_name, args)?;
         let payload = this.read_scalar(payload)?.check_init()?;
         let thread = this.active_thread_mut();
         assert!(thread.panic_payload.is_none(), "the panic runtime should avoid double-panics");
@@ -83,7 +83,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         // a pointer to `Box<dyn Any + Send + 'static>`.
 
         // Get all the arguments.
-        let &[ref try_fn, ref data, ref catch_fn] = check_arg_count(args)?;
+        let [try_fn, data, catch_fn] = check_arg_count(args)?;
         let try_fn = this.read_pointer(try_fn)?;
         let data = this.read_scalar(data)?.check_init()?;
         let catch_fn = this.read_scalar(catch_fn)?.check_init()?;

--- a/src/shims/posix/foreign_items.rs
+++ b/src/shims/posix/foreign_items.rs
@@ -29,28 +29,28 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         match &*link_name.as_str() {
             // Environment related shims
             "getenv" => {
-                let &[ref name] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [name] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.getenv(name)?;
                 this.write_pointer(result, dest)?;
             }
             "unsetenv" => {
-                let &[ref name] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [name] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.unsetenv(name)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "setenv" => {
-                let &[ref name, ref value, ref overwrite] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [name, value, overwrite] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 this.read_scalar(overwrite)?.to_i32()?;
                 let result = this.setenv(name, value)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "getcwd" => {
-                let &[ref buf, ref size] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [buf, size] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.getcwd(buf, size)?;
                 this.write_pointer(result, dest)?;
             }
             "chdir" => {
-                let &[ref path] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [path] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.chdir(path)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
@@ -70,7 +70,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "read" => {
-                let &[ref fd, ref buf, ref count] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [fd, buf, count] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let fd = this.read_scalar(fd)?.to_i32()?;
                 let buf = this.read_pointer(buf)?;
                 let count = this.read_scalar(count)?.to_machine_usize(this)?;
@@ -78,7 +78,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_scalar(Scalar::from_machine_isize(result, this), dest)?;
             }
             "write" => {
-                let &[ref fd, ref buf, ref n] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [fd, buf, n] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let fd = this.read_scalar(fd)?.to_i32()?;
                 let buf = this.read_pointer(buf)?;
                 let count = this.read_scalar(n)?.to_machine_usize(this)?;
@@ -88,60 +88,60 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_scalar(Scalar::from_machine_isize(result, this), dest)?;
             }
             "unlink" => {
-                let &[ref path] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [path] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.unlink(path)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "symlink" => {
-                let &[ref target, ref linkpath] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [target, linkpath] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.symlink(target, linkpath)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "rename" => {
-                let &[ref oldpath, ref newpath] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [oldpath, newpath] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.rename(oldpath, newpath)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "mkdir" => {
-                let &[ref path, ref mode] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [path, mode] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.mkdir(path, mode)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "rmdir" => {
-                let &[ref path] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [path] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.rmdir(path)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "closedir" => {
-                let &[ref dirp] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [dirp] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.closedir(dirp)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "lseek" | "lseek64" => {
-                let &[ref fd, ref offset, ref whence] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [fd, offset, whence] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.lseek64(fd, offset, whence)?;
                 // "lseek" is only used on macOS which is 64bit-only, so `i64` always works.
                 this.write_scalar(Scalar::from_i64(result), dest)?;
             }
             "fsync" => {
-                let &[ref fd] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [fd] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.fsync(fd)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "fdatasync" => {
-                let &[ref fd] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [fd] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.fdatasync(fd)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "readlink" => {
-                let &[ref pathname, ref buf, ref bufsize] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [pathname, buf, bufsize] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.readlink(pathname, buf, bufsize)?;
                 this.write_scalar(Scalar::from_machine_isize(result, this), dest)?;
             }
 
             // Allocation
             "posix_memalign" => {
-                let &[ref ret, ref align, ref size] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [ret, align, size] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let ret = this.deref_operand(ret)?;
                 let align = this.read_scalar(align)?.to_machine_usize(this)?;
                 let size = this.read_scalar(size)?.to_machine_usize(this)?;
@@ -171,7 +171,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
             // Dynamic symbol loading
             "dlsym" => {
-                let &[ref handle, ref symbol] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [handle, symbol] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 this.read_scalar(handle)?.to_machine_usize(this)?;
                 let symbol = this.read_pointer(symbol)?;
                 let symbol_name = this.read_c_str(symbol)?;
@@ -185,7 +185,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
             // Querying system information
             "sysconf" => {
-                let &[ref name] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [name] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let name = this.read_scalar(name)?.to_i32()?;
 
                 let sysconfs = &[
@@ -210,7 +210,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
             // Thread-local storage
             "pthread_key_create" => {
-                let &[ref key, ref dtor] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [key, dtor] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let key_place = this.deref_operand(key)?;
                 let dtor = this.read_pointer(dtor)?;
 
@@ -239,21 +239,21 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_null(dest)?;
             }
             "pthread_key_delete" => {
-                let &[ref key] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [key] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let key = this.read_scalar(key)?.check_init()?.to_bits(key.layout.size)?;
                 this.machine.tls.delete_tls_key(key)?;
                 // Return success (0)
                 this.write_null(dest)?;
             }
             "pthread_getspecific" => {
-                let &[ref key] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [key] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let key = this.read_scalar(key)?.check_init()?.to_bits(key.layout.size)?;
                 let active_thread = this.get_active_thread();
                 let ptr = this.machine.tls.load_tls(key, active_thread, this)?;
                 this.write_scalar(ptr, dest)?;
             }
             "pthread_setspecific" => {
-                let &[ref key, ref new_ptr] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [key, new_ptr] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let key = this.read_scalar(key)?.check_init()?.to_bits(key.layout.size)?;
                 let active_thread = this.get_active_thread();
                 let new_data = this.read_scalar(new_ptr)?;
@@ -265,149 +265,149 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
             // Synchronization primitives
             "pthread_mutexattr_init" => {
-                let &[ref attr] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [attr] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.pthread_mutexattr_init(attr)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "pthread_mutexattr_settype" => {
-                let &[ref attr, ref kind] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [attr, kind] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.pthread_mutexattr_settype(attr, kind)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "pthread_mutexattr_destroy" => {
-                let &[ref attr] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [attr] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.pthread_mutexattr_destroy(attr)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "pthread_mutex_init" => {
-                let &[ref mutex, ref attr] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [mutex, attr] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.pthread_mutex_init(mutex, attr)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "pthread_mutex_lock" => {
-                let &[ref mutex] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [mutex] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.pthread_mutex_lock(mutex)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "pthread_mutex_trylock" => {
-                let &[ref mutex] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [mutex] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.pthread_mutex_trylock(mutex)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "pthread_mutex_unlock" => {
-                let &[ref mutex] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [mutex] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.pthread_mutex_unlock(mutex)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "pthread_mutex_destroy" => {
-                let &[ref mutex] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [mutex] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.pthread_mutex_destroy(mutex)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "pthread_rwlock_rdlock" => {
-                let &[ref rwlock] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [rwlock] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.pthread_rwlock_rdlock(rwlock)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "pthread_rwlock_tryrdlock" => {
-                let &[ref rwlock] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [rwlock] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.pthread_rwlock_tryrdlock(rwlock)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "pthread_rwlock_wrlock" => {
-                let &[ref rwlock] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [rwlock] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.pthread_rwlock_wrlock(rwlock)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "pthread_rwlock_trywrlock" => {
-                let &[ref rwlock] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [rwlock] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.pthread_rwlock_trywrlock(rwlock)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "pthread_rwlock_unlock" => {
-                let &[ref rwlock] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [rwlock] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.pthread_rwlock_unlock(rwlock)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "pthread_rwlock_destroy" => {
-                let &[ref rwlock] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [rwlock] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.pthread_rwlock_destroy(rwlock)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "pthread_condattr_init" => {
-                let &[ref attr] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [attr] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.pthread_condattr_init(attr)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "pthread_condattr_destroy" => {
-                let &[ref attr] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [attr] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.pthread_condattr_destroy(attr)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "pthread_cond_init" => {
-                let &[ref cond, ref attr] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [cond, attr] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.pthread_cond_init(cond, attr)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "pthread_cond_signal" => {
-                let &[ref cond] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [cond] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.pthread_cond_signal(cond)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "pthread_cond_broadcast" => {
-                let &[ref cond] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [cond] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.pthread_cond_broadcast(cond)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "pthread_cond_wait" => {
-                let &[ref cond, ref mutex] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [cond, mutex] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.pthread_cond_wait(cond, mutex)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "pthread_cond_timedwait" => {
-                let &[ref cond, ref mutex, ref abstime] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [cond, mutex, abstime] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 this.pthread_cond_timedwait(cond, mutex, abstime, dest)?;
             }
             "pthread_cond_destroy" => {
-                let &[ref cond] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [cond] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.pthread_cond_destroy(cond)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
 
             // Threading
             "pthread_create" => {
-                let &[ref thread, ref attr, ref start, ref arg] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [thread, attr, start, arg] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.pthread_create(thread, attr, start, arg)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "pthread_join" => {
-                let &[ref thread, ref retval] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [thread, retval] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.pthread_join(thread, retval)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "pthread_detach" => {
-                let &[ref thread] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [thread] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.pthread_detach(thread)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "pthread_self" => {
-                let &[] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 this.pthread_self(dest)?;
             }
             "sched_yield" => {
-                let &[] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.sched_yield()?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "nanosleep" => {
-                let &[ref req, ref rem] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [req, rem] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.nanosleep(req, rem)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
 
             // Miscellaneous
             "isatty" => {
-                let &[ref fd] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [fd] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 this.read_scalar(fd)?.to_i32()?;
                 // "returns 1 if fd is an open file descriptor referring to a terminal; otherwise 0 is returned, and errno is set to indicate the error"
                 // FIXME: we just say nothing is a terminal.
@@ -416,7 +416,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_null(dest)?;
             }
             "pthread_atfork" => {
-                let &[ref prepare, ref parent, ref child] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [prepare, parent, child] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 this.read_pointer(prepare)?;
                 this.read_pointer(parent)?;
                 this.read_pointer(child)?;
@@ -424,7 +424,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_null(dest)?;
             }
             "strerror_r" | "__xpg_strerror_r" => {
-                let &[ref errnum, ref buf, ref buflen] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [errnum, buf, buflen] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let errnum = this.read_scalar(errnum)?.check_init()?;
                 let buf = this.read_pointer(buf)?;
                 let buflen = this.read_scalar(buflen)?.to_machine_usize(this)?;
@@ -440,7 +440,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             // These shims are enabled only when the caller is in the standard library.
             "pthread_attr_getguardsize"
             if this.frame_in_std() => {
-                let &[ref _attr, ref guard_size] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [_attr, guard_size] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let guard_size = this.deref_operand(guard_size)?;
                 let guard_size_layout = this.libc_ty_layout("size_t")?;
                 this.write_scalar(Scalar::from_uint(crate::PAGE_SIZE, guard_size_layout.size), &guard_size.into())?;
@@ -452,25 +452,25 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             | "pthread_attr_init"
             | "pthread_attr_destroy"
             if this.frame_in_std() => {
-                let &[_] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [_] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 this.write_null(dest)?;
             }
             | "pthread_attr_setstacksize"
             if this.frame_in_std() => {
-                let &[_, _] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [_, _] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 this.write_null(dest)?;
             }
 
             | "signal"
             | "sigaltstack"
             if this.frame_in_std() => {
-                let &[_, _] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [_, _] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 this.write_null(dest)?;
             }
             | "sigaction"
             | "mprotect"
             if this.frame_in_std() => {
-                let &[_, _, _] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [_, _, _] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 this.write_null(dest)?;
             }
 

--- a/src/shims/posix/linux/foreign_items.rs
+++ b/src/shims/posix/linux/foreign_items.rs
@@ -24,7 +24,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         match &*link_name.as_str() {
             // errno
             "__errno_location" => {
-                let &[] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let errno_place = this.last_error_place()?;
                 this.write_scalar(errno_place.to_ref(this).to_scalar()?, dest)?;
             }
@@ -33,31 +33,29 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             // These symbols have different names on Linux and macOS, which is the only reason they are not
             // in the `posix` module.
             "close" => {
-                let &[ref fd] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [fd] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.close(fd)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "opendir" => {
-                let &[ref name] =
-                    this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [name] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.opendir(name)?;
                 this.write_scalar(result, dest)?;
             }
             "readdir64" => {
-                let &[ref dirp] =
-                    this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [dirp] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.linux_readdir64(dirp)?;
                 this.write_scalar(result, dest)?;
             }
             "ftruncate64" => {
-                let &[ref fd, ref length] =
+                let [fd, length] =
                     this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.ftruncate64(fd, length)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             // Linux-only
             "posix_fadvise" => {
-                let &[ref fd, ref offset, ref len, ref advice] =
+                let [fd, offset, len, advice] =
                     this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 this.read_scalar(fd)?.to_i32()?;
                 this.read_scalar(offset)?.to_machine_isize(this)?;
@@ -67,7 +65,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_null(dest)?;
             }
             "sync_file_range" => {
-                let &[ref fd, ref offset, ref nbytes, ref flags] =
+                let [fd, offset, nbytes, flags] =
                     this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.sync_file_range(fd, offset, nbytes, flags)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
@@ -76,7 +74,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             // Time related shims
             "clock_gettime" => {
                 // This is a POSIX function but it has only been tested on linux.
-                let &[ref clk_id, ref tp] =
+                let [clk_id, tp] =
                     this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.clock_gettime(clk_id, tp)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
@@ -85,7 +83,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             // Querying system information
             "pthread_attr_getstack" => {
                 // We don't support "pthread_attr_setstack", so we just pretend all stacks have the same values here.
-                let &[ref attr_place, ref addr_place, ref size_place] =
+                let [attr_place, addr_place, size_place] =
                     this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 this.deref_operand(attr_place)?;
                 let addr_place = this.deref_operand(addr_place)?;
@@ -112,13 +110,13 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "pthread_condattr_setclock" => {
-                let &[ref attr, ref clock_id] =
+                let [attr, clock_id] =
                     this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.pthread_condattr_setclock(attr, clock_id)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "pthread_condattr_getclock" => {
-                let &[ref attr, ref clock_id] =
+                let [attr, clock_id] =
                     this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.pthread_condattr_getclock(attr, clock_id)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
@@ -185,12 +183,12 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
             // Miscelanneous
             "getrandom" => {
-                let &[ref ptr, ref len, ref flags] =
+                let [ptr, len, flags] =
                     this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 getrandom(this, ptr, len, flags, dest)?;
             }
             "sched_getaffinity" => {
-                let &[ref pid, ref cpusetsize, ref mask] =
+                let [pid, cpusetsize, mask] =
                     this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 this.read_scalar(pid)?.to_i32()?;
                 this.read_scalar(cpusetsize)?.to_machine_usize(this)?;
@@ -204,7 +202,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             // Incomplete shims that we "stub out" just to get pre-main initialization code to work.
             // These shims are enabled only when the caller is in the standard library.
             "pthread_getattr_np" if this.frame_in_std() => {
-                let &[ref _thread, ref _attr] =
+                let [_thread, _attr] =
                     this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 this.write_null(dest)?;
             }

--- a/src/shims/posix/macos/dlsym.rs
+++ b/src/shims/posix/macos/dlsym.rs
@@ -36,7 +36,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
         match dlsym {
             Dlsym::getentropy => {
-                let &[ref ptr, ref len] = check_arg_count(args)?;
+                let [ptr, len] = check_arg_count(args)?;
                 let ptr = this.read_pointer(ptr)?;
                 let len = this.read_scalar(len)?.to_machine_usize(this)?;
                 this.gen_random(ptr, len)?;

--- a/src/shims/posix/macos/foreign_items.rs
+++ b/src/shims/posix/macos/foreign_items.rs
@@ -22,50 +22,47 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         match &*link_name.as_str() {
             // errno
             "__error" => {
-                let &[] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let errno_place = this.last_error_place()?;
                 this.write_scalar(errno_place.to_ref(this).to_scalar()?, dest)?;
             }
 
             // File related shims
             "close" | "close$NOCANCEL" => {
-                let &[ref result] =
-                    this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [result] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.close(result)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "stat" | "stat$INODE64" => {
-                let &[ref path, ref buf] =
+                let [path, buf] =
                     this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.macos_stat(path, buf)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "lstat" | "lstat$INODE64" => {
-                let &[ref path, ref buf] =
+                let [path, buf] =
                     this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.macos_lstat(path, buf)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "fstat" | "fstat$INODE64" => {
-                let &[ref fd, ref buf] =
-                    this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [fd, buf] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.macos_fstat(fd, buf)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "opendir" | "opendir$INODE64" => {
-                let &[ref name] =
-                    this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [name] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.opendir(name)?;
                 this.write_scalar(result, dest)?;
             }
             "readdir_r" | "readdir_r$INODE64" => {
-                let &[ref dirp, ref entry, ref result] =
+                let [dirp, entry, result] =
                     this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.macos_readdir_r(dirp, entry, result)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "ftruncate" => {
-                let &[ref fd, ref length] =
+                let [fd, length] =
                     this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.ftruncate64(fd, length)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
@@ -73,7 +70,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
             // Environment related shims
             "_NSGetEnviron" => {
-                let &[] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 this.write_pointer(
                     this.machine.env_vars.environ.expect("machine must be initialized").ptr,
                     dest,
@@ -82,34 +79,32 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
             // Time related shims
             "gettimeofday" => {
-                let &[ref tv, ref tz] =
-                    this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [tv, tz] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.gettimeofday(tv, tz)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
             "mach_absolute_time" => {
-                let &[] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.mach_absolute_time()?;
                 this.write_scalar(Scalar::from_u64(result), dest)?;
             }
 
             "mach_timebase_info" => {
-                let &[ref info] =
-                    this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [info] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.mach_timebase_info(info)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
 
             // Access to command-line arguments
             "_NSGetArgc" => {
-                let &[] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 this.write_pointer(
                     this.machine.argc.expect("machine must be initialized").ptr,
                     dest,
                 )?;
             }
             "_NSGetArgv" => {
-                let &[] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 this.write_pointer(
                     this.machine.argv.expect("machine must be initialized").ptr,
                     dest,
@@ -118,7 +113,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
             // Thread-local storage
             "_tlv_atexit" => {
-                let &[ref dtor, ref data] =
+                let [dtor, data] =
                     this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let dtor = this.read_pointer(dtor)?;
                 let dtor = this.get_ptr_fn(dtor)?.as_instance()?;
@@ -129,15 +124,13 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
             // Querying system information
             "pthread_get_stackaddr_np" => {
-                let &[ref thread] =
-                    this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [thread] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 this.read_scalar(thread)?.to_machine_usize(this)?;
                 let stack_addr = Scalar::from_uint(STACK_ADDR, this.pointer_size());
                 this.write_scalar(stack_addr, dest)?;
             }
             "pthread_get_stacksize_np" => {
-                let &[ref thread] =
-                    this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [thread] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 this.read_scalar(thread)?.to_machine_usize(this)?;
                 let stack_size = Scalar::from_uint(STACK_SIZE, this.pointer_size());
                 this.write_scalar(stack_size, dest)?;
@@ -145,8 +138,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
             // Threading
             "pthread_setname_np" => {
-                let &[ref name] =
-                    this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let [name] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let name = this.read_pointer(name)?;
                 this.pthread_setname_np(name)?;
             }
@@ -155,7 +147,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             // These shims are enabled only when the caller is in the standard library.
             "mmap" if this.frame_in_std() => {
                 // This is a horrible hack, but since the guard page mechanism calls mmap and expects a particular return value, we just give it that value.
-                let &[ref addr, _, _, _, _, _] =
+                let [addr, _, _, _, _, _] =
                     this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let addr = this.read_scalar(addr)?.check_init()?;
                 this.write_scalar(addr, dest)?;

--- a/src/shims/windows/dlsym.rs
+++ b/src/shims/windows/dlsym.rs
@@ -47,16 +47,16 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                     );
                 }
 
-                let &[
-                    ref handle,
-                    ref _event,
-                    ref _apc_routine,
-                    ref _apc_context,
-                    ref io_status_block,
-                    ref buf,
-                    ref n,
-                    ref byte_offset,
-                    ref _key,
+                let [
+                    handle,
+                    _event,
+                    _apc_routine,
+                    _apc_context,
+                    io_status_block,
+                    buf,
+                    n,
+                    byte_offset,
+                    _key,
                 ] = check_arg_count(args)?;
                 let handle = this.read_scalar(handle)?.to_machine_isize(this)?;
                 let buf = this.read_pointer(buf)?;

--- a/tests/run-pass/vec-matching-fold.rs
+++ b/tests/run-pass/vec-matching-fold.rs
@@ -7,9 +7,9 @@ fn foldl<T, U, F>(values: &[T],
     U: Clone+Debug, T:Debug,
     F: FnMut(U, &T) -> U,
 {    match values {
-        &[ref head, ref tail @ ..] =>
+        [head, tail @ ..] =>
             foldl(tail, function(initial, head), function),
-        &[] => {
+        [] => {
             let res = initial.clone(); res
         }
     }
@@ -23,9 +23,9 @@ fn foldr<T, U, F>(values: &[T],
     F: FnMut(&T, U) -> U,
 {
     match values {
-        &[ref head @ .., ref tail] =>
+        [head @ .., tail] =>
             foldr(head, function(tail, initial), function),
-        &[] => {
+        [] => {
             let res = initial.clone(); res
         }
     }


### PR DESCRIPTION
The signature of `check_shim` is very amenable to this.

```rust
fn check_shim<'a, const N: usize>(…) -> InterpResult<'tcx, &'a [OpTy<'tcx, Tag>; N]>
```

Instead of:

```rust
let &[ref ptr, ref flags] = this.check_shim(…)?;
```

we can write it just as:

```rust
let [ptr, flags] = this.check_shim(…)?;
```