### PR TITLE
Clean up all trailing whitespace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ rustc_version = "0.4"
 colored = "2"
 
 [package.metadata.rust-analyzer]
-# This crate uses #[feature(rustc_private)]. 
+# This crate uses #[feature(rustc_private)].
 # See https://github.com/rust-analyzer/rust-analyzer/pull/7891
 rustc_private = true
 

--- a/bench-cargo-miri/mse/src/main.rs
+++ b/bench-cargo-miri/mse/src/main.rs
@@ -4,7 +4,7 @@ static PCM: &[i16] = &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
 fn main() {
     #[cfg(increase_thread_usage)]
     let thread = std::thread::spawn(|| 4);
-    
+
     for _ in 0..2 {
         mse(PCM.len(), PCM, EXPECTED);
     }

--- a/rustup-toolchain
+++ b/rustup-toolchain
@@ -8,9 +8,9 @@ set -e
 # USAGE:
 #
 # ./rustup-toolchain: Update "miri" toolchain to match `rust-version` (the known-good version for this commit).
-# 
+#
 # ./rustup-toolchain HEAD: Update "miri" toolchain and `rust-version` file to latest rustc HEAD.
-# 
+#
 # ./rustup-toolchain $COMMIT: Update "miri" toolchain and `rust-version` file to match that commit.
 
 # Make sure rustup-toolchain-install-master is installed.

--- a/tests/compile-fail/data_race/dangling_thread_async_race.rs
+++ b/tests/compile-fail/data_race/dangling_thread_async_race.rs
@@ -36,7 +36,7 @@ fn main() {
 
     let join2 = unsafe {
         spawn(move || {
-            *c.0 = 64; //~ ERROR Data race detected between Write on Thread(id = 3) and Write on Thread(id = 1) 
+            *c.0 = 64; //~ ERROR Data race detected between Write on Thread(id = 3) and Write on Thread(id = 1)
         })
     };
 

--- a/tests/compile-fail/data_race/dealloc_read_race2.rs
+++ b/tests/compile-fail/data_race/dealloc_read_race2.rs
@@ -23,7 +23,7 @@ pub fn main() {
         });
 
         let j2 = spawn(move || {
-            // Also an error of the form: Data race detected between Read on Thread(id = 2) and Deallocate on Thread(id = 1) 
+            // Also an error of the form: Data race detected between Read on Thread(id = 2) and Deallocate on Thread(id = 1)
             // but the invalid allocation is detected first.
             *ptr.0 //~ ERROR dereferenced after this allocation got freed
         });

--- a/tests/compile-fail/data_race/read_write_race_stack.rs
+++ b/tests/compile-fail/data_race/read_write_race_stack.rs
@@ -40,7 +40,7 @@ pub fn main() {
             let mut stack_var = 0usize;
 
             pointer.store(&mut stack_var as *mut _, Ordering::Release);
-            
+
             sleep(Duration::from_millis(200));
 
             stack_var //~ ERROR Data race detected between Read on Thread(id = 1) and Write on Thread(id = 2)

--- a/tests/compile-fail/data_race/write_write_race_stack.rs
+++ b/tests/compile-fail/data_race/write_write_race_stack.rs
@@ -37,11 +37,11 @@ pub fn main() {
             let mut stack_var = 0usize;
 
             pointer.store(&mut stack_var as *mut _, Ordering::Release);
-            
+
             sleep(Duration::from_millis(200));
 
             stack_var = 1usize; //~ ERROR Data race detected between Write on Thread(id = 1) and Write on Thread(id = 2)
-            
+
             // read to silence errors
             stack_var
         });

--- a/tests/compile-fail/panic/double_panic.rs
+++ b/tests/compile-fail/panic/double_panic.rs
@@ -8,5 +8,5 @@ impl Drop for Foo {
 }
 fn main() {
     let _foo = Foo;
-    panic!("first"); 
+    panic!("first");
 }

--- a/tests/compile-fail/rc_as_ptr.rs
+++ b/tests/compile-fail/rc_as_ptr.rs
@@ -12,7 +12,7 @@ fn main() {
     assert!(ptr::eq(&*strong, Weak::as_ptr(&weak)));
     // The strong here keeps it alive, so we can still access the object.
     assert_eq!(42, **unsafe { &*Weak::as_ptr(&weak) });
-    
+
     drop(strong);
     // But not any more. We can do Weak::as_raw(&weak), but accessing the pointer would lead to
     // undefined behaviour.

--- a/tests/run-pass/backtrace-api-v1.rs
+++ b/tests/run-pass/backtrace-api-v1.rs
@@ -24,7 +24,7 @@ fn main() {
         unsafe {
             miri_resolve_frame_names(*frame, 0, name.as_mut_ptr(), filename.as_mut_ptr());
         }
-        
+
         let name = String::from_utf8(name).unwrap();
         let filename = String::from_utf8(filename).unwrap();
 

--- a/tests/run-pass/concurrency/data_race.rs
+++ b/tests/run-pass/concurrency/data_race.rs
@@ -16,12 +16,12 @@ fn test_fence_sync() {
     let mut var = 0u32;
     let ptr = &mut var as *mut u32;
     let evil_ptr = EvilSend(ptr);
-    
-    
+
+
     let j1 = spawn(move || {
         unsafe { *evil_ptr.0 = 1; }
         fence(Ordering::Release);
-        SYNC.store(1, Ordering::Relaxed)   
+        SYNC.store(1, Ordering::Relaxed)
     });
 
     let j2 = spawn(move || {

--- a/tests/run-pass/dyn-arbitrary-self.rs
+++ b/tests/run-pass/dyn-arbitrary-self.rs
@@ -24,14 +24,14 @@ fn stdlib_pointers() {
         sync::Arc,
         pin::Pin,
     };
-    
+
     trait Trait {
         fn by_rc(self: Rc<Self>) -> i64;
         fn by_arc(self: Arc<Self>) -> i64;
         fn by_pin_mut(self: Pin<&mut Self>) -> i64;
         fn by_pin_box(self: Pin<Box<Self>>) -> i64;
     }
-    
+
     impl Trait for i64 {
         fn by_rc(self: Rc<Self>) -> i64 {
             *self
@@ -46,7 +46,7 @@ fn stdlib_pointers() {
             *self
         }
     }
-    
+
     let rc = Rc::new(1i64) as Rc<dyn Trait>;
     assert_eq!(1, rc.by_rc());
 
@@ -66,34 +66,34 @@ fn pointers_and_wrappers() {
         ops::{Deref, CoerceUnsized, DispatchFromDyn},
         marker::Unsize,
     };
-    
+
     struct Ptr<T: ?Sized>(Box<T>);
-    
+
     impl<T: ?Sized> Deref for Ptr<T> {
         type Target = T;
-    
+
         fn deref(&self) -> &T {
             &*self.0
         }
     }
-    
+
     impl<T: Unsize<U> + ?Sized, U: ?Sized> CoerceUnsized<Ptr<U>> for Ptr<T> {}
     impl<T: Unsize<U> + ?Sized, U: ?Sized> DispatchFromDyn<Ptr<U>> for Ptr<T> {}
-    
+
     struct Wrapper<T: ?Sized>(T);
-    
+
     impl<T: ?Sized> Deref for Wrapper<T> {
         type Target = T;
-    
+
         fn deref(&self) -> &T {
             &self.0
         }
     }
-    
+
     impl<T: CoerceUnsized<U>, U> CoerceUnsized<Wrapper<U>> for Wrapper<T> {}
     impl<T: DispatchFromDyn<U>, U> DispatchFromDyn<Wrapper<U>> for Wrapper<T> {}
-    
-    
+
+
     trait Trait {
         // This method isn't object-safe yet. Unsized by-value `self` is object-safe (but not callable
         // without unsized_locals), but wrappers arond `Self` currently are not.
@@ -103,7 +103,7 @@ fn pointers_and_wrappers() {
         fn wrapper_ptr(self: Wrapper<Ptr<Self>>) -> i32;
         fn wrapper_ptr_wrapper(self: Wrapper<Ptr<Wrapper<Self>>>) -> i32;
     }
-    
+
     impl Trait for i32 {
         fn ptr_wrapper(self: Ptr<Wrapper<Self>>) -> i32 {
             **self
@@ -115,7 +115,7 @@ fn pointers_and_wrappers() {
             ***self
         }
     }
-    
+
     let pw = Ptr(Box::new(Wrapper(5))) as Ptr<Wrapper<dyn Trait>>;
     assert_eq!(pw.ptr_wrapper(), 5);
 

--- a/tests/run-pass/ptr_offset.rs
+++ b/tests/run-pass/ptr_offset.rs
@@ -18,7 +18,7 @@ fn test_offset_from() { unsafe {
     assert_eq!(x.offset_from(y), -12);
     assert_eq!((y as *const u32).offset_from(x as *const u32), 12/4);
     assert_eq!((x as *const u32).offset_from(y as *const u32), -12/4);
-    
+
     let x = (((x as usize) * 2) / 2) as *const u8;
     assert_eq!(y.offset_from(x), 12);
     assert_eq!(x.offset_from(y), -12);

--- a/tests/run-pass/stacked-borrows/stacked-borrows.rs
+++ b/tests/run-pass/stacked-borrows/stacked-borrows.rs
@@ -1,6 +1,6 @@
 // compile-flags: -Zmiri-tag-raw-pointers
 use std::ptr;
-    
+
 // Test various stacked-borrows-related things.
 fn main() {
     read_does_not_invalidate1();

--- a/tests/run-pass/threadleak_ignored.rs
+++ b/tests/run-pass/threadleak_ignored.rs
@@ -22,7 +22,7 @@ fn main() {
     // Set up a channel so that we can learn when the other thread initialized `X`
     // (so that we are sure there is something to drop).
     let (send, recv) = std::sync::mpsc::channel::<()>();
-    
+
     let _detached = std::thread::spawn(move || {
         X.with(|x| *x.borrow_mut() = Some(LoudDrop(1)));
         send.send(()).unwrap();


### PR DESCRIPTION
Editors commonly strip trailing whitespace from source code on save, because it's almost always undesired, and that leads to spurious diffs in these files when working with them in such an editor.