### PR TITLE
stop relying on python being in the PATH

### DIFF
--- a/miri
+++ b/miri
@@ -40,7 +40,7 @@ TARGET=$(rustc --version --verbose | grep "^host:" | cut -d ' ' -f 2)
 SYSROOT=$(rustc --print sysroot)
 LIBDIR=$SYSROOT/lib/rustlib/$TARGET/lib
 # macOS does not have a useful readlink/realpath so we have to use Python instead...
-MIRIDIR=$(dirname "$(python -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$0")")
+MIRIDIR=$(dirname "$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$0")")
 if ! test -d "$LIBDIR"; then
     echo "Something went wrong determining the library dir."
     echo "I got $LIBDIR but that does not exist."

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -28,7 +28,7 @@ use rustc_span::symbol::{sym, Symbol};
 use rustc_target::abi::Size;
 use rustc_target::spec::abi::Abi;
 
-use crate::{*, shims::posix::FileHandler};
+use crate::{shims::posix::FileHandler, *};
 
 // Some global facts about the emulated machine.
 pub const PAGE_SIZE: u64 = 4 * 1024; // FIXME: adjust to target architecture


### PR DESCRIPTION
Even Debian removed the package that provides `/usr/bin/python`; I guess it is time to move on.