### PR TITLE
Clarified issues when building miri with a custom rustc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,6 +206,13 @@ rustup toolchain link stage2 build/x86_64-unknown-linux-gnu/stage2
 rustup override set stage2
 ```
 
+Important: You need to delete the miri cache (located at `~/.cache/miri` on Linux; the exact location is printed after the library build: "A libstd for Miri is now available in ...") when
+you change the stdlib, otherwise the old, chached version will be used.
+
+Note: `./x.py --stage 2 compiler/rustc` currently errors with `thread 'main'
+panicked at 'fs::read(stamp) failed with No such file or directory (os error 2)`,
+you can simply ignore that error; Miri will build anyway.
+
 For more information about building and configuring a local compiler,
 see <https://rustc-dev-guide.rust-lang.org/building/how-to-build-and-run.html>.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,8 +206,9 @@ rustup toolchain link stage2 build/x86_64-unknown-linux-gnu/stage2
 rustup override set stage2
 ```
 
-Important: You need to delete the miri cache (located at `~/.cache/miri` on Linux; the exact location is printed after the library build: "A libstd for Miri is now available in ...") when
-you change the stdlib, otherwise the old, chached version will be used.
+Important: You need to delete the Miri cache when you change the stdlib; otherwise the
+old, chached version will be used. On Linux, the cache is located at `~/.cache/miri`; the exact
+location is printed after the library build: "A libstd for Miri is now available in ...".
 
 Note: `./x.py --stage 2 compiler/rustc` currently errors with `thread 'main'
 panicked at 'fs::read(stamp) failed with No such file or directory (os error 2)`,


### PR DESCRIPTION
I came across these issues (see zulip threads [here](https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/.E2.9C.94.20Changes.20not.20in.20effect) and [here](https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/Missing.20.2Elibrustc.2Estamp), issue [here](https://github.com/rust-lang/rust/issues/90244)) and would like to add this small bit to the docs. Feel free to change the wording.