### PR TITLE
Use atomic RMW for `{mutex, rwlock, cond, srwlock}_get_or_create_id` functions

### DIFF
--- a/src/data_race.rs
+++ b/src/data_race.rs
@@ -73,9 +73,9 @@ use rustc_middle::{mir, ty::layout::TyAndLayout};
 use rustc_target::abi::Size;
 
 use crate::{
-    AllocId, AllocRange, ImmTy, Immediate, InterpResult, MPlaceTy, MemPlaceMeta, MemoryKind,
-    MiriEvalContext, MiriEvalContextExt, MiriMemoryKind, OpTy, Pointer, RangeMap, Scalar,
-    ScalarMaybeUninit, Tag, ThreadId, VClock, VTimestamp, VectorIdx,
+    AllocId, AllocRange, HelpersEvalContextExt, ImmTy, Immediate, InterpResult, MPlaceTy,
+    MemoryKind, MiriEvalContext, MiriEvalContextExt, MiriMemoryKind, OpTy, Pointer, RangeMap,
+    Scalar, ScalarMaybeUninit, Tag, ThreadId, VClock, VTimestamp, VectorIdx,
 };
 
 pub type AllocExtra = VClockAlloc;
@@ -441,23 +441,6 @@ impl MemoryCellClocks {
 /// Evaluation context extensions.
 impl<'mir, 'tcx: 'mir> EvalContextExt<'mir, 'tcx> for MiriEvalContext<'mir, 'tcx> {}
 pub trait EvalContextExt<'mir, 'tcx: 'mir>: MiriEvalContextExt<'mir, 'tcx> {
-    /// Calculates the MPlaceTy given the offset and layout of an access on an operand
-    fn offset_and_layout_to_place(
-        &self,
-        op: &OpTy<'tcx, Tag>,
-        offset: u64,
-        layout: TyAndLayout<'tcx>,
-    ) -> InterpResult<'tcx, MPlaceTy<'tcx, Tag>> {
-        let this = self.eval_context_ref();
-        let op_place = this.deref_operand(op)?;
-        let offset = Size::from_bytes(offset);
-
-        // Ensure that the access is within bounds.
-        assert!(op_place.layout.size >= offset + layout.size);
-        let value_place = op_place.offset(offset, MemPlaceMeta::None, layout, this)?;
-        Ok(value_place)
-    }
-
     /// Atomic variant of read_scalar_at_offset.
     fn read_scalar_at_offset_atomic(
         &self,
@@ -467,7 +450,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: MiriEvalContextExt<'mir, 'tcx> {
         atomic: AtomicReadOp,
     ) -> InterpResult<'tcx, ScalarMaybeUninit<Tag>> {
         let this = self.eval_context_ref();
-        let value_place = this.offset_and_layout_to_place(op, offset, layout)?;
+        let value_place = this.deref_operand_and_offset(op, offset, layout)?;
         this.read_scalar_atomic(&value_place, atomic)
     }
 
@@ -481,7 +464,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: MiriEvalContextExt<'mir, 'tcx> {
         atomic: AtomicWriteOp,
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
-        let value_place = this.offset_and_layout_to_place(op, offset, layout)?;
+        let value_place = this.deref_operand_and_offset(op, offset, layout)?;
         this.write_scalar_atomic(value.into(), &value_place, atomic)
     }
 

--- a/src/shims/posix/sync.rs
+++ b/src/shims/posix/sync.rs
@@ -112,7 +112,7 @@ fn mutex_get_or_create_id<'mir, 'tcx: 'mir>(
     ecx: &mut MiriEvalContext<'mir, 'tcx>,
     mutex_op: &OpTy<'tcx, Tag>,
 ) -> InterpResult<'tcx, MutexId> {
-    let value_place = ecx.offset_and_layout_to_place(mutex_op, 4, ecx.machine.layouts.u32)?;
+    let value_place = ecx.deref_operand_and_offset(mutex_op, 4, ecx.machine.layouts.u32)?;
 
     ecx.mutex_get_or_create(|ecx, next_id| {
         let (old, success) = ecx
@@ -168,7 +168,7 @@ fn rwlock_get_or_create_id<'mir, 'tcx: 'mir>(
     ecx: &mut MiriEvalContext<'mir, 'tcx>,
     rwlock_op: &OpTy<'tcx, Tag>,
 ) -> InterpResult<'tcx, RwLockId> {
-    let value_place = ecx.offset_and_layout_to_place(rwlock_op, 4, ecx.machine.layouts.u32)?;
+    let value_place = ecx.deref_operand_and_offset(rwlock_op, 4, ecx.machine.layouts.u32)?;
 
     ecx.rwlock_get_or_create(|ecx, next_id| {
         let (old, success) = ecx
@@ -252,7 +252,7 @@ fn cond_get_or_create_id<'mir, 'tcx: 'mir>(
     ecx: &mut MiriEvalContext<'mir, 'tcx>,
     cond_op: &OpTy<'tcx, Tag>,
 ) -> InterpResult<'tcx, CondvarId> {
-    let value_place = ecx.offset_and_layout_to_place(cond_op, 4, ecx.machine.layouts.u32)?;
+    let value_place = ecx.deref_operand_and_offset(cond_op, 4, ecx.machine.layouts.u32)?;
 
     ecx.condvar_get_or_create(|ecx, next_id| {
         let (old, success) = ecx

--- a/src/shims/windows/sync.rs
+++ b/src/shims/windows/sync.rs
@@ -7,7 +7,7 @@ fn srwlock_get_or_create_id<'mir, 'tcx: 'mir>(
     ecx: &mut MiriEvalContext<'mir, 'tcx>,
     lock_op: &OpTy<'tcx, Tag>,
 ) -> InterpResult<'tcx, RwLockId> {
-    let value_place = ecx.offset_and_layout_to_place(lock_op, 0, ecx.machine.layouts.u32)?;
+    let value_place = ecx.deref_operand_and_offset(lock_op, 0, ecx.machine.layouts.u32)?;
 
     ecx.rwlock_get_or_create(|ecx, next_id| {
         let (old, success) = ecx

--- a/src/shims/windows/sync.rs
+++ b/src/shims/windows/sync.rs
@@ -7,15 +7,24 @@ fn srwlock_get_or_create_id<'mir, 'tcx: 'mir>(
     ecx: &mut MiriEvalContext<'mir, 'tcx>,
     lock_op: &OpTy<'tcx, Tag>,
 ) -> InterpResult<'tcx, RwLockId> {
-    let id = ecx.read_scalar_at_offset(lock_op, 0, ecx.machine.layouts.u32)?.to_u32()?;
-    if id == 0 {
-        // 0 is a default value and also not a valid rwlock id. Need to allocate
-        // a new rwlock.
+    let value_place = ecx.offset_and_layout_to_place(lock_op, 0, ecx.machine.layouts.u32)?;
+
+    let (old, success) = ecx
+        .atomic_compare_exchange_scalar(
+            &value_place,
+            &ImmTy::from_uint(0u32, ecx.machine.layouts.u32),
+            ecx.rwlock_next_id().to_u32_scalar().into(),
+            AtomicRwOp::AcqRel,
+            AtomicReadOp::Acquire,
+            false,
+        )?
+        .to_scalar_pair()?;
+
+    if success.to_bool().expect("compare_exchange's second return value is a bool") {
         let id = ecx.rwlock_create();
-        ecx.write_scalar_at_offset(lock_op, 0, id.to_u32_scalar(), ecx.machine.layouts.u32)?;
         Ok(id)
     } else {
-        Ok(RwLockId::from_u32(id))
+        Ok(RwLockId::from_u32(old.to_u32().expect("layout is u32")))
     }
 }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -223,10 +223,13 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         F: FnOnce(&mut MiriEvalContext<'mir, 'tcx>, MutexId) -> InterpResult<'tcx, Option<MutexId>>,
     {
         let this = self.eval_context_mut();
-        if let Some(old) = existing(this, this.machine.threads.sync.mutexes.next_index())? {
+        let next_index = this.machine.threads.sync.mutexes.next_index();
+        if let Some(old) = existing(this, next_index)? {
             Ok(old)
         } else {
-            Ok(self.mutex_create())
+            let new_index = this.machine.threads.sync.mutexes.push(Default::default());
+            assert_eq!(next_index, new_index);
+            Ok(new_index)
         }
     }
 
@@ -323,10 +326,13 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         ) -> InterpResult<'tcx, Option<RwLockId>>,
     {
         let this = self.eval_context_mut();
-        if let Some(old) = existing(this, this.machine.threads.sync.rwlocks.next_index())? {
+        let next_index = this.machine.threads.sync.rwlocks.next_index();
+        if let Some(old) = existing(this, next_index)? {
             Ok(old)
         } else {
-            Ok(self.rwlock_create())
+            let new_index = this.machine.threads.sync.rwlocks.push(Default::default());
+            assert_eq!(next_index, new_index);
+            Ok(new_index)
         }
     }
 
@@ -489,10 +495,13 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         ) -> InterpResult<'tcx, Option<CondvarId>>,
     {
         let this = self.eval_context_mut();
-        if let Some(old) = existing(this, this.machine.threads.sync.condvars.next_index())? {
+        let next_index = this.machine.threads.sync.condvars.next_index();
+        if let Some(old) = existing(this, next_index)? {
             Ok(old)
         } else {
-            Ok(self.condvar_create())
+            let new_index = this.machine.threads.sync.condvars.push(Default::default());
+            assert_eq!(next_index, new_index);
+            Ok(new_index)
         }
     }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -209,6 +209,13 @@ trait EvalContextExtPriv<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 impl<'mir, 'tcx: 'mir> EvalContextExt<'mir, 'tcx> for crate::MiriEvalContext<'mir, 'tcx> {}
 pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx> {
     #[inline]
+    /// Peek the id of the next mutex
+    fn mutex_next_id(&self) -> MutexId {
+        let this = self.eval_context_ref();
+        this.machine.threads.sync.mutexes.next_index()
+    }
+
+    #[inline]
     /// Create state for a new mutex.
     fn mutex_create(&mut self) -> MutexId {
         let this = self.eval_context_mut();
@@ -288,6 +295,13 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         assert!(this.mutex_is_locked(id), "queing on unlocked mutex");
         this.machine.threads.sync.mutexes[id].queue.push_back(thread);
         this.block_thread(thread);
+    }
+
+    #[inline]
+    /// Peek the id of the next read write lock
+    fn rwlock_next_id(&self) -> RwLockId {
+        let this = self.eval_context_ref();
+        this.machine.threads.sync.rwlocks.next_index()
     }
 
     #[inline]
@@ -436,6 +450,13 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         assert!(this.rwlock_is_locked(id), "write-queueing on unlocked rwlock");
         this.machine.threads.sync.rwlocks[id].writer_queue.push_back(writer);
         this.block_thread(writer);
+    }
+
+    #[inline]
+    /// Peek the id of the next Condvar
+    fn condvar_next_id(&self) -> CondvarId {
+        let this = self.eval_context_ref();
+        this.machine.threads.sync.condvars.next_index()
     }
 
     #[inline]


### PR DESCRIPTION
This is required for #1963 

`{mutex, rwlock, cond, srwlock}_get_or_create_id()` currently checks whether an ID field is 0 using an atomic read, allocate one and get a new ID if it is, then write it in a separate atomic write. This is fine without weak memory. For instance, in `pthread_mutex_lock` which may be called by two threads concurrently, only one thread can read 0, create and then write a new ID, the later-run thread will always see the newly created ID and never 0.
```rust
    fn pthread_mutex_lock(&mut self, mutex_op: &OpTy<'tcx, Tag>) -> InterpResult<'tcx, i32> {
        let this = self.eval_context_mut();

        let kind = mutex_get_kind(this, mutex_op)?.check_init()?;
        let id = mutex_get_or_create_id(this, mutex_op)?;
        let active_thread = this.get_active_thread();
```

However, with weak memory behaviour, both threads may read 0: the first thread has to see 0 because nothing else was written to it, and the second thread is not guaranteed to observe the latest value, causing a duplicate mutex to be created and both threads "successfully" acquiring the lock at the same time.

This is a pretty typical pattern requiring the use of atomic RMWs. RMW *always* reads the latest value in a location, so only one thread can create the new mutex and ID, all others scheduled later will see the new ID.