### PR TITLE
Pass the correct size to the AllocRange for log_creation

### DIFF
--- a/src/stacked_borrows.rs
+++ b/src/stacked_borrows.rs
@@ -731,7 +731,7 @@ trait EvalContextPrivExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             alloc_history.log_creation(
                 Some(orig_tag),
                 new_tag,
-                alloc_range(base_offset, base_offset + size),
+                alloc_range(base_offset, size),
                 &this.machine.threads,
             );
             if protect {


### PR DESCRIPTION
Fixes https://github.com/rust-lang/miri/issues/2127

I guess all I needed was a bit of sleep and reassurance that this diagnostic is the wrong part of that situation.