### PR TITLE
explain which targets we support to what extent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,8 @@ jobs:
             ~/.cargo/git/db
             # contains package information of crates installed via `cargo install`.
             ~/.cargo/.crates.toml
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+            ~/.cargo/.crates2.json
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-xargo0.3.25
           restore-keys: ${{ runner.os }}-cargo
 
       - name: Install rustup-toolchain-install-master and xargo

--- a/README.md
+++ b/README.md
@@ -194,6 +194,28 @@ for seed in $({ echo obase=16; seq 255; } | bc); do
 done
 ```
 
+### Supported targets
+
+Miri does not support all targets supported by Rust. The good news, however, is
+that no matter your host OS/platform, it is easy to run code for *any* target
+using `--target`!
+
+The following targets are tested on CI and thus should always work (to the
+degree documented below):
+
+- The best-supported target is `x86_64-unknown-linux-gnu`. Miri releases are
+  blocked on things working with this target. Most other Linux targets should
+  also work well; we do run the test suite on `i686-unknown-linux-gnu` as a
+  32bit target and `mips64-unknown-linux-gnuabi64` as a big-endian target.
+- `x86_64-apple-darwin` should work basically as well as Linux. We also test
+  `aarch64-apple-darwin`. However, we might ship Miri with a nightly even when
+  some features on these targets regress.
+- `x86_64-pc-windows-msvc` works, but supports fewer features than the Linux and
+  Apple targets. For example, file system access and concurrency are not
+  supported on Windows. We also test `i686-pc-windows-msvc`, with the same
+  reduced feature set. We might ship Miri with a nightly even when some features
+  on these targets regress.
+
 ### Common Problems
 
 When using the above instructions, you may encounter a number of confusing compiler

--- a/README.md
+++ b/README.md
@@ -236,7 +236,8 @@ up the sysroot.  If you are using `miri` (the Miri driver) directly, see the
 [miri-flags]: #miri--z-flags-and-environment-variables
 
 Miri adds its own set of `-Z` flags, which are usually set via the `MIRIFLAGS`
-environment variable:
+environment variable. Some of these are **unsound**, which means they can lead
+to Miri failing to detect cases of undefined behavior in a program.
 
 * `-Zmiri-check-number-validity` enables checking of integer and float validity
   (e.g., they must be initialized and not carry pointer provenance) as part of

--- a/ci.sh
+++ b/ci.sh
@@ -55,7 +55,6 @@ case $HOST_TARGET in
     ;;
   i686-pc-windows-msvc)
     MIRI_TEST_TARGET=x86_64-unknown-linux-gnu run_tests
-    MIRI_TEST_TARGET=x86_64-apple-darwin run_tests
     ;;
   *)
     echo "FATAL: unknown OS"


### PR DESCRIPTION
This is basically documenting my policy so far: Linux is the target I know best and can spend most time on. Apple is so close to Linux that it can basically ride along without much extra work. I don't have a lot of time to spend on our Windows support.

Of course, if people commit to contributing and maintaining support for a target, we can promise more than what is documented here. :)  But this is what I am willing to promise.

Also reduce the amount of work we do on the Windows test runner, since that one currently takes 10min longer than the other two.

r? @oli-obk 