### PR TITLE
Adjust diagnostics assertion so we don't ICE in setup

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -171,7 +171,7 @@ pub fn create_ecx<'mir, 'tcx: 'mir>(
 
     // Capture the current interpreter stack state (which should be empty) so that we can emit
     // allocation-tracking and tag-tracking diagnostics for allocations which are part of the
-    // runtime.
+    // early runtime setup.
     let info = ecx.preprocess_diagnostics();
 
     // Some parts of initialization require a full `InterpCx`.

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -168,6 +168,12 @@ pub fn create_ecx<'mir, 'tcx: 'mir>(
         param_env,
         Evaluator::new(config, layout_cx),
     );
+
+    // Capture the current interpreter stack state (which should be empty) so that we can emit
+    // allocation-tracking and tag-tracking diagnostics for allocations which are part of the
+    // runtime.
+    let info = ecx.preprocess_diagnostics();
+
     // Some parts of initialization require a full `InterpCx`.
     Evaluator::late_init(&mut ecx, config)?;
 
@@ -286,6 +292,10 @@ pub fn create_ecx<'mir, 'tcx: 'mir>(
             )?;
         }
     }
+
+    // Emit any diagnostics related to the setup process for the runtime, so that when the
+    // interpreter loop starts there are no unprocessed diagnostics.
+    ecx.process_diagnostics(info);
 
     Ok((ecx, ret_place))
 }

--- a/tests/run-pass/track-alloc-1.rs
+++ b/tests/run-pass/track-alloc-1.rs
@@ -1,0 +1,5 @@
+// Ensure that tracking early allocations doesn't ICE Miri.
+// Early allocations are probably part of the runtime and therefore uninteresting, but they
+// shouldn't cause a crash.
+// compile-flags: -Zmiri-track-alloc-id=1
+fn main() {}

--- a/tests/run-pass/track-alloc-1.stderr
+++ b/tests/run-pass/track-alloc-1.stderr
@@ -1,0 +1,5 @@
+note: tracking was triggered
+  |
+  = note: created allocation with id 1
+  = note: (no span available)
+


### PR DESCRIPTION
Fixes https://github.com/rust-lang/miri/issues/2076 just by handling diagnostics produced during setup. The tracking notes don't have any spans but it's better than an ICE.

It looks like we leak allocations 1..20, and allocations 13..19 don't have any creation notes, and 14 only has a `FreedAlloc` alloc tracking diagnostic.