### PR TITLE
with permissive-provenance set, we already treat ptr::invalid correctly

### DIFF
--- a/tests/compile-fail/provenance/ptr_invalid.rs
+++ b/tests/compile-fail/provenance/ptr_invalid.rs
@@ -1,0 +1,10 @@
+// compile-flags: -Zmiri-permissive-provenance
+#![feature(strict_provenance)]
+
+// Ensure that a `ptr::invalid` ptr is truly invalid.
+fn main() {
+    let x = 42;
+    let xptr = &x as *const i32;
+    let xptr_invalid = std::ptr::invalid::<i32>(xptr.expose_addr());
+    let _val = unsafe { *xptr_invalid }; //~ ERROR is not a valid pointer
+}


### PR DESCRIPTION
(same for strict provenance, but there it is not surprising)