### PR TITLE
tweak new test suite output

### DIFF
--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -109,13 +109,11 @@ regexes! {
 fn ui(mode: Mode, path: &str) {
     let target = get_target();
 
-    eprint!("{}", format!("## Running ui tests in {path} against miri for ").green().bold());
-
-    if let Some(target) = &target {
-        eprintln!("{target}");
-    } else {
-        eprintln!("host");
-    }
+    let msg = format!(
+        "## Running ui tests in {path} against miri for {}",
+        target.as_deref().unwrap_or("host")
+    );
+    eprintln!("{}", msg.green().bold());
 
     run_tests(mode, path, target);
 }


### PR DESCRIPTION
- Make the entire "## Running ui tests ..." green, including the target.
- Fix double-space in `testname.rs  .. ok`.
- Make the final summary a bit more like compiletest-rs, in particular the newlines around it
- Use the term "ignored" consistently, rather than "skipped"

r? @oli-obk 