### PR TITLE
Add support for _COARSE clocks

### DIFF
--- a/tests/run-pass/libc.rs
+++ b/tests/run-pass/libc.rs
@@ -230,6 +230,28 @@ fn test_thread_local_errno() {
     }
 }
 
+/// Tests whether clock support exists at all
+#[cfg(target_os = "linux")]
+fn test_clocks() {
+    let mut tp = std::mem::MaybeUninit::<libc::timespec>::uninit();
+    let is_error = unsafe {
+        libc::clock_gettime(libc::CLOCK_REALTIME, tp.as_mut_ptr())
+    };
+    assert_eq!(is_error, 0);
+    let is_error = unsafe {
+        libc::clock_gettime(libc::CLOCK_REALTIME_COARSE, tp.as_mut_ptr())
+    };
+    assert_eq!(is_error, 0);
+     let is_error = unsafe {
+        libc::clock_gettime(libc::CLOCK_MONOTONIC, tp.as_mut_ptr())
+    };
+    assert_eq!(is_error, 0);
+    let is_error = unsafe {
+        libc::clock_gettime(libc::CLOCK_MONOTONIC_COARSE, tp.as_mut_ptr())
+    };
+    assert_eq!(is_error, 0);
+}
+
 fn main() {
     #[cfg(target_os = "linux")]
     test_posix_fadvise();
@@ -249,4 +271,7 @@ fn main() {
     test_prctl_thread_name();
 
     test_thread_local_errno();
+
+    #[cfg(target_os = "linux")]
+    test_clocks();
 }


### PR DESCRIPTION
Original idea does not work, so I'm just going to try expanding support to include the `_COARSE` clocks.

The original motivation for this PR is that the test suite for the crate [`minstant`](https://crates.io/crates/minstant) reports UB, because it tries to use a clock type Miri didn't support, but never checked for an error code and so just used the uninit `libc::timespec`. So, that's technically a bug in `minstant`, but outside of Miri you'd have to be using an incredibly old Linux to ever see an `EINVAL` so the more helpful thing for Miri to do is behave like a newer Linux.

So now we don't detect UB in `minstant`, but we have a test failure:
```
failures:

---- src/instant.rs - instant::Instant::as_unix_nanos (line 150) stdout ----
Test executable failed (exit status: 101).

stderr:
thread 'main' panicked at 'assertion failed: (instant.as_unix_nanos(&anchor) as i64 - expected as i64).abs() < 1_000_000', src/instant.rs:11:1
```
I'm having trouble getting my head around the code in `minstant` that's involved in this test, but as far as I can tell from the man pages, these `_COARSE` clocks meet the requirements.

Closes https://github.com/rust-lang/miri/issues/1983 at least as best as I can.