### PR TITLE
ui_test tweaks

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -26,8 +26,7 @@ function run_tests {
     # optimizations up all the way).
     # Optimizations change diagnostics (mostly backtraces), so we don't check them
     #FIXME(#2155): we want to only run the pass and panic tests here, not the fail tests.
-    #MIRIFLAGS="-O -Zmir-opt-level=4" MIRI_SKIP_UI_CHECKS=1 ./miri test --locked
-    true
+    MIRIFLAGS="-O -Zmir-opt-level=4" MIRI_SKIP_UI_CHECKS=1 ./miri test --locked -- tests/{run-pass,run-fail}
   fi
 
   # On Windows, there is always "python", not "python3" or "python2".

--- a/miri
+++ b/miri
@@ -115,7 +115,7 @@ install|install-debug)
     ;;
 check|check-debug)
     # Check, and let caller control flags.
-    cargo check $CARGO_BUILD_FLAGS --manifest-path "$MIRIDIR"/Cargo.toml "$@"
+    cargo check $CARGO_BUILD_FLAGS --manifest-path "$MIRIDIR"/Cargo.toml --all-targets "$@"
     cargo check $CARGO_BUILD_FLAGS --manifest-path "$MIRIDIR"/cargo-miri/Cargo.toml "$@"
     ;;
 build|build-debug)

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -47,7 +47,8 @@ fn run_tests(mode: Mode, path: &str, target: Option<String>) {
         (true, true) => panic!("cannot use MIRI_BLESS and MIRI_SKIP_UI_CHECKS at the same time"),
     };
 
-    let path_filter = std::env::args().skip(1).next();
+    // Pass on all arguments as filters.
+    let path_filter = std::env::args().skip(1);
 
     let config = Config {
         args: flags,
@@ -56,7 +57,7 @@ fn run_tests(mode: Mode, path: &str, target: Option<String>) {
         stdout_filters: STDOUT.clone(),
         root_dir: PathBuf::from(path),
         mode,
-        path_filter,
+        path_filter: path_filter.collect(),
         program: miri_path(),
         output_conflict_handling,
     };

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -106,8 +106,6 @@ regexes! {
     r"\\"                           => "/",
     // erase platform file paths
     "sys/[a-z]+/"                    => "sys/PLATFORM/",
-    // erase error annotations in tests
-    r"\s*//~.*"                      => "",
 }
 
 fn ui(mode: Mode, path: &str) {

--- a/ui_test/src/lib.rs
+++ b/ui_test/src/lib.rs
@@ -89,7 +89,11 @@ pub fn run_tests(config: Config) {
                     // Ignore file if only/ignore rules do (not) apply
                     if ignore_file(&comments, &target) {
                         ignored.fetch_add(1, Ordering::Relaxed);
-                        eprintln!("{} ... {}", path.display(), "ignored (in-test comment)".yellow());
+                        eprintln!(
+                            "{} ... {}",
+                            path.display(),
+                            "ignored (in-test comment)".yellow()
+                        );
                         continue;
                     }
                     // Run the test for all revisions

--- a/ui_test/src/lib.rs
+++ b/ui_test/src/lib.rs
@@ -30,8 +30,8 @@ pub struct Config {
     pub mode: Mode,
     pub program: PathBuf,
     pub output_conflict_handling: OutputConflictHandling,
-    /// Only run tests with this string in their path/name
-    pub path_filter: Option<String>,
+    /// Only run tests with one of these strings in their path/name
+    pub path_filter: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -77,12 +77,13 @@ pub fn run_tests(config: Config) {
                     if !path.extension().map(|ext| ext == "rs").unwrap_or(false) {
                         continue;
                     }
-                    if let Some(path_filter) = &config.path_filter {
-                        if !path.display().to_string().contains(path_filter) {
+                    if !config.path_filter.is_empty() {
+                        let path_display = path.display().to_string();
+                        if !config.path_filter.iter().any(|filter| path_display.contains(filter)) {
                             ignored.fetch_add(1, Ordering::Relaxed);
                             eprintln!(
                                 "{} .. {}",
-                                path.display(),
+                                path_display,
                                 "ignored (command line filter)".yellow()
                             );
                             continue;

--- a/ui_test/src/lib.rs
+++ b/ui_test/src/lib.rs
@@ -98,7 +98,7 @@ pub fn run_tests(config: Config) {
                     {
                         let (m, errors) = run_test(&path, &config, &target, &revision, &comments);
 
-                        // Using `format` to prevent messages from threads from getting intermingled.
+                        // Using a single `eprintln!` to prevent messages from threads from getting intermingled.
                         let mut msg = format!("{} ", path.display());
                         if !revision.is_empty() {
                             write!(msg, "(revision `{revision}`) ").unwrap();

--- a/ui_test/src/lib.rs
+++ b/ui_test/src/lib.rs
@@ -89,7 +89,7 @@ pub fn run_tests(config: Config) {
                     // Ignore file if only/ignore rules do (not) apply
                     if ignore_file(&comments, &target) {
                         ignored.fetch_add(1, Ordering::Relaxed);
-                        eprintln!("{} ... {}", path.display(), "ignored".yellow());
+                        eprintln!("{} ... {}", path.display(), "ignored (in-test comment)".yellow());
                         continue;
                     }
                     // Run the test for all revisions

--- a/ui_test/src/tests.rs
+++ b/ui_test/src/tests.rs
@@ -10,7 +10,7 @@ fn config() -> Config {
         stdout_filters: vec![],
         root_dir: PathBuf::from("."),
         mode: Mode::Fail,
-        path_filter: None,
+        path_filter: vec![],
         program: PathBuf::from("cake"),
         output_conflict_handling: OutputConflictHandling::Error,
     }

--- a/ui_test/src/tests.rs
+++ b/ui_test/src/tests.rs
@@ -42,9 +42,9 @@ LL |     let _x: &i32 = unsafe { mem::transmute(16usize) }; //~ ERROR encountere
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 error: aborting due to previous error
     ";
-    check_annotations(unnormalized_stderr.as_bytes(), &mut errors, &config, "", &comments);
+    check_annotations(unnormalized_stderr, &mut errors, &config, "", &comments);
     match &errors[..] {
         [Error::PatternNotFound { .. }] => {}
-        _ => panic!("{:#?}", errors),
+        _ => panic!("not the expected error: {:#?}", errors),
     }
 }


### PR DESCRIPTION
- support multiple filters
- make `./miri check` also cover ui_test
- Run opt-level=4 tests again, but only the "run" tests

r? @oli-obk 