### PR TITLE
print list of failed tests in summary

### DIFF
--- a/ui_test/src/lib.rs
+++ b/ui_test/src/lib.rs
@@ -209,6 +209,11 @@ pub fn run_tests(config: Config) {
                 eprintln!();
             }
         }
+        eprintln!("{}", "failures:".red().underline());
+        for (path, _miri, _revision, _errors, _stderr) in &failures {
+            eprintln!("    {}", path.display());
+        }
+        eprintln!();
         eprintln!(
             "test result: {}. {} tests failed, {} tests passed, {} ignored, {} filtered out",
             "FAIL".red(),


### PR DESCRIPTION
compiletest does this and it is quite useful; see e.g. [here](https://github.com/rust-lang/rust/runs/6473917188?check_suite_focus=true). Example output:

![image](https://user-images.githubusercontent.com/330628/171382085-21674f46-9db4-49ef-9c52-2be06b307e28.png)
