### PR TITLE
Handle wildcard pointers in SB

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,9 +358,7 @@ to Miri failing to detect cases of undefined behavior in a program.
   for pointer-to-int and int-to-pointer casts, respectively. This will
   necessarily miss some bugs as those semantics are not efficiently
   implementable in a sanitizer, but it will only miss bugs that concerns
-  memory/pointers which is subject to these operations. Also note that this flag
-  is currently incompatible with Stacked Borrows, so you will have to also pass
-  `-Zmiri-disable-stacked-borrows` to use this.
+  memory/pointers which is subject to these operations.
 * `-Zmiri-symbolic-alignment-check` makes the alignment check more strict.  By
   default, alignment is checked by casting the pointer to an integer, and making
   sure that is a multiple of the alignment.  This can lead to cases where a

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -8,7 +8,7 @@ use rustc_middle::ty;
 use rustc_span::{source_map::DUMMY_SP, Span, SpanData, Symbol};
 
 use crate::helpers::HexRange;
-use crate::stacked_borrows::{diagnostics::TagHistory, AccessKind, SbTag};
+use crate::stacked_borrows::{diagnostics::TagHistory, AccessKind};
 use crate::*;
 
 /// Details of premature program termination.
@@ -61,9 +61,9 @@ impl MachineStopType for TerminationInfo {}
 /// Miri specific diagnostics
 pub enum NonHaltingDiagnostic {
     CreatedPointerTag(NonZeroU64),
-    /// This `Item` was popped from the borrow stack, either due to a grant of
-    /// `AccessKind` to `SbTag` or a deallocation when the second argument is `None`.
-    PoppedPointerTag(Item, Option<(SbTag, AccessKind)>),
+    /// This `Item` was popped from the borrow stack, either due to an access with the given tag or
+    /// a deallocation when the second argument is `None`.
+    PoppedPointerTag(Item, Option<(SbTagExtra, AccessKind)>),
     CreatedCallId(CallId),
     CreatedAlloc(AllocId),
     FreedAlloc(AllocId),

--- a/src/intptrcast.rs
+++ b/src/intptrcast.rs
@@ -101,14 +101,17 @@ impl<'mir, 'tcx> GlobalStateInner {
         }
     }
 
-    pub fn expose_addr(ecx: &MiriEvalContext<'mir, 'tcx>, alloc_id: AllocId) {
+    pub fn expose_ptr(ecx: &mut MiriEvalContext<'mir, 'tcx>, alloc_id: AllocId, sb: SbTag) {
         trace!("Exposing allocation id {:?}", alloc_id);
 
-        let mut global_state = ecx.machine.intptrcast.borrow_mut();
+        let global_state = ecx.machine.intptrcast.get_mut();
         // In legacy and strict mode, we don't need this, so we can save some cycles
         // by not tracking it.
         if global_state.provenance_mode == ProvenanceMode::Permissive {
             global_state.exposed.insert(alloc_id);
+            if ecx.machine.stacked_borrows.is_some() {
+                ecx.expose_tag(alloc_id, sb);
+            }
         }
     }
 

--- a/src/intptrcast.rs
+++ b/src/intptrcast.rs
@@ -142,9 +142,7 @@ impl<'mir, 'tcx> GlobalStateInner {
                 // Determine the allocation this points to at cast time.
                 let alloc_id = Self::alloc_id_from_addr(ecx, addr);
                 Pointer::new(
-                    alloc_id.map(|alloc_id| {
-                        Tag::Concrete(ConcreteTag { alloc_id, sb: SbTag::Untagged })
-                    }),
+                    alloc_id.map(|alloc_id| Tag::Concrete { alloc_id, sb: SbTag::Untagged }),
                     Size::from_bytes(addr),
                 )
             }
@@ -222,8 +220,8 @@ impl<'mir, 'tcx> GlobalStateInner {
     ) -> Option<(AllocId, Size)> {
         let (tag, addr) = ptr.into_parts(); // addr is absolute (Tag provenance)
 
-        let alloc_id = if let Tag::Concrete(concrete) = tag {
-            concrete.alloc_id
+        let alloc_id = if let Tag::Concrete { alloc_id, .. } = tag {
+            alloc_id
         } else {
             // A wildcard pointer.
             assert_eq!(ecx.machine.intptrcast.borrow().provenance_mode, ProvenanceMode::Permissive);

--- a/src/intptrcast.rs
+++ b/src/intptrcast.rs
@@ -102,12 +102,11 @@ impl<'mir, 'tcx> GlobalStateInner {
     }
 
     pub fn expose_ptr(ecx: &mut MiriEvalContext<'mir, 'tcx>, alloc_id: AllocId, sb: SbTag) {
-        trace!("Exposing allocation id {:?}", alloc_id);
-
         let global_state = ecx.machine.intptrcast.get_mut();
         // In legacy and strict mode, we don't need this, so we can save some cycles
         // by not tracking it.
         if global_state.provenance_mode == ProvenanceMode::Permissive {
+            trace!("Exposing allocation id {alloc_id:?}");
             global_state.exposed.insert(alloc_id);
             if ecx.machine.stacked_borrows.is_some() {
                 ecx.expose_tag(alloc_id, sb);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(let_else)]
 #![feature(io_error_more)]
 #![feature(yeet_expr)]
+#![feature(is_some_with)]
 #![warn(rust_2018_idioms)]
 #![allow(
     clippy::collapsible_else_if,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 #![feature(io_error_more)]
 #![feature(yeet_expr)]
 #![feature(is_some_with)]
+#![feature(nonzero_ops)]
 #![warn(rust_2018_idioms)]
 #![allow(
     clippy::collapsible_else_if,
@@ -81,15 +82,15 @@ pub use crate::eval::{
 pub use crate::helpers::{CurrentSpan, EvalContextExt as HelpersEvalContextExt};
 pub use crate::intptrcast::ProvenanceMode;
 pub use crate::machine::{
-    AllocExtra, ConcreteTag, Evaluator, FrameData, MiriEvalContext, MiriEvalContextExt,
-    MiriMemoryKind, Tag, NUM_CPUS, PAGE_SIZE, STACK_ADDR, STACK_SIZE,
+    AllocExtra, Evaluator, FrameData, MiriEvalContext, MiriEvalContextExt, MiriMemoryKind, Tag,
+    NUM_CPUS, PAGE_SIZE, STACK_ADDR, STACK_SIZE,
 };
 pub use crate::mono_hash_map::MonoHashMap;
 pub use crate::operator::EvalContextExt as OperatorEvalContextExt;
 pub use crate::range_map::RangeMap;
 pub use crate::stacked_borrows::{
-    CallId, EvalContextExt as StackedBorEvalContextExt, Item, Permission, PtrId, SbTag, Stack,
-    Stacks,
+    CallId, EvalContextExt as StackedBorEvalContextExt, Item, Permission, PtrId, SbTag, SbTagExtra,
+    Stack, Stacks,
 };
 pub use crate::sync::{CondvarId, EvalContextExt as SyncEvalContextExt, MutexId, RwLockId};
 pub use crate::thread::{

--- a/src/stacked_borrows.rs
+++ b/src/stacked_borrows.rs
@@ -543,16 +543,9 @@ impl<'tcx> Stack {
         // Now we figure out which item grants our parent (`derived_from`) this kind of access.
         // We use that to determine where to put the new item.
         let granting_idx =
-        self.find_granting(access, derived_from, exposed_tags).map_err(|_| {
-            alloc_history.grant_error(
-                derived_from,
-                new,
-                alloc_id,
-                alloc_range,
-                offset,
-                self,
-            )
-        })?;
+            self.find_granting(access, derived_from, exposed_tags).map_err(|_| {
+                alloc_history.grant_error(derived_from, new, alloc_id, alloc_range, offset, self)
+            })?;
 
         // Compute where to put the new item.
         // Either way, we ensure that we insert the new item in a way such that between
@@ -595,7 +588,9 @@ impl<'tcx> Stack {
             self.borrows.len()
         };
         // Put the new item there. As an optimization, deduplicate if it is equal to one of its new neighbors.
-        if self.borrows.get(new_idx) == Some(&new) || new_idx > 0 && self.borrows.get(new_idx - 1) == Some(&new) {
+        if self.borrows.get(new_idx) == Some(&new)
+            || new_idx > 0 && self.borrows.get(new_idx - 1) == Some(&new)
+        {
             // Optimization applies, done.
             trace!("reborrow: avoiding adding redundant item {:?}", new);
         } else {

--- a/src/stacked_borrows/diagnostics.rs
+++ b/src/stacked_borrows/diagnostics.rs
@@ -259,6 +259,6 @@ fn error_cause(stack: &Stack, tag: SbTagExtra) -> &'static str {
             ", but that tag does not exist in the borrow stack for this location"
         }
     } else {
-        ", but no exposed tags are valid in the borrow stack for this location"
+        ", but no exposed tags have suitable permission in the borrow stack for this location"
     }
 }

--- a/src/stacked_borrows/diagnostics.rs
+++ b/src/stacked_borrows/diagnostics.rs
@@ -4,6 +4,8 @@ use rustc_middle::mir::interpret::{AllocId, AllocRange};
 use rustc_span::{Span, SpanData};
 use rustc_target::abi::Size;
 
+use core::fmt::Debug;
+
 use crate::helpers::{CurrentSpan, HexRange};
 use crate::stacked_borrows::{err_sb_ub, AccessKind, Permission};
 use crate::Item;
@@ -204,9 +206,16 @@ impl AllocHistory {
         error_offset: Size,
         stack: &Stack,
     ) -> InterpError<'tcx> {
+        // TODO: Fix this properly
+        let z = &derived_from;
+        let f = if let Some(ref t) = z {
+            t as &dyn Debug
+        } else {
+            &"<wildcard>" as &dyn Debug
+        };
         let action = format!(
             "trying to reborrow {:?} for {:?} permission at {}[{:#x}]",
-            derived_from,
+            f,
             new.perm,
             alloc_id,
             error_offset.bytes(),
@@ -230,10 +239,16 @@ impl AllocHistory {
         error_offset: Size,
         stack: &Stack,
     ) -> InterpError<'tcx> {
+        let z = &tag;
+        let f = if let Some(ref t) = z {
+            t as &dyn Debug
+        } else {
+            &"<wildcard>" as &dyn Debug
+        };
         let action = format!(
             "attempting a {} using {:?} at {}[{:#x}]",
             access,
-            tag,
+            f,
             alloc_id,
             error_offset.bytes(),
         );

--- a/src/stacked_borrows/diagnostics.rs
+++ b/src/stacked_borrows/diagnostics.rs
@@ -208,11 +208,7 @@ impl AllocHistory {
     ) -> InterpError<'tcx> {
         // TODO: Fix this properly
         let z = &derived_from;
-        let f = if let Some(ref t) = z {
-            t as &dyn Debug
-        } else {
-            &"<wildcard>" as &dyn Debug
-        };
+        let f = if let Some(ref t) = z { t as &dyn Debug } else { &"<wildcard>" as &dyn Debug };
         let action = format!(
             "trying to reborrow {:?} for {:?} permission at {}[{:#x}]",
             f,
@@ -240,11 +236,7 @@ impl AllocHistory {
         stack: &Stack,
     ) -> InterpError<'tcx> {
         let z = &tag;
-        let f = if let Some(ref t) = z {
-            t as &dyn Debug
-        } else {
-            &"<wildcard>" as &dyn Debug
-        };
+        let f = if let Some(ref t) = z { t as &dyn Debug } else { &"<wildcard>" as &dyn Debug };
         let action = format!(
             "attempting a {} using {:?} at {}[{:#x}]",
             access,

--- a/tests/fail/provenance/permissive_provenance_transmute.rs
+++ b/tests/fail/provenance/permissive_provenance_transmute.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-permissive-provenance -Zmiri-disable-stacked-borrows
+// compile-flags: -Zmiri-permissive-provenance
 #![feature(strict_provenance)]
 
 use std::mem;

--- a/tests/fail/provenance/ptr_int_unexposed.rs
+++ b/tests/fail/provenance/ptr_int_unexposed.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-permissive-provenance -Zmiri-disable-stacked-borrows
+// compile-flags: -Zmiri-permissive-provenance
 #![feature(strict_provenance)]
 
 fn main() {

--- a/tests/fail/stacked_borrows/exposed_only_ro.rs
+++ b/tests/fail/stacked_borrows/exposed_only_ro.rs
@@ -8,5 +8,5 @@ fn main() {
     let _fool = &mut x as *mut i32; // this would have fooled the old untagged pointer logic
     let addr = (&x as *const i32).expose_addr();
     let ptr = std::ptr::from_exposed_addr_mut::<i32>(addr);
-    unsafe { ptr.write(0) }; //~ ERROR: borrow stack
+    unsafe { *ptr = 0 }; //~ ERROR: borrow stack
 }

--- a/tests/fail/stacked_borrows/exposed_only_ro.rs
+++ b/tests/fail/stacked_borrows/exposed_only_ro.rs
@@ -1,0 +1,12 @@
+// compile-flags: -Zmiri-permissive-provenance
+#![feature(strict_provenance)]
+
+// If we have only exposed read-only pointers, doing a write through a wildcard ptr should fail.
+
+fn main() {
+    let mut x = 0;
+    let _fool = &mut x as *mut i32; // this would have fooled the old untagged pointer logic
+    let addr = (&x as *const i32).expose_addr();
+    let ptr = std::ptr::from_exposed_addr_mut::<i32>(addr);
+    unsafe { ptr.write(0) }; //~ ERROR: borrow stack
+}

--- a/tests/fail/stacked_borrows/exposed_only_ro.stderr
+++ b/tests/fail/stacked_borrows/exposed_only_ro.stderr
@@ -1,0 +1,18 @@
+error: Undefined Behavior: attempting a write access using "<wildcard>" at ALLOC[0x0], but no exposed tags are valid in the borrow stack for this location
+  --> $DIR/exposed_only_ro.rs:LL:CC
+   |
+LL |     unsafe { *ptr = 0 };
+   |              ^^^^^^^^
+   |              |
+   |              attempting a write access using "<wildcard>" at ALLOC[0x0], but no exposed tags are valid in the borrow stack for this location
+   |              this error occurs as part of an access at ALLOC[0x0..0x4]
+   |
+   = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
+   = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
+           
+   = note: inside `main` at $DIR/exposed_only_ro.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to previous error
+

--- a/tests/fail/stacked_borrows/exposed_only_ro.stderr
+++ b/tests/fail/stacked_borrows/exposed_only_ro.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a write access using "<wildcard>" at ALLOC[0x0], but no exposed tags are valid in the borrow stack for this location
+error: Undefined Behavior: attempting a write access using <wildcard> at ALLOC[0x0], but no exposed tags are valid in the borrow stack for this location
   --> $DIR/exposed_only_ro.rs:LL:CC
    |
 LL |     unsafe { *ptr = 0 };
    |              ^^^^^^^^
    |              |
-   |              attempting a write access using "<wildcard>" at ALLOC[0x0], but no exposed tags are valid in the borrow stack for this location
+   |              attempting a write access using <wildcard> at ALLOC[0x0], but no exposed tags are valid in the borrow stack for this location
    |              this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/tests/fail/stacked_borrows/exposed_only_ro.stderr
+++ b/tests/fail/stacked_borrows/exposed_only_ro.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: attempting a write access using <wildcard> at ALLOC[0x0], but no exposed tags are valid in the borrow stack for this location
+error: Undefined Behavior: attempting a write access using <wildcard> at ALLOC[0x0], but no exposed tags have suitable permission in the borrow stack for this location
   --> $DIR/exposed_only_ro.rs:LL:CC
    |
 LL |     unsafe { *ptr = 0 };
    |              ^^^^^^^^
    |              |
-   |              attempting a write access using <wildcard> at ALLOC[0x0], but no exposed tags are valid in the borrow stack for this location
+   |              attempting a write access using <wildcard> at ALLOC[0x0], but no exposed tags have suitable permission in the borrow stack for this location
    |              this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental

--- a/tests/fail/stacked_borrows/illegal_read_despite_exposed1.rs
+++ b/tests/fail/stacked_borrows/illegal_read_despite_exposed1.rs
@@ -1,0 +1,17 @@
+// compile-flags: -Zmiri-permissive-provenance
+
+fn main() {
+    unsafe {
+        let root = &mut 42;
+        let addr = root as *mut i32 as usize;
+        let exposed_ptr = addr as *mut i32;
+        // From the exposed ptr, we get a new unique ptr.
+        let root2 = &mut *exposed_ptr;
+        let _fool = root2 as *mut _; // this would have fooled the old untagged pointer logic
+        // Stack: Unknown(<N), Unique(N), SRW(N+1)
+        // And we test that it has uniqueness by doing a conflicting write.
+        *exposed_ptr = 0;
+        // Stack: Unknown(<N)
+        let _val = *root2; //~ ERROR: borrow stack
+    }
+}

--- a/tests/fail/stacked_borrows/illegal_read_despite_exposed1.stderr
+++ b/tests/fail/stacked_borrows/illegal_read_despite_exposed1.stderr
@@ -1,0 +1,18 @@
+error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+  --> $DIR/illegal_read_despite_exposed1.rs:LL:CC
+   |
+LL |         let _val = *root2;
+   |                    ^^^^^^
+   |                    |
+   |                    attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                    this error occurs as part of an access at ALLOC[0x0..0x4]
+   |
+   = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
+   = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
+           
+   = note: inside `main` at $DIR/illegal_read_despite_exposed1.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to previous error
+

--- a/tests/fail/stacked_borrows/illegal_read_despite_exposed2.rs
+++ b/tests/fail/stacked_borrows/illegal_read_despite_exposed2.rs
@@ -1,0 +1,18 @@
+// compile-flags: -Zmiri-permissive-provenance
+
+fn main() {
+    unsafe {
+        let root = &mut 42;
+        let addr = root as *mut i32 as usize;
+        let exposed_ptr = addr as *mut i32;
+        // From the exposed ptr, we get a new unique ptr.
+        let root2 = &mut *exposed_ptr;
+        // let _fool = root2 as *mut _; // this would [fool] us, since SRW(N+1) remains on the stack
+        // Stack: Unknown(<N), Unique(N) [, SRW(N+1)]
+        // And we test that it has uniqueness by doing a conflicting read.
+        let _val = *exposed_ptr;
+        // Stack: Unknown(<N), Disabled(N) [, SRW(N+1)]
+        // collapsed to Unknown(<N) [Unknown(<N+2)]
+        let _val = *root2; //~ ERROR: borrow stack
+    }
+}

--- a/tests/fail/stacked_borrows/illegal_read_despite_exposed2.rs
+++ b/tests/fail/stacked_borrows/illegal_read_despite_exposed2.rs
@@ -7,12 +7,14 @@ fn main() {
         let exposed_ptr = addr as *mut i32;
         // From the exposed ptr, we get a new unique ptr.
         let root2 = &mut *exposed_ptr;
-        // let _fool = root2 as *mut _; // this would [fool] us, since SRW(N+1) remains on the stack
-        // Stack: Unknown(<N), Unique(N) [, SRW(N+1)]
+        // let _fool = root2 as *mut _; // this would fool us, since SRW(N+1) remains on the stack
+        // Stack: Unknown(<N), Unique(N)
+        // Stack if _fool existed: Unknown(<N), Unique(N), SRW(N+1)
         // And we test that it has uniqueness by doing a conflicting read.
         let _val = *exposed_ptr;
-        // Stack: Unknown(<N), Disabled(N) [, SRW(N+1)]
-        // collapsed to Unknown(<N) [Unknown(<N+2)]
+        // Stack: Unknown(<N), Disabled(N)
+        // collapsed to Unknown(<N)
+        // Stack if _fool existed: Unknown(<N), Disabled(N), SRW(N+1); collapsed to Unknown(<N+2) which would not cause an ERROR
         let _val = *root2; //~ ERROR: borrow stack
     }
 }

--- a/tests/fail/stacked_borrows/illegal_read_despite_exposed2.stderr
+++ b/tests/fail/stacked_borrows/illegal_read_despite_exposed2.stderr
@@ -1,0 +1,18 @@
+error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+  --> $DIR/illegal_read_despite_exposed2.rs:LL:CC
+   |
+LL |         let _val = *root2;
+   |                    ^^^^^^
+   |                    |
+   |                    attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                    this error occurs as part of an access at ALLOC[0x0..0x4]
+   |
+   = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
+   = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
+           
+   = note: inside `main` at $DIR/illegal_read_despite_exposed2.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to previous error
+

--- a/tests/fail/stacked_borrows/illegal_write_despite_exposed1.rs
+++ b/tests/fail/stacked_borrows/illegal_write_despite_exposed1.rs
@@ -1,0 +1,16 @@
+// compile-flags: -Zmiri-permissive-provenance
+
+fn main() {
+    unsafe {
+        let root = &mut 42;
+        let addr = root as *mut i32 as usize;
+        let exposed_ptr = addr as *mut i32;
+        // From the exposed ptr, we get a new SRO ptr.
+        let root2 = &*exposed_ptr;
+        // Stack: Unknown(<N), SRO(N), SRO(N+1)
+        // And we test that it is read-only by doing a conflicting write.
+        *exposed_ptr = 0;
+        // Stack: Unknown(<N)
+        let _val = *root2; //~ ERROR: borrow stack
+    }
+}

--- a/tests/fail/stacked_borrows/illegal_write_despite_exposed1.stderr
+++ b/tests/fail/stacked_borrows/illegal_write_despite_exposed1.stderr
@@ -1,0 +1,18 @@
+error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+  --> $DIR/illegal_write_despite_exposed1.rs:LL:CC
+   |
+LL |         let _val = *root2;
+   |                    ^^^^^^
+   |                    |
+   |                    attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                    this error occurs as part of an access at ALLOC[0x0..0x4]
+   |
+   = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
+   = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
+           
+   = note: inside `main` at $DIR/illegal_write_despite_exposed1.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to previous error
+

--- a/tests/pass/ptr_int_from_exposed.rs
+++ b/tests/pass/ptr_int_from_exposed.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-permissive-provenance -Zmiri-disable-stacked-borrows
+// compile-flags: -Zmiri-permissive-provenance
 #![feature(strict_provenance)]
 
 use std::ptr;

--- a/tests/pass/stacked-borrows/int-to-ptr.rs
+++ b/tests/pass/stacked-borrows/int-to-ptr.rs
@@ -1,6 +1,6 @@
-fn main() {
-    ref_raw_int_raw();
-}
+// compile-flags: -Zmiri-permissive-provenance
+#![feature(strict_provenance)]
+use std::ptr;
 
 // Just to make sure that casting a ref to raw, to int and back to raw
 // and only then using it works. This rules out ideas like "do escape-to-raw lazily";
@@ -10,4 +10,70 @@ fn ref_raw_int_raw() {
     let xref = &mut x;
     let xraw = xref as *mut i32 as usize as *mut i32;
     assert_eq!(unsafe { *xraw }, 3);
+}
+
+/// Ensure that we do not just pick the topmost possible item on int2ptr casts.
+fn example(variant: bool) { unsafe {
+    fn not_so_innocent(x: &mut u32) -> usize {
+        let x_raw4 = x as *mut u32;
+        x_raw4.expose_addr()
+    }
+
+    let mut c = 42u32;
+
+    let x_unique1 = &mut c;
+    // [..., Unique(1)]
+    
+    let x_raw2 = x_unique1 as *mut u32;
+    let x_raw2_addr = x_raw2.expose_addr();
+    // [..., Unique(1), SharedRW(2)]
+    
+    let x_unique3 = &mut *x_raw2;
+    // [.., Unique(1), SharedRW(2), Unique(3)]
+    
+    assert_eq!(not_so_innocent(x_unique3), x_raw2_addr);
+    // [.., Unique(1), SharedRW(2), Unique(3), ..., SharedRW(4)]
+    
+    // Do an int2ptr cast. This can pick tag 2 or 4 (the two previously exposed tags).
+    // 4 is the "obvious" choice (topmost tag, what we used to do with untagged pointers).
+    // And indeed if `variant == true` it is the only possible choice.
+    // But if `variant == false` then 2 is the only possible choice!
+    let x_wildcard = ptr::from_exposed_addr_mut::<i32>(x_raw2_addr);
+    
+    if variant {
+        // If we picked 2, this will invalidate 3.
+        *x_wildcard = 10;
+        // Now we use 3. Only possible if above we picked 4.
+        *x_unique3 = 12;
+    } else {
+        // This invalidates tag 4.
+        *x_unique3 = 10;
+        // Now try to write with the "guessed" tag; it must be 2.
+        *x_wildcard = 12;
+    }
+} }
+
+fn test() { unsafe {
+    let root = &mut 42;
+    let root_raw = root as *mut i32;
+    let addr1 = root_raw as usize;
+    let child = &mut *root_raw;
+    let child_raw = child as *mut i32;
+    let addr2 = child_raw as usize;
+    assert_eq!(addr1, addr2);
+    // First use child.
+    *(addr2 as *mut i32) -= 2; // picks child_raw
+    *child -= 2;
+    // Then use root.
+    *(addr1 as *mut i32) += 2; // picks root_raw
+    *root += 2;
+    // Value should be unchanged.
+    assert_eq!(*root, 42);
+} }
+
+fn main() {
+    ref_raw_int_raw();
+    example(false);
+    example(true);
+    test();
 }

--- a/tests/pass/stacked-borrows/int-to-ptr.rs
+++ b/tests/pass/stacked-borrows/int-to-ptr.rs
@@ -13,63 +13,67 @@ fn ref_raw_int_raw() {
 }
 
 /// Ensure that we do not just pick the topmost possible item on int2ptr casts.
-fn example(variant: bool) { unsafe {
-    fn not_so_innocent(x: &mut u32) -> usize {
-        let x_raw4 = x as *mut u32;
-        x_raw4.expose_addr()
+fn example(variant: bool) {
+    unsafe {
+        fn not_so_innocent(x: &mut u32) -> usize {
+            let x_raw4 = x as *mut u32;
+            x_raw4.expose_addr()
+        }
+
+        let mut c = 42u32;
+
+        let x_unique1 = &mut c;
+        // [..., Unique(1)]
+
+        let x_raw2 = x_unique1 as *mut u32;
+        let x_raw2_addr = x_raw2.expose_addr();
+        // [..., Unique(1), SharedRW(2)]
+
+        let x_unique3 = &mut *x_raw2;
+        // [.., Unique(1), SharedRW(2), Unique(3)]
+
+        assert_eq!(not_so_innocent(x_unique3), x_raw2_addr);
+        // [.., Unique(1), SharedRW(2), Unique(3), ..., SharedRW(4)]
+
+        // Do an int2ptr cast. This can pick tag 2 or 4 (the two previously exposed tags).
+        // 4 is the "obvious" choice (topmost tag, what we used to do with untagged pointers).
+        // And indeed if `variant == true` it is the only possible choice.
+        // But if `variant == false` then 2 is the only possible choice!
+        let x_wildcard = ptr::from_exposed_addr_mut::<i32>(x_raw2_addr);
+
+        if variant {
+            // If we picked 2, this will invalidate 3.
+            *x_wildcard = 10;
+            // Now we use 3. Only possible if above we picked 4.
+            *x_unique3 = 12;
+        } else {
+            // This invalidates tag 4.
+            *x_unique3 = 10;
+            // Now try to write with the "guessed" tag; it must be 2.
+            *x_wildcard = 12;
+        }
     }
+}
 
-    let mut c = 42u32;
-
-    let x_unique1 = &mut c;
-    // [..., Unique(1)]
-    
-    let x_raw2 = x_unique1 as *mut u32;
-    let x_raw2_addr = x_raw2.expose_addr();
-    // [..., Unique(1), SharedRW(2)]
-    
-    let x_unique3 = &mut *x_raw2;
-    // [.., Unique(1), SharedRW(2), Unique(3)]
-    
-    assert_eq!(not_so_innocent(x_unique3), x_raw2_addr);
-    // [.., Unique(1), SharedRW(2), Unique(3), ..., SharedRW(4)]
-    
-    // Do an int2ptr cast. This can pick tag 2 or 4 (the two previously exposed tags).
-    // 4 is the "obvious" choice (topmost tag, what we used to do with untagged pointers).
-    // And indeed if `variant == true` it is the only possible choice.
-    // But if `variant == false` then 2 is the only possible choice!
-    let x_wildcard = ptr::from_exposed_addr_mut::<i32>(x_raw2_addr);
-    
-    if variant {
-        // If we picked 2, this will invalidate 3.
-        *x_wildcard = 10;
-        // Now we use 3. Only possible if above we picked 4.
-        *x_unique3 = 12;
-    } else {
-        // This invalidates tag 4.
-        *x_unique3 = 10;
-        // Now try to write with the "guessed" tag; it must be 2.
-        *x_wildcard = 12;
+fn test() {
+    unsafe {
+        let root = &mut 42;
+        let root_raw = root as *mut i32;
+        let addr1 = root_raw as usize;
+        let child = &mut *root_raw;
+        let child_raw = child as *mut i32;
+        let addr2 = child_raw as usize;
+        assert_eq!(addr1, addr2);
+        // First use child.
+        *(addr2 as *mut i32) -= 2; // picks child_raw
+        *child -= 2;
+        // Then use root.
+        *(addr1 as *mut i32) += 2; // picks root_raw
+        *root += 2;
+        // Value should be unchanged.
+        assert_eq!(*root, 42);
     }
-} }
-
-fn test() { unsafe {
-    let root = &mut 42;
-    let root_raw = root as *mut i32;
-    let addr1 = root_raw as usize;
-    let child = &mut *root_raw;
-    let child_raw = child as *mut i32;
-    let addr2 = child_raw as usize;
-    assert_eq!(addr1, addr2);
-    // First use child.
-    *(addr2 as *mut i32) -= 2; // picks child_raw
-    *child -= 2;
-    // Then use root.
-    *(addr1 as *mut i32) += 2; // picks root_raw
-    *root += 2;
-    // Value should be unchanged.
-    assert_eq!(*root, 42);
-} }
+}
 
 fn main() {
     ref_raw_int_raw();


### PR DESCRIPTION
This uses an permissive `Unknown` implementation, where a wildcard pointer (and any SRW derived from a wildcard pointer) can access any previously-exposed SB tag. This is missing any meaningful test-cases, and all of the edge-cases have not yet been worked through.

I think there's also some bugs here with differing Unknowns in different ranges and having things behave really weirdly too, alongside some issues with retagging to `SRO` or `Unique`.