### PR TITLE
Make scheduler preemptive

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,14 +288,16 @@ environment variable. We first document the most relevant and most commonly used
   `-Zmiri-disable-isolation` is set.
 * `-Zmiri-ignore-leaks` disables the memory leak checker, and also allows some
   remaining threads to exist when the main thread exits.
-* `-Zmiri-seed=<hex>` configures the seed of the RNG that Miri uses to resolve
-  non-determinism. This RNG is used to pick base addresses for allocations. When
-  isolation is enabled (the default), this is also used to emulate system
-  entropy. The default seed is 0. You can increase test coverage by running Miri
-  multiple times with different seeds.
-  **NOTE**: This entropy is not good enough for cryptographic use! Do not
-  generate secret keys in Miri or perform other kinds of cryptographic
-  operations that rely on proper random numbers.
+* `-Zmiri-preemption-rate` configures the probability that at the end of a basic block, the active
+  thread will be preempted. The default is `0.01` (i.e., 1%). Setting this to `0` disables
+  preemption.
+* `-Zmiri-seed=<hex>` configures the seed of the RNG that Miri uses to resolve non-determinism. This
+  RNG is used to pick base addresses for allocations, to determine preemption and failure of
+  `compare_exchange_weak`, and to control store buffering for weak memory emulation. When isolation
+  is enabled (the default), this is also used to emulate system entropy. The default seed is 0. You
+  can increase test coverage by running Miri multiple times with different seeds. **NOTE**: This
+  entropy is not good enough for cryptographic use! Do not generate secret keys in Miri or perform
+  other kinds of cryptographic operations that rely on proper random numbers.
 * `-Zmiri-strict-provenance` enables [strict
   provenance](https://github.com/rust-lang/rust/issues/95228) checking in Miri. This means that
   casting an integer to a pointer yields a result with 'invalid' provenance, i.e., with provenance

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -449,6 +449,17 @@ fn main() {
                     ),
             };
             miri_config.cmpxchg_weak_failure_rate = rate;
+        } else if let Some(param) = arg.strip_prefix("-Zmiri-preemption-rate=") {
+            let rate = match param.parse::<f64>() {
+                Ok(rate) if rate >= 0.0 && rate <= 1.0 => rate,
+                Ok(_) => panic!("-Zmiri-preemption-rate must be between `0.0` and `1.0`"),
+                Err(err) =>
+                    panic!(
+                        "-Zmiri-preemption-rate requires a `f64` between `0.0` and `1.0`: {}",
+                        err
+                    ),
+            };
+            miri_config.preemption_rate = rate;
         } else if let Some(param) = arg.strip_prefix("-Zmiri-measureme=") {
             miri_config.measureme_out = Some(param.to_string());
         } else if let Some(param) = arg.strip_prefix("-Zmiri-backtrace=") {

--- a/src/concurrency/mod.rs
+++ b/src/concurrency/mod.rs
@@ -1,3 +1,3 @@
-mod allocation_map;
 pub mod data_race;
+mod range_object_map;
 pub mod weak_memory;

--- a/src/concurrency/range_object_map.rs
+++ b/src/concurrency/range_object_map.rs
@@ -1,7 +1,6 @@
-//! Implements a map from allocation ranges to data.
-//! This is somewhat similar to RangeMap, but the ranges
-//! and data are discrete and non-splittable. An allocation in the
-//! map will always have the same range until explicitly removed
+//! Implements a map from allocation ranges to data. This is somewhat similar to RangeMap, but the
+//! ranges and data are discrete and non-splittable -- they represent distinct "objects". An
+//! allocation in the map will always have the same range until explicitly removed
 
 use rustc_target::abi::Size;
 use std::ops::{Index, IndexMut, Range};
@@ -20,7 +19,7 @@ struct Elem<T> {
 type Position = usize;
 
 #[derive(Clone, Debug)]
-pub struct AllocationMap<T> {
+pub struct RangeObjectMap<T> {
     v: Vec<Elem<T>>,
 }
 
@@ -34,7 +33,7 @@ pub enum AccessType {
     ImperfectlyOverlapping(Range<Position>),
 }
 
-impl<T> AllocationMap<T> {
+impl<T> RangeObjectMap<T> {
     pub fn new() -> Self {
         Self { v: Vec::new() }
     }
@@ -135,7 +134,7 @@ impl<T> AllocationMap<T> {
     }
 }
 
-impl<T> Index<Position> for AllocationMap<T> {
+impl<T> Index<Position> for RangeObjectMap<T> {
     type Output = T;
 
     fn index(&self, pos: Position) -> &Self::Output {
@@ -143,7 +142,7 @@ impl<T> Index<Position> for AllocationMap<T> {
     }
 }
 
-impl<T> IndexMut<Position> for AllocationMap<T> {
+impl<T> IndexMut<Position> for RangeObjectMap<T> {
     fn index_mut(&mut self, pos: Position) -> &mut Self::Output {
         &mut self.v[pos].data
     }
@@ -159,7 +158,7 @@ mod tests {
     fn empty_map() {
         // FIXME: make Size::from_bytes const
         let four = Size::from_bytes(4);
-        let map = AllocationMap::<()>::new();
+        let map = RangeObjectMap::<()>::new();
 
         // Correctly tells where we should insert the first element (at position 0)
         assert_eq!(map.find_offset(Size::from_bytes(3)), Err(0));
@@ -173,7 +172,7 @@ mod tests {
     fn no_overlapping_inserts() {
         let four = Size::from_bytes(4);
 
-        let mut map = AllocationMap::<&str>::new();
+        let mut map = RangeObjectMap::<&str>::new();
 
         // |_|_|_|_|#|#|#|#|_|_|_|_|...
         //  0 1 2 3 4 5 6 7 8 9 a b c d
@@ -187,7 +186,7 @@ mod tests {
     fn boundaries() {
         let four = Size::from_bytes(4);
 
-        let mut map = AllocationMap::<&str>::new();
+        let mut map = RangeObjectMap::<&str>::new();
 
         // |#|#|#|#|_|_|...
         //  0 1 2 3 4 5
@@ -215,7 +214,7 @@ mod tests {
     fn perfectly_overlapping() {
         let four = Size::from_bytes(4);
 
-        let mut map = AllocationMap::<&str>::new();
+        let mut map = RangeObjectMap::<&str>::new();
 
         // |#|#|#|#|_|_|...
         //  0 1 2 3 4 5
@@ -241,7 +240,7 @@ mod tests {
     fn straddling() {
         let four = Size::from_bytes(4);
 
-        let mut map = AllocationMap::<&str>::new();
+        let mut map = RangeObjectMap::<&str>::new();
 
         // |_|_|_|_|#|#|#|#|_|_|_|_|...
         //  0 1 2 3 4 5 6 7 8 9 a b c d

--- a/src/concurrency/weak_memory.rs
+++ b/src/concurrency/weak_memory.rs
@@ -85,8 +85,8 @@ use rustc_data_structures::fx::FxHashMap;
 use crate::{AtomicReadOp, AtomicRwOp, AtomicWriteOp, Tag, VClock, VTimestamp, VectorIdx};
 
 use super::{
-    allocation_map::{AccessType, AllocationMap},
     data_race::{GlobalState, ThreadClockSet},
+    range_object_map::{AccessType, RangeObjectMap},
 };
 
 pub type AllocExtra = StoreBufferAlloc;
@@ -101,7 +101,7 @@ const STORE_BUFFER_LIMIT: usize = 128;
 pub struct StoreBufferAlloc {
     /// Store buffer of each atomic object in this allocation
     // Behind a RefCell because we need to allocate/remove on read access
-    store_buffers: RefCell<AllocationMap<StoreBuffer>>,
+    store_buffers: RefCell<RangeObjectMap<StoreBuffer>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -134,7 +134,7 @@ struct StoreElement {
 
 impl StoreBufferAlloc {
     pub fn new_allocation() -> Self {
-        Self { store_buffers: RefCell::new(AllocationMap::new()) }
+        Self { store_buffers: RefCell::new(RangeObjectMap::new()) }
     }
 
     /// Checks if the range imperfectly overlaps with existing buffers

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -122,6 +122,8 @@ pub struct MiriConfig {
     /// Whether to ignore any output by the program. This is helpful when debugging miri
     /// as its messages don't get intermingled with the program messages.
     pub mute_stdout_stderr: bool,
+    /// The probability of the active thread being preempted at the end of each basic block.
+    pub preemption_rate: f64,
 }
 
 impl Default for MiriConfig {
@@ -145,12 +147,13 @@ impl Default for MiriConfig {
             tag_raw: false,
             data_race_detector: true,
             weak_memory_emulation: true,
-            cmpxchg_weak_failure_rate: 0.8,
+            cmpxchg_weak_failure_rate: 0.8, // 80%
             measureme_out: None,
             panic_on_unsupported: false,
             backtrace_style: BacktraceStyle::Short,
             provenance_mode: ProvenanceMode::Legacy,
             mute_stdout_stderr: false,
+            preemption_rate: 0.01, // 1%
         }
     }
 }

--- a/src/shims/unix/thread.rs
+++ b/src/shims/unix/thread.rs
@@ -13,10 +13,6 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
     ) -> InterpResult<'tcx, i32> {
         let this = self.eval_context_mut();
 
-        this.tcx.sess.warn(
-            "thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.\n(see https://github.com/rust-lang/miri/issues/1388)",
-        );
-
         // Create the new thread
         let new_thread_id = this.create_thread();
 

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -718,6 +718,16 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
     }
 
     #[inline]
+    fn maybe_preempt_active_thread(&mut self) {
+        use rand::Rng as _;
+
+        let this = self.eval_context_mut();
+        if this.machine.rng.get_mut().gen_bool(this.machine.preemption_rate) {
+            this.yield_active_thread();
+        }
+    }
+
+    #[inline]
     fn register_timeout_callback(
         &mut self,
         thread: ThreadId,

--- a/tests/fail/concurrency/libc_pthread_create_main_terminate.stderr
+++ b/tests/fail/concurrency/libc_pthread_create_main_terminate.stderr
@@ -1,9 +1,6 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: the main thread terminated without waiting for all remaining threads
 
 note: pass `-Zmiri-ignore-leaks` to disable this check
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/concurrency/libc_pthread_join_detached.stderr
+++ b/tests/fail/concurrency/libc_pthread_join_detached.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: trying to join a detached or already joined thread
   --> $DIR/libc_pthread_join_detached.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL | ...   assert_eq!(libc::pthread_join(native, ptr::null_mut()), 0);
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/concurrency/libc_pthread_join_joined.stderr
+++ b/tests/fail/concurrency/libc_pthread_join_joined.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: trying to join a detached or already joined thread
   --> $DIR/libc_pthread_join_joined.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL | ...   assert_eq!(libc::pthread_join(native, ptr::null_mut()), 0);
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/concurrency/libc_pthread_join_main.stderr
+++ b/tests/fail/concurrency/libc_pthread_join_main.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: trying to join a detached or already joined thread
   --> $DIR/libc_pthread_join_main.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL | ...   assert_eq!(libc::pthread_join(thread_id, ptr::null_mut()), 0);
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/concurrency/libc_pthread_join_multiple.stderr
+++ b/tests/fail/concurrency/libc_pthread_join_multiple.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: trying to join a detached or already joined thread
   --> $DIR/libc_pthread_join_multiple.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL | ...   assert_eq!(libc::pthread_join(native_copy, ptr::null_mut()), 0);
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/concurrency/libc_pthread_join_self.rs
+++ b/tests/fail/concurrency/libc_pthread_join_self.rs
@@ -1,4 +1,6 @@
 // ignore-windows: No libc on Windows
+// We are making scheduler assumptions here.
+// compile-flags: -Zmiri-preemption-rate=0
 
 // Joining itself is undefined behavior.
 

--- a/tests/fail/concurrency/libc_pthread_join_self.stderr
+++ b/tests/fail/concurrency/libc_pthread_join_self.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: trying to join itself
   --> $DIR/libc_pthread_join_self.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL |             assert_eq!(libc::pthread_join(native, ptr::null_mut()), 0);
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/concurrency/thread_local_static_dealloc.stderr
+++ b/tests/fail/concurrency/thread_local_static_dealloc.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: pointer to ALLOC was dereferenced after this allocation got freed
   --> $DIR/thread_local_static_dealloc.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL |     let _val = *(dangling_ptr as *const u8);
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/concurrency/too_few_args.stderr
+++ b/tests/fail/concurrency/too_few_args.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: callee has fewer arguments than expected
   --> $DIR/too_few_args.rs:LL:CC
    |
@@ -13,5 +10,5 @@ LL |     panic!()
    = note: inside `thread_start` at RUSTLIB/std/src/panic.rs:LL:CC
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/concurrency/too_many_args.stderr
+++ b/tests/fail/concurrency/too_many_args.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: callee has more arguments than expected
   --> $DIR/too_many_args.rs:LL:CC
    |
@@ -13,5 +10,5 @@ LL |     panic!()
    = note: inside `thread_start` at RUSTLIB/std/src/panic.rs:LL:CC
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/concurrency/unwind_top_of_stack.stderr
+++ b/tests/fail/concurrency/unwind_top_of_stack.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 thread '<unnamed>' panicked at 'explicit panic', $DIR/unwind_top_of_stack.rs:LL:CC
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 error: Undefined Behavior: unwinding past the topmost frame of the stack
@@ -16,5 +13,5 @@ LL | | }
            
    = note: inside `thread_start` at $DIR/unwind_top_of_stack.rs:LL:CC
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/data_race/alloc_read_race.rs
+++ b/tests/fail/data_race/alloc_read_race.rs
@@ -1,5 +1,5 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-weak-memory-emulation
+// compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 #![feature(new_uninit)]
 
 use std::thread::spawn;

--- a/tests/fail/data_race/alloc_read_race.stderr
+++ b/tests/fail/data_race/alloc_read_race.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: Data race detected between Read on Thread(id = 2) and Allocate on Thread(id = 1) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
   --> $DIR/alloc_read_race.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL |             *pointer.load(Ordering::Relaxed)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/data_race/alloc_write_race.rs
+++ b/tests/fail/data_race/alloc_write_race.rs
@@ -1,5 +1,5 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-weak-memory-emulation
+// compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 #![feature(new_uninit)]
 
 use std::thread::spawn;

--- a/tests/fail/data_race/alloc_write_race.stderr
+++ b/tests/fail/data_race/alloc_write_race.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: Data race detected between Write on Thread(id = 2) and Allocate on Thread(id = 1) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
   --> $DIR/alloc_write_race.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL |             *pointer.load(Ordering::Relaxed) = 2;
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/data_race/atomic_read_na_write_race1.stderr
+++ b/tests/fail/data_race/atomic_read_na_write_race1.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: Data race detected between Atomic Load on Thread(id = 2) and Write on Thread(id = 1) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
   --> $DIR/atomic_read_na_write_race1.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL |             atomic_load(c.0 as *mut usize)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/data_race/atomic_read_na_write_race2.stderr
+++ b/tests/fail/data_race/atomic_read_na_write_race2.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: Data race detected between Write on Thread(id = 2) and Atomic Load on Thread(id = 1) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
   --> $DIR/atomic_read_na_write_race2.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL |             *atomic_ref.get_mut() = 32;
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/data_race/atomic_write_na_read_race1.stderr
+++ b/tests/fail/data_race/atomic_write_na_read_race1.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: Data race detected between Read on Thread(id = 2) and Atomic Store on Thread(id = 1) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
   --> $DIR/atomic_write_na_read_race1.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL |             *atomic_ref.get_mut()
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/data_race/atomic_write_na_read_race2.stderr
+++ b/tests/fail/data_race/atomic_write_na_read_race2.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: Data race detected between Atomic Store on Thread(id = 2) and Read on Thread(id = 1) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
   --> $DIR/atomic_write_na_read_race2.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL |             atomic_store(c.0 as *mut usize, 32);
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/data_race/atomic_write_na_write_race1.stderr
+++ b/tests/fail/data_race/atomic_write_na_write_race1.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: Data race detected between Atomic Store on Thread(id = 2) and Write on Thread(id = 1) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
   --> $DIR/atomic_write_na_write_race1.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL |             atomic_store(c.0 as *mut usize, 64);
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/data_race/atomic_write_na_write_race2.stderr
+++ b/tests/fail/data_race/atomic_write_na_write_race2.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: Data race detected between Write on Thread(id = 2) and Atomic Store on Thread(id = 1) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
   --> $DIR/atomic_write_na_write_race2.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL |             *atomic_ref.get_mut() = 32;
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/data_race/dangling_thread_async_race.stderr
+++ b/tests/fail/data_race/dangling_thread_async_race.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: Data race detected between Write on Thread(id = 3) and Write on Thread(id = 1) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
   --> $DIR/dangling_thread_async_race.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL |             *c.0 = 64;
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/data_race/dangling_thread_race.stderr
+++ b/tests/fail/data_race/dangling_thread_race.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: Data race detected between Write on Thread(id = 0, name = "main") and Write on Thread(id = 1) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
   --> $DIR/dangling_thread_race.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL |         *c.0 = 64;
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/data_race/dealloc_read_race1.stderr
+++ b/tests/fail/data_race/dealloc_read_race1.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: Data race detected between Deallocate on Thread(id = 2) and Read on Thread(id = 1) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
   --> $DIR/dealloc_read_race1.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL |             __rust_dealloc(ptr.0 as *mut _, std::mem::size_of::<usize>(), s
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/data_race/dealloc_read_race2.stderr
+++ b/tests/fail/data_race/dealloc_read_race2.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: pointer to ALLOC was dereferenced after this allocation got freed
   --> $DIR/dealloc_read_race2.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL |             *ptr.0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/data_race/dealloc_read_race_stack.rs
+++ b/tests/fail/data_race/dealloc_read_race_stack.rs
@@ -1,5 +1,5 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation
+// compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
 use std::thread::{spawn, sleep};
 use std::ptr::null_mut;

--- a/tests/fail/data_race/dealloc_read_race_stack.stderr
+++ b/tests/fail/data_race/dealloc_read_race_stack.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: Data race detected between Deallocate on Thread(id = 1) and Read on Thread(id = 2) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
   --> $DIR/dealloc_read_race_stack.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL |             }
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/data_race/dealloc_write_race1.stderr
+++ b/tests/fail/data_race/dealloc_write_race1.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: Data race detected between Deallocate on Thread(id = 2) and Write on Thread(id = 1) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
   --> $DIR/dealloc_write_race1.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL |             __rust_dealloc(ptr.0 as *mut _, std::mem::size_of::<usize>(), s
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/data_race/dealloc_write_race2.stderr
+++ b/tests/fail/data_race/dealloc_write_race2.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: pointer to ALLOC was dereferenced after this allocation got freed
   --> $DIR/dealloc_write_race2.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL |             *ptr.0 = 2;
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/data_race/dealloc_write_race_stack.rs
+++ b/tests/fail/data_race/dealloc_write_race_stack.rs
@@ -1,5 +1,5 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation
+// compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
 use std::thread::{spawn, sleep};
 use std::ptr::null_mut;

--- a/tests/fail/data_race/dealloc_write_race_stack.stderr
+++ b/tests/fail/data_race/dealloc_write_race_stack.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: Data race detected between Deallocate on Thread(id = 1) and Write on Thread(id = 2) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
   --> $DIR/dealloc_write_race_stack.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL |             }
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/data_race/enable_after_join_to_main.stderr
+++ b/tests/fail/data_race/enable_after_join_to_main.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: Data race detected between Write on Thread(id = 6) and Write on Thread(id = 5) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
   --> $DIR/enable_after_join_to_main.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL |             *c.0 = 64;
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/data_race/fence_after_load.stderr
+++ b/tests/fail/data_race/fence_after_load.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: Data race detected between Write on Thread(id = 0, name = "main") and Write on Thread(id = 1) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
   --> $DIR/fence_after_load.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL |     unsafe { V = 2 }
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/data_race/read_write_race.stderr
+++ b/tests/fail/data_race/read_write_race.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: Data race detected between Write on Thread(id = 2) and Read on Thread(id = 1) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
   --> $DIR/read_write_race.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL |             *c.0 = 64;
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/data_race/read_write_race_stack.rs
+++ b/tests/fail/data_race/read_write_race_stack.rs
@@ -1,5 +1,5 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-isolation -Zmir-opt-level=0 -Zmiri-disable-weak-memory-emulation
+// compile-flags: -Zmiri-disable-isolation -Zmir-opt-level=0 -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
 // Note: mir-opt-level set to 0 to prevent the read of stack_var in thread 1
 // from being optimized away and preventing the detection of the data-race.

--- a/tests/fail/data_race/read_write_race_stack.stderr
+++ b/tests/fail/data_race/read_write_race_stack.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: Data race detected between Read on Thread(id = 1) and Write on Thread(id = 2) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
   --> $DIR/read_write_race_stack.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL |             stack_var
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/data_race/relax_acquire_race.rs
+++ b/tests/fail/data_race/relax_acquire_race.rs
@@ -1,5 +1,5 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-weak-memory-emulation
+// compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
 use std::thread::spawn;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/tests/fail/data_race/relax_acquire_race.stderr
+++ b/tests/fail/data_race/relax_acquire_race.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: Data race detected between Read on Thread(id = 3) and Write on Thread(id = 1) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
   --> $DIR/relax_acquire_race.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL |                 *c.0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/data_race/release_seq_race.rs
+++ b/tests/fail/data_race/release_seq_race.rs
@@ -1,5 +1,5 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation
+// compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
 use std::thread::{spawn, sleep};
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/tests/fail/data_race/release_seq_race.stderr
+++ b/tests/fail/data_race/release_seq_race.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: Data race detected between Read on Thread(id = 3) and Write on Thread(id = 1) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
   --> $DIR/release_seq_race.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL |                 *c.0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/data_race/release_seq_race_same_thread.rs
+++ b/tests/fail/data_race/release_seq_race_same_thread.rs
@@ -1,5 +1,5 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation
+// compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
 use std::thread::spawn;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/tests/fail/data_race/release_seq_race_same_thread.stderr
+++ b/tests/fail/data_race/release_seq_race_same_thread.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: Data race detected between Read on Thread(id = 2) and Write on Thread(id = 1) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
   --> $DIR/release_seq_race_same_thread.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL |                 *c.0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/data_race/rmw_race.rs
+++ b/tests/fail/data_race/rmw_race.rs
@@ -1,5 +1,5 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-weak-memory-emulation
+// compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
 use std::thread::spawn;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/tests/fail/data_race/rmw_race.stderr
+++ b/tests/fail/data_race/rmw_race.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: Data race detected between Read on Thread(id = 3) and Write on Thread(id = 1) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
   --> $DIR/rmw_race.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL |                 *c.0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/data_race/write_write_race.stderr
+++ b/tests/fail/data_race/write_write_race.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: Data race detected between Write on Thread(id = 2) and Write on Thread(id = 1) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
   --> $DIR/write_write_race.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL |             *c.0 = 64;
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/data_race/write_write_race_stack.rs
+++ b/tests/fail/data_race/write_write_race_stack.rs
@@ -1,5 +1,5 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation
+// compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
 use std::thread::{spawn, sleep};
 use std::ptr::null_mut;

--- a/tests/fail/data_race/write_write_race_stack.stderr
+++ b/tests/fail/data_race/write_write_race_stack.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: Data race detected between Write on Thread(id = 1) and Write on Thread(id = 2) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
   --> $DIR/write_write_race_stack.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL |             stack_var = 1usize;
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/should-pass/cpp20_rwc_syncs.rs
+++ b/tests/fail/should-pass/cpp20_rwc_syncs.rs
@@ -1,6 +1,6 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
 // compile-flags: -Zmiri-ignore-leaks
-// error-pattern:
+// error-pattern: unreachable
 
 // https://plv.mpi-sws.org/scfix/paper.pdf
 // 2.2 Second Problem: SC Fences are Too Weak
@@ -76,7 +76,7 @@ fn test_cpp20_rwc_syncs() {
     // Our ui_test does not yet support overriding failure status codes.
     if (b, c) == (0, 0) {
         // This *should* be unreachable, but Miri will reach it.
-        std::process::exit(1);
+        unsafe { std::hint::unreachable_unchecked(); }
     }
 }
 

--- a/tests/fail/should-pass/cpp20_rwc_syncs.stderr
+++ b/tests/fail/should-pass/cpp20_rwc_syncs.stderr
@@ -1,3 +1,25 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
+error: Undefined Behavior: entering unreachable code
+  --> RUSTLIB/core/src/hint.rs:LL:CC
+   |
+LL |     unsafe { intrinsics::unreachable() }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^ entering unreachable code
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+           
+   = note: inside `std::hint::unreachable_unchecked` at RUSTLIB/core/src/hint.rs:LL:CC
+note: inside `test_cpp20_rwc_syncs` at $DIR/cpp20_rwc_syncs.rs:LL:CC
+  --> $DIR/cpp20_rwc_syncs.rs:LL:CC
+   |
+LL |         unsafe { std::hint::unreachable_unchecked(); }
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: inside `main` at $DIR/cpp20_rwc_syncs.rs:LL:CC
+  --> $DIR/cpp20_rwc_syncs.rs:LL:CC
+   |
+LL |         test_cpp20_rwc_syncs();
+   |         ^^^^^^^^^^^^^^^^^^^^^^
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to previous error
 

--- a/tests/fail/sync/libc_pthread_mutex_deadlock.stderr
+++ b/tests/fail/sync/libc_pthread_mutex_deadlock.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: deadlock: the evaluated program deadlocked
   --> $DIR/libc_pthread_mutex_deadlock.rs:LL:CC
    |
@@ -11,5 +8,5 @@ LL |             assert_eq!(libc::pthread_mutex_lock(lock_copy.0.get() as *mut _
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/sync/libc_pthread_mutex_wrong_owner.stderr
+++ b/tests/fail/sync/libc_pthread_mutex_wrong_owner.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: unlocked a default mutex that was not locked by the current thread
   --> $DIR/libc_pthread_mutex_wrong_owner.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL | ...t_eq!(libc::pthread_mutex_unlock(lock_copy.0.get() as *mut _), 0);
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/sync/libc_pthread_rwlock_read_wrong_owner.stderr
+++ b/tests/fail/sync/libc_pthread_rwlock_read_wrong_owner.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: unlocked an rwlock that was not locked by the active thread
   --> $DIR/libc_pthread_rwlock_read_wrong_owner.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL | ...   assert_eq!(libc::pthread_rwlock_unlock(lock_copy.0.get() as *mut _), 
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/sync/libc_pthread_rwlock_write_read_deadlock.stderr
+++ b/tests/fail/sync/libc_pthread_rwlock_write_read_deadlock.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: deadlock: the evaluated program deadlocked
   --> $DIR/libc_pthread_rwlock_write_read_deadlock.rs:LL:CC
    |
@@ -11,5 +8,5 @@ LL |             assert_eq!(libc::pthread_rwlock_wrlock(lock_copy.0.get() as *mu
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/sync/libc_pthread_rwlock_write_write_deadlock.stderr
+++ b/tests/fail/sync/libc_pthread_rwlock_write_write_deadlock.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: deadlock: the evaluated program deadlocked
   --> $DIR/libc_pthread_rwlock_write_write_deadlock.rs:LL:CC
    |
@@ -11,5 +8,5 @@ LL |             assert_eq!(libc::pthread_rwlock_wrlock(lock_copy.0.get() as *mu
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/sync/libc_pthread_rwlock_write_wrong_owner.stderr
+++ b/tests/fail/sync/libc_pthread_rwlock_write_wrong_owner.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: Undefined Behavior: unlocked an rwlock that was not locked by the active thread
   --> $DIR/libc_pthread_rwlock_write_wrong_owner.rs:LL:CC
    |
@@ -14,5 +11,5 @@ LL | ...   assert_eq!(libc::pthread_rwlock_unlock(lock_copy.0.get() as *mut _), 
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/weak_memory/racing_mixed_size.stderr
+++ b/tests/fail/weak_memory/racing_mixed_size.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: unsupported operation: racy imperfectly overlapping atomic access is not possible in the C++20 memory model, and not supported by Miri's weak memory emulation
   --> $DIR/racing_mixed_size.rs:LL:CC
    |
@@ -13,5 +10,5 @@ LL |             std::intrinsics::atomic_load_relaxed(hi);
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/fail/weak_memory/racing_mixed_size_read.stderr
+++ b/tests/fail/weak_memory/racing_mixed_size_read.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 error: unsupported operation: racy imperfectly overlapping atomic access is not possible in the C++20 memory model, and not supported by Miri's weak memory emulation
   --> $DIR/racing_mixed_size_read.rs:LL:CC
    |
@@ -13,5 +10,5 @@ LL |             std::intrinsics::atomic_load_relaxed(hi);
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
-error: aborting due to previous error; 1 warning emitted
+error: aborting due to previous error
 

--- a/tests/pass/concurrency/channels.stderr
+++ b/tests/pass/concurrency/channels.stderr
@@ -1,3 +1,0 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-

--- a/tests/pass/concurrency/concurrent_caller_location.stderr
+++ b/tests/pass/concurrency/concurrent_caller_location.stderr
@@ -1,3 +1,0 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-

--- a/tests/pass/concurrency/data_race.stderr
+++ b/tests/pass/concurrency/data_race.stderr
@@ -1,3 +1,0 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-

--- a/tests/pass/concurrency/disable_data_race_detector.stderr
+++ b/tests/pass/concurrency/disable_data_race_detector.stderr
@@ -1,3 +1,0 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-

--- a/tests/pass/concurrency/issue1643.stderr
+++ b/tests/pass/concurrency/issue1643.stderr
@@ -1,3 +1,0 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-

--- a/tests/pass/concurrency/linux-futex.stderr
+++ b/tests/pass/concurrency/linux-futex.stderr
@@ -1,3 +1,0 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-

--- a/tests/pass/concurrency/simple.stderr
+++ b/tests/pass/concurrency/simple.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 thread '<unnamed>' panicked at 'Hello!', $DIR/simple.rs:LL:CC
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 thread 'childthread' panicked at 'Hello, world!', $DIR/simple.rs:LL:CC

--- a/tests/pass/concurrency/spin_loop.rs
+++ b/tests/pass/concurrency/spin_loop.rs
@@ -1,0 +1,42 @@
+use std::thread;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static FLAG: AtomicUsize = AtomicUsize::new(0);
+
+fn spin() {
+    let j = thread::spawn(|| {
+        while FLAG.load(Ordering::Acquire) == 0 {
+            // We do *not* yield, and yet this should terminate eventually.
+        }
+    });
+    thread::yield_now(); // schedule the other thread
+    FLAG.store(1, Ordering::Release);
+    j.join().unwrap();
+}
+
+fn two_player_ping_pong() {
+    static FLAG: AtomicUsize = AtomicUsize::new(0);
+
+    let waiter1 = thread::spawn(|| {
+        while FLAG.load(Ordering::Acquire) == 0 {
+            // We do *not* yield, and yet this should terminate eventually.
+        }
+    });
+    let waiter2 = thread::spawn(|| {
+        while FLAG.load(Ordering::Acquire) == 0 {
+            // We do *not* yield, and yet this should terminate eventually.
+        }
+    });
+    let progress = thread::spawn(|| {
+        FLAG.store(1, Ordering::Release);
+    });
+    // The first `join` blocks the main thread and thus takes it out of the equation.
+    waiter1.join().unwrap();
+    waiter2.join().unwrap();
+    progress.join().unwrap();
+}
+
+fn main() {
+    spin();
+    two_player_ping_pong();
+}

--- a/tests/pass/concurrency/spin_loop.rs
+++ b/tests/pass/concurrency/spin_loop.rs
@@ -1,3 +1,4 @@
+// ignore-windows: Concurrency on Windows is not supported yet.
 use std::thread;
 use std::sync::atomic::{AtomicUsize, Ordering};
 

--- a/tests/pass/concurrency/spin_loop.stderr
+++ b/tests/pass/concurrency/spin_loop.stderr
@@ -1,0 +1,3 @@
+warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
+         (see https://github.com/rust-lang/miri/issues/1388)
+

--- a/tests/pass/concurrency/spin_loop.stderr
+++ b/tests/pass/concurrency/spin_loop.stderr
@@ -1,3 +1,0 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-

--- a/tests/pass/concurrency/spin_loops_nopreempt.rs
+++ b/tests/pass/concurrency/spin_loops_nopreempt.rs
@@ -1,4 +1,6 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
+// This specifically tests behavior *without* preemption.
+// compile-flags: -Zmiri-preemption-rate=0
 
 use std::thread;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};

--- a/tests/pass/concurrency/spin_loops_nopreempt.stderr
+++ b/tests/pass/concurrency/spin_loops_nopreempt.stderr
@@ -1,0 +1,3 @@
+warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
+         (see https://github.com/rust-lang/miri/issues/1388)
+

--- a/tests/pass/concurrency/spin_loops_nopreempt.stderr
+++ b/tests/pass/concurrency/spin_loops_nopreempt.stderr
@@ -1,3 +1,0 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-

--- a/tests/pass/concurrency/sync.rs
+++ b/tests/pass/concurrency/sync.rs
@@ -1,5 +1,6 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-isolation -Zmiri-strict-provenance
+// We are making scheduler assumptions here.
+// compile-flags: -Zmiri-disable-isolation -Zmiri-strict-provenance -Zmiri-preemption-rate=0
 
 use std::sync::{Arc, Barrier, Condvar, Mutex, Once, RwLock};
 use std::thread;

--- a/tests/pass/concurrency/sync.stderr
+++ b/tests/pass/concurrency/sync.stderr
@@ -1,3 +1,0 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-

--- a/tests/pass/concurrency/thread_locals.stderr
+++ b/tests/pass/concurrency/thread_locals.stderr
@@ -1,3 +1,0 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-

--- a/tests/pass/concurrency/tls_lib_drop.stderr
+++ b/tests/pass/concurrency/tls_lib_drop.stderr
@@ -1,3 +1,0 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-

--- a/tests/pass/libc.stderr
+++ b/tests/pass/libc.stderr
@@ -1,3 +1,0 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-

--- a/tests/pass/panic/concurrent-panic.rs
+++ b/tests/pass/panic/concurrent-panic.rs
@@ -1,4 +1,6 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
+// We are making scheduler assumptions here.
+// compile-flags: -Zmiri-preemption-rate=0
 
 //! Cause a panic in one thread while another thread is unwinding. This checks
 //! that separate threads have their own panicking state.

--- a/tests/pass/panic/concurrent-panic.stderr
+++ b/tests/pass/panic/concurrent-panic.stderr
@@ -1,6 +1,3 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 Thread 1 starting, will block on mutex
 Thread 1 reported it has started
 thread '<unnamed>' panicked at 'panic in thread 2', $DIR/concurrent-panic.rs:LL:CC

--- a/tests/pass/threadleak_ignored.stderr
+++ b/tests/pass/threadleak_ignored.stderr
@@ -1,4 +1,1 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-
 Dropping 0

--- a/tests/pass/weak_memory/consistency.stderr
+++ b/tests/pass/weak_memory/consistency.stderr
@@ -1,3 +1,0 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-

--- a/tests/pass/weak_memory/extra_cpp.stderr
+++ b/tests/pass/weak_memory/extra_cpp.stderr
@@ -1,3 +1,0 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-

--- a/tests/pass/weak_memory/extra_cpp_unsafe.stderr
+++ b/tests/pass/weak_memory/extra_cpp_unsafe.stderr
@@ -1,3 +1,0 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-

--- a/tests/pass/weak_memory/weak.rs
+++ b/tests/pass/weak_memory/weak.rs
@@ -1,5 +1,5 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-ignore-leaks
+// compile-flags: -Zmiri-ignore-leaks -Zmiri-preemption-rate=0
 
 // Tests showing weak memory behaviours are exhibited. All tests
 // return true when the desired behaviour is seen.

--- a/tests/pass/weak_memory/weak.stderr
+++ b/tests/pass/weak_memory/weak.stderr
@@ -1,3 +1,0 @@
-warning: thread support is experimental: the scheduler is not preemptive, and can get stuck in spin loops.
-         (see https://github.com/rust-lang/miri/issues/1388)
-


### PR DESCRIPTION
This is actually fairly easy. :D I just roll the dice on each terminator to decide whether we want to yield the active thread. I think with this we are also justified to no longer show "experimental" warnings when a thread is spawned. :)

Closes https://github.com/rust-lang/miri/issues/1388