### PR TITLE
Optimize `SbTag::eq`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
     clippy::single_match,
     clippy::useless_format,
     clippy::derive_partial_eq_without_eq,
+    clippy::derive_hash_xor_eq,
     clippy::too_many_arguments
 )]
 

--- a/src/stacked_borrows.rs
+++ b/src/stacked_borrows.rs
@@ -27,10 +27,25 @@ pub type CallId = NonZeroU64;
 pub type AllocExtra = Stacks;
 
 /// Tracking pointer provenance
-#[derive(Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Copy, Clone, Hash, Eq)]
 pub enum SbTag {
     Tagged(PtrId),
     Untagged,
+}
+
+impl SbTag {
+    fn as_u64(self) -> u64 {
+        match self {
+            SbTag::Tagged(id) => id.get(),
+            SbTag::Untagged => 0,
+        }
+    }
+}
+
+impl PartialEq for SbTag {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_u64() == other.as_u64()
+    }
 }
 
 impl fmt::Debug for SbTag {

--- a/src/stacked_borrows.rs
+++ b/src/stacked_borrows.rs
@@ -44,6 +44,9 @@ impl SbTag {
 
 impl PartialEq for SbTag {
     fn eq(&self, other: &Self) -> bool {
+        // The codegen for the derived Partialeq is bad here and includes a branch.
+        // Since this code is extremely hot, this is optimized here.
+        // https://github.com/rust-lang/rust/issues/49892
         self.as_u64() == other.as_u64()
     }
 }


### PR DESCRIPTION
The code before generated really bad code with a branch.
This nudges LLVM towards being smarter and simply comparing
the integers.

See https://github.com/rust-lang/miri/pull/2214#issuecomment-1150124617