### PR TITLE
Prevent futex_wait from actually waiting if a concurrent waker was executed before us

### DIFF
--- a/src/shims/unix/linux/sync.rs
+++ b/src/shims/unix/linux/sync.rs
@@ -132,10 +132,10 @@ pub fn futex<'tcx>(
             // otherwise we will deadlock.
             //
             // There are two scenarios to consider:
-            // 1. If we (FUTEX_WAIT) executes first, we'll push ourselves into
+            // 1. If we (FUTEX_WAIT) execute first, we'll push ourselves into
             //    the waiters queue and go to sleep. They (addr write & FUTEX_WAKE)
             //    will see us in the queue and wake us up.
-            // 2. If they (addr write & FUTEX_WAKE) executes first, we must observe
+            // 2. If they (addr write & FUTEX_WAKE) execute first, we must observe
             //    addr's new value. If we see an outdated value that happens to equal
             //    the expected val, then we'll put ourselves to sleep with no one to wake us
             //    up, so we end up with a deadlock. This is prevented by having a SeqCst
@@ -157,7 +157,9 @@ pub fn futex<'tcx>(
             //    right value. This is useless to us, since we need the read itself
             //    to see an up-to-date value.
             //
-            // It is also critical that the fence, the atomic load, and the comparison
+            // The above case distinction is valid since both FUTEX_WAIT and FUTEX_WAKE
+            // contain a SeqCst fence, therefore inducting a total order between the operations.
+            // It is also critical that the fence, the atomic load, and the comparison in FUTEX_WAIT
             // altogether happen atomically. If the other thread's fence in FUTEX_WAKE
             // gets interleaved after our fence, then we lose the guarantee on the
             // atomic load being up-to-date; if the other thread's write on addr and FUTEX_WAKE

--- a/tests/pass/concurrency/linux-futex.rs
+++ b/tests/pass/concurrency/linux-futex.rs
@@ -212,7 +212,7 @@ const FREE: i32 = 0;
 const HELD: i32 = 1;
 fn concurrent_wait_wake() {
     static FUTEX: AtomicI32 = AtomicI32::new(0);
-    for _ in 0..100 {
+    for _ in 0..20 {
         // Suppose the main thread is holding a lock implemented using futex...
         FUTEX.store(HELD, Ordering::Relaxed);
 

--- a/tests/pass/concurrency/linux-futex.rs
+++ b/tests/pass/concurrency/linux-futex.rs
@@ -6,6 +6,8 @@ extern crate libc;
 
 use std::mem::MaybeUninit;
 use std::ptr;
+use std::sync::atomic::AtomicI32;
+use std::sync::atomic::Ordering;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -206,6 +208,47 @@ fn wait_wake_bitset() {
     t.join().unwrap();
 }
 
+const FREE: i32 = 0;
+const HELD: i32 = 1;
+fn concurrent_wait_wake() {
+    static FUTEX: AtomicI32 = AtomicI32::new(0);
+    for _ in 0..100 {
+        // Suppose the main thread is holding a lock implemented using futex...
+        FUTEX.store(HELD, Ordering::Relaxed);
+
+        let t = thread::spawn(move || {
+            // If this syscall runs first, then we'll be woken up by
+            // the main thread's FUTEX_WAKE, and all is fine.
+            //
+            // If this sycall runs after the main thread's store
+            // and FUTEX_WAKE, the syscall must observe that
+            // the FUTEX is FREE != HELD and return without waiting
+            // or we'll deadlock.
+            unsafe {
+                libc::syscall(
+                    libc::SYS_futex,
+                    &FUTEX as *const AtomicI32,
+                    libc::FUTEX_WAIT,
+                    HELD,
+                    ptr::null::<libc::timespec>(),
+                );
+            }
+        });
+
+        FUTEX.store(FREE, Ordering::Relaxed);
+        unsafe {
+            libc::syscall(
+                libc::SYS_futex,
+                &FUTEX as *const AtomicI32,
+                libc::FUTEX_WAKE,
+                1,
+            );
+        }
+
+        t.join().unwrap();
+    }
+}
+
 fn main() {
     wake_nobody();
     wake_dangling();
@@ -214,4 +257,5 @@ fn main() {
     wait_absolute_timeout();
     wait_wake();
     wait_wake_bitset();
+    concurrent_wait_wake();
 }


### PR DESCRIPTION
Fixes #2223

Two SC fences were placed in `futex_wake` (after the caller has changed `addr`), and in `futex_wait` (before we read `addr`). This guarantees that `futex_wait` sees the value written to `addr` before the last `futex_wake` call, should one exists, and avoid going into sleep with no one else to wake us up.
https://github.com/rust-lang/miri/blob/ada7b72a879d79aaa06f0a2a95edd520615da1a2/src/concurrency/weak_memory.rs#L324-L326

Earlier I proposed to use `fetch_add(0)` to read the latest value in MO, though this isn't the proper way to do it and breaks aliasing: syscall caller may pass in a `*const` from a `&` and Miri complains about write to a `SharedReadOnly` location, causing this test to fail.
https://github.com/rust-lang/miri/blob/ada7b72a879d79aaa06f0a2a95edd520615da1a2/tests/pass/concurrency/linux-futex.rs#L56-L68

