### PR TITLE
Format tests and benches with rustfmt (1-50 of 300)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,8 +116,11 @@ jobs:
           rustup override set nightly
       - name: Formatting (miri, ui_test)
         run: cargo fmt --all --check
-      - name: Formatting (cargo-miri)
-        run: cargo fmt --manifest-path cargo-miri/Cargo.toml --all --check
+      - name: Formatting (everything else)
+        # TODO: Add `tests` (work in progress).
+        # Maybe change to `find . -name '*.rs'`, superseding the previous step.
+        run: find bench-cargo-miri benches cargo-miri test-cargo-miri -name '*.rs'
+          | xargs rustfmt --edition=2021 --config-path ./rustfmt.toml --check
 
   # These jobs doesn't actually test anything, but they're only used to tell
   # bors the build completed, as there is no practical way to detect when a

--- a/bench-cargo-miri/mse/src/main.rs
+++ b/bench-cargo-miri/mse/src/main.rs
@@ -30,4 +30,3 @@ fn mse(samples: usize, frame_buf: &[i16], buf_ref: &[u8]) -> f64 {
     }
     mse / max_samples as f64
 }
-

--- a/benches/helpers/repeat_manual.rs
+++ b/benches/helpers/repeat_manual.rs
@@ -1,7 +1,9 @@
 fn main() {
     let mut data: [u8; 1024] = unsafe { std::mem::uninitialized() };
     for i in 0..data.len() {
-        unsafe { std::ptr::write(&mut data[i], 0); }
+        unsafe {
+            std::ptr::write(&mut data[i], 0);
+        }
     }
     assert_eq!(data.len(), 1024);
 }

--- a/test-cargo-miri/cdylib/src/lib.rs
+++ b/test-cargo-miri/cdylib/src/lib.rs
@@ -2,5 +2,5 @@ use byteorder::{BigEndian, ByteOrder};
 
 #[no_mangle]
 extern "C" fn use_the_dependency() {
-    let _n = <BigEndian as ByteOrder>::read_u64(&[1,2,3,4,5,6,7,8]);
+    let _n = <BigEndian as ByteOrder>::read_u64(&[1, 2, 3, 4, 5, 6, 7, 8]);
 }

--- a/test-cargo-miri/issue-1567/src/lib.rs
+++ b/test-cargo-miri/issue-1567/src/lib.rs
@@ -1,5 +1,5 @@
 use byteorder::{BigEndian, ByteOrder};
 
 pub fn use_the_dependency() {
-    let _n = <BigEndian as ByteOrder>::read_u32(&[1,2,3,4]);
+    let _n = <BigEndian as ByteOrder>::read_u32(&[1, 2, 3, 4]);
 }

--- a/test-cargo-miri/issue-1705/src/lib.rs
+++ b/test-cargo-miri/issue-1705/src/lib.rs
@@ -1,5 +1,5 @@
-use byteorder::{LittleEndian, ByteOrder};
+use byteorder::{ByteOrder, LittleEndian};
 
 pub fn use_the_dependency() {
-    let _n = <LittleEndian as ByteOrder>::read_u32(&[1,2,3,4]);
+    let _n = <LittleEndian as ByteOrder>::read_u32(&[1, 2, 3, 4]);
 }

--- a/test-cargo-miri/issue-rust-86261/src/lib.rs
+++ b/test-cargo-miri/issue-rust-86261/src/lib.rs
@@ -3,7 +3,7 @@
 // Regression test for https://github.com/rust-lang/rust/issues/86261:
 // `#[no_mangle]` on a `use` item.
 #[no_mangle]
-use std::{thread,panic, io, boxed, any, string};
+use std::{any, boxed, io, panic, string, thread};
 
 // `#[no_mangle]` on a struct has a similar problem.
 #[no_mangle]

--- a/test-cargo-miri/src/main.rs
+++ b/test-cargo-miri/src/main.rs
@@ -8,7 +8,7 @@ fn main() {
     assert_eq!(env!("MIRITESTVAR"), "testval");
 
     // Exercise external crate, printing to stdout.
-    let buf = &[1,2,3,4];
+    let buf = &[1, 2, 3, 4];
     let n = <BigEndian as ByteOrder>::read_u32(buf);
     assert_eq!(n, 0x01020304);
     println!("{:#010x}", n);
@@ -32,7 +32,7 @@ fn main() {
         #[cfg(unix)]
         for line in io::stdin().lock().lines() {
             let num: i32 = line.unwrap().parse().unwrap();
-            println!("{}", 2*num);
+            println!("{}", 2 * num);
         }
         // On non-Unix, reading from stdin is not supported. So we hard-code the right answer.
         #[cfg(not(unix))]

--- a/test-cargo-miri/tests/test.rs
+++ b/test-cargo-miri/tests/test.rs
@@ -67,9 +67,5 @@ fn page_size() {
     let page_size = page_size::get();
 
     // In particular, this checks that it is not 0.
-    assert!(
-        page_size.is_power_of_two(),
-        "page size not a power of two: {}",
-        page_size
-    );
+    assert!(page_size.is_power_of_two(), "page size not a power of two: {}", page_size);
 }

--- a/tests/fail/abort-terminator.rs
+++ b/tests/fail/abort-terminator.rs
@@ -1,7 +1,9 @@
 // error-pattern: the program aborted
 #![feature(c_unwind)]
 
-extern "C" fn panic_abort() { panic!() }
+extern "C" fn panic_abort() {
+    panic!()
+}
 
 fn main() {
     panic_abort();

--- a/tests/fail/abort-terminator.stderr
+++ b/tests/fail/abort-terminator.stderr
@@ -3,8 +3,10 @@ note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 error: abnormal termination: the program aborted execution
   --> $DIR/abort-terminator.rs:LL:CC
    |
-LL | extern "C" fn panic_abort() { panic!() }
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the program aborted execution
+LL | / extern "C" fn panic_abort() {
+LL | |     panic!()
+LL | | }
+   | |_^ the program aborted execution
    |
    = note: inside `panic_abort` at $DIR/abort-terminator.rs:LL:CC
 note: inside `main` at $DIR/abort-terminator.rs:LL:CC

--- a/tests/fail/alloc/global_system_mixup.rs
+++ b/tests/fail/alloc/global_system_mixup.rs
@@ -8,10 +8,12 @@
 
 #![feature(allocator_api, slice_ptr_get)]
 
-use std::alloc::{Allocator, Global, System, Layout};
+use std::alloc::{Allocator, Global, Layout, System};
 
 fn main() {
     let l = Layout::from_size_align(1, 1).unwrap();
     let ptr = Global.allocate(l).unwrap().as_non_null_ptr();
-    unsafe { System.deallocate(ptr, l); }
+    unsafe {
+        System.deallocate(ptr, l);
+    }
 }

--- a/tests/fail/alloc/global_system_mixup.stderr
+++ b/tests/fail/alloc/global_system_mixup.stderr
@@ -12,7 +12,7 @@ LL |         FREE();
 note: inside `main` at $DIR/global_system_mixup.rs:LL:CC
   --> $DIR/global_system_mixup.rs:LL:CC
    |
-LL |     unsafe { System.deallocate(ptr, l); }
+LL |         System.deallocate(ptr, l);
    | ^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/concurrency/too_few_args.rs
+++ b/tests/fail/concurrency/too_few_args.rs
@@ -19,7 +19,8 @@ fn main() {
         let attr: libc::pthread_attr_t = mem::zeroed();
         // assert_eq!(libc::pthread_attr_init(&mut attr), 0); FIXME: this function is not yet implemented.
         let thread_start: extern "C" fn() -> *mut libc::c_void = thread_start;
-        let thread_start: extern "C" fn(*mut libc::c_void) -> *mut libc::c_void = mem::transmute(thread_start);
+        let thread_start: extern "C" fn(*mut libc::c_void) -> *mut libc::c_void =
+            mem::transmute(thread_start);
         assert_eq!(libc::pthread_create(&mut native, &attr, thread_start, ptr::null_mut()), 0);
         assert_eq!(libc::pthread_join(native, ptr::null_mut()), 0);
     }

--- a/tests/fail/concurrency/too_many_args.rs
+++ b/tests/fail/concurrency/too_many_args.rs
@@ -19,7 +19,8 @@ fn main() {
         let attr: libc::pthread_attr_t = mem::zeroed();
         // assert_eq!(libc::pthread_attr_init(&mut attr), 0); FIXME: this function is not yet implemented.
         let thread_start: extern "C" fn(*mut libc::c_void, i32) -> *mut libc::c_void = thread_start;
-        let thread_start: extern "C" fn(*mut libc::c_void) -> *mut libc::c_void = mem::transmute(thread_start);
+        let thread_start: extern "C" fn(*mut libc::c_void) -> *mut libc::c_void =
+            mem::transmute(thread_start);
         assert_eq!(libc::pthread_create(&mut native, &attr, thread_start, ptr::null_mut()), 0);
         assert_eq!(libc::pthread_join(native, ptr::null_mut()), 0);
     }

--- a/tests/fail/concurrency/unwind_top_of_stack.rs
+++ b/tests/fail/concurrency/unwind_top_of_stack.rs
@@ -20,8 +20,10 @@ fn main() {
         let attr: libc::pthread_attr_t = mem::zeroed();
         // assert_eq!(libc::pthread_attr_init(&mut attr), 0); FIXME: this function is not yet implemented.
         // Cast to avoid inserting abort-on-unwind.
-        let thread_start: extern "C-unwind" fn(*mut libc::c_void) -> *mut libc::c_void = thread_start;
-        let thread_start: extern "C" fn(*mut libc::c_void) -> *mut libc::c_void = mem::transmute(thread_start);
+        let thread_start: extern "C-unwind" fn(*mut libc::c_void) -> *mut libc::c_void =
+            thread_start;
+        let thread_start: extern "C" fn(*mut libc::c_void) -> *mut libc::c_void =
+            mem::transmute(thread_start);
         assert_eq!(libc::pthread_create(&mut native, &attr, thread_start, ptr::null_mut()), 0);
         assert_eq!(libc::pthread_join(native, ptr::null_mut()), 0);
     }

--- a/tests/fail/dangling_pointers/storage_dead_dangling.rs
+++ b/tests/fail/dangling_pointers/storage_dead_dangling.rs
@@ -4,7 +4,9 @@
 static mut LEAK: usize = 0;
 
 fn fill(v: &mut i32) {
-    unsafe { LEAK = v as *mut _ as usize; }
+    unsafe {
+        LEAK = v as *mut _ as usize;
+    }
 }
 
 fn evil() {

--- a/tests/fail/data_race/alloc_read_race.rs
+++ b/tests/fail/data_race/alloc_read_race.rs
@@ -2,10 +2,10 @@
 // compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 #![feature(new_uninit)]
 
-use std::thread::spawn;
-use std::ptr::null_mut;
-use std::sync::atomic::{Ordering, AtomicPtr};
 use std::mem::MaybeUninit;
+use std::ptr::null_mut;
+use std::sync::atomic::{AtomicPtr, Ordering};
+use std::thread::spawn;
 
 #[derive(Copy, Clone)]
 struct EvilSend<T>(pub T);

--- a/tests/fail/data_race/alloc_write_race.rs
+++ b/tests/fail/data_race/alloc_write_race.rs
@@ -2,9 +2,9 @@
 // compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 #![feature(new_uninit)]
 
-use std::thread::spawn;
 use std::ptr::null_mut;
-use std::sync::atomic::{Ordering, AtomicPtr};
+use std::sync::atomic::{AtomicPtr, Ordering};
+use std::thread::spawn;
 
 #[derive(Copy, Clone)]
 struct EvilSend<T>(pub T);
@@ -30,7 +30,8 @@ pub fn main() {
             // Uses relaxed semantics to not generate
             // a release sequence.
             let pointer = &*ptr.0;
-            pointer.store(Box::into_raw(Box::<usize>::new_uninit()) as *mut usize, Ordering::Relaxed);
+            pointer
+                .store(Box::into_raw(Box::<usize>::new_uninit()) as *mut usize, Ordering::Relaxed);
         });
 
         let j2 = spawn(move || {

--- a/tests/fail/data_race/atomic_read_na_write_race1.rs
+++ b/tests/fail/data_race/atomic_read_na_write_race1.rs
@@ -1,9 +1,9 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
 #![feature(core_intrinsics)]
 
-use std::thread::spawn;
-use std::sync::atomic::AtomicUsize;
 use std::intrinsics::atomic_load;
+use std::sync::atomic::AtomicUsize;
+use std::thread::spawn;
 
 #[derive(Copy, Clone)]
 struct EvilSend<T>(pub T);

--- a/tests/fail/data_race/atomic_read_na_write_race2.rs
+++ b/tests/fail/data_race/atomic_read_na_write_race2.rs
@@ -1,8 +1,8 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
 
-use std::thread::spawn;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
+use std::thread::spawn;
 
 #[derive(Copy, Clone)]
 struct EvilSend<T>(pub T);

--- a/tests/fail/data_race/atomic_write_na_read_race1.rs
+++ b/tests/fail/data_race/atomic_write_na_read_race1.rs
@@ -1,8 +1,8 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
 
-use std::thread::spawn;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
+use std::thread::spawn;
 
 #[derive(Copy, Clone)]
 struct EvilSend<T>(pub T);

--- a/tests/fail/data_race/atomic_write_na_read_race2.rs
+++ b/tests/fail/data_race/atomic_write_na_read_race2.rs
@@ -1,9 +1,9 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
 #![feature(core_intrinsics)]
 
-use std::thread::spawn;
-use std::sync::atomic::AtomicUsize;
 use std::intrinsics::atomic_store;
+use std::sync::atomic::AtomicUsize;
+use std::thread::spawn;
 
 #[derive(Copy, Clone)]
 struct EvilSend<T>(pub T);
@@ -16,9 +16,7 @@ pub fn main() {
     let b = &mut a as *mut AtomicUsize;
     let c = EvilSend(b);
     unsafe {
-        let j1 = spawn(move || {
-            *(c.0 as *mut usize)
-        });
+        let j1 = spawn(move || *(c.0 as *mut usize));
 
         let j2 = spawn(move || {
             //Equivalent to: (&*c.0).store(32, Ordering::SeqCst)

--- a/tests/fail/data_race/atomic_write_na_read_race2.rs
+++ b/tests/fail/data_race/atomic_write_na_read_race2.rs
@@ -16,7 +16,9 @@ pub fn main() {
     let b = &mut a as *mut AtomicUsize;
     let c = EvilSend(b);
     unsafe {
-        let j1 = spawn(move || *(c.0 as *mut usize));
+        let j1 = spawn(move || {
+            let _val = *(c.0 as *mut usize);
+        });
 
         let j2 = spawn(move || {
             //Equivalent to: (&*c.0).store(32, Ordering::SeqCst)

--- a/tests/fail/data_race/atomic_write_na_write_race1.rs
+++ b/tests/fail/data_race/atomic_write_na_write_race1.rs
@@ -1,9 +1,9 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
 #![feature(core_intrinsics)]
 
-use std::thread::spawn;
-use std::sync::atomic::AtomicUsize;
 use std::intrinsics::atomic_store;
+use std::sync::atomic::AtomicUsize;
+use std::thread::spawn;
 
 #[derive(Copy, Clone)]
 struct EvilSend<T>(pub T);

--- a/tests/fail/data_race/atomic_write_na_write_race2.rs
+++ b/tests/fail/data_race/atomic_write_na_write_race2.rs
@@ -1,8 +1,8 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
 
-use std::thread::spawn;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
+use std::thread::spawn;
 
 #[derive(Copy, Clone)]
 struct EvilSend<T>(pub T);

--- a/tests/fail/data_race/dangling_thread_async_race.rs
+++ b/tests/fail/data_race/dangling_thread_async_race.rs
@@ -1,17 +1,15 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
 // compile-flags: -Zmiri-disable-isolation
 
-use std::thread::{spawn, sleep};
-use std::time::Duration;
 use std::mem;
-
+use std::thread::{sleep, spawn};
+use std::time::Duration;
 
 #[derive(Copy, Clone)]
 struct EvilSend<T>(pub T);
 
 unsafe impl<T> Send for EvilSend<T> {}
 unsafe impl<T> Sync for EvilSend<T> {}
-
 
 fn main() {
     let mut a = 0u32;

--- a/tests/fail/data_race/dangling_thread_race.rs
+++ b/tests/fail/data_race/dangling_thread_race.rs
@@ -1,17 +1,15 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
 // compile-flags: -Zmiri-disable-isolation
 
-use std::thread::{spawn, sleep};
-use std::time::Duration;
 use std::mem;
-
+use std::thread::{sleep, spawn};
+use std::time::Duration;
 
 #[derive(Copy, Clone)]
 struct EvilSend<T>(pub T);
 
 unsafe impl<T> Send for EvilSend<T> {}
 unsafe impl<T> Sync for EvilSend<T> {}
-
 
 fn main() {
     let mut a = 0u32;
@@ -33,7 +31,6 @@ fn main() {
     // and ensure that data-race detection
     // remains enabled nevertheless.
     spawn(|| ()).join().unwrap();
-
 
     unsafe {
         *c.0 = 64; //~ ERROR Data race detected between Write on Thread(id = 0, name = "main") and Write on Thread(id = 1)

--- a/tests/fail/data_race/dealloc_read_race2.rs
+++ b/tests/fail/data_race/dealloc_read_race2.rs
@@ -19,7 +19,11 @@ pub fn main() {
 
     unsafe {
         let j1 = spawn(move || {
-            __rust_dealloc(ptr.0 as *mut _, std::mem::size_of::<usize>(), std::mem::align_of::<usize>())
+            __rust_dealloc(
+                ptr.0 as *mut _,
+                std::mem::size_of::<usize>(),
+                std::mem::align_of::<usize>(),
+            )
         });
 
         let j2 = spawn(move || {

--- a/tests/fail/data_race/dealloc_read_race_stack.rs
+++ b/tests/fail/data_race/dealloc_read_race_stack.rs
@@ -1,9 +1,9 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
 // compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
-use std::thread::{spawn, sleep};
 use std::ptr::null_mut;
-use std::sync::atomic::{Ordering, AtomicPtr};
+use std::sync::atomic::{AtomicPtr, Ordering};
+use std::thread::{sleep, spawn};
 use std::time::Duration;
 
 #[derive(Copy, Clone)]
@@ -36,7 +36,6 @@ pub fn main() {
                 sleep(Duration::from_millis(200));
 
                 // Now `stack_var` gets deallocated.
-
             } //~ ERROR Data race detected between Deallocate on Thread(id = 1) and Read on Thread(id = 2)
         });
 

--- a/tests/fail/data_race/dealloc_write_race2.rs
+++ b/tests/fail/data_race/dealloc_write_race2.rs
@@ -18,7 +18,11 @@ pub fn main() {
 
     unsafe {
         let j1 = spawn(move || {
-            __rust_dealloc(ptr.0 as *mut _, std::mem::size_of::<usize>(), std::mem::align_of::<usize>());
+            __rust_dealloc(
+                ptr.0 as *mut _,
+                std::mem::size_of::<usize>(),
+                std::mem::align_of::<usize>(),
+            );
         });
 
         let j2 = spawn(move || {

--- a/tests/fail/data_race/dealloc_write_race_stack.rs
+++ b/tests/fail/data_race/dealloc_write_race_stack.rs
@@ -1,9 +1,9 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
 // compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
-use std::thread::{spawn, sleep};
 use std::ptr::null_mut;
-use std::sync::atomic::{Ordering, AtomicPtr};
+use std::sync::atomic::{AtomicPtr, Ordering};
+use std::thread::{sleep, spawn};
 use std::time::Duration;
 
 #[derive(Copy, Clone)]
@@ -36,7 +36,6 @@ pub fn main() {
                 sleep(Duration::from_millis(200));
 
                 // Now `stack_var` gets deallocated.
-
             } //~ ERROR Data race detected between Deallocate on Thread(id = 1) and Write on Thread(id = 2)
         });
 

--- a/tests/fail/data_race/fence_after_load.rs
+++ b/tests/fail/data_race/fence_after_load.rs
@@ -1,10 +1,10 @@
 // We want to control preemption here.
 // compile-flags: -Zmiri-disable-isolation -Zmiri-preemption-rate=0
 // ignore-windows: Concurrency on Windows is not supported yet.
+use std::sync::atomic::{fence, AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering, fence};
-use std::time::Duration;
 use std::thread;
+use std::time::Duration;
 
 fn main() {
     static mut V: u32 = 0;

--- a/tests/fail/data_race/read_write_race.rs
+++ b/tests/fail/data_race/read_write_race.rs
@@ -13,9 +13,7 @@ pub fn main() {
     let b = &mut a as *mut u32;
     let c = EvilSend(b);
     unsafe {
-        let j1 = spawn(move || {
-            *c.0
-        });
+        let j1 = spawn(move || *c.0);
 
         let j2 = spawn(move || {
             *c.0 = 64; //~ ERROR Data race detected between Write on Thread(id = 2) and Read on Thread(id = 1)

--- a/tests/fail/data_race/read_write_race.rs
+++ b/tests/fail/data_race/read_write_race.rs
@@ -13,7 +13,9 @@ pub fn main() {
     let b = &mut a as *mut u32;
     let c = EvilSend(b);
     unsafe {
-        let j1 = spawn(move || *c.0);
+        let j1 = spawn(move || {
+            let _val = *c.0;
+        });
 
         let j2 = spawn(move || {
             *c.0 = 64; //~ ERROR Data race detected between Write on Thread(id = 2) and Read on Thread(id = 1)

--- a/tests/fail/data_race/read_write_race_stack.rs
+++ b/tests/fail/data_race/read_write_race_stack.rs
@@ -4,9 +4,9 @@
 // Note: mir-opt-level set to 0 to prevent the read of stack_var in thread 1
 // from being optimized away and preventing the detection of the data-race.
 
-use std::thread::{spawn, sleep};
 use std::ptr::null_mut;
-use std::sync::atomic::{Ordering, AtomicPtr};
+use std::sync::atomic::{AtomicPtr, Ordering};
+use std::thread::{sleep, spawn};
 use std::time::Duration;
 
 #[derive(Copy, Clone)]

--- a/tests/fail/data_race/relax_acquire_race.rs
+++ b/tests/fail/data_race/relax_acquire_race.rs
@@ -1,8 +1,8 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
 // compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
-use std::thread::spawn;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread::spawn;
 
 #[derive(Copy, Clone)]
 struct EvilSend<T>(pub T);

--- a/tests/fail/data_race/release_seq_race.rs
+++ b/tests/fail/data_race/release_seq_race.rs
@@ -1,8 +1,8 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
 // compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
-use std::thread::{spawn, sleep};
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread::{sleep, spawn};
 use std::time::Duration;
 
 #[derive(Copy, Clone)]

--- a/tests/fail/data_race/release_seq_race_same_thread.rs
+++ b/tests/fail/data_race/release_seq_race_same_thread.rs
@@ -1,8 +1,8 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
 // compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
-use std::thread::spawn;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread::spawn;
 
 #[derive(Copy, Clone)]
 struct EvilSend<T>(pub T);

--- a/tests/fail/data_race/rmw_race.rs
+++ b/tests/fail/data_race/rmw_race.rs
@@ -1,8 +1,8 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
 // compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
-use std::thread::spawn;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread::spawn;
 
 #[derive(Copy, Clone)]
 struct EvilSend<T>(pub T);

--- a/tests/fail/data_race/write_write_race_stack.rs
+++ b/tests/fail/data_race/write_write_race_stack.rs
@@ -1,9 +1,9 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
 // compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
-use std::thread::{spawn, sleep};
 use std::ptr::null_mut;
-use std::sync::atomic::{Ordering, AtomicPtr};
+use std::sync::atomic::{AtomicPtr, Ordering};
+use std::thread::{sleep, spawn};
 use std::time::Duration;
 
 #[derive(Copy, Clone)]

--- a/tests/fail/environ-gets-deallocated.rs
+++ b/tests/fail/environ-gets-deallocated.rs
@@ -1,14 +1,14 @@
 // ignore-windows: Windows does not have a global environ list that the program can access directly
 
-#[cfg(target_os="linux")]
+#[cfg(target_os = "linux")]
 fn get_environ() -> *const *const u8 {
-  extern "C" {
-    static mut environ: *const *const u8;
-  }
-  unsafe { environ }
+    extern "C" {
+        static mut environ: *const *const u8;
+    }
+    unsafe { environ }
 }
 
-#[cfg(target_os="macos")]
+#[cfg(target_os = "macos")]
 fn get_environ() -> *const *const u8 {
     extern "C" {
         fn _NSGetEnviron() -> *mut *const *const u8;

--- a/tests/fail/function_pointers/cast_box_int_to_fn_ptr.rs
+++ b/tests/fail/function_pointers/cast_box_int_to_fn_ptr.rs
@@ -3,9 +3,7 @@
 
 fn main() {
     let b = Box::new(42);
-    let g = unsafe {
-        std::mem::transmute::<&Box<usize>, &fn(i32)>(&b)
-    };
+    let g = unsafe { std::mem::transmute::<&Box<usize>, &fn(i32)>(&b) };
 
     (*g)(42) //~ ERROR it does not point to a function
 }

--- a/tests/fail/function_pointers/cast_fn_ptr1.rs
+++ b/tests/fail/function_pointers/cast_fn_ptr1.rs
@@ -1,9 +1,7 @@
 fn main() {
     fn f() {}
 
-    let g = unsafe {
-        std::mem::transmute::<fn(), fn(i32)>(f)
-    };
+    let g = unsafe { std::mem::transmute::<fn(), fn(i32)>(f) };
 
     g(42) //~ ERROR calling a function with more arguments than it expected
 }

--- a/tests/fail/function_pointers/cast_fn_ptr2.rs
+++ b/tests/fail/function_pointers/cast_fn_ptr2.rs
@@ -1,9 +1,7 @@
 fn main() {
-    fn f(_ : (i32,i32)) {}
+    fn f(_: (i32, i32)) {}
 
-    let g = unsafe {
-        std::mem::transmute::<fn((i32,i32)), fn(i32)>(f)
-    };
+    let g = unsafe { std::mem::transmute::<fn((i32, i32)), fn(i32)>(f) };
 
     g(42) //~ ERROR calling a function with argument of type (i32, i32) passing data of type i32
 }

--- a/tests/fail/function_pointers/cast_fn_ptr3.rs
+++ b/tests/fail/function_pointers/cast_fn_ptr3.rs
@@ -1,10 +1,7 @@
 fn main() {
-    fn f(_ : (i32,i32)) {}
+    fn f(_: (i32, i32)) {}
 
-    let g = unsafe {
-        std::mem::transmute::<fn((i32,i32)), fn()>(f)
-    };
+    let g = unsafe { std::mem::transmute::<fn((i32, i32)), fn()>(f) };
 
     g() //~ ERROR calling a function with fewer arguments than it requires
 }
-

--- a/tests/fail/function_pointers/cast_fn_ptr4.rs
+++ b/tests/fail/function_pointers/cast_fn_ptr4.rs
@@ -1,9 +1,7 @@
 fn main() {
-    fn f(_ : *const [i32]) {}
+    fn f(_: *const [i32]) {}
 
-    let g = unsafe {
-        std::mem::transmute::<fn(*const [i32]), fn(*const i32)>(f)
-    };
+    let g = unsafe { std::mem::transmute::<fn(*const [i32]), fn(*const i32)>(f) };
 
     g(&42 as *const i32) //~ ERROR calling a function with argument of type *const [i32] passing data of type *const i32
 }

--- a/tests/fail/function_pointers/cast_fn_ptr5.rs
+++ b/tests/fail/function_pointers/cast_fn_ptr5.rs
@@ -1,9 +1,9 @@
 fn main() {
-    fn f() -> u32 { 42 }
+    fn f() -> u32 {
+        42
+    }
 
-    let g = unsafe {
-        std::mem::transmute::<fn() -> u32, fn()>(f)
-    };
+    let g = unsafe { std::mem::transmute::<fn() -> u32, fn()>(f) };
 
     g() //~ ERROR calling a function with return type u32 passing return place of type ()
 }

--- a/tests/fail/function_pointers/cast_int_to_fn_ptr.rs
+++ b/tests/fail/function_pointers/cast_int_to_fn_ptr.rs
@@ -2,9 +2,7 @@
 // compile-flags: -Zmiri-disable-validation
 
 fn main() {
-    let g = unsafe {
-        std::mem::transmute::<usize, fn(i32)>(42)
-    };
+    let g = unsafe { std::mem::transmute::<usize, fn(i32)>(42) };
 
     g(42) //~ ERROR not a valid pointer
 }

--- a/tests/fail/function_pointers/fn_ptr_offset.rs
+++ b/tests/fail/function_pointers/fn_ptr_offset.rs
@@ -6,9 +6,9 @@ use std::mem;
 fn f() {}
 
 fn main() {
-    let x : fn() = f;
-    let y : *mut u8 = unsafe { mem::transmute(x) };
+    let x: fn() = f;
+    let y: *mut u8 = unsafe { mem::transmute(x) };
     let y = y.wrapping_offset(1);
-    let x : fn() = unsafe { mem::transmute(y) };
+    let x: fn() = unsafe { mem::transmute(y) };
     x(); //~ ERROR function pointer but it does not point to a function
 }

--- a/tests/fail/intrinsics/simd-div-by-zero.rs
+++ b/tests/fail/intrinsics/simd-div-by-zero.rs
@@ -8,8 +8,10 @@ extern "platform-intrinsic" {
 #[allow(non_camel_case_types)]
 struct i32x2(i32, i32);
 
-fn main() { unsafe {
-    let x = i32x2(1, 1);
-    let y = i32x2(1, 0);
-    simd_div(x, y); //~ERROR Undefined Behavior: dividing by zero
-} }
+fn main() {
+    unsafe {
+        let x = i32x2(1, 1);
+        let y = i32x2(1, 0);
+        simd_div(x, y); //~ERROR Undefined Behavior: dividing by zero
+    }
+}

--- a/tests/fail/intrinsics/simd-div-by-zero.stderr
+++ b/tests/fail/intrinsics/simd-div-by-zero.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: dividing by zero
   --> $DIR/simd-div-by-zero.rs:LL:CC
    |
-LL |     simd_div(x, y);
-   |     ^^^^^^^^^^^^^^ dividing by zero
+LL |         simd_div(x, y);
+   |         ^^^^^^^^^^^^^^ dividing by zero
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/simd-div-overflow.rs
+++ b/tests/fail/intrinsics/simd-div-overflow.rs
@@ -8,8 +8,10 @@ extern "platform-intrinsic" {
 #[allow(non_camel_case_types)]
 struct i32x2(i32, i32);
 
-fn main() { unsafe {
-    let x = i32x2(1, i32::MIN);
-    let y = i32x2(1, -1);
-    simd_div(x, y); //~ERROR Undefined Behavior: overflow in signed division
-} }
+fn main() {
+    unsafe {
+        let x = i32x2(1, i32::MIN);
+        let y = i32x2(1, -1);
+        simd_div(x, y); //~ERROR Undefined Behavior: overflow in signed division
+    }
+}

--- a/tests/fail/intrinsics/simd-div-overflow.stderr
+++ b/tests/fail/intrinsics/simd-div-overflow.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: overflow in signed division (dividing MIN by -1)
   --> $DIR/simd-div-overflow.rs:LL:CC
    |
-LL |     simd_div(x, y);
-   |     ^^^^^^^^^^^^^^ overflow in signed division (dividing MIN by -1)
+LL |         simd_div(x, y);
+   |         ^^^^^^^^^^^^^^ overflow in signed division (dividing MIN by -1)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/simd-float-to-int.rs
+++ b/tests/fail/intrinsics/simd-float-to-int.rs
@@ -2,6 +2,8 @@
 #![feature(portable_simd)]
 use std::simd::*;
 
-fn main() { unsafe {
-    let _x : i32x2 = f32x2::from_array([f32::MAX, f32::MIN]).to_int_unchecked();
-} }
+fn main() {
+    unsafe {
+        let _x: i32x2 = f32x2::from_array([f32::MAX, f32::MIN]).to_int_unchecked();
+    }
+}

--- a/tests/fail/intrinsics/simd-float-to-int.stderr
+++ b/tests/fail/intrinsics/simd-float-to-int.stderr
@@ -11,8 +11,8 @@ LL | implement! { f32 }
 note: inside `main` at $DIR/simd-float-to-int.rs:LL:CC
   --> $DIR/simd-float-to-int.rs:LL:CC
    |
-LL |     let _x : i32x2 = f32x2::from_array([f32::MAX, f32::MIN]).to_int_unchecked();
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         let _x: i32x2 = f32x2::from_array([f32::MAX, f32::MIN]).to_int_unchecked();
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: this error originates in the macro `implement` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/simd-gather.rs
+++ b/tests/fail/intrinsics/simd-gather.rs
@@ -2,8 +2,10 @@
 #![feature(portable_simd)]
 use std::simd::*;
 
-fn main() { unsafe {
-    let vec: &[i8] = &[10, 11, 12, 13, 14, 15, 16, 17, 18];
-    let idxs = Simd::from_array([9, 3, 0, 17]);
-    let _result = Simd::gather_select_unchecked(&vec, Mask::splat(true), idxs, Simd::splat(0));
-} }
+fn main() {
+    unsafe {
+        let vec: &[i8] = &[10, 11, 12, 13, 14, 15, 16, 17, 18];
+        let idxs = Simd::from_array([9, 3, 0, 17]);
+        let _result = Simd::gather_select_unchecked(&vec, Mask::splat(true), idxs, Simd::splat(0));
+    }
+}

--- a/tests/fail/intrinsics/simd-gather.stderr
+++ b/tests/fail/intrinsics/simd-gather.stderr
@@ -11,8 +11,8 @@ LL |         unsafe { intrinsics::simd_gather(or, ptrs, enable.to_int()) }
 note: inside `main` at $DIR/simd-gather.rs:LL:CC
   --> $DIR/simd-gather.rs:LL:CC
    |
-LL |     let _result = Simd::gather_select_unchecked(&vec, Mask::splat(true), idxs, Simd::splat(0));
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         let _result = Simd::gather_select_unchecked(&vec, Mask::splat(true), idxs, Simd::splat(0));
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/simd-reduce-invalid-bool.rs
+++ b/tests/fail/intrinsics/simd-reduce-invalid-bool.rs
@@ -8,7 +8,9 @@ extern "platform-intrinsic" {
 #[allow(non_camel_case_types)]
 struct i32x2(i32, i32);
 
-fn main() { unsafe {
-    let x = i32x2(0, 1);
-    simd_reduce_any(x); //~ERROR must be all-0-bits or all-1-bits
-} }
+fn main() {
+    unsafe {
+        let x = i32x2(0, 1);
+        simd_reduce_any(x); //~ERROR must be all-0-bits or all-1-bits
+    }
+}

--- a/tests/fail/intrinsics/simd-reduce-invalid-bool.stderr
+++ b/tests/fail/intrinsics/simd-reduce-invalid-bool.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: each element of a SIMD mask must be all-0-bits or all-1-bits
   --> $DIR/simd-reduce-invalid-bool.rs:LL:CC
    |
-LL |     simd_reduce_any(x);
-   |     ^^^^^^^^^^^^^^^^^^ each element of a SIMD mask must be all-0-bits or all-1-bits
+LL |         simd_reduce_any(x);
+   |         ^^^^^^^^^^^^^^^^^^ each element of a SIMD mask must be all-0-bits or all-1-bits
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information


### PR DESCRIPTION
Extracted from #2097.

I filtered this PR to contain exclusively "easy" cases to start off with, i.e. where there is no compiletest_rs (or other) comment in the vicinity that might need to get manually repositioned.