### PR TITLE
Actually pass through the request for --color=always

### DIFF
--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -957,7 +957,10 @@ fn phase_runner(binary: &Path, binary_args: env::Args, phase: RunnerPhase) {
             // to emit the diagnostic structure that Cargo would consume from rustc to emit colored
             // diagnostics, and ask rustc to emit them.
             // See https://github.com/rust-lang/miri/issues/2037
-            if arg.split(',').any(|a| a == "diagnostic-rendered-ansi") {
+            // First skip over the leading `=`, then check for diagnostic-rendered-ansi in the
+            // comma-separated list
+            if suffix.strip_prefix('=').unwrap().split(',').any(|a| a == "diagnostic-rendered-ansi")
+            {
                 cmd.arg("--color=always");
             }
             // But aside from remembering that colored output was requested, drop this argument.

--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -952,15 +952,14 @@ fn phase_runner(binary: &Path, binary_args: env::Args, phase: RunnerPhase) {
             assert!(suffix.starts_with('='));
             // Drop this argument.
         } else if let Some(suffix) = arg.strip_prefix(json_flag) {
-            assert!(suffix.starts_with('='));
+            let suffix = suffix.strip_prefix('=').unwrap();
             // This is how we pass through --color=always. We detect that Cargo is detecting rustc
             // to emit the diagnostic structure that Cargo would consume from rustc to emit colored
             // diagnostics, and ask rustc to emit them.
             // See https://github.com/rust-lang/miri/issues/2037
             // First skip over the leading `=`, then check for diagnostic-rendered-ansi in the
             // comma-separated list
-            if suffix.strip_prefix('=').unwrap().split(',').any(|a| a == "diagnostic-rendered-ansi")
-            {
+            if suffix.split(',').any(|a| a == "diagnostic-rendered-ansi") {
                 cmd.arg("--color=always");
             }
             // But aside from remembering that colored output was requested, drop this argument.


### PR DESCRIPTION
https://github.com/rust-lang/miri/pull/2243 actually doesn't work :joy:

The suggestion to split on `,` was good but `arg` is actually the whole `--json=diagnostic-rendered-ansi,artifacts,future-incompat
`, and of course I didn't test that change locally and we have no test for this in CI.

Therefore, I would like some guidance on making a test for this because I'm going to rely on this working.