### PR TITLE
Format tests with rustfmt (101-150 of 300)

### DIFF
--- a/tests/pass/generator.rs
+++ b/tests/pass/generator.rs
@@ -1,15 +1,19 @@
 #![feature(generators, generator_trait, never_type)]
 
-use std::ops::{GeneratorState::{self, *}, Generator};
-use std::pin::Pin;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::fmt::Debug;
 use std::mem::ManuallyDrop;
+use std::ops::{
+    Generator,
+    GeneratorState::{self, *},
+};
+use std::pin::Pin;
 use std::ptr;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 fn basic() {
     fn finish<T>(mut amt: usize, mut t: T) -> T::Return
-        where T: Generator<Yield = usize>
+    where
+        T: Generator<Yield = usize>,
     {
         // We are not moving the `t` around until it gets dropped, so this is okay.
         let mut t = unsafe { Pin::new_unchecked(&mut t) };
@@ -23,7 +27,7 @@ fn basic() {
                 }
                 GeneratorState::Complete(ret) => {
                     assert_eq!(amt, 0);
-                    return ret
+                    return ret;
                 }
             }
         }
@@ -46,7 +50,7 @@ fn basic() {
         assert_eq!(x, 2);
     });
 
-    finish(7*8/2, || {
+    finish(7 * 8 / 2, || {
         for i in 0..8 {
             yield i;
         }
@@ -67,7 +71,10 @@ fn basic() {
     });
 
     finish(2, || {
-        if { yield 1; false } {
+        if {
+            yield 1;
+            false
+        } {
             yield 1;
             panic!()
         }
@@ -90,7 +97,9 @@ fn basic() {
     let b = true;
     finish(1, || {
         yield 1;
-        if b { return; }
+        if b {
+            return;
+        }
         #[allow(unused)]
         let x = never();
         #[allow(unreachable_code)]
@@ -101,7 +110,10 @@ fn basic() {
     finish(3, || {
         yield 1;
         #[allow(unreachable_code)]
-        let _x: (String, !) = (String::new(), { yield 2; return });
+        let _x: (String, !) = (String::new(), {
+            yield 2;
+            return;
+        });
     });
 }
 

--- a/tests/pass/hashmap.rs
+++ b/tests/pass/hashmap.rs
@@ -17,19 +17,19 @@ fn test_all_refs<'a, T: 'a>(dummy: &mut T, iter: impl Iterator<Item = &'a mut T>
 
 fn smoketest_map<S: BuildHasher>(mut map: HashMap<i32, i32, S>) {
     map.insert(0, 0);
-    assert_eq!(map.values().fold(0, |x, y| x+y), 0);
+    assert_eq!(map.values().fold(0, |x, y| x + y), 0);
 
     let num = 25;
     for i in 1..num {
         map.insert(i, i);
     }
-    assert_eq!(map.values().fold(0, |x, y| x+y), num*(num-1)/2); // check the right things are in the table now
+    assert_eq!(map.values().fold(0, |x, y| x + y), num * (num - 1) / 2); // check the right things are in the table now
 
     // Inserting again replaces the existing entries
     for i in 0..num {
-        map.insert(i, num-1-i);
+        map.insert(i, num - 1 - i);
     }
-    assert_eq!(map.values().fold(0, |x, y| x+y), num*(num-1)/2);
+    assert_eq!(map.values().fold(0, |x, y| x + y), num * (num - 1) / 2);
 
     test_all_refs(&mut 13, map.values_mut());
 }

--- a/tests/pass/integer-ops.rs
+++ b/tests/pass/integer-ops.rs
@@ -42,7 +42,7 @@ pub fn main() {
     let m = -0xFEDCBA987654322i64;
     assert_eq!(n.rotate_right(4), m);
 
-    let n =  0x0123456789ABCDEFi64;
+    let n = 0x0123456789ABCDEFi64;
     let m = -0x1032547698BADCFFi64;
     assert_eq!(n.swap_bytes(), m);
 
@@ -169,9 +169,9 @@ pub fn main() {
     assert_eq!(0x10i32.overflowing_shr(4), (0x1, false));
     assert_eq!(0x10i32.overflowing_shr(36), (0x1, true));
 
-    assert_eq!(10i8.overflowing_abs(), (10,false));
-    assert_eq!((-10i8).overflowing_abs(), (10,false));
-    assert_eq!((-128i8).overflowing_abs(), (-128,true));
+    assert_eq!(10i8.overflowing_abs(), (10, false));
+    assert_eq!((-10i8).overflowing_abs(), (10, false));
+    assert_eq!((-128i8).overflowing_abs(), (-128, true));
 
     // Logarithms
     macro_rules! test_log {
@@ -180,7 +180,7 @@ pub fn main() {
             assert_eq!($type::MIN.checked_log10(), None);
             assert_eq!($type::MAX.checked_log2(), Some($max_log2));
             assert_eq!($type::MAX.checked_log10(), Some($max_log10));
-        }
+        };
     }
 
     test_log!(i8, 6, 2);

--- a/tests/pass/intrinsics-math.rs
+++ b/tests/pass/intrinsics-math.rs
@@ -9,15 +9,14 @@
 // except according to those terms.
 
 macro_rules! assert_approx_eq {
-    ($a:expr, $b:expr) => ({
+    ($a:expr, $b:expr) => {{
         let (a, b) = (&$a, &$b);
-        assert!((*a - *b).abs() < 1.0e-6,
-                "{} is not approximately equal to {}", *a, *b);
-    })
+        assert!((*a - *b).abs() < 1.0e-6, "{} is not approximately equal to {}", *a, *b);
+    }};
 }
 
 fn ldexp(a: f64, b: i32) -> f64 {
-    extern {
+    extern "C" {
         fn ldexp(x: f64, n: i32) -> f64;
     }
     unsafe { ldexp(a, b) }

--- a/tests/pass/intrinsics.rs
+++ b/tests/pass/intrinsics.rs
@@ -20,8 +20,12 @@ fn main() {
     assert_eq!(size_of_val(&[1, 2, 3] as &[i32]), 12);
     assert_eq!(size_of_val("foobar"), 6);
 
-    unsafe { assert_eq!(size_of_val_raw(&[1] as &[i32] as *const [i32]), 4); }
-    unsafe { assert_eq!(size_of_val_raw(0x100 as *const i32), 4); }
+    unsafe {
+        assert_eq!(size_of_val_raw(&[1] as &[i32] as *const [i32]), 4);
+    }
+    unsafe {
+        assert_eq!(size_of_val_raw(0x100 as *const i32), 4);
+    }
 
     assert_eq!(intrinsics::type_name::<Option<i32>>(), "core::option::Option<i32>");
 
@@ -33,7 +37,7 @@ fn main() {
     let _v = intrinsics::discriminant_value(&Some(()));
     let _v = intrinsics::discriminant_value(&0);
     let _v = intrinsics::discriminant_value(&true);
-    let _v = intrinsics::discriminant_value(&vec![1,2,3]);
+    let _v = intrinsics::discriminant_value(&vec![1, 2, 3]);
 
     let addr = &13 as *const i32;
     let addr2 = (addr as usize).wrapping_add(usize::MAX).wrapping_add(1);

--- a/tests/pass/ints.rs
+++ b/tests/pass/ints.rs
@@ -17,7 +17,7 @@ fn indirect_add() -> i64 {
 }
 
 fn arith() -> i32 {
-    3*3 + 4*4
+    3 * 3 + 4 * 4
 }
 
 fn match_int() -> i16 {
@@ -48,7 +48,7 @@ fn main() {
     assert_eq!(neg(), -1);
     assert_eq!(add(), 3);
     assert_eq!(indirect_add(), 3);
-    assert_eq!(arith(), 5*5);
+    assert_eq!(arith(), 5 * 5);
     assert_eq!(match_int(), 20);
     assert_eq!(match_int_range(), 4);
     assert_eq!(i64::MIN.overflowing_mul(-1), (i64::MIN, true));

--- a/tests/pass/issues/issue-15063.rs
+++ b/tests/pass/issues/issue-15063.rs
@@ -1,8 +1,10 @@
 #[allow(dead_code)]
-enum Two { A, B }
+enum Two {
+    A,
+    B,
+}
 impl Drop for Two {
-    fn drop(&mut self) {
-    }
+    fn drop(&mut self) {}
 }
 fn main() {
     let _k = Two::A;

--- a/tests/pass/issues/issue-15080.rs
+++ b/tests/pass/issues/issue-15080.rs
@@ -1,7 +1,7 @@
 fn main() {
     let mut x: &[_] = &[1, 2, 3, 4];
 
-    let mut result = vec!();
+    let mut result = vec![];
     loop {
         x = match *x {
             [1, n, 3, ref rest @ ..] => {
@@ -12,8 +12,7 @@ fn main() {
                 result.push(n);
                 rest
             }
-            [] =>
-                break
+            [] => break,
         }
     }
     assert_eq!(result, [2, 4]);

--- a/tests/pass/issues/issue-15523-big.rs
+++ b/tests/pass/issues/issue-15523-big.rs
@@ -27,7 +27,6 @@ fn main() {
     assert!(Eu64::Pos2 < Eu64::PosMax);
     assert!(Eu64::Pos1 < Eu64::PosMax);
 
-
     assert!(Ei64::Pos2 > Ei64::Pos1);
     assert!(Ei64::Pos2 > Ei64::Neg1);
     assert!(Ei64::Pos1 > Ei64::Neg1);

--- a/tests/pass/issues/issue-17877.rs
+++ b/tests/pass/issues/issue-17877.rs
@@ -3,7 +3,7 @@ fn main() {
         match [0u8; 16 * 1024] {
             _ => 42_usize,
         },
-        42_usize
+        42_usize,
     );
 
     assert_eq!(
@@ -12,6 +12,6 @@ fn main() {
             [0, ..] => 1_usize,
             _ => 2_usize,
         },
-        1_usize
+        1_usize,
     );
 }

--- a/tests/pass/issues/issue-17877.rs
+++ b/tests/pass/issues/issue-17877.rs
@@ -1,11 +1,17 @@
 fn main() {
-    assert_eq!(match [0u8; 16*1024] {
-        _ => 42_usize,
-    }, 42_usize);
+    assert_eq!(
+        match [0u8; 16 * 1024] {
+            _ => 42_usize,
+        },
+        42_usize
+    );
 
-    assert_eq!(match [0u8; 16*1024] {
-        [1, ..] => 0_usize,
-        [0, ..] => 1_usize,
-        _ => 2_usize
-    }, 1_usize);
+    assert_eq!(
+        match [0u8; 16 * 1024] {
+            [1, ..] => 0_usize,
+            [0, ..] => 1_usize,
+            _ => 2_usize,
+        },
+        1_usize
+    );
 }

--- a/tests/pass/issues/issue-23261.rs
+++ b/tests/pass/issues/issue-23261.rs
@@ -2,7 +2,7 @@
 
 struct Foo<T: ?Sized> {
     a: i32,
-    inner: T
+    inner: T,
 }
 
 trait Get {

--- a/tests/pass/issues/issue-27901.rs
+++ b/tests/pass/issues/issue-27901.rs
@@ -1,5 +1,9 @@
-trait Stream { type Item; }
-impl<'a> Stream for &'a str { type Item = u8; }
+trait Stream {
+    type Item;
+}
+impl<'a> Stream for &'a str {
+    type Item = u8;
+}
 fn f<'s>(s: &'s str) -> (&'s str, <&'s str as Stream>::Item) {
     (s, 42)
 }

--- a/tests/pass/issues/issue-29746.rs
+++ b/tests/pass/issues/issue-29746.rs
@@ -25,11 +25,11 @@ macro_rules! zip {
 }
 
 fn main() {
-    let p1 = vec![1i32,    2].into_iter();
-    let p2 = vec!["10",    "20"].into_iter();
-    let p3 = vec![100u16,  200].into_iter();
+    let p1 = vec![1i32, 2].into_iter();
+    let p2 = vec!["10", "20"].into_iter();
+    let p3 = vec![100u16, 200].into_iter();
     let p4 = vec![1000i64, 2000].into_iter();
 
-    let e = zip!([p1,p2,p3,p4]).collect::<Vec<_>>();
-    assert_eq!(e[0], (1i32,"10",100u16,1000i64));
+    let e = zip!([p1, p2, p3, p4]).collect::<Vec<_>>();
+    assert_eq!(e[0], (1i32, "10", 100u16, 1000i64));
 }

--- a/tests/pass/issues/issue-30530.rs
+++ b/tests/pass/issues/issue-30530.rs
@@ -21,7 +21,8 @@ pub enum Handler {
 }
 
 fn main() {
-    #[allow(unused_must_use)] {
+    #[allow(unused_must_use)]
+    {
         take(Handler::Default, Box::new(main));
     }
 }

--- a/tests/pass/issues/issue-34571.rs
+++ b/tests/pass/issues/issue-34571.rs
@@ -5,6 +5,6 @@ enum Foo {
 
 fn main() {
     match Foo::Foo(1) {
-        _ => ()
+        _ => (),
     }
 }

--- a/tests/pass/issues/issue-36278-prefix-nesting.rs
+++ b/tests/pass/issues/issue-36278-prefix-nesting.rs
@@ -9,11 +9,12 @@ struct P<T: ?Sized>([u8; SZ], T);
 type Ack<T> = P<P<T>>;
 
 fn main() {
-    let size_of_sized; let size_of_unsized;
+    let size_of_sized;
+    let size_of_unsized;
     let x: Box<Ack<[u8; 0]>> = Box::new(P([0; SZ], P([0; SZ], [0; 0])));
     size_of_sized = mem::size_of_val::<Ack<_>>(&x);
     let align_of_sized = mem::align_of_val::<Ack<_>>(&x);
-    let y: Box<Ack<[u8   ]>> = x;
+    let y: Box<Ack<[u8]>> = x;
     size_of_unsized = mem::size_of_val::<Ack<_>>(&y);
     assert_eq!(size_of_sized, size_of_unsized);
     assert_eq!(align_of_sized, 1);

--- a/tests/pass/issues/issue-5917.rs
+++ b/tests/pass/issues/issue-5917.rs
@@ -1,7 +1,6 @@
-
-struct T (&'static [isize]);
-static STATIC : T = T (&[5, 4, 3]);
-pub fn main () {
+struct T(&'static [isize]);
+static STATIC: T = T(&[5, 4, 3]);
+pub fn main() {
     let T(ref v) = STATIC;
     assert_eq!(v[0], 5);
 }

--- a/tests/pass/issues/issue-miri-133.rs
+++ b/tests/pass/issues/issue-miri-133.rs
@@ -4,17 +4,12 @@ struct S<U, V> {
     _u: U,
     size_of_u: usize,
     _v: V,
-    size_of_v: usize
+    size_of_v: usize,
 }
 
 impl<U, V> S<U, V> {
     fn new(u: U, v: V) -> Self {
-        S {
-            _u: u,
-            size_of_u: size_of::<U>(),
-            _v: v,
-            size_of_v: size_of::<V>()
-        }
+        S { _u: u, size_of_u: size_of::<U>(), _v: v, size_of_v: size_of::<V>() }
     }
 }
 

--- a/tests/pass/issues/issue-miri-2068-2.rs
+++ b/tests/pass/issues/issue-miri-2068-2.rs
@@ -2,13 +2,15 @@
 
 use std::mem::MaybeUninit;
 
-fn main() { unsafe {
-    let mut x = MaybeUninit::<i64>::uninit();
-    // Put in a ptr.
-    x.as_mut_ptr().cast::<&i32>().write_unaligned(&0);
-    // Overwrite parts of that pointer with 'uninit' through a Scalar.
-    let ptr = x.as_mut_ptr().cast::<i32>();
-    *ptr = MaybeUninit::uninit().assume_init();
-    // Reading this back should hence work fine.
-    let _c = *ptr;
-} }
+fn main() {
+    unsafe {
+        let mut x = MaybeUninit::<i64>::uninit();
+        // Put in a ptr.
+        x.as_mut_ptr().cast::<&i32>().write_unaligned(&0);
+        // Overwrite parts of that pointer with 'uninit' through a Scalar.
+        let ptr = x.as_mut_ptr().cast::<i32>();
+        *ptr = MaybeUninit::uninit().assume_init();
+        // Reading this back should hence work fine.
+        let _c = *ptr;
+    }
+}

--- a/tests/pass/last-use-in-cap-clause.rs
+++ b/tests/pass/last-use-in-cap-clause.rs
@@ -1,12 +1,14 @@
 // Make sure #1399 stays fixed
 
 #[allow(dead_code)]
-struct A { a: Box<isize> }
+struct A {
+    a: Box<isize>,
+}
 
 fn foo() -> Box<dyn FnMut() -> isize + 'static> {
     let k: Box<_> = Box::new(22);
-    let _u = A {a: k.clone()};
-    let result  = || 22;
+    let _u = A { a: k.clone() };
+    let result = || 22;
     Box::new(result)
 }
 

--- a/tests/pass/leak-in-static.rs
+++ b/tests/pass/leak-in-static.rs
@@ -1,4 +1,7 @@
-use std::{ptr, sync::atomic::{AtomicPtr, Ordering}};
+use std::{
+    ptr,
+    sync::atomic::{AtomicPtr, Ordering},
+};
 
 static mut LEAKER: Option<Box<Vec<i32>>> = None;
 

--- a/tests/pass/libc.rs
+++ b/tests/pass/libc.rs
@@ -95,7 +95,7 @@ fn test_mutex_libc_init_recursive() {
         assert_eq!(libc::pthread_mutexattr_init(&mut attr as *mut _), 0);
         assert_eq!(
             libc::pthread_mutexattr_settype(&mut attr as *mut _, libc::PTHREAD_MUTEX_RECURSIVE),
-            0
+            0,
         );
         let mut mutex: libc::pthread_mutex_t = std::mem::zeroed();
         assert_eq!(libc::pthread_mutex_init(&mut mutex as *mut _, &mut attr as *mut _), 0);
@@ -118,11 +118,11 @@ fn test_mutex_libc_init_normal() {
         let mut mutexattr: libc::pthread_mutexattr_t = std::mem::zeroed();
         assert_eq!(
             libc::pthread_mutexattr_settype(&mut mutexattr as *mut _, 0x12345678),
-            libc::EINVAL
+            libc::EINVAL,
         );
         assert_eq!(
             libc::pthread_mutexattr_settype(&mut mutexattr as *mut _, libc::PTHREAD_MUTEX_NORMAL),
-            0
+            0,
         );
         let mut mutex: libc::pthread_mutex_t = std::mem::zeroed();
         assert_eq!(libc::pthread_mutex_init(&mut mutex as *mut _, &mutexattr as *const _), 0);
@@ -141,9 +141,9 @@ fn test_mutex_libc_init_errorcheck() {
         assert_eq!(
             libc::pthread_mutexattr_settype(
                 &mut mutexattr as *mut _,
-                libc::PTHREAD_MUTEX_ERRORCHECK
+                libc::PTHREAD_MUTEX_ERRORCHECK,
             ),
-            0
+            0,
         );
         let mut mutex: libc::pthread_mutex_t = std::mem::zeroed();
         assert_eq!(libc::pthread_mutex_init(&mut mutex as *mut _, &mutexattr as *const _), 0);
@@ -216,7 +216,7 @@ fn test_prctl_thread_name() {
         let mut buf = [255; 10];
         assert_eq!(
             libc::prctl(libc::PR_GET_NAME, buf.as_mut_ptr(), 0 as c_long, 0 as c_long, 0 as c_long),
-            0
+            0,
         );
         assert_eq!(b"<unnamed>\0", &buf);
         let thread_name = CString::new("hello").expect("CString::new failed");
@@ -226,14 +226,14 @@ fn test_prctl_thread_name() {
                 thread_name.as_ptr(),
                 0 as c_long,
                 0 as c_long,
-                0 as c_long
+                0 as c_long,
             ),
-            0
+            0,
         );
         let mut buf = [255; 6];
         assert_eq!(
             libc::prctl(libc::PR_GET_NAME, buf.as_mut_ptr(), 0 as c_long, 0 as c_long, 0 as c_long),
-            0
+            0,
         );
         assert_eq!(b"hello\0", &buf);
         let long_thread_name = CString::new("01234567890123456789").expect("CString::new failed");
@@ -243,14 +243,14 @@ fn test_prctl_thread_name() {
                 long_thread_name.as_ptr(),
                 0 as c_long,
                 0 as c_long,
-                0 as c_long
+                0 as c_long,
             ),
-            0
+            0,
         );
         let mut buf = [255; 16];
         assert_eq!(
             libc::prctl(libc::PR_GET_NAME, buf.as_mut_ptr(), 0 as c_long, 0 as c_long, 0 as c_long),
-            0
+            0,
         );
         assert_eq!(b"012345678901234\0", &buf);
     }

--- a/tests/pass/libc.rs
+++ b/tests/pass/libc.rs
@@ -7,7 +7,9 @@ extern crate libc;
 
 #[cfg(target_os = "linux")]
 fn tmp() -> std::path::PathBuf {
-    std::env::var("MIRI_TEMP").map(std::path::PathBuf::from).unwrap_or_else(|_| std::env::temp_dir())
+    std::env::var("MIRI_TEMP")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::env::temp_dir())
 }
 
 #[cfg(target_os = "linux")]
@@ -91,7 +93,10 @@ fn test_mutex_libc_init_recursive() {
     unsafe {
         let mut attr: libc::pthread_mutexattr_t = std::mem::zeroed();
         assert_eq!(libc::pthread_mutexattr_init(&mut attr as *mut _), 0);
-        assert_eq!(libc::pthread_mutexattr_settype(&mut attr as *mut _, libc::PTHREAD_MUTEX_RECURSIVE), 0);
+        assert_eq!(
+            libc::pthread_mutexattr_settype(&mut attr as *mut _, libc::PTHREAD_MUTEX_RECURSIVE),
+            0
+        );
         let mut mutex: libc::pthread_mutex_t = std::mem::zeroed();
         assert_eq!(libc::pthread_mutex_init(&mut mutex as *mut _, &mut attr as *mut _), 0);
         assert_eq!(libc::pthread_mutex_lock(&mut mutex as *mut _), 0);
@@ -111,8 +116,14 @@ fn test_mutex_libc_init_recursive() {
 fn test_mutex_libc_init_normal() {
     unsafe {
         let mut mutexattr: libc::pthread_mutexattr_t = std::mem::zeroed();
-        assert_eq!(libc::pthread_mutexattr_settype(&mut mutexattr as *mut _, 0x12345678), libc::EINVAL);
-        assert_eq!(libc::pthread_mutexattr_settype(&mut mutexattr as *mut _, libc::PTHREAD_MUTEX_NORMAL), 0);
+        assert_eq!(
+            libc::pthread_mutexattr_settype(&mut mutexattr as *mut _, 0x12345678),
+            libc::EINVAL
+        );
+        assert_eq!(
+            libc::pthread_mutexattr_settype(&mut mutexattr as *mut _, libc::PTHREAD_MUTEX_NORMAL),
+            0
+        );
         let mut mutex: libc::pthread_mutex_t = std::mem::zeroed();
         assert_eq!(libc::pthread_mutex_init(&mut mutex as *mut _, &mutexattr as *const _), 0);
         assert_eq!(libc::pthread_mutex_lock(&mut mutex as *mut _), 0);
@@ -127,7 +138,13 @@ fn test_mutex_libc_init_normal() {
 fn test_mutex_libc_init_errorcheck() {
     unsafe {
         let mut mutexattr: libc::pthread_mutexattr_t = std::mem::zeroed();
-        assert_eq!(libc::pthread_mutexattr_settype(&mut mutexattr as *mut _, libc::PTHREAD_MUTEX_ERRORCHECK), 0);
+        assert_eq!(
+            libc::pthread_mutexattr_settype(
+                &mut mutexattr as *mut _,
+                libc::PTHREAD_MUTEX_ERRORCHECK
+            ),
+            0
+        );
         let mut mutex: libc::pthread_mutex_t = std::mem::zeroed();
         assert_eq!(libc::pthread_mutex_init(&mut mutex as *mut _, &mutexattr as *const _), 0);
         assert_eq!(libc::pthread_mutex_lock(&mut mutex as *mut _), 0);
@@ -193,21 +210,48 @@ fn test_rwlock_libc_static_initializer() {
 /// Note: `prctl` exists only on Linux.
 #[cfg(target_os = "linux")]
 fn test_prctl_thread_name() {
-    use std::ffi::CString;
     use libc::c_long;
+    use std::ffi::CString;
     unsafe {
         let mut buf = [255; 10];
-        assert_eq!(libc::prctl(libc::PR_GET_NAME, buf.as_mut_ptr(), 0 as c_long, 0 as c_long, 0 as c_long), 0);
+        assert_eq!(
+            libc::prctl(libc::PR_GET_NAME, buf.as_mut_ptr(), 0 as c_long, 0 as c_long, 0 as c_long),
+            0
+        );
         assert_eq!(b"<unnamed>\0", &buf);
         let thread_name = CString::new("hello").expect("CString::new failed");
-        assert_eq!(libc::prctl(libc::PR_SET_NAME, thread_name.as_ptr(), 0 as c_long, 0 as c_long, 0 as c_long), 0);
+        assert_eq!(
+            libc::prctl(
+                libc::PR_SET_NAME,
+                thread_name.as_ptr(),
+                0 as c_long,
+                0 as c_long,
+                0 as c_long
+            ),
+            0
+        );
         let mut buf = [255; 6];
-        assert_eq!(libc::prctl(libc::PR_GET_NAME, buf.as_mut_ptr(), 0 as c_long, 0 as c_long, 0 as c_long), 0);
+        assert_eq!(
+            libc::prctl(libc::PR_GET_NAME, buf.as_mut_ptr(), 0 as c_long, 0 as c_long, 0 as c_long),
+            0
+        );
         assert_eq!(b"hello\0", &buf);
         let long_thread_name = CString::new("01234567890123456789").expect("CString::new failed");
-        assert_eq!(libc::prctl(libc::PR_SET_NAME, long_thread_name.as_ptr(), 0 as c_long, 0 as c_long, 0 as c_long), 0);
+        assert_eq!(
+            libc::prctl(
+                libc::PR_SET_NAME,
+                long_thread_name.as_ptr(),
+                0 as c_long,
+                0 as c_long,
+                0 as c_long
+            ),
+            0
+        );
         let mut buf = [255; 16];
-        assert_eq!(libc::prctl(libc::PR_GET_NAME, buf.as_mut_ptr(), 0 as c_long, 0 as c_long, 0 as c_long), 0);
+        assert_eq!(
+            libc::prctl(libc::PR_GET_NAME, buf.as_mut_ptr(), 0 as c_long, 0 as c_long, 0 as c_long),
+            0
+        );
         assert_eq!(b"012345678901234\0", &buf);
     }
 }
@@ -225,7 +269,9 @@ fn test_thread_local_errno() {
             assert_eq!(*__errno_location(), 0);
             *__errno_location() = 0xBAD1DEA;
             assert_eq!(*__errno_location(), 0xBAD1DEA);
-        }).join().unwrap();
+        })
+        .join()
+        .unwrap();
         assert_eq!(*__errno_location(), 0xBEEF);
     }
 }
@@ -234,21 +280,13 @@ fn test_thread_local_errno() {
 #[cfg(target_os = "linux")]
 fn test_clocks() {
     let mut tp = std::mem::MaybeUninit::<libc::timespec>::uninit();
-    let is_error = unsafe {
-        libc::clock_gettime(libc::CLOCK_REALTIME, tp.as_mut_ptr())
-    };
+    let is_error = unsafe { libc::clock_gettime(libc::CLOCK_REALTIME, tp.as_mut_ptr()) };
     assert_eq!(is_error, 0);
-    let is_error = unsafe {
-        libc::clock_gettime(libc::CLOCK_REALTIME_COARSE, tp.as_mut_ptr())
-    };
+    let is_error = unsafe { libc::clock_gettime(libc::CLOCK_REALTIME_COARSE, tp.as_mut_ptr()) };
     assert_eq!(is_error, 0);
-     let is_error = unsafe {
-        libc::clock_gettime(libc::CLOCK_MONOTONIC, tp.as_mut_ptr())
-    };
+    let is_error = unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, tp.as_mut_ptr()) };
     assert_eq!(is_error, 0);
-    let is_error = unsafe {
-        libc::clock_gettime(libc::CLOCK_MONOTONIC_COARSE, tp.as_mut_ptr())
-    };
+    let is_error = unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC_COARSE, tp.as_mut_ptr()) };
     assert_eq!(is_error, 0);
 }
 

--- a/tests/pass/linked-list.rs
+++ b/tests/pass/linked-list.rs
@@ -45,8 +45,7 @@ fn main() {
 
     assert_eq!(m.len(), 3 + len * 2);
     let mut m2 = m.clone();
-    assert_eq!(m.into_iter().collect::<Vec<_>>(),
-               [-10, -2, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 99]);
+    assert_eq!(m.into_iter().collect::<Vec<_>>(), [-10, -2, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 99]);
 
     test_all_refs(&mut 13, m2.iter_mut());
 }

--- a/tests/pass/linux-getrandom-without-isolation.rs
+++ b/tests/pass/linux-getrandom-without-isolation.rs
@@ -6,10 +6,36 @@ extern crate libc;
 fn main() {
     let mut buf = [0u8; 5];
     unsafe {
-        assert_eq!(libc::syscall(libc::SYS_getrandom, 0 as *mut libc::c_void, 0 as libc::size_t, 0 as libc::c_uint), 0);
-        assert_eq!(libc::syscall(libc::SYS_getrandom, buf.as_mut_ptr() as *mut libc::c_void, 5 as libc::size_t, 0 as libc::c_uint), 5);
+        assert_eq!(
+            libc::syscall(
+                libc::SYS_getrandom,
+                0 as *mut libc::c_void,
+                0 as libc::size_t,
+                0 as libc::c_uint
+            ),
+            0
+        );
+        assert_eq!(
+            libc::syscall(
+                libc::SYS_getrandom,
+                buf.as_mut_ptr() as *mut libc::c_void,
+                5 as libc::size_t,
+                0 as libc::c_uint
+            ),
+            5
+        );
 
-        assert_eq!(libc::getrandom(0 as *mut libc::c_void, 0 as libc::size_t, 0 as libc::c_uint), 0);
-        assert_eq!(libc::getrandom(buf.as_mut_ptr() as *mut libc::c_void, 5 as libc::size_t, 0 as libc::c_uint), 5);
+        assert_eq!(
+            libc::getrandom(0 as *mut libc::c_void, 0 as libc::size_t, 0 as libc::c_uint),
+            0
+        );
+        assert_eq!(
+            libc::getrandom(
+                buf.as_mut_ptr() as *mut libc::c_void,
+                5 as libc::size_t,
+                0 as libc::c_uint
+            ),
+            5
+        );
     }
 }

--- a/tests/pass/linux-getrandom-without-isolation.rs
+++ b/tests/pass/linux-getrandom-without-isolation.rs
@@ -11,31 +11,31 @@ fn main() {
                 libc::SYS_getrandom,
                 0 as *mut libc::c_void,
                 0 as libc::size_t,
-                0 as libc::c_uint
+                0 as libc::c_uint,
             ),
-            0
+            0,
         );
         assert_eq!(
             libc::syscall(
                 libc::SYS_getrandom,
                 buf.as_mut_ptr() as *mut libc::c_void,
                 5 as libc::size_t,
-                0 as libc::c_uint
+                0 as libc::c_uint,
             ),
-            5
+            5,
         );
 
         assert_eq!(
             libc::getrandom(0 as *mut libc::c_void, 0 as libc::size_t, 0 as libc::c_uint),
-            0
+            0,
         );
         assert_eq!(
             libc::getrandom(
                 buf.as_mut_ptr() as *mut libc::c_void,
                 5 as libc::size_t,
-                0 as libc::c_uint
+                0 as libc::c_uint,
             ),
-            5
+            5,
         );
     }
 }

--- a/tests/pass/linux-getrandom.rs
+++ b/tests/pass/linux-getrandom.rs
@@ -5,10 +5,36 @@ extern crate libc;
 fn main() {
     let mut buf = [0u8; 5];
     unsafe {
-        assert_eq!(libc::syscall(libc::SYS_getrandom, 0 as *mut libc::c_void, 0 as libc::size_t, 0 as libc::c_uint), 0);
-        assert_eq!(libc::syscall(libc::SYS_getrandom, buf.as_mut_ptr() as *mut libc::c_void, 5 as libc::size_t, 0 as libc::c_uint), 5);
+        assert_eq!(
+            libc::syscall(
+                libc::SYS_getrandom,
+                0 as *mut libc::c_void,
+                0 as libc::size_t,
+                0 as libc::c_uint
+            ),
+            0
+        );
+        assert_eq!(
+            libc::syscall(
+                libc::SYS_getrandom,
+                buf.as_mut_ptr() as *mut libc::c_void,
+                5 as libc::size_t,
+                0 as libc::c_uint
+            ),
+            5
+        );
 
-        assert_eq!(libc::getrandom(0 as *mut libc::c_void, 0 as libc::size_t, 0 as libc::c_uint), 0);
-        assert_eq!(libc::getrandom(buf.as_mut_ptr() as *mut libc::c_void, 5 as libc::size_t, 0 as libc::c_uint), 5);
+        assert_eq!(
+            libc::getrandom(0 as *mut libc::c_void, 0 as libc::size_t, 0 as libc::c_uint),
+            0
+        );
+        assert_eq!(
+            libc::getrandom(
+                buf.as_mut_ptr() as *mut libc::c_void,
+                5 as libc::size_t,
+                0 as libc::c_uint
+            ),
+            5
+        );
     }
 }

--- a/tests/pass/linux-getrandom.rs
+++ b/tests/pass/linux-getrandom.rs
@@ -10,31 +10,31 @@ fn main() {
                 libc::SYS_getrandom,
                 0 as *mut libc::c_void,
                 0 as libc::size_t,
-                0 as libc::c_uint
+                0 as libc::c_uint,
             ),
-            0
+            0,
         );
         assert_eq!(
             libc::syscall(
                 libc::SYS_getrandom,
                 buf.as_mut_ptr() as *mut libc::c_void,
                 5 as libc::size_t,
-                0 as libc::c_uint
+                0 as libc::c_uint,
             ),
-            5
+            5,
         );
 
         assert_eq!(
             libc::getrandom(0 as *mut libc::c_void, 0 as libc::size_t, 0 as libc::c_uint),
-            0
+            0,
         );
         assert_eq!(
             libc::getrandom(
                 buf.as_mut_ptr() as *mut libc::c_void,
                 5 as libc::size_t,
-                0 as libc::c_uint
+                0 as libc::c_uint,
             ),
-            5
+            5,
         );
     }
 }

--- a/tests/pass/loop-break-value.rs
+++ b/tests/pass/loop-break-value.rs
@@ -16,7 +16,7 @@ pub fn main() {
             let _never: ! = loop {
                 break loop {
                     break 'outer panic!();
-                }
+                };
             };
         }
     };
@@ -36,19 +36,15 @@ pub fn main() {
     assert_eq!(coerced, &[17u32]);
 
     let trait_unified = loop {
-        break if true {
-            break Default::default()
-        } else {
-            break [13, 14]
-        };
+        break if true { break Default::default() } else { break [13, 14] };
     };
     assert_eq!(trait_unified, [0, 0]);
 
     let trait_unified_2 = loop {
         if false {
-            break [String::from("Hello")]
+            break [String::from("Hello")];
         } else {
-            break Default::default()
+            break Default::default();
         };
     };
     // compare lengths; ptr comparison is not deterministic
@@ -56,11 +52,7 @@ pub fn main() {
     assert_eq!(trait_unified_2[0].len(), 0);
 
     let trait_unified_3 = loop {
-        break if false {
-            break [String::from("Hello")]
-        } else {
-            ["Yes".into()]
-        };
+        break if false { break [String::from("Hello")] } else { ["Yes".into()] };
     };
     assert_eq!(trait_unified_3, ["Yes"]);
 
@@ -87,7 +79,7 @@ pub fn main() {
             Default::default()
         } else {
             break;
-        }
+        };
     };
     assert_eq!(regular_break_3, ());
 

--- a/tests/pass/malloc.rs
+++ b/tests/pass/malloc.rs
@@ -4,7 +4,7 @@
 
 extern crate libc;
 
-use core::{slice, ptr};
+use core::{ptr, slice};
 
 fn main() {
     // Test that small allocations sometimes *are* not very aligned.

--- a/tests/pass/many_shr_bor.rs
+++ b/tests/pass/many_shr_bor.rs
@@ -24,7 +24,7 @@ fn test1() {
 fn test2(r: &mut RefCell<i32>) {
     let x = &*r; // releasing write lock, first suspension recorded
     let mut x_ref = x.borrow_mut();
-    let x_inner : &mut i32 = &mut *x_ref; // new inner write lock, with same lifetime as outer lock
+    let x_inner: &mut i32 = &mut *x_ref; // new inner write lock, with same lifetime as outer lock
     let _x_inner_shr = &*x_inner; // releasing inner write lock, recording suspension
     let _y = &*r; // second suspension for the outer write lock
     let _x_inner_shr2 = &*x_inner; // 2nd suspension for inner write lock

--- a/tests/pass/match_slice.rs
+++ b/tests/pass/match_slice.rs
@@ -1,8 +1,8 @@
 fn main() {
     let x = "hello";
     match x {
-        "foo" => {},
-        "bar" => {},
-        _ => {},
+        "foo" => {}
+        "bar" => {}
+        _ => {}
     }
 }

--- a/tests/pass/move-arg-2-unique.rs
+++ b/tests/pass/move-arg-2-unique.rs
@@ -1,6 +1,8 @@
 #![feature(box_syntax)]
 
-fn test(foo: Box<Vec<isize>> ) { assert_eq!((*foo)[0], 10); }
+fn test(foo: Box<Vec<isize>>) {
+    assert_eq!((*foo)[0], 10);
+}
 
 pub fn main() {
     let x = box vec![10];

--- a/tests/pass/move-uninit-primval.rs
+++ b/tests/pass/move-uninit-primval.rs
@@ -7,9 +7,7 @@ struct Foo {
 
 fn main() {
     unsafe {
-        let foo = Foo {
-            _inner: std::mem::uninitialized(),
-        };
+        let foo = Foo { _inner: std::mem::uninitialized() };
         let _bar = foo;
     }
 }

--- a/tests/pass/negative_discriminant.rs
+++ b/tests/pass/negative_discriminant.rs
@@ -1,4 +1,7 @@
-enum AB { A = -1, B = 1 }
+enum AB {
+    A = -1,
+    B = 1,
+}
 
 fn main() {
     match AB::A {

--- a/tests/pass/overflow_checks_off.rs
+++ b/tests/pass/overflow_checks_off.rs
@@ -8,7 +8,7 @@
 // use std::ops::*;
 
 fn main() {
-    assert_eq!(-{-0x80i8}, -0x80);
+    assert_eq!(-{ -0x80i8 }, -0x80);
 
     assert_eq!(0xffu8 + 1, 0_u8);
     assert_eq!(0u8 - 1, 0xff_u8);

--- a/tests/pass/overloaded-calls-simple.rs
+++ b/tests/pass/overloaded-calls-simple.rs
@@ -1,4 +1,3 @@
-
 #![feature(lang_items, unboxed_closures, fn_traits)]
 
 struct S3 {
@@ -6,18 +5,15 @@ struct S3 {
     y: i32,
 }
 
-impl FnOnce<(i32,i32)> for S3 {
+impl FnOnce<(i32, i32)> for S3 {
     type Output = i32;
-    extern "rust-call" fn call_once(self, (z,zz): (i32,i32)) -> i32 {
+    extern "rust-call" fn call_once(self, (z, zz): (i32, i32)) -> i32 {
         self.x * self.y * z * zz
     }
 }
 
 fn main() {
-    let s = S3 {
-        x: 3,
-        y: 3,
-    };
+    let s = S3 { x: 3, y: 3 };
     let ans = s(3, 1);
     assert_eq!(ans, 27);
 }

--- a/tests/pass/packed_struct.rs
+++ b/tests/pass/packed_struct.rs
@@ -31,34 +31,31 @@ fn test_basic() {
         assert_eq!(x, 42);
     }
 
-    let mut x = S {
-        fill: 0,
-        a: 42,
-        b: 99,
-    };
+    let mut x = S { fill: 0, a: 42, b: 99 };
     let a = x.a;
     let b = x.b;
     assert_eq!(a, 42);
     assert_eq!(b, 99);
     assert_eq!(&x.fill, &0); // `fill` just requirs 1-byte-align, so this is fine
     // can't do `assert_eq!(x.a, 42)`, because `assert_eq!` takes a reference
-    assert_eq!({x.a}, 42);
-    assert_eq!({x.b}, 99);
+    assert_eq!({ x.a }, 42);
+    assert_eq!({ x.b }, 99);
     // but we *can* take a raw pointer!
     assert_eq!(unsafe { ptr::addr_of!(x.a).read_unaligned() }, 42);
     assert_eq!(unsafe { ptr::addr_of!(x.b).read_unaligned() }, 99);
 
     x.b = 77;
-    assert_eq!({x.b}, 77);
+    assert_eq!({ x.b }, 77);
 
-    test(Test2 { x: 0, other: &Test1 { x: 0, other: &42 }});
+    test(Test2 { x: 0, other: &Test1 { x: 0, other: &42 } });
 }
 
 fn test_unsizing() {
     #[repr(packed)]
     #[allow(dead_code)]
     struct UnalignedPtr<'a, T: ?Sized>
-    where T: 'a,
+    where
+        T: 'a,
     {
         data: &'a T,
     }
@@ -67,7 +64,8 @@ fn test_unsizing() {
     where
         T: std::marker::Unsize<U> + ?Sized,
         U: ?Sized,
-    { }
+    {
+    }
 
     let arr = [1, 2, 3];
     let arr_unaligned: UnalignedPtr<[i32; 3]> = UnalignedPtr { data: &arr };
@@ -86,7 +84,7 @@ fn test_drop() {
         }
     }
 
-    #[repr(packed,C)]
+    #[repr(packed, C)]
     struct Packed<T> {
         f1: u8, // this should move the second field to something not very aligned
         f2: T,
@@ -100,10 +98,10 @@ fn test_inner_packed() {
     // Even if just the inner struct is packed, accesses to the outer field can get unaligned.
     // Make sure that works.
     #[repr(packed)]
-    #[derive(Clone,Copy)]
+    #[derive(Clone, Copy)]
     struct Inner(u32);
 
-    #[derive(Clone,Copy)]
+    #[derive(Clone, Copy)]
     struct Outer(u8, Inner);
 
     let o = Outer(0, Inner(42));
@@ -115,12 +113,12 @@ fn test_inner_packed() {
 fn test_static() {
     #[repr(packed)]
     struct Foo {
-        i: i32
+        i: i32,
     }
 
     static FOO: Foo = Foo { i: 42 };
 
-    assert_eq!({FOO.i}, 42);
+    assert_eq!({ FOO.i }, 42);
 }
 
 fn test_derive() {
@@ -132,8 +130,8 @@ fn test_derive() {
         c: usize,
     }
 
-    let x = P {a: 1usize, b: 2u8, c: 3usize};
-    let y = P {a: 1usize, b: 2u8, c: 4usize};
+    let x = P { a: 1usize, b: 2u8, c: 3usize };
+    let y = P { a: 1usize, b: 2u8, c: 4usize };
 
     let _clone = x.clone();
     assert!(x != y);

--- a/tests/pass/partially-uninit.rs
+++ b/tests/pass/partially-uninit.rs
@@ -4,10 +4,12 @@ use std::mem::{self, MaybeUninit};
 #[derive(Copy, Clone, Debug, PartialEq)]
 struct Demo(bool, u16);
 
-fn main() { unsafe {
-    // Transmute-round-trip through a type with Scalar layout is lossless.
-    // This is tricky because that 'scalar' is *partially* uninitialized.
-    let x = Demo(true, 3);
-    let y: MaybeUninit<u32> = mem::transmute(x);
-    assert_eq!(x, mem::transmute(y));
-} }
+fn main() {
+    unsafe {
+        // Transmute-round-trip through a type with Scalar layout is lossless.
+        // This is tricky because that 'scalar' is *partially* uninitialized.
+        let x = Demo(true, 3);
+        let y: MaybeUninit<u32> = mem::transmute(x);
+        assert_eq!(x, mem::transmute(y));
+    }
+}

--- a/tests/pass/pointers.rs
+++ b/tests/pass/pointers.rs
@@ -37,7 +37,7 @@ fn match_ref_mut() -> i8 {
         let opt = Some(&mut t);
         match opt {
             Some(&mut (ref mut x, ref mut y)) => *x += *y,
-            None => {},
+            None => {}
         }
     }
     t.0
@@ -59,7 +59,10 @@ fn main() {
     // Compare even dangling pointers with NULL, and with others in the same allocation, including
     // out-of-bounds.
     assert!(dangling_pointer() != std::ptr::null());
-    assert!(match dangling_pointer() as usize { 0 => false, _ => true });
+    assert!(match dangling_pointer() as usize {
+        0 => false,
+        _ => true,
+    });
     let dangling = dangling_pointer();
     assert!(dangling == dangling);
     assert!(dangling.wrapping_add(1) != dangling);

--- a/tests/pass/portable-simd.rs
+++ b/tests/pass/portable-simd.rs
@@ -16,10 +16,10 @@ fn simd_ops_f32() {
     assert_eq!(a.max(b * f32x4::splat(4.0)), f32x4::from_array([10.0, 10.0, 12.0, 10.0]));
     assert_eq!(a.min(b * f32x4::splat(4.0)), f32x4::from_array([4.0, 8.0, 10.0, -16.0]));
 
-    assert_eq!(a.mul_add(b, a), (a*b)+a);
-    assert_eq!(b.mul_add(b, a), (b*b)+a);
-    assert_eq!((a*a).sqrt(), a);
-    assert_eq!((b*b).sqrt(), b.abs());
+    assert_eq!(a.mul_add(b, a), (a * b) + a);
+    assert_eq!(b.mul_add(b, a), (b * b) + a);
+    assert_eq!((a * a).sqrt(), a);
+    assert_eq!((b * b).sqrt(), b.abs());
 
     assert_eq!(a.lanes_eq(f32x4::splat(5.0) * b), Mask::from_array([false, true, false, false]));
     assert_eq!(a.lanes_ne(f32x4::splat(5.0) * b), Mask::from_array([true, false, true, true]));
@@ -65,10 +65,10 @@ fn simd_ops_f64() {
     assert_eq!(a.max(b * f64x4::splat(4.0)), f64x4::from_array([10.0, 10.0, 12.0, 10.0]));
     assert_eq!(a.min(b * f64x4::splat(4.0)), f64x4::from_array([4.0, 8.0, 10.0, -16.0]));
 
-    assert_eq!(a.mul_add(b, a), (a*b)+a);
-    assert_eq!(b.mul_add(b, a), (b*b)+a);
-    assert_eq!((a*a).sqrt(), a);
-    assert_eq!((b*b).sqrt(), b.abs());
+    assert_eq!(a.mul_add(b, a), (a * b) + a);
+    assert_eq!(b.mul_add(b, a), (b * b) + a);
+    assert_eq!((a * a).sqrt(), a);
+    assert_eq!((b * b).sqrt(), b.abs());
 
     assert_eq!(a.lanes_eq(f64x4::splat(5.0) * b), Mask::from_array([false, true, false, false]));
     assert_eq!(a.lanes_ne(f64x4::splat(5.0) * b), Mask::from_array([true, false, true, true]));

--- a/tests/pass/products.rs
+++ b/tests/pass/products.rs
@@ -11,7 +11,10 @@ fn tuple_5() -> (i16, i16, i16, i16, i16) {
 }
 
 #[derive(Debug, PartialEq)]
-struct Pair { x: i8, y: i8 }
+struct Pair {
+    x: i8,
+    y: i8,
+}
 
 fn pair() -> Pair {
     Pair { x: 10, y: 20 }
@@ -27,6 +30,6 @@ fn main() {
     assert_eq!(tuple(), (1,));
     assert_eq!(tuple_2(), (1, 2));
     assert_eq!(tuple_5(), (1, 2, 3, 4, 5));
-    assert_eq!(pair(), Pair { x: 10, y: 20} );
+    assert_eq!(pair(), Pair { x: 10, y: 20 });
     assert_eq!(field_access(), (15, 20));
 }

--- a/tests/pass/ptr_offset.rs
+++ b/tests/pass/ptr_offset.rs
@@ -8,21 +8,23 @@ fn main() {
     ptr_offset();
 }
 
-fn test_offset_from() { unsafe {
-    let buf = [0u32; 4];
+fn test_offset_from() {
+    unsafe {
+        let buf = [0u32; 4];
 
-    let x = buf.as_ptr() as *const u8;
-    let y = x.offset(12);
+        let x = buf.as_ptr() as *const u8;
+        let y = x.offset(12);
 
-    assert_eq!(y.offset_from(x), 12);
-    assert_eq!(x.offset_from(y), -12);
-    assert_eq!((y as *const u32).offset_from(x as *const u32), 12/4);
-    assert_eq!((x as *const u32).offset_from(y as *const u32), -12/4);
+        assert_eq!(y.offset_from(x), 12);
+        assert_eq!(x.offset_from(y), -12);
+        assert_eq!((y as *const u32).offset_from(x as *const u32), 12 / 4);
+        assert_eq!((x as *const u32).offset_from(y as *const u32), -12 / 4);
 
-    let x = (((x as usize) * 2) / 2) as *const u8;
-    assert_eq!(y.offset_from(x), 12);
-    assert_eq!(x.offset_from(y), -12);
-} }
+        let x = (((x as usize) * 2) / 2) as *const u8;
+        assert_eq!(y.offset_from(x), 12);
+        assert_eq!(x.offset_from(y), -12);
+    }
+}
 
 // This also internally uses offset_from.
 fn test_vec_into_iter() {
@@ -50,7 +52,9 @@ fn ptr_arith_offset_overflow() {
 }
 
 fn ptr_offset() {
-    fn f() -> i32 { 42 }
+    fn f() -> i32 {
+        42
+    }
 
     let v = [1i16, 2];
     let x = &v as *const [i16; 2] as *const i16;

--- a/tests/pass/ptr_raw.rs
+++ b/tests/pass/ptr_raw.rs
@@ -5,12 +5,16 @@ fn basic_raw() {
     assert_eq!(*x, 12);
 
     let raw = x as *mut i32;
-    unsafe { *raw = 42; }
+    unsafe {
+        *raw = 42;
+    }
 
     assert_eq!(*x, 42);
 
     let raw = x as *mut i32;
-    unsafe { *raw = 12; }
+    unsafe {
+        *raw = 12;
+    }
     *x = 23;
 
     assert_eq!(*x, 23);

--- a/tests/pass/rc.rs
+++ b/tests/pass/rc.rs
@@ -3,9 +3,9 @@
 #![feature(get_mut_unchecked)]
 
 use std::cell::{Cell, RefCell};
+use std::fmt::Debug;
 use std::rc::{Rc, Weak};
 use std::sync::{Arc, Weak as ArcWeak};
-use std::fmt::Debug;
 
 fn rc_refcell() {
     let r = Rc::new(RefCell::new(42));
@@ -30,7 +30,7 @@ fn rc_refcell2() {
     let x = r2.borrow();
     let r3 = r.clone();
     let y = r3.borrow();
-    assert_eq!((*x + *y)/2, 52);
+    assert_eq!((*x + *y) / 2, 52);
 }
 
 fn rc_raw() {
@@ -62,9 +62,9 @@ fn check_unique_rc<T: ?Sized>(mut r: Rc<T>) {
 }
 
 fn rc_from() {
-    check_unique_rc::<[_]>(Rc::from(&[1,2,3] as &[_]));
-    check_unique_rc::<[_]>(Rc::from(vec![1,2,3]));
-    check_unique_rc::<[_]>(Rc::from(Box::new([1,2,3]) as Box<[_]>));
+    check_unique_rc::<[_]>(Rc::from(&[1, 2, 3] as &[_]));
+    check_unique_rc::<[_]>(Rc::from(vec![1, 2, 3]));
+    check_unique_rc::<[_]>(Rc::from(Box::new([1, 2, 3]) as Box<[_]>));
     check_unique_rc::<str>(Rc::from("Hello, World!"));
 }
 

--- a/tests/pass/regions-mock-trans.rs
+++ b/tests/pass/regions-mock-trans.rs
@@ -9,32 +9,29 @@ use std::mem;
 struct Arena(());
 
 struct Bcx<'a> {
-    fcx: &'a Fcx<'a>
+    fcx: &'a Fcx<'a>,
 }
 
 #[allow(dead_code)]
 struct Fcx<'a> {
     arena: &'a Arena,
-    ccx: &'a Ccx
+    ccx: &'a Ccx,
 }
 
 #[allow(dead_code)]
 struct Ccx {
-    x: isize
+    x: isize,
 }
 
-fn alloc<'a>(_bcx : &'a Arena) -> &'a mut Bcx<'a> {
-    unsafe {
-        mem::transmute(libc::malloc(mem::size_of::<Bcx<'a>>()
-            as libc::size_t))
-    }
+fn alloc<'a>(_bcx: &'a Arena) -> &'a mut Bcx<'a> {
+    unsafe { mem::transmute(libc::malloc(mem::size_of::<Bcx<'a>>() as libc::size_t)) }
 }
 
-fn h<'a>(bcx : &'a Bcx<'a>) -> &'a mut Bcx<'a> {
+fn h<'a>(bcx: &'a Bcx<'a>) -> &'a mut Bcx<'a> {
     return alloc(bcx.fcx.arena);
 }
 
-fn g(fcx : &Fcx) {
+fn g(fcx: &Fcx) {
     let bcx = Bcx { fcx: fcx };
     let bcx2 = h(&bcx);
     unsafe {
@@ -42,7 +39,7 @@ fn g(fcx : &Fcx) {
     }
 }
 
-fn f(ccx : &Ccx) {
+fn f(ccx: &Ccx) {
     let a = Arena(());
     let fcx = Fcx { arena: &a, ccx: ccx };
     return g(&fcx);

--- a/tests/pass/send-is-not-static-par-for.rs
+++ b/tests/pass/send-is-not-static-par-for.rs
@@ -1,9 +1,10 @@
 use std::sync::Mutex;
 
 fn par_for<I, F>(iter: I, f: F)
-    where I: Iterator,
-          I::Item: Send,
-          F: Fn(I::Item) + Sync
+where
+    I: Iterator,
+    I::Item: Send,
+    F: Fn(I::Item) + Sync,
 {
     for item in iter {
         f(item)
@@ -12,9 +13,7 @@ fn par_for<I, F>(iter: I, f: F)
 
 fn sum(x: &[i32]) {
     let sum_lengths = Mutex::new(0);
-    par_for(x.windows(4), |x| {
-        *sum_lengths.lock().unwrap() += x.len()
-    });
+    par_for(x.windows(4), |x| *sum_lengths.lock().unwrap() += x.len());
 
     assert_eq!(*sum_lengths.lock().unwrap(), (x.len() - 3) * 4);
 }
@@ -23,9 +22,7 @@ fn main() {
     let mut elements = [0; 20];
 
     // iterators over references into this stack frame
-    par_for(elements.iter_mut().enumerate(), |(i, x)| {
-        *x = i as i32
-    });
+    par_for(elements.iter_mut().enumerate(), |(i, x)| *x = i as i32);
 
     sum(&elements)
 }

--- a/tests/pass/sendable-class.rs
+++ b/tests/pass/sendable-class.rs
@@ -8,11 +8,8 @@ struct Foo {
     j: char,
 }
 
-fn foo(i:isize, j: char) -> Foo {
-    Foo {
-        i: i,
-        j: j
-    }
+fn foo(i: isize, j: char) -> Foo {
+    Foo { i: i, j: j }
 }
 
 pub fn main() {

--- a/tests/pass/simd-intrinsic-generic-elements.rs
+++ b/tests/pass/simd-intrinsic-generic-elements.rs
@@ -11,8 +11,7 @@ struct i32x4(i32, i32, i32, i32);
 #[repr(simd)]
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[allow(non_camel_case_types)]
-struct i32x8(i32, i32, i32, i32,
-             i32, i32, i32, i32);
+struct i32x8(i32, i32, i32, i32, i32, i32, i32, i32);
 
 fn main() {
     let _x2 = i32x2(20, 21);
@@ -22,5 +21,4 @@ fn main() {
     let _y2 = i32x2(120, 121);
     let _y4 = i32x4(140, 141, 142, 143);
     let _y8 = i32x8(180, 181, 182, 183, 184, 185, 186, 187);
-
 }

--- a/tests/pass/slices.rs
+++ b/tests/pass/slices.rs
@@ -5,8 +5,8 @@
 #![feature(layout_for_ptr)]
 #![feature(strict_provenance)]
 
-use std::slice;
 use std::ptr;
+use std::slice;
 
 fn slice_of_zst() {
     fn foo<T>(v: &[T]) -> Option<&[T]> {
@@ -40,7 +40,8 @@ fn slice_of_zst() {
     assert!(foo(slice).is_some());
 
     // Test mutable iterators as well
-    let slice: &mut [()] = unsafe { slice::from_raw_parts_mut(ptr::invalid_mut(-5isize as usize), 10) };
+    let slice: &mut [()] =
+        unsafe { slice::from_raw_parts_mut(ptr::invalid_mut(-5isize as usize), 10) };
     assert_eq!(slice.len(), 10);
     assert_eq!(slice.iter_mut().count(), 10);
 
@@ -56,11 +57,11 @@ fn slice_of_zst() {
 fn test_iter_ref_consistency() {
     use std::fmt::Debug;
 
-    fn test<T : Copy + Debug + PartialEq>(x : T) {
-        let v : &[T] = &[x, x, x];
-        let v_ptrs : [*const T; 3] = match v {
+    fn test<T: Copy + Debug + PartialEq>(x: T) {
+        let v: &[T] = &[x, x, x];
+        let v_ptrs: [*const T; 3] = match v {
             [ref v1, ref v2, ref v3] => [v1 as *const _, v2 as *const _, v3 as *const _],
-            _ => unreachable!()
+            _ => unreachable!(),
         };
         let len = v.len();
 
@@ -104,19 +105,19 @@ fn test_iter_ref_consistency() {
                 assert_eq!(it.size_hint(), (remaining, Some(remaining)));
 
                 let prev = it.next_back().unwrap();
-                assert_eq!(prev as *const _, v_ptrs[remaining-1]);
+                assert_eq!(prev as *const _, v_ptrs[remaining - 1]);
             }
             assert_eq!(it.size_hint(), (0, Some(0)));
             assert_eq!(it.next_back(), None, "The final call to next_back() should return None");
         }
     }
 
-    fn test_mut<T : Copy + Debug + PartialEq>(x : T) {
-        let v : &mut [T] = &mut [x, x, x];
-        let v_ptrs : [*mut T; 3] = match v {
+    fn test_mut<T: Copy + Debug + PartialEq>(x: T) {
+        let v: &mut [T] = &mut [x, x, x];
+        let v_ptrs: [*mut T; 3] = match v {
             [ref v1, ref v2, ref v3] =>
-              [v1 as *const _ as *mut _, v2 as *const _ as *mut _, v3 as *const _ as *mut _],
-            _ => unreachable!()
+                [v1 as *const _ as *mut _, v2 as *const _ as *mut _, v3 as *const _ as *mut _],
+            _ => unreachable!(),
         };
         let len = v.len();
 
@@ -160,7 +161,7 @@ fn test_iter_ref_consistency() {
                 assert_eq!(it.size_hint(), (remaining, Some(remaining)));
 
                 let prev = it.next_back().unwrap();
-                assert_eq!(prev as *mut _, v_ptrs[remaining-1]);
+                assert_eq!(prev as *mut _, v_ptrs[remaining - 1]);
             }
             assert_eq!(it.size_hint(), (0, Some(0)));
             assert_eq!(it.next_back(), None, "The final call to next_back() should return None");
@@ -215,10 +216,14 @@ fn test_for_invalidated_pointers() {
     // The invalidated `*const` pointer (the first argument to `core::ptr::copy`) is then used
     // after the fact when `core::ptr::copy` is called, which triggers undefined behavior.
 
-    unsafe { assert_eq!(0, *buffer.as_mut_ptr_range().start ); }
+    unsafe {
+        assert_eq!(0, *buffer.as_mut_ptr_range().start);
+    }
     // Check that the pointer range is in-bounds, while we're at it
     let range = buffer.as_mut_ptr_range();
-    unsafe { assert_eq!(*range.start, *range.end.sub(len)); }
+    unsafe {
+        assert_eq!(*range.start, *range.end.sub(len));
+    }
 
     buffer.reverse();
 

--- a/tests/pass/specialization.rs
+++ b/tests/pass/specialization.rs
@@ -6,11 +6,15 @@ trait IsUnit {
 }
 
 impl<T> IsUnit for T {
-    default fn is_unit() -> bool { false }
+    default fn is_unit() -> bool {
+        false
+    }
 }
 
 impl IsUnit for () {
-    fn is_unit() -> bool { true }
+    fn is_unit() -> bool {
+        true
+    }
 }
 
 fn specialization() -> (bool, bool) {

--- a/tests/pass/stacked-borrows/2phase.rs
+++ b/tests/pass/stacked-borrows/2phase.rs
@@ -22,8 +22,8 @@ fn two_phase3(b: bool) {
     x.push((
         {
             if b {
-                x = &mut y
-            };
+                x = &mut y;
+            }
             22
         },
         x.len(),

--- a/tests/pass/stacked-borrows/2phase.rs
+++ b/tests/pass/stacked-borrows/2phase.rs
@@ -21,7 +21,9 @@ fn two_phase3(b: bool) {
     let mut y = vec![];
     x.push((
         {
-            if b { x = &mut y };
+            if b {
+                x = &mut y
+            };
             22
         },
         x.len(),
@@ -31,16 +33,16 @@ fn two_phase3(b: bool) {
 #[allow(unreachable_code)]
 fn two_phase_raw() {
     let x: &mut Vec<i32> = &mut vec![];
-    x.push(
-        {
-            // Unfortunately this does not trigger the problem of creating a
-            // raw ponter from a pointer that had a two-phase borrow derived from
-            // it because of the implicit &mut reborrow.
-            let raw = x as *mut _;
-            unsafe { *raw = vec![1]; }
-            return
+    x.push({
+        // Unfortunately this does not trigger the problem of creating a
+        // raw ponter from a pointer that had a two-phase borrow derived from
+        // it because of the implicit &mut reborrow.
+        let raw = x as *mut _;
+        unsafe {
+            *raw = vec![1];
         }
-    );
+        return;
+    });
 }
 
 fn two_phase_overlapping1() {
@@ -68,13 +70,11 @@ fn with_interior_mutability() {
     let mut x = Cell::new(1);
     let l = &x;
 
-    x
-        .do_the_thing({
-            x.set(3);
-            l.set(4);
-            x.get() + l.get()
-        })
-    ;
+    x.do_the_thing({
+        x.set(3);
+        l.set(4);
+        x.get() + l.get()
+    });
 }
 
 fn main() {

--- a/tests/pass/stacked-borrows/interior_mutability.rs
+++ b/tests/pass/stacked-borrows/interior_mutability.rs
@@ -1,5 +1,5 @@
-use std::mem::MaybeUninit;
 use std::cell::{Cell, RefCell, UnsafeCell};
+use std::mem::MaybeUninit;
 
 fn main() {
     aliasing_mut_and_shr();
@@ -28,7 +28,7 @@ fn aliasing_mut_and_shr() {
     let mut bmut = rc.borrow_mut();
     inner(&rc, &mut *bmut);
     drop(bmut);
-    assert_eq!(*rc.borrow(), 23+12);
+    assert_eq!(*rc.borrow(), 23 + 12);
 }
 
 fn aliasing_frz_and_shr() {
@@ -59,9 +59,11 @@ fn into_interior_mutability() {
 
 // Two-phase borrows of the pointer returned by UnsafeCell::get() should not
 // invalidate aliases.
-fn unsafe_cell_2phase() { unsafe {
-    let x = &UnsafeCell::new(vec![]);
-    let x2 = &*x;
-    (*x.get()).push(0);
-    let _val = (*x2.get()).get(0);
-} }
+fn unsafe_cell_2phase() {
+    unsafe {
+        let x = &UnsafeCell::new(vec![]);
+        let x2 = &*x;
+        (*x.get()).push(0);
+        let _val = (*x2.get()).get(0);
+    }
+}


### PR DESCRIPTION
Extracted from #2097.

Like https://github.com/rust-lang/miri/pull/2244, these are "easy" cases that do not involve moving around comments.