### PR TITLE
Format tests with rustfmt (151-200 of 300)

### DIFF
--- a/tests/fail/intrinsics/simd-rem-by-zero.rs
+++ b/tests/fail/intrinsics/simd-rem-by-zero.rs
@@ -8,8 +8,10 @@ extern "platform-intrinsic" {
 #[allow(non_camel_case_types)]
 struct i32x2(i32, i32);
 
-fn main() { unsafe {
-    let x = i32x2(1, 1);
-    let y = i32x2(1, 0);
-    simd_rem(x, y); //~ERROR Undefined Behavior: calculating the remainder with a divisor of zero
-} }
+fn main() {
+    unsafe {
+        let x = i32x2(1, 1);
+        let y = i32x2(1, 0);
+        simd_rem(x, y); //~ERROR Undefined Behavior: calculating the remainder with a divisor of zero
+    }
+}

--- a/tests/fail/intrinsics/simd-rem-by-zero.stderr
+++ b/tests/fail/intrinsics/simd-rem-by-zero.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: calculating the remainder with a divisor of zero
   --> $DIR/simd-rem-by-zero.rs:LL:CC
    |
-LL |     simd_rem(x, y);
-   |     ^^^^^^^^^^^^^^ calculating the remainder with a divisor of zero
+LL |         simd_rem(x, y);
+   |         ^^^^^^^^^^^^^^ calculating the remainder with a divisor of zero
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/simd-scatter.rs
+++ b/tests/fail/intrinsics/simd-scatter.rs
@@ -2,8 +2,14 @@
 #![feature(portable_simd)]
 use std::simd::*;
 
-fn main() { unsafe {
-    let mut vec: Vec<i8> = vec![10, 11, 12, 13, 14, 15, 16, 17, 18];
-    let idxs = Simd::from_array([9, 3, 0, 17]);
-    Simd::from_array([-27, 82, -41, 124]).scatter_select_unchecked(&mut vec, Mask::splat(true), idxs);
-} }
+fn main() {
+    unsafe {
+        let mut vec: Vec<i8> = vec![10, 11, 12, 13, 14, 15, 16, 17, 18];
+        let idxs = Simd::from_array([9, 3, 0, 17]);
+        Simd::from_array([-27, 82, -41, 124]).scatter_select_unchecked(
+            &mut vec,
+            Mask::splat(true),
+            idxs,
+        );
+    }
+}

--- a/tests/fail/intrinsics/simd-scatter.stderr
+++ b/tests/fail/intrinsics/simd-scatter.stderr
@@ -11,8 +11,12 @@ LL |             intrinsics::simd_scatter(self, ptrs, enable.to_int())
 note: inside `main` at $DIR/simd-scatter.rs:LL:CC
   --> $DIR/simd-scatter.rs:LL:CC
    |
-LL |     Simd::from_array([-27, 82, -41, 124]).scatter_select_unchecked(&mut vec, Mask::splat(true), idxs);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | /         Simd::from_array([-27, 82, -41, 124]).scatter_select_unchecked(
+LL | |             &mut vec,
+LL | |             Mask::splat(true),
+LL | |             idxs,
+LL | |         );
+   | |_________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/simd-select-bitmask-invalid.rs
+++ b/tests/fail/intrinsics/simd-select-bitmask-invalid.rs
@@ -9,7 +9,9 @@ extern "platform-intrinsic" {
 #[derive(Copy, Clone)]
 struct i32x2(i32, i32);
 
-fn main() { unsafe {
-    let x = i32x2(0, 1);
-    simd_select_bitmask(0b11111111u8, x, x); //~ERROR bitmask less than 8 bits long must be filled with 0s for the remaining bits
-} }
+fn main() {
+    unsafe {
+        let x = i32x2(0, 1);
+        simd_select_bitmask(0b11111111u8, x, x); //~ERROR bitmask less than 8 bits long must be filled with 0s for the remaining bits
+    }
+}

--- a/tests/fail/intrinsics/simd-select-bitmask-invalid.stderr
+++ b/tests/fail/intrinsics/simd-select-bitmask-invalid.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: a SIMD bitmask less than 8 bits long must be filled with 0s for the remaining bits
   --> $DIR/simd-select-bitmask-invalid.rs:LL:CC
    |
-LL |     simd_select_bitmask(0b11111111u8, x, x);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ a SIMD bitmask less than 8 bits long must be filled with 0s for the remaining bits
+LL |         simd_select_bitmask(0b11111111u8, x, x);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ a SIMD bitmask less than 8 bits long must be filled with 0s for the remaining bits
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/simd-select-invalid-bool.rs
+++ b/tests/fail/intrinsics/simd-select-invalid-bool.rs
@@ -9,7 +9,9 @@ extern "platform-intrinsic" {
 #[derive(Copy, Clone)]
 struct i32x2(i32, i32);
 
-fn main() { unsafe {
-    let x = i32x2(0, 1);
-    simd_select(x, x, x); //~ERROR must be all-0-bits or all-1-bits
-} }
+fn main() {
+    unsafe {
+        let x = i32x2(0, 1);
+        simd_select(x, x, x); //~ERROR must be all-0-bits or all-1-bits
+    }
+}

--- a/tests/fail/intrinsics/simd-select-invalid-bool.stderr
+++ b/tests/fail/intrinsics/simd-select-invalid-bool.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: each element of a SIMD mask must be all-0-bits or all-1-bits
   --> $DIR/simd-select-invalid-bool.rs:LL:CC
    |
-LL |     simd_select(x, x, x);
-   |     ^^^^^^^^^^^^^^^^^^^^ each element of a SIMD mask must be all-0-bits or all-1-bits
+LL |         simd_select(x, x, x);
+   |         ^^^^^^^^^^^^^^^^^^^^ each element of a SIMD mask must be all-0-bits or all-1-bits
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/simd-shl-too-far.rs
+++ b/tests/fail/intrinsics/simd-shl-too-far.rs
@@ -8,8 +8,10 @@ extern "platform-intrinsic" {
 #[allow(non_camel_case_types)]
 struct i32x2(i32, i32);
 
-fn main() { unsafe {
-    let x = i32x2(1, 1);
-    let y = i32x2(100, 0);
-    simd_shl(x, y); //~ERROR overflowing shift by 100 in `simd_shl` in SIMD lane 0
-} }
+fn main() {
+    unsafe {
+        let x = i32x2(1, 1);
+        let y = i32x2(100, 0);
+        simd_shl(x, y); //~ERROR overflowing shift by 100 in `simd_shl` in SIMD lane 0
+    }
+}

--- a/tests/fail/intrinsics/simd-shl-too-far.stderr
+++ b/tests/fail/intrinsics/simd-shl-too-far.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: overflowing shift by 100 in `simd_shl` in SIMD lane 0
   --> $DIR/simd-shl-too-far.rs:LL:CC
    |
-LL |     simd_shl(x, y);
-   |     ^^^^^^^^^^^^^^ overflowing shift by 100 in `simd_shl` in SIMD lane 0
+LL |         simd_shl(x, y);
+   |         ^^^^^^^^^^^^^^ overflowing shift by 100 in `simd_shl` in SIMD lane 0
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/simd-shr-too-far.rs
+++ b/tests/fail/intrinsics/simd-shr-too-far.rs
@@ -8,8 +8,10 @@ extern "platform-intrinsic" {
 #[allow(non_camel_case_types)]
 struct i32x2(i32, i32);
 
-fn main() { unsafe {
-    let x = i32x2(1, 1);
-    let y = i32x2(20, 40);
-    simd_shr(x, y); //~ERROR overflowing shift by 40 in `simd_shr` in SIMD lane 1
-} }
+fn main() {
+    unsafe {
+        let x = i32x2(1, 1);
+        let y = i32x2(20, 40);
+        simd_shr(x, y); //~ERROR overflowing shift by 40 in `simd_shr` in SIMD lane 1
+    }
+}

--- a/tests/fail/intrinsics/simd-shr-too-far.stderr
+++ b/tests/fail/intrinsics/simd-shr-too-far.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: overflowing shift by 40 in `simd_shr` in SIMD lane 1
   --> $DIR/simd-shr-too-far.rs:LL:CC
    |
-LL |     simd_shr(x, y);
-   |     ^^^^^^^^^^^^^^ overflowing shift by 40 in `simd_shr` in SIMD lane 1
+LL |         simd_shr(x, y);
+   |         ^^^^^^^^^^^^^^ overflowing shift by 40 in `simd_shr` in SIMD lane 1
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/invalid_enum_tag.rs
+++ b/tests/fail/invalid_enum_tag.rs
@@ -8,7 +8,10 @@ use std::mem;
 
 #[repr(C)]
 pub enum Foo {
-    A, B, C, D
+    A,
+    B,
+    C,
+    D,
 }
 
 fn main() {

--- a/tests/fail/issue-miri-1112.rs
+++ b/tests/fail/issue-miri-1112.rs
@@ -12,11 +12,7 @@ pub struct Meta {
 
 impl Meta {
     pub fn new() -> Self {
-        Meta {
-            drop_fn: |_| {},
-            size: 0,
-            align: 1,
-        }
+        Meta { drop_fn: |_| {}, size: 0, align: 1 }
     }
 }
 

--- a/tests/fail/memleak_rc.rs
+++ b/tests/fail/memleak_rc.rs
@@ -2,8 +2,8 @@
 // stderr-per-bitwidth
 // normalize-stderr-test: ".*│.*" -> "$$stripped$$"
 
-use std::rc::Rc;
 use std::cell::RefCell;
+use std::rc::Rc;
 
 struct Dummy(Rc<RefCell<Option<Dummy>>>);
 

--- a/tests/fail/modifying_constants.rs
+++ b/tests/fail/modifying_constants.rs
@@ -4,6 +4,6 @@
 fn main() {
     let x = &1; // the `&1` is promoted to a constant, but it used to be that only the pointer is marked static, not the pointee
     let y = unsafe { &mut *(x as *const i32 as *mut i32) };
-    *y = 42;  //~ ERROR read-only
+    *y = 42; //~ ERROR read-only
     assert_eq!(*x, 42);
 }

--- a/tests/fail/never_say_never.rs
+++ b/tests/fail/never_say_never.rs
@@ -7,9 +7,11 @@
 fn main() {
     let y = &5;
     let x: ! = unsafe {
-        *(y as *const _ as *const !)  //~ ERROR entering unreachable code
+        *(y as *const _ as *const !) //~ ERROR entering unreachable code
     };
     f(x)
 }
 
-fn f(x: !) -> ! { x }
+fn f(x: !) -> ! {
+    x
+}

--- a/tests/fail/never_transmute_void.rs
+++ b/tests/fail/never_transmute_void.rs
@@ -14,8 +14,6 @@ mod m {
 }
 
 fn main() {
-    let v = unsafe {
-        std::mem::transmute::<(), m::Void>(())
-    };
+    let v = unsafe { std::mem::transmute::<(), m::Void>(()) };
     m::f(v); //~ inside `main`
 }

--- a/tests/fail/rc_as_ptr.rs
+++ b/tests/fail/rc_as_ptr.rs
@@ -1,8 +1,8 @@
 // This should fail even without validation
 // compile-flags: -Zmiri-disable-validation
 
-use std::rc::{Rc, Weak};
 use std::ptr;
+use std::rc::{Rc, Weak};
 
 /// Taken from the `Weak::as_ptr` doctest.
 fn main() {

--- a/tests/fail/reading_half_a_pointer.rs
+++ b/tests/fail/reading_half_a_pointer.rs
@@ -13,7 +13,7 @@ struct Wrapper {
     data: Data,
 }
 
-static G : i32 = 0;
+static G: i32 = 0;
 
 fn main() {
     let mut w = Wrapper { align: 0, data: Data { pad: 0, ptr: &G } };

--- a/tests/fail/shim_arg_size.rs
+++ b/tests/fail/shim_arg_size.rs
@@ -4,10 +4,10 @@ fn main() {
     extern "C" {
         // Use the wrong type(ie. not the pointer width) for the `size`
         // argument.
-        #[cfg(target_pointer_width="64")]
+        #[cfg(target_pointer_width = "64")]
         fn malloc(size: u32) -> *mut std::ffi::c_void;
 
-        #[cfg(target_pointer_width="32")]
+        #[cfg(target_pointer_width = "32")]
         fn malloc(size: u16) -> *mut std::ffi::c_void;
     }
 

--- a/tests/fail/should-pass/cpp20_rwc_syncs.rs
+++ b/tests/fail/should-pass/cpp20_rwc_syncs.rs
@@ -76,7 +76,9 @@ fn test_cpp20_rwc_syncs() {
     // Our ui_test does not yet support overriding failure status codes.
     if (b, c) == (0, 0) {
         // This *should* be unreachable, but Miri will reach it.
-        unsafe { std::hint::unreachable_unchecked(); }
+        unsafe {
+            std::hint::unreachable_unchecked();
+        }
     }
 }
 

--- a/tests/fail/should-pass/cpp20_rwc_syncs.stderr
+++ b/tests/fail/should-pass/cpp20_rwc_syncs.stderr
@@ -11,8 +11,8 @@ LL |     unsafe { intrinsics::unreachable() }
 note: inside `test_cpp20_rwc_syncs` at $DIR/cpp20_rwc_syncs.rs:LL:CC
   --> $DIR/cpp20_rwc_syncs.rs:LL:CC
    |
-LL |         unsafe { std::hint::unreachable_unchecked(); }
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |             std::hint::unreachable_unchecked();
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: inside `main` at $DIR/cpp20_rwc_syncs.rs:LL:CC
   --> $DIR/cpp20_rwc_syncs.rs:LL:CC
    |

--- a/tests/fail/stacked_borrows/alias_through_mutation.rs
+++ b/tests/fail/stacked_borrows/alias_through_mutation.rs
@@ -1,6 +1,8 @@
 // This makes a ref that was passed to us via &mut alias with things it should not alias with
 fn retarget(x: &mut &u32, target: &mut u32) {
-    unsafe { *x = &mut *(target as *mut _); }
+    unsafe {
+        *x = &mut *(target as *mut _);
+    }
 }
 
 fn main() {

--- a/tests/fail/stacked_borrows/alias_through_mutation.stderr
+++ b/tests/fail/stacked_borrows/alias_through_mutation.stderr
@@ -12,8 +12,8 @@ LL |     let _val = *target_alias;
 help: <TAG> was created by a retag at offsets [0x0..0x4]
   --> $DIR/alias_through_mutation.rs:LL:CC
    |
-LL |     unsafe { *x = &mut *(target as *mut _); }
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         *x = &mut *(target as *mut _);
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^
 help: <TAG> was later invalidated at offsets [0x0..0x4]
   --> $DIR/alias_through_mutation.rs:LL:CC
    |

--- a/tests/fail/stacked_borrows/aliasing_mut1.rs
+++ b/tests/fail/stacked_borrows/aliasing_mut1.rs
@@ -8,8 +8,7 @@ fn main() {
     // We need to apply some tricky to be able to call `safe` with two mutable references
     // with the same tag: We transmute both the fn ptr (to take raw ptrs) and the argument
     // (to be raw, but still have the unique tag).
-    let safe_raw: fn(x: *mut i32, y: *mut i32) = unsafe {
-        mem::transmute::<fn(&mut i32, &mut i32), _>(safe)
-    };
+    let safe_raw: fn(x: *mut i32, y: *mut i32) =
+        unsafe { mem::transmute::<fn(&mut i32, &mut i32), _>(safe) };
     safe_raw(xraw, xraw);
 }

--- a/tests/fail/stacked_borrows/aliasing_mut2.rs
+++ b/tests/fail/stacked_borrows/aliasing_mut2.rs
@@ -8,8 +8,7 @@ fn main() {
     let xraw: *mut i32 = unsafe { mem::transmute_copy(&xref) };
     let xshr = &*xref;
     // transmute fn ptr around so that we can avoid retagging
-    let safe_raw: fn(x: *const i32, y: *mut i32) = unsafe {
-        mem::transmute::<fn(&i32, &mut i32), _>(safe)
-    };
+    let safe_raw: fn(x: *const i32, y: *mut i32) =
+        unsafe { mem::transmute::<fn(&i32, &mut i32), _>(safe) };
     safe_raw(xshr, xraw);
 }

--- a/tests/fail/stacked_borrows/aliasing_mut3.rs
+++ b/tests/fail/stacked_borrows/aliasing_mut3.rs
@@ -8,8 +8,7 @@ fn main() {
     let xraw: *mut i32 = unsafe { mem::transmute_copy(&xref) };
     let xshr = &*xref;
     // transmute fn ptr around so that we can avoid retagging
-    let safe_raw: fn(x: *mut i32, y: *const i32) = unsafe {
-        mem::transmute::<fn(&mut i32, &i32), _>(safe)
-    };
+    let safe_raw: fn(x: *mut i32, y: *const i32) =
+        unsafe { mem::transmute::<fn(&mut i32, &i32), _>(safe) };
     safe_raw(xraw, xshr);
 }

--- a/tests/fail/stacked_borrows/aliasing_mut4.rs
+++ b/tests/fail/stacked_borrows/aliasing_mut4.rs
@@ -1,5 +1,5 @@
-use std::mem;
 use std::cell::Cell;
+use std::mem;
 
 // Make sure &mut UnsafeCell also is exclusive
 pub fn safe(_x: &i32, _y: &mut Cell<i32>) {} //~ ERROR protect
@@ -10,8 +10,7 @@ fn main() {
     let xraw: *mut i32 = unsafe { mem::transmute_copy(&xref) };
     let xshr = &*xref;
     // transmute fn ptr around so that we can avoid retagging
-    let safe_raw: fn(x: *const i32, y: *mut Cell<i32>) = unsafe {
-        mem::transmute::<fn(&i32, &mut Cell<i32>), _>(safe)
-    };
+    let safe_raw: fn(x: *const i32, y: *mut Cell<i32>) =
+        unsafe { mem::transmute::<fn(&i32, &mut Cell<i32>), _>(safe) };
     safe_raw(xshr, xraw as *mut _);
 }

--- a/tests/fail/stacked_borrows/box_exclusive_violation1.rs
+++ b/tests/fail/stacked_borrows/box_exclusive_violation1.rs
@@ -1,14 +1,14 @@
 fn demo_mut_advanced_unique(mut our: Box<i32>) -> i32 {
-  unknown_code_1(&*our);
+    unknown_code_1(&*our);
 
-  // This "re-asserts" uniqueness of the reference: After writing, we know
-  // our tag is at the top of the stack.
-  *our = 5;
+    // This "re-asserts" uniqueness of the reference: After writing, we know
+    // our tag is at the top of the stack.
+    *our = 5;
 
-  unknown_code_2();
+    unknown_code_2();
 
-  // We know this will return 5
-  *our //~ ERROR borrow stack
+    // We know this will return 5
+    *our //~ ERROR borrow stack
 }
 
 // Now comes the evil context
@@ -16,13 +16,17 @@ use std::ptr;
 
 static mut LEAK: *mut i32 = ptr::null_mut();
 
-fn unknown_code_1(x: &i32) { unsafe {
-    LEAK = x as *const _ as *mut _;
-} }
+fn unknown_code_1(x: &i32) {
+    unsafe {
+        LEAK = x as *const _ as *mut _;
+    }
+}
 
-fn unknown_code_2() { unsafe {
-    *LEAK = 7;
-} }
+fn unknown_code_2() {
+    unsafe {
+        *LEAK = 7;
+    }
+}
 
 fn main() {
     demo_mut_advanced_unique(Box::new(0));

--- a/tests/fail/stacked_borrows/box_exclusive_violation1.stderr
+++ b/tests/fail/stacked_borrows/box_exclusive_violation1.stderr
@@ -1,11 +1,11 @@
 error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/box_exclusive_violation1.rs:LL:CC
    |
-LL |   *our
-   |   ^^^^
-   |   |
-   |   attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
-   |   this error occurs as part of an access at ALLOC[0x0..0x4]
+LL |     *our
+   |     ^^^^
+   |     |
+   |     attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |     this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
@@ -13,18 +13,18 @@ help: <TAG> was created by a retag at offsets [0x0..0x4]
   --> $DIR/box_exclusive_violation1.rs:LL:CC
    |
 LL | / fn demo_mut_advanced_unique(mut our: Box<i32>) -> i32 {
-LL | |   unknown_code_1(&*our);
+LL | |     unknown_code_1(&*our);
 LL | |
-LL | |   // This "re-asserts" uniqueness of the reference: After writing, we know
+LL | |     // This "re-asserts" uniqueness of the reference: After writing, we know
 ...  |
-LL | |   *our
+LL | |     *our
 LL | | }
    | |_^
 help: <TAG> was later invalidated at offsets [0x0..0x4]
   --> $DIR/box_exclusive_violation1.rs:LL:CC
    |
-LL |     *LEAK = 7;
-   |     ^^^^^^^^^
+LL |         *LEAK = 7;
+   |         ^^^^^^^^^
    = note: inside `demo_mut_advanced_unique` at $DIR/box_exclusive_violation1.rs:LL:CC
 note: inside `main` at $DIR/box_exclusive_violation1.rs:LL:CC
   --> $DIR/box_exclusive_violation1.rs:LL:CC

--- a/tests/fail/stacked_borrows/buggy_as_mut_slice.rs
+++ b/tests/fail/stacked_borrows/buggy_as_mut_slice.rs
@@ -2,14 +2,12 @@ mod safe {
     use std::slice::from_raw_parts_mut;
 
     pub fn as_mut_slice<T>(self_: &Vec<T>) -> &mut [T] {
-        unsafe {
-            from_raw_parts_mut(self_.as_ptr() as *mut T, self_.len())
-        }
+        unsafe { from_raw_parts_mut(self_.as_ptr() as *mut T, self_.len()) }
     }
 }
 
 fn main() {
-    let v = vec![0,1,2];
+    let v = vec![0, 1, 2];
     let v1 = safe::as_mut_slice(&v);
     let _v2 = safe::as_mut_slice(&v);
     v1[1] = 5;

--- a/tests/fail/stacked_borrows/buggy_as_mut_slice.stderr
+++ b/tests/fail/stacked_borrows/buggy_as_mut_slice.stderr
@@ -17,8 +17,8 @@ LL |     let v1 = safe::as_mut_slice(&v);
 help: <TAG> was later invalidated at offsets [0x0..0xc]
   --> $DIR/buggy_as_mut_slice.rs:LL:CC
    |
-LL |             from_raw_parts_mut(self_.as_ptr() as *mut T, self_.len())
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         unsafe { from_raw_parts_mut(self_.as_ptr() as *mut T, self_.len()) }
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: inside `main` at $DIR/buggy_as_mut_slice.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/buggy_split_at_mut.rs
+++ b/tests/fail/stacked_borrows/buggy_split_at_mut.rs
@@ -8,14 +8,16 @@ mod safe {
         unsafe {
             assert!(mid <= len);
 
-            (from_raw_parts_mut(ptr, len - mid), // BUG: should be "mid" instead of "len - mid"
-            from_raw_parts_mut(ptr.offset(mid as isize), len - mid))
+            (
+                from_raw_parts_mut(ptr, len - mid), // BUG: should be "mid" instead of "len - mid"
+                from_raw_parts_mut(ptr.offset(mid as isize), len - mid),
+            )
         }
     }
 }
 
 fn main() {
-    let mut array = [1,2,3,4];
+    let mut array = [1, 2, 3, 4];
     let (a, b) = safe::split_at_mut(&mut array, 0);
     //~^ ERROR borrow stack
     a[1] = 5;

--- a/tests/fail/stacked_borrows/buggy_split_at_mut.stderr
+++ b/tests/fail/stacked_borrows/buggy_split_at_mut.stderr
@@ -12,13 +12,13 @@ LL |     let (a, b) = safe::split_at_mut(&mut array, 0);
 help: <TAG> was created by a retag at offsets [0x0..0x10]
   --> $DIR/buggy_split_at_mut.rs:LL:CC
    |
-LL |             (from_raw_parts_mut(ptr, len - mid), // BUG: should be "mid" instead of "len - mid"
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |                 from_raw_parts_mut(ptr, len - mid), // BUG: should be "mid" instead of "len - mid"
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: <TAG> was later invalidated at offsets [0x0..0x10]
   --> $DIR/buggy_split_at_mut.rs:LL:CC
    |
-LL |             from_raw_parts_mut(ptr.offset(mid as isize), len - mid))
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |                 from_raw_parts_mut(ptr.offset(mid as isize), len - mid),
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: inside `main` at $DIR/buggy_split_at_mut.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_read6.rs
+++ b/tests/fail/stacked_borrows/illegal_read6.rs
@@ -1,8 +1,10 @@
 // Creating a shared reference does not leak the data to raw pointers.
-fn main() { unsafe {
-    let x = &mut 0;
-    let raw = x as *mut _;
-    let x = &mut *x; // kill `raw`
-    let _y = &*x; // this should not activate `raw` again
-    let _val = *raw; //~ ERROR borrow stack
-} }
+fn main() {
+    unsafe {
+        let x = &mut 0;
+        let raw = x as *mut _;
+        let x = &mut *x; // kill `raw`
+        let _y = &*x; // this should not activate `raw` again
+        let _val = *raw; //~ ERROR borrow stack
+    }
+}

--- a/tests/fail/stacked_borrows/illegal_read6.stderr
+++ b/tests/fail/stacked_borrows/illegal_read6.stderr
@@ -1,24 +1,24 @@
 error: Undefined Behavior: attempting a read access using <untagged> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/illegal_read6.rs:LL:CC
    |
-LL |     let _val = *raw;
-   |                ^^^^
-   |                |
-   |                attempting a read access using <untagged> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
-   |                this error occurs as part of an access at ALLOC[0x0..0x4]
+LL |         let _val = *raw;
+   |                    ^^^^
+   |                    |
+   |                    attempting a read access using <untagged> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                    this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
 help: tag was most recently created at offsets [0x0..0x4]
   --> $DIR/illegal_read6.rs:LL:CC
    |
-LL |     let raw = x as *mut _;
-   |               ^
+LL |         let raw = x as *mut _;
+   |                   ^
 help: tag was later invalidated at offsets [0x0..0x4]
   --> $DIR/illegal_read6.rs:LL:CC
    |
-LL |     let x = &mut *x; // kill `raw`
-   |             ^^^^^^^
+LL |         let x = &mut *x; // kill `raw`
+   |                 ^^^^^^^
    = note: inside `main` at $DIR/illegal_read6.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_read7.rs
+++ b/tests/fail/stacked_borrows/illegal_read7.rs
@@ -4,17 +4,19 @@
 use std::cell::Cell;
 use std::ptr;
 
-fn main() { unsafe {
-    let x = &mut Cell::new(0);
-    let raw = x as *mut Cell<i32>;
-    let x = &mut *raw;
-    let _shr = &*x;
-    // The state here is interesting because the top of the stack is [Unique, SharedReadWrite],
-    // just like if we had done `x as *mut _`.
-    // If we said that reading from a lower item is fine if the top item is `SharedReadWrite`
-    // (one way to maybe preserve a stack discipline), then we could now read from `raw`
-    // without invalidating `x`.  That would be bad!  It would mean that creating `shr`
-    // leaked `x` to `raw`.
-    let _val = ptr::read(raw);
-    let _val = *x.get_mut(); //~ ERROR borrow stack
-} }
+fn main() {
+    unsafe {
+        let x = &mut Cell::new(0);
+        let raw = x as *mut Cell<i32>;
+        let x = &mut *raw;
+        let _shr = &*x;
+        // The state here is interesting because the top of the stack is [Unique, SharedReadWrite],
+        // just like if we had done `x as *mut _`.
+        // If we said that reading from a lower item is fine if the top item is `SharedReadWrite`
+        // (one way to maybe preserve a stack discipline), then we could now read from `raw`
+        // without invalidating `x`.  That would be bad!  It would mean that creating `shr`
+        // leaked `x` to `raw`.
+        let _val = ptr::read(raw);
+        let _val = *x.get_mut(); //~ ERROR borrow stack
+    }
+}

--- a/tests/fail/stacked_borrows/illegal_read7.stderr
+++ b/tests/fail/stacked_borrows/illegal_read7.stderr
@@ -1,24 +1,24 @@
 error: Undefined Behavior: trying to reborrow <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/illegal_read7.rs:LL:CC
    |
-LL |     let _val = *x.get_mut();
-   |                 ^^^^^^^^^^^
-   |                 |
-   |                 trying to reborrow <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
-   |                 this error occurs as part of a reborrow at ALLOC[0x0..0x4]
+LL |         let _val = *x.get_mut();
+   |                     ^^^^^^^^^^^
+   |                     |
+   |                     trying to reborrow <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                     this error occurs as part of a reborrow at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
 help: <TAG> was created by a retag at offsets [0x0..0x4]
   --> $DIR/illegal_read7.rs:LL:CC
    |
-LL |     let x = &mut *raw;
-   |             ^^^^^^^^^
+LL |         let x = &mut *raw;
+   |                 ^^^^^^^^^
 help: <TAG> was later invalidated at offsets [0x0..0x4]
   --> $DIR/illegal_read7.rs:LL:CC
    |
-LL |     let _val = ptr::read(raw);
-   |                ^^^^^^^^^^^^^^
+LL |         let _val = ptr::read(raw);
+   |                    ^^^^^^^^^^^^^^
    = note: inside `main` at $DIR/illegal_read7.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_read8.rs
+++ b/tests/fail/stacked_borrows/illegal_read8.rs
@@ -1,13 +1,15 @@
 // Make sure that creating a raw ptr next to a shared ref works
 // but the shared ref still gets invalidated when the raw ptr is used for writing.
 
-fn main() { unsafe {
-    use std::mem;
-    let x = &mut 0;
-    let y1: &i32 = mem::transmute(&*x); // launder lifetimes
-    let y2 = x as *mut _;
-    let _val = *y2;
-    let _val = *y1;
-    *y2 += 1;
-    let _fail = *y1; //~ ERROR borrow stack
-} }
+fn main() {
+    unsafe {
+        use std::mem;
+        let x = &mut 0;
+        let y1: &i32 = mem::transmute(&*x); // launder lifetimes
+        let y2 = x as *mut _;
+        let _val = *y2;
+        let _val = *y1;
+        *y2 += 1;
+        let _fail = *y1; //~ ERROR borrow stack
+    }
+}

--- a/tests/fail/stacked_borrows/illegal_read8.stderr
+++ b/tests/fail/stacked_borrows/illegal_read8.stderr
@@ -1,24 +1,24 @@
 error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/illegal_read8.rs:LL:CC
    |
-LL |     let _fail = *y1;
-   |                 ^^^
-   |                 |
-   |                 attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
-   |                 this error occurs as part of an access at ALLOC[0x0..0x4]
+LL |         let _fail = *y1;
+   |                     ^^^
+   |                     |
+   |                     attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                     this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
 help: <TAG> was created by a retag at offsets [0x0..0x4]
   --> $DIR/illegal_read8.rs:LL:CC
    |
-LL |     let y1: &i32 = mem::transmute(&*x); // launder lifetimes
-   |                    ^^^^^^^^^^^^^^^^^^^
+LL |         let y1: &i32 = mem::transmute(&*x); // launder lifetimes
+   |                        ^^^^^^^^^^^^^^^^^^^
 help: <TAG> was later invalidated at offsets [0x0..0x4]
   --> $DIR/illegal_read8.rs:LL:CC
    |
-LL |     *y2 += 1;
-   |     ^^^^^^^^
+LL |         *y2 += 1;
+   |         ^^^^^^^^
    = note: inside `main` at $DIR/illegal_read8.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/interior_mut1.rs
+++ b/tests/fail/stacked_borrows/interior_mut1.rs
@@ -1,15 +1,17 @@
 use std::cell::UnsafeCell;
 
-fn main() { unsafe {
-    let c = &UnsafeCell::new(UnsafeCell::new(0));
-    let inner_uniq = &mut *c.get();
-    // stack: [c: SharedReadWrite, inner_uniq: Unique]
+fn main() {
+    unsafe {
+        let c = &UnsafeCell::new(UnsafeCell::new(0));
+        let inner_uniq = &mut *c.get();
+        // stack: [c: SharedReadWrite, inner_uniq: Unique]
 
-    let inner_shr = &*inner_uniq; // adds a SharedReadWrite
-    // stack: [c: SharedReadWrite, inner_uniq: Unique, inner_shr: SharedReadWrite]
+        let inner_shr = &*inner_uniq; // adds a SharedReadWrite
+        // stack: [c: SharedReadWrite, inner_uniq: Unique, inner_shr: SharedReadWrite]
 
-    *c.get() = UnsafeCell::new(1); // invalidates inner_shr
-    // stack: [c: SharedReadWrite]
+        *c.get() = UnsafeCell::new(1); // invalidates inner_shr
+        // stack: [c: SharedReadWrite]
 
-    let _val = *inner_shr.get(); //~ ERROR borrow stack
-} }
+        let _val = *inner_shr.get(); //~ ERROR borrow stack
+    }
+}

--- a/tests/fail/stacked_borrows/interior_mut1.stderr
+++ b/tests/fail/stacked_borrows/interior_mut1.stderr
@@ -1,24 +1,24 @@
 error: Undefined Behavior: trying to reborrow <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/interior_mut1.rs:LL:CC
    |
-LL |     let _val = *inner_shr.get();
-   |                 ^^^^^^^^^^^^^^^
-   |                 |
-   |                 trying to reborrow <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
-   |                 this error occurs as part of a reborrow at ALLOC[0x0..0x4]
+LL |         let _val = *inner_shr.get();
+   |                     ^^^^^^^^^^^^^^^
+   |                     |
+   |                     trying to reborrow <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                     this error occurs as part of a reborrow at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
 help: <TAG> was created by a retag at offsets [0x0..0x4]
   --> $DIR/interior_mut1.rs:LL:CC
    |
-LL |     let inner_shr = &*inner_uniq; // adds a SharedReadWrite
-   |                     ^^^^^^^^^^^^
+LL |         let inner_shr = &*inner_uniq; // adds a SharedReadWrite
+   |                         ^^^^^^^^^^^^
 help: <TAG> was later invalidated at offsets [0x0..0x4]
   --> $DIR/interior_mut1.rs:LL:CC
    |
-LL |     *c.get() = UnsafeCell::new(1); // invalidates inner_shr
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         *c.get() = UnsafeCell::new(1); // invalidates inner_shr
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: inside `main` at $DIR/interior_mut1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/panic/panic/panic1.rs
+++ b/tests/panic/panic/panic1.rs
@@ -1,7 +1,6 @@
 // rustc-env: RUST_BACKTRACE=1
 // compile-flags: -Zmiri-disable-isolation
 
-
 fn main() {
     std::panic!("panicking from libstd");
 }

--- a/tests/panic/transmute_fat2.rs
+++ b/tests/panic/transmute_fat2.rs
@@ -1,16 +1,10 @@
 fn main() {
-    #[cfg(all(target_endian="little", target_pointer_width="64"))]
-    let bad = unsafe {
-        std::mem::transmute::<u128, &[u8]>(42)
-    };
-    #[cfg(all(target_endian="big", target_pointer_width="64"))]
-    let bad = unsafe {
-        std::mem::transmute::<u128, &[u8]>(42 << 64)
-    };
-    #[cfg(all(target_endian="little", target_pointer_width="32"))]
-    let bad = unsafe {
-        std::mem::transmute::<u64, &[u8]>(42)
-    };
+    #[cfg(all(target_endian = "little", target_pointer_width = "64"))]
+    let bad = unsafe { std::mem::transmute::<u128, &[u8]>(42) };
+    #[cfg(all(target_endian = "big", target_pointer_width = "64"))]
+    let bad = unsafe { std::mem::transmute::<u128, &[u8]>(42 << 64) };
+    #[cfg(all(target_endian = "little", target_pointer_width = "32"))]
+    let bad = unsafe { std::mem::transmute::<u64, &[u8]>(42) };
     // This created a slice with length 0, so the following will fail the bounds check.
     bad[0];
 }

--- a/tests/pass/stacked-borrows/refcell.rs
+++ b/tests/pass/stacked-borrows/refcell.rs
@@ -1,4 +1,4 @@
-use std::cell::{RefCell, Ref, RefMut};
+use std::cell::{Ref, RefCell, RefMut};
 
 fn main() {
     basic();
@@ -70,8 +70,8 @@ fn ref_mut_protector() {
 
 /// Make sure we do not have bad enum layout optimizations.
 fn rust_issue_68303() {
-    let optional=Some(RefCell::new(false));
-    let mut handle=optional.as_ref().unwrap().borrow_mut();
+    let optional = Some(RefCell::new(false));
+    let mut handle = optional.as_ref().unwrap().borrow_mut();
     assert!(optional.is_some());
-    *handle=true;
+    *handle = true;
 }

--- a/tests/pass/stacked-borrows/stacked-borrows.rs
+++ b/tests/pass/stacked-borrows/stacked-borrows.rs
@@ -50,7 +50,9 @@ fn mut_raw_then_mut_shr() {
     let xraw = &mut *xref as *mut _;
     let xshr = &*xref;
     assert_eq!(*xshr, 2);
-    unsafe { *xraw = 4; }
+    unsafe {
+        *xraw = 4;
+    }
     assert_eq!(x, 4);
 }
 
@@ -60,7 +62,9 @@ fn mut_shr_then_mut_raw() {
     let xref = &mut 2;
     let _xshr = &*xref;
     let xraw = xref as *mut _;
-    unsafe { *xraw = 3; }
+    unsafe {
+        *xraw = 3;
+    }
     assert_eq!(*xref, 3);
 }
 
@@ -75,7 +79,9 @@ fn mut_raw_mut() {
         let xraw = xref1 as *mut _;
         let _xref2 = unsafe { &mut *xraw };
         let _val = *xref1;
-        unsafe { *xraw = 4; }
+        unsafe {
+            *xraw = 4;
+        }
         // we can now use both xraw and xref1, for reading
         assert_eq!(*xref1, 4);
         assert_eq!(unsafe { *xraw }, 4);
@@ -112,23 +118,27 @@ fn direct_mut_to_const_raw() {
 }
 
 // Make sure that we can create two raw pointers from a mutable reference and use them both.
-fn two_raw() { unsafe {
-    let x = &mut 0;
-    let y1 = x as *mut _;
-    let y2 = x as *mut _;
-    *y1 += 2;
-    *y2 += 1;
-} }
+fn two_raw() {
+    unsafe {
+        let x = &mut 0;
+        let y1 = x as *mut _;
+        let y2 = x as *mut _;
+        *y1 += 2;
+        *y2 += 1;
+    }
+}
 
 // Make sure that creating a *mut does not invalidate existing shared references.
-fn shr_and_raw() { unsafe {
-    use std::mem;
-    let x = &mut 0;
-    let y1: &i32 = mem::transmute(&*x); // launder lifetimes
-    let y2 = x as *mut _;
-    let _val = *y1;
-    *y2 += 1;
-} }
+fn shr_and_raw() {
+    unsafe {
+        use std::mem;
+        let x = &mut 0;
+        let y1: &i32 = mem::transmute(&*x); // launder lifetimes
+        let y2 = x as *mut _;
+        let _val = *y1;
+        *y2 += 1;
+    }
+}
 
 fn disjoint_mutable_subborrows() {
     struct Foo {
@@ -136,23 +146,20 @@ fn disjoint_mutable_subborrows() {
         b: Vec<u32>,
     }
 
-    unsafe fn borrow_field_a<'a>(this:*mut Foo) -> &'a mut String {
+    unsafe fn borrow_field_a<'a>(this: *mut Foo) -> &'a mut String {
         &mut (*this).a
     }
 
-    unsafe fn borrow_field_b<'a>(this:*mut Foo) -> &'a mut Vec<u32> {
+    unsafe fn borrow_field_b<'a>(this: *mut Foo) -> &'a mut Vec<u32> {
         &mut (*this).b
     }
 
-    let mut foo = Foo {
-        a: "hello".into(),
-        b: vec![0,1,2],
-    };
+    let mut foo = Foo { a: "hello".into(), b: vec![0, 1, 2] };
 
     let ptr = &mut foo as *mut Foo;
 
-    let a = unsafe{ borrow_field_a(ptr) };
-    let b = unsafe{ borrow_field_b(ptr) };
+    let a = unsafe { borrow_field_a(ptr) };
+    let b = unsafe { borrow_field_b(ptr) };
     b.push(4);
     a.push_str(" world");
     eprintln!("{:?} {:?}", a, b);
@@ -181,7 +188,9 @@ fn raw_ref_to_part() {
 fn array_casts() {
     let mut x: [usize; 2] = [0, 0];
     let p = &mut x as *mut usize;
-    unsafe { *p.add(1) = 1; }
+    unsafe {
+        *p.add(1) = 1;
+    }
 
     let x: [usize; 2] = [0, 1];
     let p = &x as *const usize;
@@ -192,7 +201,7 @@ fn array_casts() {
 fn mut_below_shr() {
     let x = 0;
     let y = &x;
-    let p = unsafe { core::mem::transmute::<&&i32,&&mut i32>(&y) };
+    let p = unsafe { core::mem::transmute::<&&i32, &&mut i32>(&y) };
     let r = &**p;
     let _val = *r;
 }

--- a/tests/pass/static_memory_modification.rs
+++ b/tests/pass/static_memory_modification.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{Ordering, AtomicUsize};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 static mut X: usize = 5;
 static Y: AtomicUsize = AtomicUsize::new(5);

--- a/tests/pass/static_mut.rs
+++ b/tests/pass/static_mut.rs
@@ -1,5 +1,5 @@
 static mut FOO: i32 = 42;
-static BAR: Foo = Foo(unsafe { &FOO as *const _} );
+static BAR: Foo = Foo(unsafe { &FOO as *const _ });
 
 #[allow(dead_code)]
 struct Foo(*const i32);

--- a/tests/pass/strings.rs
+++ b/tests/pass/strings.rs
@@ -22,7 +22,7 @@ fn fat_pointer_on_32_bit() {
 
 fn str_indexing() {
     let mut x = "Hello".to_string();
-    let _v = &mut x[..3];  // Test IndexMut on String.
+    let _v = &mut x[..3]; // Test IndexMut on String.
 }
 
 fn unique_aliasing() {

--- a/tests/pass/tag-align-dyn-u64.rs
+++ b/tests/pass/tag-align-dyn-u64.rs
@@ -11,17 +11,17 @@
 use std::mem;
 
 enum Tag<A> {
-    Tag2(A)
+    Tag2(A),
 }
 
 #[allow(dead_code)]
 struct Rec {
     c8: u8,
-    t: Tag<u64>
+    t: Tag<u64>,
 }
 
 fn mk_rec() -> Rec {
-    return Rec { c8:0, t:Tag::Tag2(0) };
+    return Rec { c8: 0, t: Tag::Tag2(0) };
 }
 
 fn is_u64_aligned(u: &Tag<u64>) -> bool {

--- a/tests/pass/time.rs
+++ b/tests/pass/time.rs
@@ -1,6 +1,6 @@
 // compile-flags: -Zmiri-disable-isolation
 
-use std::time::{SystemTime, Instant, Duration};
+use std::time::{Duration, Instant, SystemTime};
 
 fn duration_sanity(diff: Duration) {
     // On my laptop, I observed times around 15-40ms. Add 10x lee-way both ways.
@@ -25,7 +25,9 @@ fn main() {
     let year = 1970 + years_since_epoch;
     assert!(2020 <= year && year < 2100);
     // Do some work to make time pass.
-    for _ in 0..10 { drop(vec![42]); }
+    for _ in 0..10 {
+        drop(vec![42]);
+    }
     let now2 = SystemTime::now();
     assert!(now2 > now1);
     // Sanity-check the difference we got.
@@ -37,7 +39,9 @@ fn main() {
     // Check `Instant`.
     let now1 = Instant::now();
     // Do some work to make time pass.
-    for _ in 0..10 { drop(vec![42]); }
+    for _ in 0..10 {
+        drop(vec![42]);
+    }
     let now2 = Instant::now();
     assert!(now2 > now1);
     // Sanity-check the difference we got.

--- a/tests/pass/track-caller-attribute.rs
+++ b/tests/pass/track-caller-attribute.rs
@@ -16,7 +16,9 @@ fn nested_tracked() -> &'static Location<'static> {
 }
 
 macro_rules! caller_location_from_macro {
-    () => (core::panic::Location::caller());
+    () => {
+        core::panic::Location::caller()
+    };
 }
 
 fn test_fn_ptr() {
@@ -62,7 +64,6 @@ fn test_trait_obj() {
     assert_eq!(location.file(), file!());
     assert_eq!(location.line(), expected_line);
     assert_eq!(location.column(), 28);
-
 }
 
 fn main() {

--- a/tests/pass/transmute_fat.rs
+++ b/tests/pass/transmute_fat.rs
@@ -3,9 +3,7 @@
 
 fn main() {
     // If we are careful, we can exploit data layout...
-    let raw = unsafe {
-        std::mem::transmute::<&[u8], [*const u8; 2]>(&[42])
-    };
+    let raw = unsafe { std::mem::transmute::<&[u8], [*const u8; 2]>(&[42]) };
     let ptr: *const u8 = unsafe { std::mem::transmute_copy(&raw) };
     assert_eq!(unsafe { *ptr }, 42);
 }

--- a/tests/pass/u128.rs
+++ b/tests/pass/u128.rs
@@ -10,7 +10,7 @@ fn main() {
     assert_eq!(x, y | 1);
     assert_eq!(
         0xFAFF_0000_FF8F_0000__FFFF_0000_FFFF_FFFE,
-        y & 0xFAFF_0000_FF8F_0000__FFFF_0000_FFFF_FFFF
+        y & 0xFAFF_0000_FF8F_0000__FFFF_0000_FFFF_FFFF,
     );
     let z: u128 = 0xABCD_EF;
     assert_eq!(z * z, 0x734C_C2F2_A521);
@@ -22,7 +22,7 @@ fn main() {
     assert_eq!(0x1234_5678_9ABC_DEFF_EDCB_A987_5A86_421, k - z);
     assert_eq!(
         0x1000_0000_0000_0000_0000_0000_0000_000,
-        k - 0x234_5678_9ABC_DEFF_EDCB_A987_6543_210
+        k - 0x234_5678_9ABC_DEFF_EDCB_A987_6543_210,
     );
     assert_eq!(0x6EF5_DE4C_D3BC_2AAA_3BB4_CC5D_D6EE_8, k / 42);
     assert_eq!(0, k % 42);
@@ -51,7 +51,7 @@ fn main() {
     assert_eq!("20000000000000000000000", format!("{:o}", j));
     assert_eq!(
         "10000000000000000000000000000000000000000000000000000000000000000000",
-        format!("{:b}", j)
+        format!("{:b}", j),
     );
     assert_eq!("340282366920938463463374607431768211455", format!("{}", u128::MAX));
     assert_eq!("147573952589676412928", format!("{:?}", j));

--- a/tests/pass/u128.rs
+++ b/tests/pass/u128.rs
@@ -8,9 +8,10 @@ fn main() {
     let y: u128 = 0xFFFF_FFFF_FFFF_FFFF__FFFF_FFFF_FFFF_FFFE;
     assert_eq!(!1, y);
     assert_eq!(x, y | 1);
-    assert_eq!(0xFAFF_0000_FF8F_0000__FFFF_0000_FFFF_FFFE,
-               y &
-               0xFAFF_0000_FF8F_0000__FFFF_0000_FFFF_FFFF);
+    assert_eq!(
+        0xFAFF_0000_FF8F_0000__FFFF_0000_FFFF_FFFE,
+        y & 0xFAFF_0000_FF8F_0000__FFFF_0000_FFFF_FFFF
+    );
     let z: u128 = 0xABCD_EF;
     assert_eq!(z * z, 0x734C_C2F2_A521);
     assert_eq!(z * z * z * z, 0x33EE_0E2A_54E2_59DA_A0E7_8E41);
@@ -19,8 +20,10 @@ fn main() {
     assert_eq!(k + k, 0x2468_ACF1_3579_BDFF_DB97_530E_CA86_420);
     assert_eq!(0, k - k);
     assert_eq!(0x1234_5678_9ABC_DEFF_EDCB_A987_5A86_421, k - z);
-    assert_eq!(0x1000_0000_0000_0000_0000_0000_0000_000,
-               k - 0x234_5678_9ABC_DEFF_EDCB_A987_6543_210);
+    assert_eq!(
+        0x1000_0000_0000_0000_0000_0000_0000_000,
+        k - 0x234_5678_9ABC_DEFF_EDCB_A987_6543_210
+    );
     assert_eq!(0x6EF5_DE4C_D3BC_2AAA_3BB4_CC5D_D6EE_8, k / 42);
     assert_eq!(0, k % 42);
     assert_eq!(15, z % 42);
@@ -38,7 +41,7 @@ fn main() {
     assert_eq!((z as f32) as u128, z);
     assert_eq!((z as f64 * 16.0) as u128, z * 16);
     assert_eq!((z as f32 * 16.0) as u128, z * 16);
-    let l :u128 = 432 << 100;
+    let l: u128 = 432 << 100;
     assert_eq!((l as f32) as u128, l);
     assert_eq!((l as f64) as u128, l);
     // formatting
@@ -46,10 +49,11 @@ fn main() {
     assert_eq!("147573952589676412928", format!("{}", j));
     assert_eq!("80000000000000000", format!("{:x}", j));
     assert_eq!("20000000000000000000000", format!("{:o}", j));
-    assert_eq!("10000000000000000000000000000000000000000000000000000000000000000000",
-               format!("{:b}", j));
-    assert_eq!("340282366920938463463374607431768211455",
-        format!("{}", u128::MAX));
+    assert_eq!(
+        "10000000000000000000000000000000000000000000000000000000000000000000",
+        format!("{:b}", j)
+    );
+    assert_eq!("340282366920938463463374607431768211455", format!("{}", u128::MAX));
     assert_eq!("147573952589676412928", format!("{:?}", j));
     // common traits
     assert_eq!(x, b(x.clone()));

--- a/tests/pass/union.rs
+++ b/tests/pass/union.rs
@@ -45,7 +45,10 @@ fn b() {
 
 fn c() {
     #[repr(u32)]
-    enum Tag { I, F }
+    enum Tag {
+        I,
+        F,
+    }
 
     #[repr(C)]
     union U {
@@ -68,10 +71,10 @@ fn c() {
             }
         }
     }
-    assert!(is_zero(Value { tag: Tag::I, u: U { i: 0 }}));
-    assert!(is_zero(Value { tag: Tag::F, u: U { f: 0.0 }}));
-    assert!(!is_zero(Value { tag: Tag::I, u: U { i: 1 }}));
-    assert!(!is_zero(Value { tag: Tag::F, u: U { f: 42.0 }}));
+    assert!(is_zero(Value { tag: Tag::I, u: U { i: 0 } }));
+    assert!(is_zero(Value { tag: Tag::F, u: U { f: 0.0 } }));
+    assert!(!is_zero(Value { tag: Tag::I, u: U { i: 1 } }));
+    assert!(!is_zero(Value { tag: Tag::F, u: U { f: 42.0 } }));
 }
 
 fn d() {
@@ -82,8 +85,10 @@ fn d() {
     let u = MyUnion { f1: 10 };
     unsafe {
         match u {
-            MyUnion { f1: 10 } => { }
-            MyUnion { f2: _f2 } => { panic!("foo"); }
+            MyUnion { f1: 10 } => {}
+            MyUnion { f2: _f2 } => {
+                panic!("foo");
+            }
         }
     }
 }

--- a/tests/pass/union.rs
+++ b/tests/pass/union.rs
@@ -86,9 +86,7 @@ fn d() {
     unsafe {
         match u {
             MyUnion { f1: 10 } => {}
-            MyUnion { f2: _f2 } => {
-                panic!("foo");
-            }
+            MyUnion { f2: _f2 } => panic!("foo"),
         }
     }
 }

--- a/tests/pass/unops.rs
+++ b/tests/pass/unops.rs
@@ -1,5 +1,5 @@
 fn main() {
     assert_eq!(!true, false);
     assert_eq!(!0xFFu16, 0xFF00);
-    assert_eq!(-{1i16}, -1i16);
+    assert_eq!(-{ 1i16 }, -1i16);
 }

--- a/tests/pass/unsized-tuple-impls.rs
+++ b/tests/pass/unsized-tuple-impls.rs
@@ -2,8 +2,8 @@
 use std::mem;
 
 fn main() {
-    let x : &(i32, i32, [i32]) = &(0, 1, [2, 3]);
-    let y : &(i32, i32, [i32]) = &(0, 1, [2, 3, 4]);
+    let x: &(i32, i32, [i32]) = &(0, 1, [2, 3]);
+    let y: &(i32, i32, [i32]) = &(0, 1, [2, 3, 4]);
     let mut a = [y, x];
     a.sort();
     assert_eq!(a, [x, y]);

--- a/tests/pass/validation_lifetime_resolution.rs
+++ b/tests/pass/validation_lifetime_resolution.rs
@@ -7,16 +7,22 @@ trait Id {
 impl<'a> Id for &'a mut i32 {
     type Out = &'a mut i32;
 
-    fn id(self) -> Self { self }
+    fn id(self) -> Self {
+        self
+    }
 }
 
 impl<'a> Id for &'a mut u32 {
     type Out = &'a mut u32;
 
-    fn id(self) -> Self { self }
+    fn id(self) -> Self {
+        self
+    }
 }
 
-fn foo<T>(mut x: T) where for<'a> &'a mut T: Id
+fn foo<T>(mut x: T)
+where
+    for<'a> &'a mut T: Id,
 {
     let x = &mut x;
     let _y = x.id();

--- a/tests/pass/vec-matching-fold.rs
+++ b/tests/pass/vec-matching-fold.rs
@@ -1,32 +1,30 @@
 use std::fmt::Debug;
 
-fn foldl<T, U, F>(values: &[T],
-                  initial: U,
-                  mut function: F)
-                  -> U where
-    U: Clone+Debug, T:Debug,
+fn foldl<T, U, F>(values: &[T], initial: U, mut function: F) -> U
+where
+    U: Clone + Debug,
+    T: Debug,
     F: FnMut(U, &T) -> U,
-{    match values {
-        [head, tail @ ..] =>
-            foldl(tail, function(initial, head), function),
+{
+    match values {
+        [head, tail @ ..] => foldl(tail, function(initial, head), function),
         [] => {
-            let res = initial.clone(); res
+            let res = initial.clone();
+            res
         }
     }
 }
 
-fn foldr<T, U, F>(values: &[T],
-                  initial: U,
-                  mut function: F)
-                  -> U where
+fn foldr<T, U, F>(values: &[T], initial: U, mut function: F) -> U
+where
     U: Clone,
     F: FnMut(&T, U) -> U,
 {
     match values {
-        [head @ .., tail] =>
-            foldr(head, function(tail, initial), function),
+        [head @ .., tail] => foldr(head, function(tail, initial), function),
         [] => {
-            let res = initial.clone(); res
+            let res = initial.clone();
+            res
         }
     }
 }

--- a/tests/pass/vec.rs
+++ b/tests/pass/vec.rs
@@ -33,51 +33,37 @@ fn make_vec_macro_repeat_zeroed() -> Vec<u8> {
 }
 
 fn vec_into_iter() -> u8 {
-    vec![1, 2, 3, 4]
-        .into_iter()
-        .map(|x| x * x)
-        .fold(0, |x, y| x + y)
+    vec![1, 2, 3, 4].into_iter().map(|x| x * x).fold(0, |x, y| x + y)
 }
 
 fn vec_into_iter_rev() -> u8 {
-    vec![1, 2, 3, 4]
-        .into_iter()
-        .map(|x| x * x)
-        .fold(0, |x, y| x + y)
+    vec![1, 2, 3, 4].into_iter().map(|x| x * x).fold(0, |x, y| x + y)
 }
 
 fn vec_into_iter_zst() -> usize {
-    vec![[0u64; 0], [0u64; 0]]
-        .into_iter()
-        .rev()
-        .map(|x| x.len())
-        .sum()
+    vec![[0u64; 0], [0u64; 0]].into_iter().rev().map(|x| x.len()).sum()
 }
 
 fn vec_into_iter_rev_zst() -> usize {
-    vec![[0u64; 0], [0u64; 0]]
-        .into_iter()
-        .rev()
-        .map(|x| x.len())
-        .sum()
+    vec![[0u64; 0], [0u64; 0]].into_iter().rev().map(|x| x.len()).sum()
 }
 
 fn vec_iter_and_mut() {
-    let mut v = vec![1,2,3,4];
+    let mut v = vec![1, 2, 3, 4];
     for i in v.iter_mut() {
         *i += 1;
     }
-    assert_eq!(v.iter().sum::<i32>(), 2+3+4+5);
+    assert_eq!(v.iter().sum::<i32>(), 2 + 3 + 4 + 5);
 
     test_all_refs(&mut 13, v.iter_mut());
 }
 
 fn vec_iter_and_mut_rev() {
-    let mut v = vec![1,2,3,4];
+    let mut v = vec![1, 2, 3, 4];
     for i in v.iter_mut().rev() {
         *i += 1;
     }
-    assert_eq!(v.iter().sum::<i32>(), 2+3+4+5);
+    assert_eq!(v.iter().sum::<i32>(), 2 + 3 + 4 + 5);
 }
 
 fn vec_reallocate() -> Vec<u8> {

--- a/tests/pass/vecdeque.rs
+++ b/tests/pass/vecdeque.rs
@@ -23,7 +23,7 @@ fn main() {
     src.push_front(Box::new(2));
     dst.append(&mut src);
     for a in dst.iter() {
-      assert_eq!(**a, 2);
+        assert_eq!(**a, 2);
     }
 
     // Regression test for Debug impl's

--- a/tests/pass/weak_memory/weak.rs
+++ b/tests/pass/weak_memory/weak.rs
@@ -94,7 +94,6 @@ fn initialization_write() -> bool {
     r2 == 11
 }
 
-
 // Asserts that the function returns true at least once in 100 runs
 macro_rules! assert_once {
     ($f:ident) => {

--- a/tests/pass/wtf8.rs
+++ b/tests/pass/wtf8.rs
@@ -1,7 +1,7 @@
 // only-windows
 
-use std::os::windows::ffi::{OsStrExt, OsStringExt};
 use std::ffi::{OsStr, OsString};
+use std::os::windows::ffi::{OsStrExt, OsStringExt};
 
 fn test1() {
     let base = "a\té \u{7f}💩\r";

--- a/tests/pass/zst.rs
+++ b/tests/pass/zst.rs
@@ -19,6 +19,10 @@ fn main() {
     assert_eq!(use_zst(), A);
     let x = 42 as *mut [u8; 0];
     // Reading and writing is ok.
-    unsafe { *x = zst_val; }
-    unsafe { let _y = *x; }
+    unsafe {
+        *x = zst_val;
+    }
+    unsafe {
+        let _y = *x;
+    }
 }


### PR DESCRIPTION
Extracted from #2097.

This PR is still only doing the easy cases with no comments involved.

In the next PRs after this, I'll start grouping by common comment patterns, e.g. all the cases resembling https://github.com/rust-lang/miri/pull/2097#discussion_r862436672 together in one PR.