### PR TITLE
Require local annotations for local diagnostics

### DIFF
--- a/tests/fail/abort-terminator.rs
+++ b/tests/fail/abort-terminator.rs
@@ -1,7 +1,6 @@
-// error-pattern: the program aborted
 #![feature(c_unwind)]
 
-extern "C" fn panic_abort() {
+extern "C" fn panic_abort() { //~ ERROR: the program aborted
     panic!()
 }
 

--- a/tests/fail/concurrency/too_few_args.rs
+++ b/tests/fail/concurrency/too_few_args.rs
@@ -1,5 +1,4 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
-// error-pattern: callee has fewer arguments than expected
 
 //! The thread function must have exactly one argument.
 
@@ -10,7 +9,7 @@ extern crate libc;
 use std::{mem, ptr};
 
 extern "C" fn thread_start() -> *mut libc::c_void {
-    panic!()
+    panic!() //~ ERROR: callee has fewer arguments than expected
 }
 
 fn main() {

--- a/tests/fail/concurrency/too_many_args.rs
+++ b/tests/fail/concurrency/too_many_args.rs
@@ -1,5 +1,4 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
-// error-pattern: callee has more arguments than expected
 
 //! The thread function must have exactly one argument.
 
@@ -10,7 +9,7 @@ extern crate libc;
 use std::{mem, ptr};
 
 extern "C" fn thread_start(_null: *mut libc::c_void, _x: i32) -> *mut libc::c_void {
-    panic!()
+    panic!() //~ ERROR: callee has more arguments than expected
 }
 
 fn main() {

--- a/tests/fail/concurrency/unwind_top_of_stack.rs
+++ b/tests/fail/concurrency/unwind_top_of_stack.rs
@@ -1,6 +1,5 @@
 // ignore-windows: Concurrency on Windows is not supported yet.
 // compile-flags: -Zmiri-disable-abi-check
-// error-pattern: unwinding past the topmost frame of the stack
 
 //! Unwinding past the top frame of a stack is Undefined Behavior.
 
@@ -11,6 +10,7 @@ extern crate libc;
 use std::{mem, ptr};
 
 extern "C-unwind" fn thread_start(_null: *mut libc::c_void) -> *mut libc::c_void {
+//~^ ERROR unwinding past the topmost frame of the stack
     panic!()
 }
 

--- a/tests/fail/concurrency/unwind_top_of_stack.stderr
+++ b/tests/fail/concurrency/unwind_top_of_stack.stderr
@@ -4,6 +4,7 @@ error: Undefined Behavior: unwinding past the topmost frame of the stack
   --> $DIR/unwind_top_of_stack.rs:LL:CC
    |
 LL | / extern "C-unwind" fn thread_start(_null: *mut libc::c_void) -> *mut libc::c_void {
+LL | |
 LL | |     panic!()
 LL | | }
    | |_^ unwinding past the topmost frame of the stack

--- a/tests/fail/intrinsics/overflowing-unchecked-rsh.rs
+++ b/tests/fail/intrinsics/overflowing-unchecked-rsh.rs
@@ -2,10 +2,9 @@
 
 use std::intrinsics::*;
 
-// error-pattern: overflowing shift by 64 in `unchecked_shr`
-
 fn main() {
     unsafe {
         let _n = unchecked_shr(1i64, 64);
+        //~^ ERROR: overflowing shift by 64 in `unchecked_shr`
     }
 }

--- a/tests/fail/intrinsics/uninit_uninhabited_type.rs
+++ b/tests/fail/intrinsics/uninit_uninhabited_type.rs
@@ -1,7 +1,7 @@
-// error-pattern: attempted to instantiate uninhabited type `!`
 #![feature(never_type)]
 
 #[allow(deprecated, invalid_value)]
 fn main() {
     unsafe { std::mem::uninitialized::<!>() };
+    //~^ ERROR: attempted to instantiate uninhabited type `!`
 }

--- a/tests/fail/intrinsics/zero_fn_ptr.rs
+++ b/tests/fail/intrinsics/zero_fn_ptr.rs
@@ -1,6 +1,5 @@
-// error-pattern: attempted to zero-initialize type `fn()`, which is invalid
-
 #[allow(deprecated, invalid_value)]
 fn main() {
     unsafe { std::mem::zeroed::<fn()>() };
+    //~^ ERROR: attempted to zero-initialize type `fn()`, which is invalid
 }

--- a/tests/fail/panic/bad_unwind.rs
+++ b/tests/fail/panic/bad_unwind.rs
@@ -1,4 +1,3 @@
-// error-pattern: unwinding past a stack frame that does not allow unwinding
 #![feature(c_unwind)]
 
 //! Unwinding when the caller ABI is "C" (without "-unwind") is UB.
@@ -11,4 +10,5 @@ fn main() {
     let unwind: extern "C-unwind" fn() = unwind;
     let unwind: extern "C" fn() = unsafe { std::mem::transmute(unwind) };
     std::panic::catch_unwind(|| unwind()).unwrap_err();
+    //~^ ERROR: unwinding past a stack frame that does not allow unwinding
 }

--- a/tests/fail/sync/libc_pthread_rwlock_read_write_deadlock_single_thread.rs
+++ b/tests/fail/sync/libc_pthread_rwlock_read_write_deadlock_single_thread.rs
@@ -1,5 +1,4 @@
 // ignore-windows: No libc on Windows
-// error-pattern: deadlock
 
 #![feature(rustc_private)]
 
@@ -9,6 +8,6 @@ fn main() {
     let rw = std::cell::UnsafeCell::new(libc::PTHREAD_RWLOCK_INITIALIZER);
     unsafe {
         assert_eq!(libc::pthread_rwlock_rdlock(rw.get()), 0);
-        libc::pthread_rwlock_wrlock(rw.get());
+        libc::pthread_rwlock_wrlock(rw.get()); //~ ERROR: deadlock
     }
 }

--- a/tests/fail/sync/libc_pthread_rwlock_write_read_deadlock_single_thread.rs
+++ b/tests/fail/sync/libc_pthread_rwlock_write_read_deadlock_single_thread.rs
@@ -1,5 +1,4 @@
 // ignore-windows: No libc on Windows
-// error-pattern: deadlock
 
 #![feature(rustc_private)]
 
@@ -9,6 +8,6 @@ fn main() {
     let rw = std::cell::UnsafeCell::new(libc::PTHREAD_RWLOCK_INITIALIZER);
     unsafe {
         assert_eq!(libc::pthread_rwlock_wrlock(rw.get()), 0);
-        libc::pthread_rwlock_rdlock(rw.get());
+        libc::pthread_rwlock_rdlock(rw.get()); //~ ERROR: deadlock
     }
 }

--- a/tests/fail/sync/libc_pthread_rwlock_write_write_deadlock_single_thread.rs
+++ b/tests/fail/sync/libc_pthread_rwlock_write_write_deadlock_single_thread.rs
@@ -1,5 +1,4 @@
 // ignore-windows: No libc on Windows
-// error-pattern: deadlock
 
 #![feature(rustc_private)]
 
@@ -9,6 +8,6 @@ fn main() {
     let rw = std::cell::UnsafeCell::new(libc::PTHREAD_RWLOCK_INITIALIZER);
     unsafe {
         assert_eq!(libc::pthread_rwlock_wrlock(rw.get()), 0);
-        libc::pthread_rwlock_wrlock(rw.get());
+        libc::pthread_rwlock_wrlock(rw.get()); //~ ERROR: deadlock
     }
 }

--- a/tests/fail/transmute_fat1.rs
+++ b/tests/fail/transmute_fat1.rs
@@ -1,10 +1,13 @@
-// error-pattern: type validation failed: encountered a pointer
-// normalize-stderr-test: "\[u8; (08|16)\]" -> "$$ARRAY"
+#[cfg(target_pointer_width = "64")]
+const N: usize = 16;
+
+#[cfg(target_pointer_width = "32")]
+const N: usize = 8;
 
 fn main() {
-    #[cfg(target_pointer_width = "64")]
-    let bad = unsafe { std::mem::transmute::<&[u8], [u8; 16]>(&[1u8]) };
-    #[cfg(target_pointer_width = "32")]
-    let bad = unsafe { std::mem::transmute::<&[u8], [u8; 08]>(&[1u8]) };
+    let bad = unsafe {
+        std::mem::transmute::<&[u8], [u8; N]>(&[1u8])
+        //~^ ERROR: type validation failed: encountered a pointer
+    };
     let _val = bad[0] + bad[bad.len() - 1];
 }

--- a/tests/fail/transmute_fat1.stderr
+++ b/tests/fail/transmute_fat1.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: type validation failed: encountered a pointer, but expected plain (non-pointer) bytes
   --> $DIR/transmute_fat1.rs:LL:CC
    |
-LL |     let bad = unsafe { std::mem::transmute::<&[u8], $ARRAY>(&[1u8]) };
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer, but expected plain (non-pointer) bytes
+LL |         std::mem::transmute::<&[u8], [u8; N]>(&[1u8])
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer, but expected plain (non-pointer) bytes
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/unaligned_pointers/alignment.rs
+++ b/tests/fail/unaligned_pointers/alignment.rs
@@ -1,14 +1,14 @@
-// error-pattern: but alignment 4 is required
-// normalize-stderr-test: "\.add\(1\)" -> "       "
+// normalize-stderr-test: "\| +\^+" -> "| ^"
 
 fn main() {
     // No retry needed, this fails reliably.
 
     let mut x = [0u8; 20];
     let x_ptr: *mut u8 = x.as_mut_ptr();
-    // At least one of these is definitely unaligned.
+    #[rustfmt::skip]
     unsafe {
-        *(x_ptr as *mut u32) = 42;
-        *(x_ptr.add(1) as *mut u32) = 42;
-    }
+        // At least one of these is definitely unaligned.
+        *(x_ptr as *mut u32) = 42; *(x_ptr.add(1) as *mut u32) = 42;
+        //~^ ERROR: but alignment 4 is required
+    };
 }

--- a/tests/fail/unaligned_pointers/alignment.stderr
+++ b/tests/fail/unaligned_pointers/alignment.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: accessing memory with alignment ALIGN, but alignment ALIGN is required
   --> $DIR/alignment.rs:LL:CC
    |
-LL |         *(x_ptr as *mut u32) = 42;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ accessing memory with alignment ALIGN, but alignment ALIGN is required
+LL |         *(x_ptr as *mut u32) = 42; *(x_ptr.add(1) as *mut u32) = 42;
+   | ^ accessing memory with alignment ALIGN, but alignment ALIGN is required
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/ui_test/src/lib.rs
+++ b/ui_test/src/lib.rs
@@ -374,8 +374,6 @@ fn check_annotations(
     comments: &Comments,
 ) {
     if let Some((ref error_pattern, definition_line)) = comments.error_pattern {
-        let mut found = false;
-
         // first check the diagnostics messages outside of our file. We check this first, so that
         // you can mix in-file annotations with // error-pattern annotations, even if there is overlap
         // in the messages.
@@ -384,22 +382,7 @@ fn check_annotations(
             .position(|msg| msg.message.contains(error_pattern))
         {
             messages_from_unknown_file_or_line.remove(i);
-            found = true;
-        }
-
-        // if nothing was found, check the ones inside our file. We permit this because some tests may have
-        // flaky line numbers for their messages.
-        if !found {
-            for line in &mut messages {
-                if let Some(i) = line.iter().position(|msg| msg.message.contains(error_pattern)) {
-                    line.remove(i);
-                    found = true;
-                    break;
-                }
-            }
-        }
-
-        if !found {
+        } else {
             errors.push(Error::PatternNotFound {
                 pattern: error_pattern.to_string(),
                 definition_line,

--- a/ui_test/src/rustc_stderr.rs
+++ b/ui_test/src/rustc_stderr.rs
@@ -116,7 +116,7 @@ impl Span {
 }
 
 pub(crate) fn filter_annotations_from_rendered(rendered: &str) -> std::borrow::Cow<'_, str> {
-    let annotations = Regex::new(r"\s*//~.*").unwrap();
+    let annotations = Regex::new(r"\s*//(\[[^\]]\])?~.*").unwrap();
     annotations.replace_all(&rendered, "")
 }
 


### PR DESCRIPTION
if/when we get flaky diagnostics we can revisit and add more helpers for those