### PR TITLE
Format tests with rustfmt (201-224 of 300)

### DIFF
--- a/tests/fail/concurrency/thread_local_static_dealloc.rs
+++ b/tests/fail/concurrency/thread_local_static_dealloc.rs
@@ -7,7 +7,9 @@
 #[thread_local]
 static mut TLS: u8 = 0;
 
-fn main() { unsafe {
-    let dangling_ptr = std::thread::spawn(|| &TLS as *const u8 as usize).join().unwrap();
-    let _val = *(dangling_ptr as *const u8); //~ ERROR dereferenced after this allocation got freed
-} }
+fn main() {
+    unsafe {
+        let dangling_ptr = std::thread::spawn(|| &TLS as *const u8 as usize).join().unwrap();
+        let _val = *(dangling_ptr as *const u8); //~ ERROR dereferenced after this allocation got freed
+    }
+}

--- a/tests/fail/concurrency/thread_local_static_dealloc.stderr
+++ b/tests/fail/concurrency/thread_local_static_dealloc.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: pointer to ALLOC was dereferenced after this allocation got freed
   --> $DIR/thread_local_static_dealloc.rs:LL:CC
    |
-LL |     let _val = *(dangling_ptr as *const u8);
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pointer to ALLOC was dereferenced after this allocation got freed
+LL |         let _val = *(dangling_ptr as *const u8);
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pointer to ALLOC was dereferenced after this allocation got freed
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/stacked_borrows/interior_mut2.rs
+++ b/tests/fail/stacked_borrows/interior_mut2.rs
@@ -7,22 +7,24 @@ unsafe fn unsafe_cell_get<T>(x: &UnsafeCell<T>) -> &'static mut T {
     mem::transmute(x)
 }
 
-fn main() { unsafe {
-    let c = &UnsafeCell::new(UnsafeCell::new(0));
-    let inner_uniq = &mut *c.get();
-    let inner_shr = &*inner_uniq;
-    // stack: [c: SharedReadWrite, inner_uniq: Unique, inner_shr: SharedReadWrite]
+fn main() {
+    unsafe {
+        let c = &UnsafeCell::new(UnsafeCell::new(0));
+        let inner_uniq = &mut *c.get();
+        let inner_shr = &*inner_uniq;
+        // stack: [c: SharedReadWrite, inner_uniq: Unique, inner_shr: SharedReadWrite]
 
-    let _val = c.get().read(); // invalidates inner_uniq
-    // stack: [c: SharedReadWrite, inner_uniq: Disabled, inner_shr: SharedReadWrite]
+        let _val = c.get().read(); // invalidates inner_uniq
+        // stack: [c: SharedReadWrite, inner_uniq: Disabled, inner_shr: SharedReadWrite]
 
-    // We have to be careful not to add any raw pointers above inner_uniq in
-    // the stack, hence the use of unsafe_cell_get.
-    let _val = *unsafe_cell_get(inner_shr); // this still works
+        // We have to be careful not to add any raw pointers above inner_uniq in
+        // the stack, hence the use of unsafe_cell_get.
+        let _val = *unsafe_cell_get(inner_shr); // this still works
 
-    *c.get() = UnsafeCell::new(0); // now inner_shr gets invalidated
-    // stack: [c: SharedReadWrite]
+        *c.get() = UnsafeCell::new(0); // now inner_shr gets invalidated
+        // stack: [c: SharedReadWrite]
 
-    // now this does not work any more
-    let _val = *inner_shr.get(); //~ ERROR borrow stack
-} }
+        // now this does not work any more
+        let _val = *inner_shr.get(); //~ ERROR borrow stack
+    }
+}

--- a/tests/fail/stacked_borrows/interior_mut2.stderr
+++ b/tests/fail/stacked_borrows/interior_mut2.stderr
@@ -1,24 +1,24 @@
 error: Undefined Behavior: trying to reborrow <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/interior_mut2.rs:LL:CC
    |
-LL |     let _val = *inner_shr.get();
-   |                 ^^^^^^^^^^^^^^^
-   |                 |
-   |                 trying to reborrow <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
-   |                 this error occurs as part of a reborrow at ALLOC[0x0..0x4]
+LL |         let _val = *inner_shr.get();
+   |                     ^^^^^^^^^^^^^^^
+   |                     |
+   |                     trying to reborrow <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                     this error occurs as part of a reborrow at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
 help: <TAG> was created by a retag at offsets [0x0..0x4]
   --> $DIR/interior_mut2.rs:LL:CC
    |
-LL |     let inner_shr = &*inner_uniq;
-   |                     ^^^^^^^^^^^^
+LL |         let inner_shr = &*inner_uniq;
+   |                         ^^^^^^^^^^^^
 help: <TAG> was later invalidated at offsets [0x0..0x4]
   --> $DIR/interior_mut2.rs:LL:CC
    |
-LL |     *c.get() = UnsafeCell::new(0); // now inner_shr gets invalidated
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         *c.get() = UnsafeCell::new(0); // now inner_shr gets invalidated
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: inside `main` at $DIR/interior_mut2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/issue-miri-1050-1.rs
+++ b/tests/fail/stacked_borrows/issue-miri-1050-1.rs
@@ -1,6 +1,8 @@
 // error-pattern: pointer to 4 bytes starting at offset 0 is out-of-bounds
 
-fn main() { unsafe {
-    let ptr = Box::into_raw(Box::new(0u16));
-    Box::from_raw(ptr as *mut u32);
-} }
+fn main() {
+    unsafe {
+        let ptr = Box::into_raw(Box::new(0u16));
+        Box::from_raw(ptr as *mut u32);
+    }
+}

--- a/tests/fail/stacked_borrows/issue-miri-1050-1.stderr
+++ b/tests/fail/stacked_borrows/issue-miri-1050-1.stderr
@@ -12,8 +12,8 @@ LL |         Box(unsafe { Unique::new_unchecked(raw) }, alloc)
 note: inside `main` at $DIR/issue-miri-1050-1.rs:LL:CC
   --> $DIR/issue-miri-1050-1.rs:LL:CC
    |
-LL |     Box::from_raw(ptr as *mut u32);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         Box::from_raw(ptr as *mut u32);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/issue-miri-1050-2.rs
+++ b/tests/fail/stacked_borrows/issue-miri-1050-2.rs
@@ -1,7 +1,9 @@
 // error-pattern: is not a valid pointer
 use std::ptr::NonNull;
 
-fn main() { unsafe {
-    let ptr = NonNull::<i32>::dangling();
-    Box::from_raw(ptr.as_ptr());
-} }
+fn main() {
+    unsafe {
+        let ptr = NonNull::<i32>::dangling();
+        Box::from_raw(ptr.as_ptr());
+    }
+}

--- a/tests/fail/stacked_borrows/issue-miri-1050-2.stderr
+++ b/tests/fail/stacked_borrows/issue-miri-1050-2.stderr
@@ -12,8 +12,8 @@ LL |         Box(unsafe { Unique::new_unchecked(raw) }, alloc)
 note: inside `main` at $DIR/issue-miri-1050-2.rs:LL:CC
   --> $DIR/issue-miri-1050-2.rs:LL:CC
    |
-LL |     Box::from_raw(ptr.as_ptr());
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         Box::from_raw(ptr.as_ptr());
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/mut_exclusive_violation1.rs
+++ b/tests/fail/stacked_borrows/mut_exclusive_violation1.rs
@@ -1,14 +1,14 @@
 fn demo_mut_advanced_unique(our: &mut i32) -> i32 {
-  unknown_code_1(&*our);
+    unknown_code_1(&*our);
 
-  // This "re-asserts" uniqueness of the reference: After writing, we know
-  // our tag is at the top of the stack.
-  *our = 5;
+    // This "re-asserts" uniqueness of the reference: After writing, we know
+    // our tag is at the top of the stack.
+    *our = 5;
 
-  unknown_code_2();
+    unknown_code_2();
 
-  // We know this will return 5
-  *our
+    // We know this will return 5
+    *our
 }
 
 // Now comes the evil context
@@ -16,13 +16,17 @@ use std::ptr;
 
 static mut LEAK: *mut i32 = ptr::null_mut();
 
-fn unknown_code_1(x: &i32) { unsafe {
-    LEAK = x as *const _ as *mut _;
-} }
+fn unknown_code_1(x: &i32) {
+    unsafe {
+        LEAK = x as *const _ as *mut _;
+    }
+}
 
-fn unknown_code_2() { unsafe {
-    *LEAK = 7; //~ ERROR borrow stack
-} }
+fn unknown_code_2() {
+    unsafe {
+        *LEAK = 7; //~ ERROR borrow stack
+    }
+}
 
 fn main() {
     demo_mut_advanced_unique(&mut 0);

--- a/tests/fail/stacked_borrows/mut_exclusive_violation1.stderr
+++ b/tests/fail/stacked_borrows/mut_exclusive_violation1.stderr
@@ -1,30 +1,30 @@
 error: Undefined Behavior: attempting a write access using <untagged> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/mut_exclusive_violation1.rs:LL:CC
    |
-LL |     *LEAK = 7;
-   |     ^^^^^^^^^
-   |     |
-   |     attempting a write access using <untagged> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
-   |     this error occurs as part of an access at ALLOC[0x0..0x4]
+LL |         *LEAK = 7;
+   |         ^^^^^^^^^
+   |         |
+   |         attempting a write access using <untagged> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |         this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
 help: tag was most recently created at offsets [0x0..0x4]
   --> $DIR/mut_exclusive_violation1.rs:LL:CC
    |
-LL |     LEAK = x as *const _ as *mut _;
-   |            ^
+LL |         LEAK = x as *const _ as *mut _;
+   |                ^
 help: tag was later invalidated at offsets [0x0..0x4]
   --> $DIR/mut_exclusive_violation1.rs:LL:CC
    |
-LL |   *our = 5;
-   |   ^^^^^^^^
+LL |     *our = 5;
+   |     ^^^^^^^^
    = note: inside `unknown_code_2` at $DIR/mut_exclusive_violation1.rs:LL:CC
 note: inside `demo_mut_advanced_unique` at $DIR/mut_exclusive_violation1.rs:LL:CC
   --> $DIR/mut_exclusive_violation1.rs:LL:CC
    |
-LL |   unknown_code_2();
-   |   ^^^^^^^^^^^^^^^^
+LL |     unknown_code_2();
+   |     ^^^^^^^^^^^^^^^^
 note: inside `main` at $DIR/mut_exclusive_violation1.rs:LL:CC
   --> $DIR/mut_exclusive_violation1.rs:LL:CC
    |

--- a/tests/fail/stacked_borrows/mut_exclusive_violation2.rs
+++ b/tests/fail/stacked_borrows/mut_exclusive_violation2.rs
@@ -1,10 +1,12 @@
 use std::ptr::NonNull;
 
-fn main() { unsafe {
-    let x = &mut 0;
-    let mut ptr1 = NonNull::from(x);
-    let mut ptr2 = ptr1.clone();
-    let raw1 = ptr1.as_mut();
-    let _raw2 = ptr2.as_mut();
-    let _val = *raw1; //~ ERROR borrow stack
-} }
+fn main() {
+    unsafe {
+        let x = &mut 0;
+        let mut ptr1 = NonNull::from(x);
+        let mut ptr2 = ptr1.clone();
+        let raw1 = ptr1.as_mut();
+        let _raw2 = ptr2.as_mut();
+        let _val = *raw1; //~ ERROR borrow stack
+    }
+}

--- a/tests/fail/stacked_borrows/mut_exclusive_violation2.stderr
+++ b/tests/fail/stacked_borrows/mut_exclusive_violation2.stderr
@@ -1,24 +1,24 @@
 error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/mut_exclusive_violation2.rs:LL:CC
    |
-LL |     let _val = *raw1;
-   |                ^^^^^
-   |                |
-   |                attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
-   |                this error occurs as part of an access at ALLOC[0x0..0x4]
+LL |         let _val = *raw1;
+   |                    ^^^^^
+   |                    |
+   |                    attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |                    this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
 help: <TAG> was created by a retag at offsets [0x0..0x4]
   --> $DIR/mut_exclusive_violation2.rs:LL:CC
    |
-LL |     let raw1 = ptr1.as_mut();
-   |                ^^^^^^^^^^^^^
+LL |         let raw1 = ptr1.as_mut();
+   |                    ^^^^^^^^^^^^^
 help: <TAG> was later invalidated at offsets [0x0..0x4]
   --> $DIR/mut_exclusive_violation2.rs:LL:CC
    |
-LL |     let _raw2 = ptr2.as_mut();
-   |                 ^^^^^^^^^^^^^
+LL |         let _raw2 = ptr2.as_mut();
+   |                     ^^^^^^^^^^^^^
    = note: inside `main` at $DIR/mut_exclusive_violation2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/return_invalid_mut_option.rs
+++ b/tests/fail/stacked_borrows/return_invalid_mut_option.rs
@@ -10,7 +10,7 @@ fn foo(x: &mut (i32, i32)) -> Option<&mut i32> {
 
 fn main() {
     match foo(&mut (1, 2)) {
-        Some(_x) => {}, //~ ERROR borrow stack
-        None => {},
+        Some(_x) => {} //~ ERROR borrow stack
+        None => {}
     }
 }

--- a/tests/fail/stacked_borrows/return_invalid_mut_option.stderr
+++ b/tests/fail/stacked_borrows/return_invalid_mut_option.stderr
@@ -1,7 +1,7 @@
 error: Undefined Behavior: trying to reborrow <TAG> for Unique permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
   --> $DIR/return_invalid_mut_option.rs:LL:CC
    |
-LL |         Some(_x) => {},
+LL |         Some(_x) => {}
    |              ^^
    |              |
    |              trying to reborrow <TAG> for Unique permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location

--- a/tests/fail/stacked_borrows/return_invalid_shr_option.rs
+++ b/tests/fail/stacked_borrows/return_invalid_shr_option.rs
@@ -9,7 +9,7 @@ fn foo(x: &mut (i32, i32)) -> Option<&i32> {
 
 fn main() {
     match foo(&mut (1, 2)) {
-        Some(_x) => {}, //~ ERROR borrow stack
-        None => {},
+        Some(_x) => {} //~ ERROR borrow stack
+        None => {}
     }
 }

--- a/tests/fail/stacked_borrows/return_invalid_shr_option.stderr
+++ b/tests/fail/stacked_borrows/return_invalid_shr_option.stderr
@@ -1,7 +1,7 @@
 error: Undefined Behavior: trying to reborrow <TAG> for SharedReadOnly permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location
   --> $DIR/return_invalid_shr_option.rs:LL:CC
    |
-LL |         Some(_x) => {},
+LL |         Some(_x) => {}
    |              ^^
    |              |
    |              trying to reborrow <TAG> for SharedReadOnly permission at ALLOC[0x4], but that tag does not exist in the borrow stack for this location

--- a/tests/fail/stacked_borrows/shared_rw_borrows_are_weak1.rs
+++ b/tests/fail/stacked_borrows/shared_rw_borrows_are_weak1.rs
@@ -2,13 +2,15 @@
 // *below* an already granted Unique -- so writing to
 // the SharedReadWrite will invalidate the Unique.
 
-use std::mem;
 use std::cell::Cell;
+use std::mem;
 
-fn main() { unsafe {
-    let x = &mut Cell::new(0);
-    let y: &mut Cell<i32> = mem::transmute(&mut *x); // launder lifetime
-    let shr_rw = &*x; // thanks to interior mutability this will be a SharedReadWrite
-    shr_rw.set(1);
-    y.get_mut(); //~ ERROR borrow stack
-} }
+fn main() {
+    unsafe {
+        let x = &mut Cell::new(0);
+        let y: &mut Cell<i32> = mem::transmute(&mut *x); // launder lifetime
+        let shr_rw = &*x; // thanks to interior mutability this will be a SharedReadWrite
+        shr_rw.set(1);
+        y.get_mut(); //~ ERROR borrow stack
+    }
+}

--- a/tests/fail/stacked_borrows/shared_rw_borrows_are_weak1.stderr
+++ b/tests/fail/stacked_borrows/shared_rw_borrows_are_weak1.stderr
@@ -1,24 +1,24 @@
 error: Undefined Behavior: trying to reborrow <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/shared_rw_borrows_are_weak1.rs:LL:CC
    |
-LL |     y.get_mut();
-   |     ^^^^^^^^^^^
-   |     |
-   |     trying to reborrow <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
-   |     this error occurs as part of a reborrow at ALLOC[0x0..0x4]
+LL |         y.get_mut();
+   |         ^^^^^^^^^^^
+   |         |
+   |         trying to reborrow <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |         this error occurs as part of a reborrow at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
 help: <TAG> was created by a retag at offsets [0x0..0x4]
   --> $DIR/shared_rw_borrows_are_weak1.rs:LL:CC
    |
-LL |     let y: &mut Cell<i32> = mem::transmute(&mut *x); // launder lifetime
-   |                             ^^^^^^^^^^^^^^^^^^^^^^^
+LL |         let y: &mut Cell<i32> = mem::transmute(&mut *x); // launder lifetime
+   |                                 ^^^^^^^^^^^^^^^^^^^^^^^
 help: <TAG> was later invalidated at offsets [0x0..0x4]
   --> $DIR/shared_rw_borrows_are_weak1.rs:LL:CC
    |
-LL |     shr_rw.set(1);
-   |     ^^^^^^^^^^^^^
+LL |         shr_rw.set(1);
+   |         ^^^^^^^^^^^^^
    = note: inside `main` at $DIR/shared_rw_borrows_are_weak1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/shared_rw_borrows_are_weak2.rs
+++ b/tests/fail/stacked_borrows/shared_rw_borrows_are_weak2.rs
@@ -3,13 +3,15 @@
 // the SharedReadWrite will invalidate the SharedReadWrite.
 // normalize-stderr-test: "0x[0-9a-fA-F]+" -> "$$HEX"
 
-use std::mem;
 use std::cell::RefCell;
+use std::mem;
 
-fn main() { unsafe {
-    let x = &mut RefCell::new(0);
-    let y: &i32 = mem::transmute(&*x.borrow()); // launder lifetime
-    let shr_rw = &*x; // thanks to interior mutability this will be a SharedReadWrite
-    shr_rw.replace(1);
-    let _val = *y; //~ ERROR borrow stack
-} }
+fn main() {
+    unsafe {
+        let x = &mut RefCell::new(0);
+        let y: &i32 = mem::transmute(&*x.borrow()); // launder lifetime
+        let shr_rw = &*x; // thanks to interior mutability this will be a SharedReadWrite
+        shr_rw.replace(1);
+        let _val = *y; //~ ERROR borrow stack
+    }
+}

--- a/tests/fail/stacked_borrows/shared_rw_borrows_are_weak2.stderr
+++ b/tests/fail/stacked_borrows/shared_rw_borrows_are_weak2.stderr
@@ -1,24 +1,24 @@
 error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[$HEX], but that tag does not exist in the borrow stack for this location
   --> $DIR/shared_rw_borrows_are_weak2.rs:LL:CC
    |
-LL |     let _val = *y;
-   |                ^^
-   |                |
-   |                attempting a read access using <TAG> at ALLOC[$HEX], but that tag does not exist in the borrow stack for this location
-   |                this error occurs as part of an access at ALLOC[$HEX..$HEX]
+LL |         let _val = *y;
+   |                    ^^
+   |                    |
+   |                    attempting a read access using <TAG> at ALLOC[$HEX], but that tag does not exist in the borrow stack for this location
+   |                    this error occurs as part of an access at ALLOC[$HEX..$HEX]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
 help: <TAG> was created by a retag at offsets [$HEX..$HEX]
   --> $DIR/shared_rw_borrows_are_weak2.rs:LL:CC
    |
-LL |     let y: &i32 = mem::transmute(&*x.borrow()); // launder lifetime
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         let y: &i32 = mem::transmute(&*x.borrow()); // launder lifetime
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: <TAG> was later invalidated at offsets [$HEX..$HEX]
   --> $DIR/shared_rw_borrows_are_weak2.rs:LL:CC
    |
-LL |     shr_rw.replace(1);
-   |     ^^^^^^^^^^^^^^^^^
+LL |         shr_rw.replace(1);
+   |         ^^^^^^^^^^^^^^^^^
    = note: inside `main` at $DIR/shared_rw_borrows_are_weak2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/sync/libc_pthread_mutex_destroy_locked.rs
+++ b/tests/fail/sync/libc_pthread_mutex_destroy_locked.rs
@@ -7,7 +7,10 @@ extern crate libc;
 fn main() {
     unsafe {
         let mut mutexattr: libc::pthread_mutexattr_t = std::mem::zeroed();
-        assert_eq!(libc::pthread_mutexattr_settype(&mut mutexattr as *mut _, libc::PTHREAD_MUTEX_NORMAL), 0);
+        assert_eq!(
+            libc::pthread_mutexattr_settype(&mut mutexattr as *mut _, libc::PTHREAD_MUTEX_NORMAL),
+            0
+        );
         let mut mutex: libc::pthread_mutex_t = std::mem::zeroed();
         assert_eq!(libc::pthread_mutex_init(&mut mutex as *mut _, &mutexattr as *const _), 0);
         assert_eq!(libc::pthread_mutex_lock(&mut mutex as *mut _), 0);

--- a/tests/fail/sync/libc_pthread_mutex_destroy_locked.rs
+++ b/tests/fail/sync/libc_pthread_mutex_destroy_locked.rs
@@ -9,7 +9,7 @@ fn main() {
         let mut mutexattr: libc::pthread_mutexattr_t = std::mem::zeroed();
         assert_eq!(
             libc::pthread_mutexattr_settype(&mut mutexattr as *mut _, libc::PTHREAD_MUTEX_NORMAL),
-            0
+            0,
         );
         let mut mutex: libc::pthread_mutex_t = std::mem::zeroed();
         assert_eq!(libc::pthread_mutex_init(&mut mutex as *mut _, &mutexattr as *const _), 0);

--- a/tests/fail/sync/libc_pthread_mutex_normal_deadlock.rs
+++ b/tests/fail/sync/libc_pthread_mutex_normal_deadlock.rs
@@ -7,7 +7,10 @@ extern crate libc;
 fn main() {
     unsafe {
         let mut mutexattr: libc::pthread_mutexattr_t = std::mem::zeroed();
-        assert_eq!(libc::pthread_mutexattr_settype(&mut mutexattr as *mut _, libc::PTHREAD_MUTEX_NORMAL), 0);
+        assert_eq!(
+            libc::pthread_mutexattr_settype(&mut mutexattr as *mut _, libc::PTHREAD_MUTEX_NORMAL),
+            0
+        );
         let mut mutex: libc::pthread_mutex_t = std::mem::zeroed();
         assert_eq!(libc::pthread_mutex_init(&mut mutex as *mut _, &mutexattr as *const _), 0);
         assert_eq!(libc::pthread_mutex_lock(&mut mutex as *mut _), 0);

--- a/tests/fail/sync/libc_pthread_mutex_normal_deadlock.rs
+++ b/tests/fail/sync/libc_pthread_mutex_normal_deadlock.rs
@@ -9,7 +9,7 @@ fn main() {
         let mut mutexattr: libc::pthread_mutexattr_t = std::mem::zeroed();
         assert_eq!(
             libc::pthread_mutexattr_settype(&mut mutexattr as *mut _, libc::PTHREAD_MUTEX_NORMAL),
-            0
+            0,
         );
         let mut mutex: libc::pthread_mutex_t = std::mem::zeroed();
         assert_eq!(libc::pthread_mutex_init(&mut mutex as *mut _, &mutexattr as *const _), 0);

--- a/tests/fail/sync/libc_pthread_mutex_normal_unlock_unlocked.rs
+++ b/tests/fail/sync/libc_pthread_mutex_normal_unlock_unlocked.rs
@@ -7,7 +7,10 @@ extern crate libc;
 fn main() {
     unsafe {
         let mut mutexattr: libc::pthread_mutexattr_t = std::mem::zeroed();
-        assert_eq!(libc::pthread_mutexattr_settype(&mut mutexattr as *mut _, libc::PTHREAD_MUTEX_NORMAL), 0);
+        assert_eq!(
+            libc::pthread_mutexattr_settype(&mut mutexattr as *mut _, libc::PTHREAD_MUTEX_NORMAL),
+            0
+        );
         let mut mutex: libc::pthread_mutex_t = std::mem::zeroed();
         assert_eq!(libc::pthread_mutex_init(&mut mutex as *mut _, &mutexattr as *const _), 0);
         assert_eq!(libc::pthread_mutex_lock(&mut mutex as *mut _), 0);

--- a/tests/fail/sync/libc_pthread_mutex_normal_unlock_unlocked.rs
+++ b/tests/fail/sync/libc_pthread_mutex_normal_unlock_unlocked.rs
@@ -9,7 +9,7 @@ fn main() {
         let mut mutexattr: libc::pthread_mutexattr_t = std::mem::zeroed();
         assert_eq!(
             libc::pthread_mutexattr_settype(&mut mutexattr as *mut _, libc::PTHREAD_MUTEX_NORMAL),
-            0
+            0,
         );
         let mut mutex: libc::pthread_mutex_t = std::mem::zeroed();
         assert_eq!(libc::pthread_mutex_init(&mut mutex as *mut _, &mutexattr as *const _), 0);

--- a/tests/fail/transmute-pair-uninit.rs
+++ b/tests/fail/transmute-pair-uninit.rs
@@ -10,7 +10,7 @@ fn main() {
     let y = &x;
     // Now read this bytewise. There should be (`ptr_size + 1`) def bytes followed by
     // (`ptr_size - 1`) undef bytes (the padding after the bool) in there.
-    let z : *const u8 = y as *const _ as *const _;
+    let z: *const u8 = y as *const _ as *const _;
     let first_undef = mem::size_of::<usize>() as isize + 1;
     for i in 0..first_undef {
         let byte = unsafe { *z.offset(i) };
@@ -18,5 +18,7 @@ fn main() {
     }
     let v = unsafe { *z.offset(first_undef) };
     //~^ ERROR uninitialized
-    if v == 0 { println!("it is zero"); }
+    if v == 0 {
+        println!("it is zero");
+    }
 }

--- a/tests/fail/transmute_fat1.rs
+++ b/tests/fail/transmute_fat1.rs
@@ -2,13 +2,9 @@
 // normalize-stderr-test: "\[u8; (08|16)\]" -> "$$ARRAY"
 
 fn main() {
-    #[cfg(target_pointer_width="64")]
-    let bad = unsafe {
-        std::mem::transmute::<&[u8], [u8; 16]>(&[1u8])
-    };
-    #[cfg(target_pointer_width="32")]
-    let bad = unsafe {
-        std::mem::transmute::<&[u8], [u8; 08]>(&[1u8])
-    };
-    let _val = bad[0] + bad[bad.len()-1];
+    #[cfg(target_pointer_width = "64")]
+    let bad = unsafe { std::mem::transmute::<&[u8], [u8; 16]>(&[1u8]) };
+    #[cfg(target_pointer_width = "32")]
+    let bad = unsafe { std::mem::transmute::<&[u8], [u8; 08]>(&[1u8]) };
+    let _val = bad[0] + bad[bad.len() - 1];
 }

--- a/tests/fail/transmute_fat1.stderr
+++ b/tests/fail/transmute_fat1.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: type validation failed: encountered a pointer, but expected plain (non-pointer) bytes
   --> $DIR/transmute_fat1.rs:LL:CC
    |
-LL |         std::mem::transmute::<&[u8], $ARRAY>(&[1u8])
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer, but expected plain (non-pointer) bytes
+LL |     let bad = unsafe { std::mem::transmute::<&[u8], $ARRAY>(&[1u8]) };
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered a pointer, but expected plain (non-pointer) bytes
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/unaligned_pointers/alignment.rs
+++ b/tests/fail/unaligned_pointers/alignment.rs
@@ -8,7 +8,7 @@ fn main() {
     let x_ptr: *mut u8 = x.as_mut_ptr();
     // At least one of these is definitely unaligned.
     unsafe {
-        *(x_ptr        as *mut u32) = 42;
+        *(x_ptr as *mut u32) = 42;
         *(x_ptr.add(1) as *mut u32) = 42;
     }
 }

--- a/tests/fail/unaligned_pointers/alignment.stderr
+++ b/tests/fail/unaligned_pointers/alignment.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: accessing memory with alignment ALIGN, but alignment ALIGN is required
   --> $DIR/alignment.rs:LL:CC
    |
-LL |         *(x_ptr        as *mut u32) = 42;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ accessing memory with alignment ALIGN, but alignment ALIGN is required
+LL |         *(x_ptr as *mut u32) = 42;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ accessing memory with alignment ALIGN, but alignment ALIGN is required
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/validity/cast_fn_ptr1.rs
+++ b/tests/fail/validity/cast_fn_ptr1.rs
@@ -2,7 +2,7 @@ fn main() {
     // Cast a function pointer such that on a call, the argument gets transmuted
     // from raw ptr to reference. This is ABI-compatible, so it's not the call that
     // should fail, but validation should.
-    fn f(_x: &i32) { }
+    fn f(_x: &i32) {}
 
     let g: fn(*const i32) = unsafe { std::mem::transmute(f as fn(&i32)) };
 

--- a/tests/fail/validity/cast_fn_ptr2.rs
+++ b/tests/fail/validity/cast_fn_ptr2.rs
@@ -2,7 +2,9 @@ fn main() {
     // Cast a function pointer such that when returning, the return value gets transmuted
     // from raw ptr to reference. This is ABI-compatible, so it's not the call that
     // should fail, but validation should.
-    fn f() -> *const i32 { 0usize as *const i32 }
+    fn f() -> *const i32 {
+        0usize as *const i32
+    }
 
     let g: fn() -> &'static i32 = unsafe { std::mem::transmute(f as fn() -> *const i32) };
 

--- a/tests/fail/validity/invalid_enum_tag.rs
+++ b/tests/fail/validity/invalid_enum_tag.rs
@@ -1,6 +1,9 @@
 #[repr(C)]
 pub enum Foo {
-    A, B, C, D
+    A,
+    B,
+    C,
+    D,
 }
 
 fn main() {

--- a/tests/fail/validity/invalid_wide_raw.rs
+++ b/tests/fail/validity/invalid_wide_raw.rs
@@ -1,11 +1,11 @@
 #![allow(invalid_value)]
 
 fn main() {
-    trait T { }
+    trait T {}
     #[derive(Debug)]
     struct S {
         #[allow(dead_code)]
-        x: * mut dyn T
+        x: *mut dyn T,
     }
     dbg!(S { x: unsafe { std::mem::transmute((0usize, 0usize)) } }); //~ ERROR: encountered dangling vtable pointer in wide pointer
 }

--- a/tests/fail/validity/ref_to_uninhabited1.rs
+++ b/tests/fail/validity/ref_to_uninhabited1.rs
@@ -1,7 +1,9 @@
 #![feature(never_type)]
-use std::mem::{transmute, forget};
+use std::mem::{forget, transmute};
 
-fn main() { unsafe {
-    let x: Box<!> = transmute(&mut 42); //~ERROR encountered a box pointing to uninhabited type !
-    forget(x);
-} }
+fn main() {
+    unsafe {
+        let x: Box<!> = transmute(&mut 42); //~ERROR encountered a box pointing to uninhabited type !
+        forget(x);
+    }
+}

--- a/tests/fail/validity/ref_to_uninhabited1.stderr
+++ b/tests/fail/validity/ref_to_uninhabited1.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: type validation failed: encountered a box pointing to uninhabited type !
   --> $DIR/ref_to_uninhabited1.rs:LL:CC
    |
-LL |     let x: Box<!> = transmute(&mut 42);
-   |                     ^^^^^^^^^^^^^^^^^^ type validation failed: encountered a box pointing to uninhabited type !
+LL |         let x: Box<!> = transmute(&mut 42);
+   |                         ^^^^^^^^^^^^^^^^^^ type validation failed: encountered a box pointing to uninhabited type !
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/validity/ref_to_uninhabited2.rs
+++ b/tests/fail/validity/ref_to_uninhabited2.rs
@@ -2,6 +2,8 @@ use std::mem::transmute;
 
 enum Void {}
 
-fn main() { unsafe {
-    let _x: &(i32, Void) = transmute(&42); //~ERROR encountered a reference pointing to uninhabited type (i32, Void)
-} }
+fn main() {
+    unsafe {
+        let _x: &(i32, Void) = transmute(&42); //~ERROR encountered a reference pointing to uninhabited type (i32, Void)
+    }
+}

--- a/tests/fail/validity/ref_to_uninhabited2.stderr
+++ b/tests/fail/validity/ref_to_uninhabited2.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: type validation failed: encountered a reference pointing to uninhabited type (i32, Void)
   --> $DIR/ref_to_uninhabited2.rs:LL:CC
    |
-LL |     let _x: &(i32, Void) = transmute(&42);
-   |                            ^^^^^^^^^^^^^^ type validation failed: encountered a reference pointing to uninhabited type (i32, Void)
+LL |         let _x: &(i32, Void) = transmute(&42);
+   |                                ^^^^^^^^^^^^^^ type validation failed: encountered a reference pointing to uninhabited type (i32, Void)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/validity/too-big-slice.rs
+++ b/tests/fail/validity/too-big-slice.rs
@@ -1,6 +1,8 @@
 use std::mem;
 
-fn main() { unsafe {
-    let ptr = Box::into_raw(Box::new(0u8));
-    let _x: &[u8] = mem::transmute((ptr, usize::MAX)); //~ ERROR: invalid reference metadata: slice is bigger than largest supported object
-} }
+fn main() {
+    unsafe {
+        let ptr = Box::into_raw(Box::new(0u8));
+        let _x: &[u8] = mem::transmute((ptr, usize::MAX)); //~ ERROR: invalid reference metadata: slice is bigger than largest supported object
+    }
+}

--- a/tests/fail/validity/too-big-slice.stderr
+++ b/tests/fail/validity/too-big-slice.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: type validation failed: encountered invalid reference metadata: slice is bigger than largest supported object
   --> $DIR/too-big-slice.rs:LL:CC
    |
-LL |     let _x: &[u8] = mem::transmute((ptr, usize::MAX));
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid reference metadata: slice is bigger than largest supported object
+LL |         let _x: &[u8] = mem::transmute((ptr, usize::MAX));
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid reference metadata: slice is bigger than largest supported object
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/validity/too-big-unsized.rs
+++ b/tests/fail/validity/too-big-unsized.rs
@@ -6,8 +6,10 @@ struct MySlice {
     tail: [u8],
 }
 
-fn main() { unsafe {
-    let ptr = Box::into_raw(Box::new(0u8));
-    // The slice part is actually not "too big", but together with the `prefix` field it is.
-    let _x: &MySlice = mem::transmute((ptr, isize::MAX as usize)); //~ ERROR: invalid reference metadata: total size is bigger than largest supported object
-} }
+fn main() {
+    unsafe {
+        let ptr = Box::into_raw(Box::new(0u8));
+        // The slice part is actually not "too big", but together with the `prefix` field it is.
+        let _x: &MySlice = mem::transmute((ptr, isize::MAX as usize)); //~ ERROR: invalid reference metadata: total size is bigger than largest supported object
+    }
+}

--- a/tests/fail/validity/too-big-unsized.stderr
+++ b/tests/fail/validity/too-big-unsized.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: type validation failed: encountered invalid reference metadata: total size is bigger than largest supported object
   --> $DIR/too-big-unsized.rs:LL:CC
    |
-LL |     let _x: &MySlice = mem::transmute((ptr, isize::MAX as usize));
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid reference metadata: total size is bigger than largest supported object
+LL |         let _x: &MySlice = mem::transmute((ptr, isize::MAX as usize));
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered invalid reference metadata: total size is bigger than largest supported object
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information


### PR DESCRIPTION
Extracted from #2097. Last of the easy cases which do not involve moving around a comment.