### PR TITLE
Format tests with rustfmt (225-275 of 300)

### DIFF
--- a/tests/fail/box-cell-alias.rs
+++ b/tests/fail/box-cell-alias.rs
@@ -6,7 +6,9 @@ use std::cell::Cell;
 
 fn helper(val: Box<Cell<u8>>, ptr: *const Cell<u8>) -> u8 {
     val.set(10);
-    unsafe { (*ptr).set(20); } //~ ERROR does not exist in the borrow stack
+    unsafe {
+        (*ptr).set(20);
+    } //~ ERROR does not exist in the borrow stack
     val.get()
 }
 

--- a/tests/fail/box-cell-alias.rs
+++ b/tests/fail/box-cell-alias.rs
@@ -7,8 +7,8 @@ use std::cell::Cell;
 fn helper(val: Box<Cell<u8>>, ptr: *const Cell<u8>) -> u8 {
     val.set(10);
     unsafe {
-        (*ptr).set(20);
-    } //~ ERROR does not exist in the borrow stack
+        (*ptr).set(20); //~ ERROR does not exist in the borrow stack
+    }
     val.get()
 }
 

--- a/tests/fail/box-cell-alias.stderr
+++ b/tests/fail/box-cell-alias.stderr
@@ -1,11 +1,11 @@
 error: Undefined Behavior: trying to reborrow <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/box-cell-alias.rs:LL:CC
    |
-LL |     unsafe { (*ptr).set(20); }
-   |              ^^^^^^^^^^^^^^
-   |              |
-   |              trying to reborrow <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
-   |              this error occurs as part of a reborrow at ALLOC[0x0..0x1]
+LL |         (*ptr).set(20);
+   |         ^^^^^^^^^^^^^^
+   |         |
+   |         trying to reborrow <TAG> for SharedReadWrite permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |         this error occurs as part of a reborrow at ALLOC[0x0..0x1]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/dangling_pointers/maybe_null_pointer_write_zst.rs
+++ b/tests/fail/dangling_pointers/maybe_null_pointer_write_zst.rs
@@ -7,5 +7,7 @@ fn main() {
     // Also not assigning directly as that's array initialization, not assignment.
     let zst_val = [1u8; 0];
     let ptr = (&0u8 as *const u8).wrapping_sub(0x800) as *mut [u8; 0];
-    unsafe { *ptr = zst_val; } //~ ERROR out-of-bounds
+    unsafe {
+        *ptr = zst_val;
+    } //~ ERROR out-of-bounds
 }

--- a/tests/fail/dangling_pointers/maybe_null_pointer_write_zst.rs
+++ b/tests/fail/dangling_pointers/maybe_null_pointer_write_zst.rs
@@ -8,6 +8,6 @@ fn main() {
     let zst_val = [1u8; 0];
     let ptr = (&0u8 as *const u8).wrapping_sub(0x800) as *mut [u8; 0];
     unsafe {
-        *ptr = zst_val;
-    } //~ ERROR out-of-bounds
+        *ptr = zst_val; //~ ERROR out-of-bounds
+    }
 }

--- a/tests/fail/dangling_pointers/maybe_null_pointer_write_zst.stderr
+++ b/tests/fail/dangling_pointers/maybe_null_pointer_write_zst.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: dereferencing pointer failed: ALLOC has size 1, so pointer at offset -2048 is out-of-bounds
   --> $DIR/maybe_null_pointer_write_zst.rs:LL:CC
    |
-LL |     unsafe { *ptr = zst_val; }
-   |              ^^^^^^^^^^^^^^ dereferencing pointer failed: ALLOC has size 1, so pointer at offset -2048 is out-of-bounds
+LL |         *ptr = zst_val;
+   |         ^^^^^^^^^^^^^^ dereferencing pointer failed: ALLOC has size 1, so pointer at offset -2048 is out-of-bounds
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/copy_null.rs
+++ b/tests/fail/intrinsics/copy_null.rs
@@ -10,6 +10,6 @@ fn main() {
     let ptr = &mut data[0] as *mut u16;
     // Even copying 0 elements from NULL should error.
     unsafe {
-        copy_nonoverlapping(std::ptr::null(), ptr, 0);
-    } //~ ERROR: memory access failed: null pointer is not a valid pointer
+        copy_nonoverlapping(std::ptr::null(), ptr, 0); //~ ERROR: memory access failed: null pointer is not a valid pointer
+    }
 }

--- a/tests/fail/intrinsics/copy_null.rs
+++ b/tests/fail/intrinsics/copy_null.rs
@@ -9,5 +9,7 @@ fn main() {
     let mut data = [0u16; 4];
     let ptr = &mut data[0] as *mut u16;
     // Even copying 0 elements from NULL should error.
-    unsafe { copy_nonoverlapping(std::ptr::null(), ptr, 0); } //~ ERROR: memory access failed: null pointer is not a valid pointer
+    unsafe {
+        copy_nonoverlapping(std::ptr::null(), ptr, 0);
+    } //~ ERROR: memory access failed: null pointer is not a valid pointer
 }

--- a/tests/fail/intrinsics/copy_null.stderr
+++ b/tests/fail/intrinsics/copy_null.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: memory access failed: null pointer is not a valid pointer
   --> $DIR/copy_null.rs:LL:CC
    |
-LL |     unsafe { copy_nonoverlapping(std::ptr::null(), ptr, 0); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ memory access failed: null pointer is not a valid pointer
+LL |         copy_nonoverlapping(std::ptr::null(), ptr, 0);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ memory access failed: null pointer is not a valid pointer
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/copy_unaligned.rs
+++ b/tests/fail/intrinsics/copy_unaligned.rs
@@ -10,6 +10,6 @@ fn main() {
     let ptr = (&mut data[0] as *mut u16 as *mut u8).wrapping_add(1) as *mut u16;
     // Even copying 0 elements to something unaligned should error
     unsafe {
-        copy_nonoverlapping(&data[5], ptr, 0);
-    } //~ ERROR accessing memory with alignment 1, but alignment 2 is required
+        copy_nonoverlapping(&data[5], ptr, 0); //~ ERROR accessing memory with alignment 1, but alignment 2 is required
+    }
 }

--- a/tests/fail/intrinsics/copy_unaligned.rs
+++ b/tests/fail/intrinsics/copy_unaligned.rs
@@ -9,5 +9,7 @@ fn main() {
     let mut data = [0u16; 8];
     let ptr = (&mut data[0] as *mut u16 as *mut u8).wrapping_add(1) as *mut u16;
     // Even copying 0 elements to something unaligned should error
-    unsafe { copy_nonoverlapping(&data[5], ptr, 0); } //~ ERROR accessing memory with alignment 1, but alignment 2 is required
+    unsafe {
+        copy_nonoverlapping(&data[5], ptr, 0);
+    } //~ ERROR accessing memory with alignment 1, but alignment 2 is required
 }

--- a/tests/fail/intrinsics/copy_unaligned.stderr
+++ b/tests/fail/intrinsics/copy_unaligned.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: accessing memory with alignment ALIGN, but alignment ALIGN is required
   --> $DIR/copy_unaligned.rs:LL:CC
    |
-LL |     unsafe { copy_nonoverlapping(&data[5], ptr, 0); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ accessing memory with alignment ALIGN, but alignment ALIGN is required
+LL |         copy_nonoverlapping(&data[5], ptr, 0);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ accessing memory with alignment ALIGN, but alignment ALIGN is required
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/exact_div1.rs
+++ b/tests/fail/intrinsics/exact_div1.rs
@@ -2,6 +2,6 @@
 fn main() {
     // divison by 0
     unsafe {
-        std::intrinsics::exact_div(2, 0);
-    } //~ ERROR divisor of zero
+        std::intrinsics::exact_div(2, 0); //~ ERROR divisor of zero
+    }
 }

--- a/tests/fail/intrinsics/exact_div1.rs
+++ b/tests/fail/intrinsics/exact_div1.rs
@@ -1,5 +1,7 @@
 #![feature(core_intrinsics)]
 fn main() {
     // divison by 0
-    unsafe { std::intrinsics::exact_div(2, 0); } //~ ERROR divisor of zero
+    unsafe {
+        std::intrinsics::exact_div(2, 0);
+    } //~ ERROR divisor of zero
 }

--- a/tests/fail/intrinsics/exact_div1.stderr
+++ b/tests/fail/intrinsics/exact_div1.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: calculating the remainder with a divisor of zero
   --> $DIR/exact_div1.rs:LL:CC
    |
-LL |     unsafe { std::intrinsics::exact_div(2, 0); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ calculating the remainder with a divisor of zero
+LL |         std::intrinsics::exact_div(2, 0);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ calculating the remainder with a divisor of zero
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/exact_div2.rs
+++ b/tests/fail/intrinsics/exact_div2.rs
@@ -1,5 +1,7 @@
 #![feature(core_intrinsics)]
 fn main() {
     // divison with a remainder
-    unsafe { std::intrinsics::exact_div(2u16, 3); } //~ ERROR 2_u16 cannot be divided by 3_u16 without remainder
+    unsafe {
+        std::intrinsics::exact_div(2u16, 3);
+    } //~ ERROR 2_u16 cannot be divided by 3_u16 without remainder
 }

--- a/tests/fail/intrinsics/exact_div2.rs
+++ b/tests/fail/intrinsics/exact_div2.rs
@@ -2,6 +2,6 @@
 fn main() {
     // divison with a remainder
     unsafe {
-        std::intrinsics::exact_div(2u16, 3);
-    } //~ ERROR 2_u16 cannot be divided by 3_u16 without remainder
+        std::intrinsics::exact_div(2u16, 3); //~ ERROR 2_u16 cannot be divided by 3_u16 without remainder
+    }
 }

--- a/tests/fail/intrinsics/exact_div2.stderr
+++ b/tests/fail/intrinsics/exact_div2.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: exact_div: 2_u16 cannot be divided by 3_u16 without remainder
   --> $DIR/exact_div2.rs:LL:CC
    |
-LL |     unsafe { std::intrinsics::exact_div(2u16, 3); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ exact_div: 2_u16 cannot be divided by 3_u16 without remainder
+LL |         std::intrinsics::exact_div(2u16, 3);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ exact_div: 2_u16 cannot be divided by 3_u16 without remainder
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/exact_div3.rs
+++ b/tests/fail/intrinsics/exact_div3.rs
@@ -1,5 +1,7 @@
 #![feature(core_intrinsics)]
 fn main() {
     // signed divison with a remainder
-    unsafe { std::intrinsics::exact_div(-19i8, 2); } //~ ERROR -19_i8 cannot be divided by 2_i8 without remainder
+    unsafe {
+        std::intrinsics::exact_div(-19i8, 2);
+    } //~ ERROR -19_i8 cannot be divided by 2_i8 without remainder
 }

--- a/tests/fail/intrinsics/exact_div3.rs
+++ b/tests/fail/intrinsics/exact_div3.rs
@@ -2,6 +2,6 @@
 fn main() {
     // signed divison with a remainder
     unsafe {
-        std::intrinsics::exact_div(-19i8, 2);
-    } //~ ERROR -19_i8 cannot be divided by 2_i8 without remainder
+        std::intrinsics::exact_div(-19i8, 2); //~ ERROR -19_i8 cannot be divided by 2_i8 without remainder
+    }
 }

--- a/tests/fail/intrinsics/exact_div3.stderr
+++ b/tests/fail/intrinsics/exact_div3.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: exact_div: -19_i8 cannot be divided by 2_i8 without remainder
   --> $DIR/exact_div3.rs:LL:CC
    |
-LL |     unsafe { std::intrinsics::exact_div(-19i8, 2); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ exact_div: -19_i8 cannot be divided by 2_i8 without remainder
+LL |         std::intrinsics::exact_div(-19i8, 2);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ exact_div: -19_i8 cannot be divided by 2_i8 without remainder
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/exact_div4.rs
+++ b/tests/fail/intrinsics/exact_div4.rs
@@ -1,5 +1,7 @@
 #![feature(core_intrinsics)]
 fn main() {
     // divison of MIN by -1
-    unsafe { std::intrinsics::exact_div(i64::MIN, -1); } //~ ERROR overflow in signed remainder (dividing MIN by -1)
+    unsafe {
+        std::intrinsics::exact_div(i64::MIN, -1);
+    } //~ ERROR overflow in signed remainder (dividing MIN by -1)
 }

--- a/tests/fail/intrinsics/exact_div4.rs
+++ b/tests/fail/intrinsics/exact_div4.rs
@@ -2,6 +2,6 @@
 fn main() {
     // divison of MIN by -1
     unsafe {
-        std::intrinsics::exact_div(i64::MIN, -1);
-    } //~ ERROR overflow in signed remainder (dividing MIN by -1)
+        std::intrinsics::exact_div(i64::MIN, -1); //~ ERROR overflow in signed remainder (dividing MIN by -1)
+    }
 }

--- a/tests/fail/intrinsics/exact_div4.stderr
+++ b/tests/fail/intrinsics/exact_div4.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: overflow in signed remainder (dividing MIN by -1)
   --> $DIR/exact_div4.rs:LL:CC
    |
-LL |     unsafe { std::intrinsics::exact_div(i64::MIN, -1); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow in signed remainder (dividing MIN by -1)
+LL |         std::intrinsics::exact_div(i64::MIN, -1);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow in signed remainder (dividing MIN by -1)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/float_to_int_32_inf1.rs
+++ b/tests/fail/intrinsics/float_to_int_32_inf1.rs
@@ -7,6 +7,6 @@ extern "rust-intrinsic" {
 
 fn main() {
     unsafe {
-        float_to_int_unchecked::<f32, i32>(f32::INFINITY);
-    } //~ ERROR: cannot be represented in target type `i32`
+        float_to_int_unchecked::<f32, i32>(f32::INFINITY); //~ ERROR: cannot be represented in target type `i32`
+    }
 }

--- a/tests/fail/intrinsics/float_to_int_32_inf1.rs
+++ b/tests/fail/intrinsics/float_to_int_32_inf1.rs
@@ -6,5 +6,7 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    unsafe { float_to_int_unchecked::<f32, i32>(f32::INFINITY); } //~ ERROR: cannot be represented in target type `i32`
+    unsafe {
+        float_to_int_unchecked::<f32, i32>(f32::INFINITY);
+    } //~ ERROR: cannot be represented in target type `i32`
 }

--- a/tests/fail/intrinsics/float_to_int_32_inf1.stderr
+++ b/tests/fail/intrinsics/float_to_int_32_inf1.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: `float_to_int_unchecked` intrinsic called on +Inf which cannot be represented in target type `i32`
   --> $DIR/float_to_int_32_inf1.rs:LL:CC
    |
-LL |     unsafe { float_to_int_unchecked::<f32, i32>(f32::INFINITY); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on +Inf which cannot be represented in target type `i32`
+LL |         float_to_int_unchecked::<f32, i32>(f32::INFINITY);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on +Inf which cannot be represented in target type `i32`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/float_to_int_32_infneg1.rs
+++ b/tests/fail/intrinsics/float_to_int_32_infneg1.rs
@@ -6,5 +6,7 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    unsafe { float_to_int_unchecked::<f32, i32>(f32::NEG_INFINITY); } //~ ERROR: cannot be represented in target type `i32`
+    unsafe {
+        float_to_int_unchecked::<f32, i32>(f32::NEG_INFINITY);
+    } //~ ERROR: cannot be represented in target type `i32`
 }

--- a/tests/fail/intrinsics/float_to_int_32_infneg1.rs
+++ b/tests/fail/intrinsics/float_to_int_32_infneg1.rs
@@ -7,6 +7,6 @@ extern "rust-intrinsic" {
 
 fn main() {
     unsafe {
-        float_to_int_unchecked::<f32, i32>(f32::NEG_INFINITY);
-    } //~ ERROR: cannot be represented in target type `i32`
+        float_to_int_unchecked::<f32, i32>(f32::NEG_INFINITY); //~ ERROR: cannot be represented in target type `i32`
+    }
 }

--- a/tests/fail/intrinsics/float_to_int_32_infneg1.stderr
+++ b/tests/fail/intrinsics/float_to_int_32_infneg1.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: `float_to_int_unchecked` intrinsic called on -Inf which cannot be represented in target type `i32`
   --> $DIR/float_to_int_32_infneg1.rs:LL:CC
    |
-LL |     unsafe { float_to_int_unchecked::<f32, i32>(f32::NEG_INFINITY); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on -Inf which cannot be represented in target type `i32`
+LL |         float_to_int_unchecked::<f32, i32>(f32::NEG_INFINITY);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on -Inf which cannot be represented in target type `i32`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/float_to_int_32_nan.rs
+++ b/tests/fail/intrinsics/float_to_int_32_nan.rs
@@ -6,5 +6,7 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    unsafe { float_to_int_unchecked::<f32, u32>(f32::NAN); } //~ ERROR: cannot be represented in target type `u32`
+    unsafe {
+        float_to_int_unchecked::<f32, u32>(f32::NAN);
+    } //~ ERROR: cannot be represented in target type `u32`
 }

--- a/tests/fail/intrinsics/float_to_int_32_nan.rs
+++ b/tests/fail/intrinsics/float_to_int_32_nan.rs
@@ -7,6 +7,6 @@ extern "rust-intrinsic" {
 
 fn main() {
     unsafe {
-        float_to_int_unchecked::<f32, u32>(f32::NAN);
-    } //~ ERROR: cannot be represented in target type `u32`
+        float_to_int_unchecked::<f32, u32>(f32::NAN); //~ ERROR: cannot be represented in target type `u32`
+    }
 }

--- a/tests/fail/intrinsics/float_to_int_32_nan.stderr
+++ b/tests/fail/intrinsics/float_to_int_32_nan.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: `float_to_int_unchecked` intrinsic called on NaN which cannot be represented in target type `u32`
   --> $DIR/float_to_int_32_nan.rs:LL:CC
    |
-LL |     unsafe { float_to_int_unchecked::<f32, u32>(f32::NAN); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on NaN which cannot be represented in target type `u32`
+LL |         float_to_int_unchecked::<f32, u32>(f32::NAN);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on NaN which cannot be represented in target type `u32`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/float_to_int_32_nanneg.rs
+++ b/tests/fail/intrinsics/float_to_int_32_nanneg.rs
@@ -6,5 +6,7 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    unsafe { float_to_int_unchecked::<f32, u32>(-f32::NAN); } //~ ERROR: cannot be represented in target type `u32`
+    unsafe {
+        float_to_int_unchecked::<f32, u32>(-f32::NAN);
+    } //~ ERROR: cannot be represented in target type `u32`
 }

--- a/tests/fail/intrinsics/float_to_int_32_nanneg.rs
+++ b/tests/fail/intrinsics/float_to_int_32_nanneg.rs
@@ -7,6 +7,6 @@ extern "rust-intrinsic" {
 
 fn main() {
     unsafe {
-        float_to_int_unchecked::<f32, u32>(-f32::NAN);
-    } //~ ERROR: cannot be represented in target type `u32`
+        float_to_int_unchecked::<f32, u32>(-f32::NAN); //~ ERROR: cannot be represented in target type `u32`
+    }
 }

--- a/tests/fail/intrinsics/float_to_int_32_nanneg.stderr
+++ b/tests/fail/intrinsics/float_to_int_32_nanneg.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: `float_to_int_unchecked` intrinsic called on NaN which cannot be represented in target type `u32`
   --> $DIR/float_to_int_32_nanneg.rs:LL:CC
    |
-LL |     unsafe { float_to_int_unchecked::<f32, u32>(-f32::NAN); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on NaN which cannot be represented in target type `u32`
+LL |         float_to_int_unchecked::<f32, u32>(-f32::NAN);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on NaN which cannot be represented in target type `u32`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/float_to_int_32_neg.rs
+++ b/tests/fail/intrinsics/float_to_int_32_neg.rs
@@ -6,5 +6,7 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    unsafe { float_to_int_unchecked::<f32, u32>(-1.000000001f32); } //~ ERROR: cannot be represented in target type `u32`
+    unsafe {
+        float_to_int_unchecked::<f32, u32>(-1.000000001f32);
+    } //~ ERROR: cannot be represented in target type `u32`
 }

--- a/tests/fail/intrinsics/float_to_int_32_neg.rs
+++ b/tests/fail/intrinsics/float_to_int_32_neg.rs
@@ -7,6 +7,6 @@ extern "rust-intrinsic" {
 
 fn main() {
     unsafe {
-        float_to_int_unchecked::<f32, u32>(-1.000000001f32);
-    } //~ ERROR: cannot be represented in target type `u32`
+        float_to_int_unchecked::<f32, u32>(-1.000000001f32); //~ ERROR: cannot be represented in target type `u32`
+    }
 }

--- a/tests/fail/intrinsics/float_to_int_32_neg.stderr
+++ b/tests/fail/intrinsics/float_to_int_32_neg.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: `float_to_int_unchecked` intrinsic called on -1 which cannot be represented in target type `u32`
   --> $DIR/float_to_int_32_neg.rs:LL:CC
    |
-LL |     unsafe { float_to_int_unchecked::<f32, u32>(-1.000000001f32); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on -1 which cannot be represented in target type `u32`
+LL |         float_to_int_unchecked::<f32, u32>(-1.000000001f32);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on -1 which cannot be represented in target type `u32`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/float_to_int_32_too_big1.rs
+++ b/tests/fail/intrinsics/float_to_int_32_too_big1.rs
@@ -7,6 +7,6 @@ extern "rust-intrinsic" {
 
 fn main() {
     unsafe {
-        float_to_int_unchecked::<f32, i32>(2147483648.0f32);
-    } //~ ERROR: cannot be represented in target type `i32`
+        float_to_int_unchecked::<f32, i32>(2147483648.0f32); //~ ERROR: cannot be represented in target type `i32`
+    }
 }

--- a/tests/fail/intrinsics/float_to_int_32_too_big1.rs
+++ b/tests/fail/intrinsics/float_to_int_32_too_big1.rs
@@ -6,5 +6,7 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    unsafe { float_to_int_unchecked::<f32, i32>(2147483648.0f32); } //~ ERROR: cannot be represented in target type `i32`
+    unsafe {
+        float_to_int_unchecked::<f32, i32>(2147483648.0f32);
+    } //~ ERROR: cannot be represented in target type `i32`
 }

--- a/tests/fail/intrinsics/float_to_int_32_too_big1.stderr
+++ b/tests/fail/intrinsics/float_to_int_32_too_big1.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: `float_to_int_unchecked` intrinsic called on 2.14748365E+9 which cannot be represented in target type `i32`
   --> $DIR/float_to_int_32_too_big1.rs:LL:CC
    |
-LL |     unsafe { float_to_int_unchecked::<f32, i32>(2147483648.0f32); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on 2.14748365E+9 which cannot be represented in target type `i32`
+LL |         float_to_int_unchecked::<f32, i32>(2147483648.0f32);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on 2.14748365E+9 which cannot be represented in target type `i32`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/float_to_int_32_too_big2.rs
+++ b/tests/fail/intrinsics/float_to_int_32_too_big2.rs
@@ -6,5 +6,7 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    unsafe { float_to_int_unchecked::<f32, u32>((u32::MAX-127) as f32); } //~ ERROR: cannot be represented in target type `u32`
+    unsafe {
+        float_to_int_unchecked::<f32, u32>((u32::MAX - 127) as f32);
+    } //~ ERROR: cannot be represented in target type `u32`
 }

--- a/tests/fail/intrinsics/float_to_int_32_too_big2.rs
+++ b/tests/fail/intrinsics/float_to_int_32_too_big2.rs
@@ -7,6 +7,6 @@ extern "rust-intrinsic" {
 
 fn main() {
     unsafe {
-        float_to_int_unchecked::<f32, u32>((u32::MAX - 127) as f32);
-    } //~ ERROR: cannot be represented in target type `u32`
+        float_to_int_unchecked::<f32, u32>((u32::MAX - 127) as f32); //~ ERROR: cannot be represented in target type `u32`
+    }
 }

--- a/tests/fail/intrinsics/float_to_int_32_too_big2.stderr
+++ b/tests/fail/intrinsics/float_to_int_32_too_big2.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: `float_to_int_unchecked` intrinsic called on 4.2949673E+9 which cannot be represented in target type `u32`
   --> $DIR/float_to_int_32_too_big2.rs:LL:CC
    |
-LL |     unsafe { float_to_int_unchecked::<f32, u32>((u32::MAX-127) as f32); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on 4.2949673E+9 which cannot be represented in target type `u32`
+LL |         float_to_int_unchecked::<f32, u32>((u32::MAX - 127) as f32);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on 4.2949673E+9 which cannot be represented in target type `u32`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/float_to_int_32_too_small1.rs
+++ b/tests/fail/intrinsics/float_to_int_32_too_small1.rs
@@ -6,5 +6,7 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    unsafe { float_to_int_unchecked::<f32, i32>(-2147483904.0f32); } //~ ERROR: cannot be represented in target type `i32`
+    unsafe {
+        float_to_int_unchecked::<f32, i32>(-2147483904.0f32);
+    } //~ ERROR: cannot be represented in target type `i32`
 }

--- a/tests/fail/intrinsics/float_to_int_32_too_small1.rs
+++ b/tests/fail/intrinsics/float_to_int_32_too_small1.rs
@@ -7,6 +7,6 @@ extern "rust-intrinsic" {
 
 fn main() {
     unsafe {
-        float_to_int_unchecked::<f32, i32>(-2147483904.0f32);
-    } //~ ERROR: cannot be represented in target type `i32`
+        float_to_int_unchecked::<f32, i32>(-2147483904.0f32); //~ ERROR: cannot be represented in target type `i32`
+    }
 }

--- a/tests/fail/intrinsics/float_to_int_32_too_small1.stderr
+++ b/tests/fail/intrinsics/float_to_int_32_too_small1.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: `float_to_int_unchecked` intrinsic called on -2.1474839E+9 which cannot be represented in target type `i32`
   --> $DIR/float_to_int_32_too_small1.rs:LL:CC
    |
-LL |     unsafe { float_to_int_unchecked::<f32, i32>(-2147483904.0f32); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on -2.1474839E+9 which cannot be represented in target type `i32`
+LL |         float_to_int_unchecked::<f32, i32>(-2147483904.0f32);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on -2.1474839E+9 which cannot be represented in target type `i32`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/float_to_int_64_inf1.rs
+++ b/tests/fail/intrinsics/float_to_int_64_inf1.rs
@@ -7,6 +7,6 @@ extern "rust-intrinsic" {
 
 fn main() {
     unsafe {
-        float_to_int_unchecked::<f64, u128>(f64::INFINITY);
-    } //~ ERROR: cannot be represented in target type `u128`
+        float_to_int_unchecked::<f64, u128>(f64::INFINITY); //~ ERROR: cannot be represented in target type `u128`
+    }
 }

--- a/tests/fail/intrinsics/float_to_int_64_inf1.rs
+++ b/tests/fail/intrinsics/float_to_int_64_inf1.rs
@@ -6,5 +6,7 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    unsafe { float_to_int_unchecked::<f64, u128>(f64::INFINITY); } //~ ERROR: cannot be represented in target type `u128`
+    unsafe {
+        float_to_int_unchecked::<f64, u128>(f64::INFINITY);
+    } //~ ERROR: cannot be represented in target type `u128`
 }

--- a/tests/fail/intrinsics/float_to_int_64_inf1.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_inf1.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: `float_to_int_unchecked` intrinsic called on +Inf which cannot be represented in target type `u128`
   --> $DIR/float_to_int_64_inf1.rs:LL:CC
    |
-LL |     unsafe { float_to_int_unchecked::<f64, u128>(f64::INFINITY); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on +Inf which cannot be represented in target type `u128`
+LL |         float_to_int_unchecked::<f64, u128>(f64::INFINITY);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on +Inf which cannot be represented in target type `u128`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/float_to_int_64_infneg1.rs
+++ b/tests/fail/intrinsics/float_to_int_64_infneg1.rs
@@ -7,6 +7,6 @@ extern "rust-intrinsic" {
 
 fn main() {
     unsafe {
-        float_to_int_unchecked::<f64, u128>(f64::NEG_INFINITY);
-    } //~ ERROR: cannot be represented in target type `u128`
+        float_to_int_unchecked::<f64, u128>(f64::NEG_INFINITY); //~ ERROR: cannot be represented in target type `u128`
+    }
 }

--- a/tests/fail/intrinsics/float_to_int_64_infneg1.rs
+++ b/tests/fail/intrinsics/float_to_int_64_infneg1.rs
@@ -6,5 +6,7 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    unsafe { float_to_int_unchecked::<f64, u128>(f64::NEG_INFINITY); } //~ ERROR: cannot be represented in target type `u128`
+    unsafe {
+        float_to_int_unchecked::<f64, u128>(f64::NEG_INFINITY);
+    } //~ ERROR: cannot be represented in target type `u128`
 }

--- a/tests/fail/intrinsics/float_to_int_64_infneg1.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_infneg1.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: `float_to_int_unchecked` intrinsic called on -Inf which cannot be represented in target type `u128`
   --> $DIR/float_to_int_64_infneg1.rs:LL:CC
    |
-LL |     unsafe { float_to_int_unchecked::<f64, u128>(f64::NEG_INFINITY); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on -Inf which cannot be represented in target type `u128`
+LL |         float_to_int_unchecked::<f64, u128>(f64::NEG_INFINITY);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on -Inf which cannot be represented in target type `u128`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/float_to_int_64_infneg2.rs
+++ b/tests/fail/intrinsics/float_to_int_64_infneg2.rs
@@ -7,6 +7,6 @@ extern "rust-intrinsic" {
 
 fn main() {
     unsafe {
-        float_to_int_unchecked::<f64, i128>(f64::NEG_INFINITY);
-    } //~ ERROR: cannot be represented in target type `i128`
+        float_to_int_unchecked::<f64, i128>(f64::NEG_INFINITY); //~ ERROR: cannot be represented in target type `i128`
+    }
 }

--- a/tests/fail/intrinsics/float_to_int_64_infneg2.rs
+++ b/tests/fail/intrinsics/float_to_int_64_infneg2.rs
@@ -6,5 +6,7 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    unsafe { float_to_int_unchecked::<f64, i128>(f64::NEG_INFINITY); } //~ ERROR: cannot be represented in target type `i128`
+    unsafe {
+        float_to_int_unchecked::<f64, i128>(f64::NEG_INFINITY);
+    } //~ ERROR: cannot be represented in target type `i128`
 }

--- a/tests/fail/intrinsics/float_to_int_64_infneg2.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_infneg2.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: `float_to_int_unchecked` intrinsic called on -Inf which cannot be represented in target type `i128`
   --> $DIR/float_to_int_64_infneg2.rs:LL:CC
    |
-LL |     unsafe { float_to_int_unchecked::<f64, i128>(f64::NEG_INFINITY); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on -Inf which cannot be represented in target type `i128`
+LL |         float_to_int_unchecked::<f64, i128>(f64::NEG_INFINITY);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on -Inf which cannot be represented in target type `i128`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/float_to_int_64_nan.rs
+++ b/tests/fail/intrinsics/float_to_int_64_nan.rs
@@ -7,6 +7,6 @@ extern "rust-intrinsic" {
 
 fn main() {
     unsafe {
-        float_to_int_unchecked::<f64, u32>(f64::NAN);
-    } //~ ERROR: cannot be represented in target type `u32`
+        float_to_int_unchecked::<f64, u32>(f64::NAN); //~ ERROR: cannot be represented in target type `u32`
+    }
 }

--- a/tests/fail/intrinsics/float_to_int_64_nan.rs
+++ b/tests/fail/intrinsics/float_to_int_64_nan.rs
@@ -6,5 +6,7 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    unsafe { float_to_int_unchecked::<f64, u32>(f64::NAN); } //~ ERROR: cannot be represented in target type `u32`
+    unsafe {
+        float_to_int_unchecked::<f64, u32>(f64::NAN);
+    } //~ ERROR: cannot be represented in target type `u32`
 }

--- a/tests/fail/intrinsics/float_to_int_64_nan.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_nan.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: `float_to_int_unchecked` intrinsic called on NaN which cannot be represented in target type `u32`
   --> $DIR/float_to_int_64_nan.rs:LL:CC
    |
-LL |     unsafe { float_to_int_unchecked::<f64, u32>(f64::NAN); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on NaN which cannot be represented in target type `u32`
+LL |         float_to_int_unchecked::<f64, u32>(f64::NAN);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on NaN which cannot be represented in target type `u32`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/float_to_int_64_neg.rs
+++ b/tests/fail/intrinsics/float_to_int_64_neg.rs
@@ -7,6 +7,6 @@ extern "rust-intrinsic" {
 
 fn main() {
     unsafe {
-        float_to_int_unchecked::<f64, u128>(-1.0000000000001f64);
-    } //~ ERROR: cannot be represented in target type `u128`
+        float_to_int_unchecked::<f64, u128>(-1.0000000000001f64); //~ ERROR: cannot be represented in target type `u128`
+    }
 }

--- a/tests/fail/intrinsics/float_to_int_64_neg.rs
+++ b/tests/fail/intrinsics/float_to_int_64_neg.rs
@@ -6,5 +6,7 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    unsafe { float_to_int_unchecked::<f64, u128>(-1.0000000000001f64); } //~ ERROR: cannot be represented in target type `u128`
+    unsafe {
+        float_to_int_unchecked::<f64, u128>(-1.0000000000001f64);
+    } //~ ERROR: cannot be represented in target type `u128`
 }

--- a/tests/fail/intrinsics/float_to_int_64_neg.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_neg.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: `float_to_int_unchecked` intrinsic called on -1 which cannot be represented in target type `u128`
   --> $DIR/float_to_int_64_neg.rs:LL:CC
    |
-LL |     unsafe { float_to_int_unchecked::<f64, u128>(-1.0000000000001f64); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on -1 which cannot be represented in target type `u128`
+LL |         float_to_int_unchecked::<f64, u128>(-1.0000000000001f64);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on -1 which cannot be represented in target type `u128`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/float_to_int_64_too_big1.rs
+++ b/tests/fail/intrinsics/float_to_int_64_too_big1.rs
@@ -7,6 +7,6 @@ extern "rust-intrinsic" {
 
 fn main() {
     unsafe {
-        float_to_int_unchecked::<f64, i32>(2147483648.0f64);
-    } //~ ERROR: cannot be represented in target type `i32`
+        float_to_int_unchecked::<f64, i32>(2147483648.0f64); //~ ERROR: cannot be represented in target type `i32`
+    }
 }

--- a/tests/fail/intrinsics/float_to_int_64_too_big1.rs
+++ b/tests/fail/intrinsics/float_to_int_64_too_big1.rs
@@ -6,5 +6,7 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    unsafe { float_to_int_unchecked::<f64, i32>(2147483648.0f64); } //~ ERROR: cannot be represented in target type `i32`
+    unsafe {
+        float_to_int_unchecked::<f64, i32>(2147483648.0f64);
+    } //~ ERROR: cannot be represented in target type `i32`
 }

--- a/tests/fail/intrinsics/float_to_int_64_too_big1.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_big1.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: `float_to_int_unchecked` intrinsic called on 2147483648 which cannot be represented in target type `i32`
   --> $DIR/float_to_int_64_too_big1.rs:LL:CC
    |
-LL |     unsafe { float_to_int_unchecked::<f64, i32>(2147483648.0f64); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on 2147483648 which cannot be represented in target type `i32`
+LL |         float_to_int_unchecked::<f64, i32>(2147483648.0f64);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on 2147483648 which cannot be represented in target type `i32`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/float_to_int_64_too_big2.rs
+++ b/tests/fail/intrinsics/float_to_int_64_too_big2.rs
@@ -6,5 +6,7 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    unsafe { float_to_int_unchecked::<f64, i64>(9223372036854775808.0f64); } //~ ERROR: cannot be represented in target type `i64`
+    unsafe {
+        float_to_int_unchecked::<f64, i64>(9223372036854775808.0f64);
+    } //~ ERROR: cannot be represented in target type `i64`
 }

--- a/tests/fail/intrinsics/float_to_int_64_too_big2.rs
+++ b/tests/fail/intrinsics/float_to_int_64_too_big2.rs
@@ -7,6 +7,6 @@ extern "rust-intrinsic" {
 
 fn main() {
     unsafe {
-        float_to_int_unchecked::<f64, i64>(9223372036854775808.0f64);
-    } //~ ERROR: cannot be represented in target type `i64`
+        float_to_int_unchecked::<f64, i64>(9223372036854775808.0f64); //~ ERROR: cannot be represented in target type `i64`
+    }
 }

--- a/tests/fail/intrinsics/float_to_int_64_too_big2.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_big2.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: `float_to_int_unchecked` intrinsic called on 9.2233720368547758E+18 which cannot be represented in target type `i64`
   --> $DIR/float_to_int_64_too_big2.rs:LL:CC
    |
-LL |     unsafe { float_to_int_unchecked::<f64, i64>(9223372036854775808.0f64); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on 9.2233720368547758E+18 which cannot be represented in target type `i64`
+LL |         float_to_int_unchecked::<f64, i64>(9223372036854775808.0f64);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on 9.2233720368547758E+18 which cannot be represented in target type `i64`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/float_to_int_64_too_big3.rs
+++ b/tests/fail/intrinsics/float_to_int_64_too_big3.rs
@@ -7,6 +7,6 @@ extern "rust-intrinsic" {
 
 fn main() {
     unsafe {
-        float_to_int_unchecked::<f64, u64>(18446744073709551616.0f64);
-    } //~ ERROR: cannot be represented in target type `u64`
+        float_to_int_unchecked::<f64, u64>(18446744073709551616.0f64); //~ ERROR: cannot be represented in target type `u64`
+    }
 }

--- a/tests/fail/intrinsics/float_to_int_64_too_big3.rs
+++ b/tests/fail/intrinsics/float_to_int_64_too_big3.rs
@@ -6,5 +6,7 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    unsafe { float_to_int_unchecked::<f64, u64>(18446744073709551616.0f64); } //~ ERROR: cannot be represented in target type `u64`
+    unsafe {
+        float_to_int_unchecked::<f64, u64>(18446744073709551616.0f64);
+    } //~ ERROR: cannot be represented in target type `u64`
 }

--- a/tests/fail/intrinsics/float_to_int_64_too_big3.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_big3.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: `float_to_int_unchecked` intrinsic called on 1.8446744073709552E+19 which cannot be represented in target type `u64`
   --> $DIR/float_to_int_64_too_big3.rs:LL:CC
    |
-LL |     unsafe { float_to_int_unchecked::<f64, u64>(18446744073709551616.0f64); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on 1.8446744073709552E+19 which cannot be represented in target type `u64`
+LL |         float_to_int_unchecked::<f64, u64>(18446744073709551616.0f64);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on 1.8446744073709552E+19 which cannot be represented in target type `u64`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/float_to_int_64_too_big4.rs
+++ b/tests/fail/intrinsics/float_to_int_64_too_big4.rs
@@ -6,5 +6,7 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    unsafe { float_to_int_unchecked::<f64, u128>(u128::MAX as f64); } //~ ERROR: cannot be represented in target type `u128`
+    unsafe {
+        float_to_int_unchecked::<f64, u128>(u128::MAX as f64);
+    } //~ ERROR: cannot be represented in target type `u128`
 }

--- a/tests/fail/intrinsics/float_to_int_64_too_big4.rs
+++ b/tests/fail/intrinsics/float_to_int_64_too_big4.rs
@@ -7,6 +7,6 @@ extern "rust-intrinsic" {
 
 fn main() {
     unsafe {
-        float_to_int_unchecked::<f64, u128>(u128::MAX as f64);
-    } //~ ERROR: cannot be represented in target type `u128`
+        float_to_int_unchecked::<f64, u128>(u128::MAX as f64); //~ ERROR: cannot be represented in target type `u128`
+    }
 }

--- a/tests/fail/intrinsics/float_to_int_64_too_big4.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_big4.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: `float_to_int_unchecked` intrinsic called on 3.4028236692093846E+38 which cannot be represented in target type `u128`
   --> $DIR/float_to_int_64_too_big4.rs:LL:CC
    |
-LL |     unsafe { float_to_int_unchecked::<f64, u128>(u128::MAX as f64); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on 3.4028236692093846E+38 which cannot be represented in target type `u128`
+LL |         float_to_int_unchecked::<f64, u128>(u128::MAX as f64);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on 3.4028236692093846E+38 which cannot be represented in target type `u128`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/float_to_int_64_too_big5.rs
+++ b/tests/fail/intrinsics/float_to_int_64_too_big5.rs
@@ -7,6 +7,6 @@ extern "rust-intrinsic" {
 
 fn main() {
     unsafe {
-        float_to_int_unchecked::<f64, i128>(240282366920938463463374607431768211455.0f64);
-    } //~ ERROR: cannot be represented in target type `i128`
+        float_to_int_unchecked::<f64, i128>(240282366920938463463374607431768211455.0f64); //~ ERROR: cannot be represented in target type `i128`
+    }
 }

--- a/tests/fail/intrinsics/float_to_int_64_too_big5.rs
+++ b/tests/fail/intrinsics/float_to_int_64_too_big5.rs
@@ -6,5 +6,7 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    unsafe { float_to_int_unchecked::<f64, i128>(240282366920938463463374607431768211455.0f64); } //~ ERROR: cannot be represented in target type `i128`
+    unsafe {
+        float_to_int_unchecked::<f64, i128>(240282366920938463463374607431768211455.0f64);
+    } //~ ERROR: cannot be represented in target type `i128`
 }

--- a/tests/fail/intrinsics/float_to_int_64_too_big5.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_big5.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: `float_to_int_unchecked` intrinsic called on 2.4028236692093845E+38 which cannot be represented in target type `i128`
   --> $DIR/float_to_int_64_too_big5.rs:LL:CC
    |
-LL |     unsafe { float_to_int_unchecked::<f64, i128>(240282366920938463463374607431768211455.0f64); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on 2.4028236692093845E+38 which cannot be represented in target type `i128`
+LL |         float_to_int_unchecked::<f64, i128>(240282366920938463463374607431768211455.0f64);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on 2.4028236692093845E+38 which cannot be represented in target type `i128`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/float_to_int_64_too_big6.rs
+++ b/tests/fail/intrinsics/float_to_int_64_too_big6.rs
@@ -6,5 +6,7 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    unsafe { float_to_int_unchecked::<f64, u128>(f64::MAX); } //~ ERROR: cannot be represented in target type `u128`
+    unsafe {
+        float_to_int_unchecked::<f64, u128>(f64::MAX);
+    } //~ ERROR: cannot be represented in target type `u128`
 }

--- a/tests/fail/intrinsics/float_to_int_64_too_big6.rs
+++ b/tests/fail/intrinsics/float_to_int_64_too_big6.rs
@@ -7,6 +7,6 @@ extern "rust-intrinsic" {
 
 fn main() {
     unsafe {
-        float_to_int_unchecked::<f64, u128>(f64::MAX);
-    } //~ ERROR: cannot be represented in target type `u128`
+        float_to_int_unchecked::<f64, u128>(f64::MAX); //~ ERROR: cannot be represented in target type `u128`
+    }
 }

--- a/tests/fail/intrinsics/float_to_int_64_too_big6.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_big6.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: `float_to_int_unchecked` intrinsic called on 1.7976931348623157E+308 which cannot be represented in target type `u128`
   --> $DIR/float_to_int_64_too_big6.rs:LL:CC
    |
-LL |     unsafe { float_to_int_unchecked::<f64, u128>(f64::MAX); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on 1.7976931348623157E+308 which cannot be represented in target type `u128`
+LL |         float_to_int_unchecked::<f64, u128>(f64::MAX);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on 1.7976931348623157E+308 which cannot be represented in target type `u128`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/float_to_int_64_too_big7.rs
+++ b/tests/fail/intrinsics/float_to_int_64_too_big7.rs
@@ -6,5 +6,7 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    unsafe { float_to_int_unchecked::<f64, i128>(f64::MIN); } //~ ERROR: cannot be represented in target type `i128`
+    unsafe {
+        float_to_int_unchecked::<f64, i128>(f64::MIN);
+    } //~ ERROR: cannot be represented in target type `i128`
 }

--- a/tests/fail/intrinsics/float_to_int_64_too_big7.rs
+++ b/tests/fail/intrinsics/float_to_int_64_too_big7.rs
@@ -7,6 +7,6 @@ extern "rust-intrinsic" {
 
 fn main() {
     unsafe {
-        float_to_int_unchecked::<f64, i128>(f64::MIN);
-    } //~ ERROR: cannot be represented in target type `i128`
+        float_to_int_unchecked::<f64, i128>(f64::MIN); //~ ERROR: cannot be represented in target type `i128`
+    }
 }

--- a/tests/fail/intrinsics/float_to_int_64_too_big7.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_big7.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: `float_to_int_unchecked` intrinsic called on -1.7976931348623157E+308 which cannot be represented in target type `i128`
   --> $DIR/float_to_int_64_too_big7.rs:LL:CC
    |
-LL |     unsafe { float_to_int_unchecked::<f64, i128>(f64::MIN); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on -1.7976931348623157E+308 which cannot be represented in target type `i128`
+LL |         float_to_int_unchecked::<f64, i128>(f64::MIN);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on -1.7976931348623157E+308 which cannot be represented in target type `i128`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/float_to_int_64_too_small1.rs
+++ b/tests/fail/intrinsics/float_to_int_64_too_small1.rs
@@ -6,5 +6,7 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    unsafe { float_to_int_unchecked::<f64, i32>(-2147483649.0f64); } //~ ERROR: cannot be represented in target type `i32`
+    unsafe {
+        float_to_int_unchecked::<f64, i32>(-2147483649.0f64);
+    } //~ ERROR: cannot be represented in target type `i32`
 }

--- a/tests/fail/intrinsics/float_to_int_64_too_small1.rs
+++ b/tests/fail/intrinsics/float_to_int_64_too_small1.rs
@@ -7,6 +7,6 @@ extern "rust-intrinsic" {
 
 fn main() {
     unsafe {
-        float_to_int_unchecked::<f64, i32>(-2147483649.0f64);
-    } //~ ERROR: cannot be represented in target type `i32`
+        float_to_int_unchecked::<f64, i32>(-2147483649.0f64); //~ ERROR: cannot be represented in target type `i32`
+    }
 }

--- a/tests/fail/intrinsics/float_to_int_64_too_small1.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_small1.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: `float_to_int_unchecked` intrinsic called on -2147483649 which cannot be represented in target type `i32`
   --> $DIR/float_to_int_64_too_small1.rs:LL:CC
    |
-LL |     unsafe { float_to_int_unchecked::<f64, i32>(-2147483649.0f64); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on -2147483649 which cannot be represented in target type `i32`
+LL |         float_to_int_unchecked::<f64, i32>(-2147483649.0f64);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on -2147483649 which cannot be represented in target type `i32`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/float_to_int_64_too_small2.rs
+++ b/tests/fail/intrinsics/float_to_int_64_too_small2.rs
@@ -7,6 +7,6 @@ extern "rust-intrinsic" {
 
 fn main() {
     unsafe {
-        float_to_int_unchecked::<f64, i64>(-9223372036854777856.0f64);
-    } //~ ERROR: cannot be represented in target type `i64`
+        float_to_int_unchecked::<f64, i64>(-9223372036854777856.0f64); //~ ERROR: cannot be represented in target type `i64`
+    }
 }

--- a/tests/fail/intrinsics/float_to_int_64_too_small2.rs
+++ b/tests/fail/intrinsics/float_to_int_64_too_small2.rs
@@ -6,5 +6,7 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    unsafe { float_to_int_unchecked::<f64, i64>(-9223372036854777856.0f64); } //~ ERROR: cannot be represented in target type `i64`
+    unsafe {
+        float_to_int_unchecked::<f64, i64>(-9223372036854777856.0f64);
+    } //~ ERROR: cannot be represented in target type `i64`
 }

--- a/tests/fail/intrinsics/float_to_int_64_too_small2.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_small2.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: `float_to_int_unchecked` intrinsic called on -9.2233720368547778E+18 which cannot be represented in target type `i64`
   --> $DIR/float_to_int_64_too_small2.rs:LL:CC
    |
-LL |     unsafe { float_to_int_unchecked::<f64, i64>(-9223372036854777856.0f64); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on -9.2233720368547778E+18 which cannot be represented in target type `i64`
+LL |         float_to_int_unchecked::<f64, i64>(-9223372036854777856.0f64);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on -9.2233720368547778E+18 which cannot be represented in target type `i64`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/float_to_int_64_too_small3.rs
+++ b/tests/fail/intrinsics/float_to_int_64_too_small3.rs
@@ -7,6 +7,6 @@ extern "rust-intrinsic" {
 
 fn main() {
     unsafe {
-        float_to_int_unchecked::<f64, i128>(-240282366920938463463374607431768211455.0f64);
-    } //~ ERROR: cannot be represented in target type `i128`
+        float_to_int_unchecked::<f64, i128>(-240282366920938463463374607431768211455.0f64); //~ ERROR: cannot be represented in target type `i128`
+    }
 }

--- a/tests/fail/intrinsics/float_to_int_64_too_small3.rs
+++ b/tests/fail/intrinsics/float_to_int_64_too_small3.rs
@@ -6,5 +6,7 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    unsafe { float_to_int_unchecked::<f64, i128>(-240282366920938463463374607431768211455.0f64); } //~ ERROR: cannot be represented in target type `i128`
+    unsafe {
+        float_to_int_unchecked::<f64, i128>(-240282366920938463463374607431768211455.0f64);
+    } //~ ERROR: cannot be represented in target type `i128`
 }

--- a/tests/fail/intrinsics/float_to_int_64_too_small3.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_small3.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: `float_to_int_unchecked` intrinsic called on -2.4028236692093845E+38 which cannot be represented in target type `i128`
   --> $DIR/float_to_int_64_too_small3.rs:LL:CC
    |
-LL |     unsafe { float_to_int_unchecked::<f64, i128>(-240282366920938463463374607431768211455.0f64); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on -2.4028236692093845E+38 which cannot be represented in target type `i128`
+LL |         float_to_int_unchecked::<f64, i128>(-240282366920938463463374607431768211455.0f64);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `float_to_int_unchecked` intrinsic called on -2.4028236692093845E+38 which cannot be represented in target type `i128`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/unchecked_add1.rs
+++ b/tests/fail/intrinsics/unchecked_add1.rs
@@ -2,6 +2,6 @@
 fn main() {
     // MAX overflow
     unsafe {
-        std::intrinsics::unchecked_add(40000u16, 30000);
-    } //~ ERROR overflow executing `unchecked_add`
+        std::intrinsics::unchecked_add(40000u16, 30000); //~ ERROR overflow executing `unchecked_add`
+    }
 }

--- a/tests/fail/intrinsics/unchecked_add1.rs
+++ b/tests/fail/intrinsics/unchecked_add1.rs
@@ -1,5 +1,7 @@
 #![feature(core_intrinsics)]
 fn main() {
     // MAX overflow
-    unsafe { std::intrinsics::unchecked_add(40000u16, 30000); } //~ ERROR overflow executing `unchecked_add`
+    unsafe {
+        std::intrinsics::unchecked_add(40000u16, 30000);
+    } //~ ERROR overflow executing `unchecked_add`
 }

--- a/tests/fail/intrinsics/unchecked_add1.stderr
+++ b/tests/fail/intrinsics/unchecked_add1.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: overflow executing `unchecked_add`
   --> $DIR/unchecked_add1.rs:LL:CC
    |
-LL |     unsafe { std::intrinsics::unchecked_add(40000u16, 30000); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow executing `unchecked_add`
+LL |         std::intrinsics::unchecked_add(40000u16, 30000);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow executing `unchecked_add`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/unchecked_add2.rs
+++ b/tests/fail/intrinsics/unchecked_add2.rs
@@ -1,5 +1,7 @@
 #![feature(core_intrinsics)]
 fn main() {
     // MIN overflow
-    unsafe { std::intrinsics::unchecked_add(-30000i16, -8000); } //~ ERROR overflow executing `unchecked_add`
+    unsafe {
+        std::intrinsics::unchecked_add(-30000i16, -8000);
+    } //~ ERROR overflow executing `unchecked_add`
 }

--- a/tests/fail/intrinsics/unchecked_add2.rs
+++ b/tests/fail/intrinsics/unchecked_add2.rs
@@ -2,6 +2,6 @@
 fn main() {
     // MIN overflow
     unsafe {
-        std::intrinsics::unchecked_add(-30000i16, -8000);
-    } //~ ERROR overflow executing `unchecked_add`
+        std::intrinsics::unchecked_add(-30000i16, -8000); //~ ERROR overflow executing `unchecked_add`
+    }
 }

--- a/tests/fail/intrinsics/unchecked_add2.stderr
+++ b/tests/fail/intrinsics/unchecked_add2.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: overflow executing `unchecked_add`
   --> $DIR/unchecked_add2.rs:LL:CC
    |
-LL |     unsafe { std::intrinsics::unchecked_add(-30000i16, -8000); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow executing `unchecked_add`
+LL |         std::intrinsics::unchecked_add(-30000i16, -8000);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow executing `unchecked_add`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/unchecked_div1.rs
+++ b/tests/fail/intrinsics/unchecked_div1.rs
@@ -2,6 +2,6 @@
 fn main() {
     // MIN/-1 cannot be represented
     unsafe {
-        std::intrinsics::unchecked_div(i16::MIN, -1);
-    } //~ ERROR overflow in signed division (dividing MIN by -1)
+        std::intrinsics::unchecked_div(i16::MIN, -1); //~ ERROR overflow in signed division (dividing MIN by -1)
+    }
 }

--- a/tests/fail/intrinsics/unchecked_div1.rs
+++ b/tests/fail/intrinsics/unchecked_div1.rs
@@ -1,5 +1,7 @@
 #![feature(core_intrinsics)]
 fn main() {
     // MIN/-1 cannot be represented
-    unsafe { std::intrinsics::unchecked_div(i16::MIN, -1); } //~ ERROR overflow in signed division (dividing MIN by -1)
+    unsafe {
+        std::intrinsics::unchecked_div(i16::MIN, -1);
+    } //~ ERROR overflow in signed division (dividing MIN by -1)
 }

--- a/tests/fail/intrinsics/unchecked_div1.stderr
+++ b/tests/fail/intrinsics/unchecked_div1.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: overflow in signed division (dividing MIN by -1)
   --> $DIR/unchecked_div1.rs:LL:CC
    |
-LL |     unsafe { std::intrinsics::unchecked_div(i16::MIN, -1); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow in signed division (dividing MIN by -1)
+LL |         std::intrinsics::unchecked_div(i16::MIN, -1);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow in signed division (dividing MIN by -1)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/unchecked_mul1.rs
+++ b/tests/fail/intrinsics/unchecked_mul1.rs
@@ -1,5 +1,7 @@
 #![feature(core_intrinsics)]
 fn main() {
     // MAX overflow
-    unsafe { std::intrinsics::unchecked_mul(300u16, 250u16); } //~ ERROR overflow executing `unchecked_mul`
+    unsafe {
+        std::intrinsics::unchecked_mul(300u16, 250u16);
+    } //~ ERROR overflow executing `unchecked_mul`
 }

--- a/tests/fail/intrinsics/unchecked_mul1.rs
+++ b/tests/fail/intrinsics/unchecked_mul1.rs
@@ -2,6 +2,6 @@
 fn main() {
     // MAX overflow
     unsafe {
-        std::intrinsics::unchecked_mul(300u16, 250u16);
-    } //~ ERROR overflow executing `unchecked_mul`
+        std::intrinsics::unchecked_mul(300u16, 250u16); //~ ERROR overflow executing `unchecked_mul`
+    }
 }

--- a/tests/fail/intrinsics/unchecked_mul1.stderr
+++ b/tests/fail/intrinsics/unchecked_mul1.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: overflow executing `unchecked_mul`
   --> $DIR/unchecked_mul1.rs:LL:CC
    |
-LL |     unsafe { std::intrinsics::unchecked_mul(300u16, 250u16); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow executing `unchecked_mul`
+LL |         std::intrinsics::unchecked_mul(300u16, 250u16);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow executing `unchecked_mul`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/unchecked_mul2.rs
+++ b/tests/fail/intrinsics/unchecked_mul2.rs
@@ -2,6 +2,6 @@
 fn main() {
     // MIN overflow
     unsafe {
-        std::intrinsics::unchecked_mul(1_000_000_000i32, -4);
-    } //~ ERROR overflow executing `unchecked_mul`
+        std::intrinsics::unchecked_mul(1_000_000_000i32, -4); //~ ERROR overflow executing `unchecked_mul`
+    }
 }

--- a/tests/fail/intrinsics/unchecked_mul2.rs
+++ b/tests/fail/intrinsics/unchecked_mul2.rs
@@ -1,5 +1,7 @@
 #![feature(core_intrinsics)]
 fn main() {
     // MIN overflow
-    unsafe { std::intrinsics::unchecked_mul(1_000_000_000i32, -4); } //~ ERROR overflow executing `unchecked_mul`
+    unsafe {
+        std::intrinsics::unchecked_mul(1_000_000_000i32, -4);
+    } //~ ERROR overflow executing `unchecked_mul`
 }

--- a/tests/fail/intrinsics/unchecked_mul2.stderr
+++ b/tests/fail/intrinsics/unchecked_mul2.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: overflow executing `unchecked_mul`
   --> $DIR/unchecked_mul2.rs:LL:CC
    |
-LL |     unsafe { std::intrinsics::unchecked_mul(1_000_000_000i32, -4); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow executing `unchecked_mul`
+LL |         std::intrinsics::unchecked_mul(1_000_000_000i32, -4);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow executing `unchecked_mul`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/unchecked_sub1.rs
+++ b/tests/fail/intrinsics/unchecked_sub1.rs
@@ -2,6 +2,6 @@
 fn main() {
     // MIN overflow
     unsafe {
-        std::intrinsics::unchecked_sub(14u32, 22);
-    } //~ ERROR overflow executing `unchecked_sub`
+        std::intrinsics::unchecked_sub(14u32, 22); //~ ERROR overflow executing `unchecked_sub`
+    }
 }

--- a/tests/fail/intrinsics/unchecked_sub1.rs
+++ b/tests/fail/intrinsics/unchecked_sub1.rs
@@ -1,5 +1,7 @@
 #![feature(core_intrinsics)]
 fn main() {
     // MIN overflow
-    unsafe { std::intrinsics::unchecked_sub(14u32, 22); } //~ ERROR overflow executing `unchecked_sub`
+    unsafe {
+        std::intrinsics::unchecked_sub(14u32, 22);
+    } //~ ERROR overflow executing `unchecked_sub`
 }

--- a/tests/fail/intrinsics/unchecked_sub1.stderr
+++ b/tests/fail/intrinsics/unchecked_sub1.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: overflow executing `unchecked_sub`
   --> $DIR/unchecked_sub1.rs:LL:CC
    |
-LL |     unsafe { std::intrinsics::unchecked_sub(14u32, 22); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow executing `unchecked_sub`
+LL |         std::intrinsics::unchecked_sub(14u32, 22);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow executing `unchecked_sub`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/intrinsics/unchecked_sub2.rs
+++ b/tests/fail/intrinsics/unchecked_sub2.rs
@@ -1,5 +1,7 @@
 #![feature(core_intrinsics)]
 fn main() {
     // MAX overflow
-    unsafe { std::intrinsics::unchecked_sub(30000i16, -7000); } //~ ERROR overflow executing `unchecked_sub`
+    unsafe {
+        std::intrinsics::unchecked_sub(30000i16, -7000);
+    } //~ ERROR overflow executing `unchecked_sub`
 }

--- a/tests/fail/intrinsics/unchecked_sub2.rs
+++ b/tests/fail/intrinsics/unchecked_sub2.rs
@@ -2,6 +2,6 @@
 fn main() {
     // MAX overflow
     unsafe {
-        std::intrinsics::unchecked_sub(30000i16, -7000);
-    } //~ ERROR overflow executing `unchecked_sub`
+        std::intrinsics::unchecked_sub(30000i16, -7000); //~ ERROR overflow executing `unchecked_sub`
+    }
 }

--- a/tests/fail/intrinsics/unchecked_sub2.stderr
+++ b/tests/fail/intrinsics/unchecked_sub2.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: overflow executing `unchecked_sub`
   --> $DIR/unchecked_sub2.rs:LL:CC
    |
-LL |     unsafe { std::intrinsics::unchecked_sub(30000i16, -7000); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow executing `unchecked_sub`
+LL |         std::intrinsics::unchecked_sub(30000i16, -7000);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ overflow executing `unchecked_sub`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/panic/unwind_panic_abort.rs
+++ b/tests/fail/panic/unwind_panic_abort.rs
@@ -8,6 +8,6 @@ extern "Rust" {
 
 fn main() {
     unsafe {
-        miri_start_panic(&mut 0);
-    } //~ ERROR unwinding past a stack frame that does not allow unwinding
+        miri_start_panic(&mut 0); //~ ERROR unwinding past a stack frame that does not allow unwinding
+    }
 }

--- a/tests/fail/panic/unwind_panic_abort.rs
+++ b/tests/fail/panic/unwind_panic_abort.rs
@@ -7,5 +7,7 @@ extern "Rust" {
 }
 
 fn main() {
-    unsafe { miri_start_panic(&mut 0); } //~ ERROR unwinding past a stack frame that does not allow unwinding
+    unsafe {
+        miri_start_panic(&mut 0);
+    } //~ ERROR unwinding past a stack frame that does not allow unwinding
 }

--- a/tests/fail/panic/unwind_panic_abort.stderr
+++ b/tests/fail/panic/unwind_panic_abort.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: unwinding past a stack frame that does not allow unwinding
   --> $DIR/unwind_panic_abort.rs:LL:CC
    |
-LL |     unsafe { miri_start_panic(&mut 0); }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^ unwinding past a stack frame that does not allow unwinding
+LL |         miri_start_panic(&mut 0);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^ unwinding past a stack frame that does not allow unwinding
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/stacked_borrows/illegal_write1.rs
+++ b/tests/fail/stacked_borrows/illegal_write1.rs
@@ -4,8 +4,8 @@ fn main() {
     {
         let x: *mut u32 = xref as *const _ as *mut _;
         unsafe {
-            *x = 42;
-        } // invalidates shared ref, activates raw
+            *x = 42; // invalidates shared ref, activates raw
+        }
     }
     let _x = *xref; //~ ERROR borrow stack
 }

--- a/tests/fail/stacked_borrows/illegal_write1.rs
+++ b/tests/fail/stacked_borrows/illegal_write1.rs
@@ -2,8 +2,10 @@ fn main() {
     let target = Box::new(42); // has an implicit raw
     let xref = &*target;
     {
-        let x : *mut u32 = xref as *const _ as *mut _;
-        unsafe { *x = 42; } // invalidates shared ref, activates raw
+        let x: *mut u32 = xref as *const _ as *mut _;
+        unsafe {
+            *x = 42;
+        } // invalidates shared ref, activates raw
     }
     let _x = *xref; //~ ERROR borrow stack
 }

--- a/tests/fail/stacked_borrows/illegal_write1.stderr
+++ b/tests/fail/stacked_borrows/illegal_write1.stderr
@@ -17,8 +17,8 @@ LL |     let xref = &*target;
 help: <TAG> was later invalidated at offsets [0x0..0x4]
   --> $DIR/illegal_write1.rs:LL:CC
    |
-LL |         unsafe { *x = 42; } // invalidates shared ref, activates raw
-   |                  ^^^^^^^
+LL |             *x = 42; // invalidates shared ref, activates raw
+   |             ^^^^^^^
    = note: inside `main` at $DIR/illegal_write1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_write2.rs
+++ b/tests/fail/stacked_borrows/illegal_write2.rs
@@ -4,7 +4,7 @@ fn main() {
     drop(&mut *target); // reborrow
     // Now make sure our ref is still the only one.
     unsafe {
-        *target2 = 13;
-    } //~ ERROR borrow stack
+        *target2 = 13; //~ ERROR borrow stack
+    }
     let _val = *target;
 }

--- a/tests/fail/stacked_borrows/illegal_write2.rs
+++ b/tests/fail/stacked_borrows/illegal_write2.rs
@@ -3,6 +3,8 @@ fn main() {
     let target2 = target as *mut _;
     drop(&mut *target); // reborrow
     // Now make sure our ref is still the only one.
-    unsafe { *target2 = 13; } //~ ERROR borrow stack
+    unsafe {
+        *target2 = 13;
+    } //~ ERROR borrow stack
     let _val = *target;
 }

--- a/tests/fail/stacked_borrows/illegal_write2.stderr
+++ b/tests/fail/stacked_borrows/illegal_write2.stderr
@@ -1,11 +1,11 @@
 error: Undefined Behavior: attempting a write access using <untagged> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/illegal_write2.rs:LL:CC
    |
-LL |     unsafe { *target2 = 13; }
-   |              ^^^^^^^^^^^^^
-   |              |
-   |              attempting a write access using <untagged> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
-   |              this error occurs as part of an access at ALLOC[0x0..0x4]
+LL |         *target2 = 13;
+   |         ^^^^^^^^^^^^^
+   |         |
+   |         attempting a write access using <untagged> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |         this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/illegal_write3.rs
+++ b/tests/fail/stacked_borrows/illegal_write3.rs
@@ -4,7 +4,7 @@ fn main() {
     let r#ref = &target; // freeze
     let ptr = r#ref as *const _ as *mut _; // raw ptr, with raw tag
     unsafe {
-        *ptr = 42;
-    } //~ ERROR only grants SharedReadOnly permission
+        *ptr = 42; //~ ERROR only grants SharedReadOnly permission
+    }
     let _val = *r#ref;
 }

--- a/tests/fail/stacked_borrows/illegal_write3.rs
+++ b/tests/fail/stacked_borrows/illegal_write3.rs
@@ -3,6 +3,8 @@ fn main() {
     // Make sure raw ptr with raw tag cannot mutate frozen location without breaking the shared ref.
     let r#ref = &target; // freeze
     let ptr = r#ref as *const _ as *mut _; // raw ptr, with raw tag
-    unsafe { *ptr = 42; } //~ ERROR only grants SharedReadOnly permission
+    unsafe {
+        *ptr = 42;
+    } //~ ERROR only grants SharedReadOnly permission
     let _val = *r#ref;
 }

--- a/tests/fail/stacked_borrows/illegal_write3.stderr
+++ b/tests/fail/stacked_borrows/illegal_write3.stderr
@@ -1,11 +1,11 @@
 error: Undefined Behavior: attempting a write access using <untagged> at ALLOC[0x0], but that tag only grants SharedReadOnly permission for this location
   --> $DIR/illegal_write3.rs:LL:CC
    |
-LL |     unsafe { *ptr = 42; }
-   |              ^^^^^^^^^
-   |              |
-   |              attempting a write access using <untagged> at ALLOC[0x0], but that tag only grants SharedReadOnly permission for this location
-   |              this error occurs as part of an access at ALLOC[0x0..0x4]
+LL |         *ptr = 42;
+   |         ^^^^^^^^^
+   |         |
+   |         attempting a write access using <untagged> at ALLOC[0x0], but that tag only grants SharedReadOnly permission for this location
+   |         this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/illegal_write6.rs
+++ b/tests/fail/stacked_borrows/illegal_write6.rs
@@ -8,7 +8,7 @@ fn foo(a: &mut u32, y: *mut u32) -> u32 {
     *a = 1;
     let _b = &*a;
     unsafe {
-        *y = 2;
-    } //~ ERROR: not granting access to tag
+        *y = 2; //~ ERROR: not granting access to tag
+    }
     return *a;
 }

--- a/tests/fail/stacked_borrows/illegal_write6.rs
+++ b/tests/fail/stacked_borrows/illegal_write6.rs
@@ -7,6 +7,8 @@ fn main() {
 fn foo(a: &mut u32, y: *mut u32) -> u32 {
     *a = 1;
     let _b = &*a;
-    unsafe { *y = 2; } //~ ERROR: not granting access to tag
+    unsafe {
+        *y = 2;
+    } //~ ERROR: not granting access to tag
     return *a;
 }

--- a/tests/fail/stacked_borrows/illegal_write6.stderr
+++ b/tests/fail/stacked_borrows/illegal_write6.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: not granting access to tag <untagged> because incompatible item is protected: [Unique for <TAG> (call ID)]
   --> $DIR/illegal_write6.rs:LL:CC
    |
-LL |     unsafe { *y = 2; }
-   |              ^^^^^^ not granting access to tag <untagged> because incompatible item is protected: [Unique for <TAG> (call ID)]
+LL |         *y = 2;
+   |         ^^^^^^ not granting access to tag <untagged> because incompatible item is protected: [Unique for <TAG> (call ID)]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
@@ -22,7 +22,8 @@ help: this protector is live for this call
 LL | / fn foo(a: &mut u32, y: *mut u32) -> u32 {
 LL | |     *a = 1;
 LL | |     let _b = &*a;
-LL | |     unsafe { *y = 2; }
+LL | |     unsafe {
+...  |
 LL | |     return *a;
 LL | | }
    | |_^

--- a/tests/fail/stacked_borrows/raw_tracking.rs
+++ b/tests/fail/stacked_borrows/raw_tracking.rs
@@ -8,8 +8,8 @@ fn main() {
     // Without raw pointer tracking, Stacked Borrows cannot distinguish raw1 and raw2, and thus
     // fails to realize that raw1 should not be used any more.
     unsafe {
-        *raw1 = 13;
-    } //~ ERROR does not exist in the borrow stack
+        *raw1 = 13; //~ ERROR does not exist in the borrow stack
+    }
     unsafe {
         *raw2 = 13;
     }

--- a/tests/fail/stacked_borrows/raw_tracking.rs
+++ b/tests/fail/stacked_borrows/raw_tracking.rs
@@ -7,6 +7,10 @@ fn main() {
     let raw2 = &mut l as *mut _; // invalidates raw1
     // Without raw pointer tracking, Stacked Borrows cannot distinguish raw1 and raw2, and thus
     // fails to realize that raw1 should not be used any more.
-    unsafe { *raw1 = 13; } //~ ERROR does not exist in the borrow stack
-    unsafe { *raw2 = 13; }
+    unsafe {
+        *raw1 = 13;
+    } //~ ERROR does not exist in the borrow stack
+    unsafe {
+        *raw2 = 13;
+    }
 }

--- a/tests/fail/stacked_borrows/raw_tracking.stderr
+++ b/tests/fail/stacked_borrows/raw_tracking.stderr
@@ -1,11 +1,11 @@
 error: Undefined Behavior: attempting a write access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/raw_tracking.rs:LL:CC
    |
-LL |     unsafe { *raw1 = 13; }
-   |              ^^^^^^^^^^
-   |              |
-   |              attempting a write access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
-   |              this error occurs as part of an access at ALLOC[0x0..0x4]
+LL |         *raw1 = 13;
+   |         ^^^^^^^^^^
+   |         |
+   |         attempting a write access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |         this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/shr_frozen_violation1.rs
+++ b/tests/fail/stacked_borrows/shr_frozen_violation1.rs
@@ -1,7 +1,7 @@
 fn foo(x: &mut i32) -> i32 {
-  *x = 5;
-  unknown_code(&*x);
-  *x // must return 5
+    *x = 5;
+    unknown_code(&*x);
+    *x // must return 5
 }
 
 fn main() {
@@ -9,5 +9,7 @@ fn main() {
 }
 
 fn unknown_code(x: &i32) {
-    unsafe { *(x as *const i32 as *mut i32) = 7; } //~ ERROR only grants SharedReadOnly permission
+    unsafe {
+        *(x as *const i32 as *mut i32) = 7;
+    } //~ ERROR only grants SharedReadOnly permission
 }

--- a/tests/fail/stacked_borrows/shr_frozen_violation1.rs
+++ b/tests/fail/stacked_borrows/shr_frozen_violation1.rs
@@ -10,6 +10,6 @@ fn main() {
 
 fn unknown_code(x: &i32) {
     unsafe {
-        *(x as *const i32 as *mut i32) = 7;
-    } //~ ERROR only grants SharedReadOnly permission
+        *(x as *const i32 as *mut i32) = 7; //~ ERROR only grants SharedReadOnly permission
+    }
 }

--- a/tests/fail/stacked_borrows/shr_frozen_violation1.stderr
+++ b/tests/fail/stacked_borrows/shr_frozen_violation1.stderr
@@ -1,25 +1,25 @@
 error: Undefined Behavior: attempting a write access using <untagged> at ALLOC[0x0], but that tag only grants SharedReadOnly permission for this location
   --> $DIR/shr_frozen_violation1.rs:LL:CC
    |
-LL |     unsafe { *(x as *const i32 as *mut i32) = 7; }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |              |
-   |              attempting a write access using <untagged> at ALLOC[0x0], but that tag only grants SharedReadOnly permission for this location
-   |              this error occurs as part of an access at ALLOC[0x0..0x4]
+LL |         *(x as *const i32 as *mut i32) = 7;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         attempting a write access using <untagged> at ALLOC[0x0], but that tag only grants SharedReadOnly permission for this location
+   |         this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
 help: tag was most recently created at offsets [0x0..0x4]
   --> $DIR/shr_frozen_violation1.rs:LL:CC
    |
-LL |     unsafe { *(x as *const i32 as *mut i32) = 7; }
-   |                ^
+LL |         *(x as *const i32 as *mut i32) = 7;
+   |           ^
    = note: inside `unknown_code` at $DIR/shr_frozen_violation1.rs:LL:CC
 note: inside `foo` at $DIR/shr_frozen_violation1.rs:LL:CC
   --> $DIR/shr_frozen_violation1.rs:LL:CC
    |
-LL |   unknown_code(&*x);
-   |   ^^^^^^^^^^^^^^^^^
+LL |     unknown_code(&*x);
+   |     ^^^^^^^^^^^^^^^^^
 note: inside `main` at $DIR/shr_frozen_violation1.rs:LL:CC
   --> $DIR/shr_frozen_violation1.rs:LL:CC
    |

--- a/tests/fail/stacked_borrows/transmute-is-no-escape.rs
+++ b/tests/fail/stacked_borrows/transmute-is-no-escape.rs
@@ -11,6 +11,6 @@ fn main() {
     // `raw` still carries a tag, so we get another pointer to the same location that does not carry a tag
     let raw = (&mut x[1] as *mut i32).wrapping_offset(-1);
     unsafe {
-        *raw = 13;
-    } //~ ERROR borrow stack
+        *raw = 13; //~ ERROR borrow stack
+    }
 }

--- a/tests/fail/stacked_borrows/transmute-is-no-escape.rs
+++ b/tests/fail/stacked_borrows/transmute-is-no-escape.rs
@@ -10,5 +10,7 @@ fn main() {
     let _raw: *mut i32 = unsafe { mem::transmute(&mut x[0]) };
     // `raw` still carries a tag, so we get another pointer to the same location that does not carry a tag
     let raw = (&mut x[1] as *mut i32).wrapping_offset(-1);
-    unsafe { *raw = 13; } //~ ERROR borrow stack
+    unsafe {
+        *raw = 13;
+    } //~ ERROR borrow stack
 }

--- a/tests/fail/stacked_borrows/transmute-is-no-escape.stderr
+++ b/tests/fail/stacked_borrows/transmute-is-no-escape.stderr
@@ -1,11 +1,11 @@
 error: Undefined Behavior: attempting a write access using <untagged> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/transmute-is-no-escape.rs:LL:CC
    |
-LL |     unsafe { *raw = 13; }
-   |              ^^^^^^^^^
-   |              |
-   |              attempting a write access using <untagged> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
-   |              this error occurs as part of an access at ALLOC[0x0..0x4]
+LL |         *raw = 13;
+   |         ^^^^^^^^^
+   |         |
+   |         attempting a write access using <untagged> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |         this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/unescaped_local.rs
+++ b/tests/fail/stacked_borrows/unescaped_local.rs
@@ -4,5 +4,7 @@ fn main() {
     let mut x = 42;
     let raw = &mut x as *mut i32 as usize as *mut i32;
     let _ptr = &mut x;
-    unsafe { *raw = 13; } //~ ERROR borrow stack
+    unsafe {
+        *raw = 13;
+    } //~ ERROR borrow stack
 }

--- a/tests/fail/stacked_borrows/unescaped_local.rs
+++ b/tests/fail/stacked_borrows/unescaped_local.rs
@@ -5,6 +5,6 @@ fn main() {
     let raw = &mut x as *mut i32 as usize as *mut i32;
     let _ptr = &mut x;
     unsafe {
-        *raw = 13;
-    } //~ ERROR borrow stack
+        *raw = 13; //~ ERROR borrow stack
+    }
 }

--- a/tests/fail/stacked_borrows/unescaped_local.stderr
+++ b/tests/fail/stacked_borrows/unescaped_local.stderr
@@ -1,11 +1,11 @@
 error: Undefined Behavior: attempting a write access using <untagged> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> $DIR/unescaped_local.rs:LL:CC
    |
-LL |     unsafe { *raw = 13; }
-   |              ^^^^^^^^^
-   |              |
-   |              attempting a write access using <untagged> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
-   |              this error occurs as part of an access at ALLOC[0x0..0x4]
+LL |         *raw = 13;
+   |         ^^^^^^^^^
+   |         |
+   |         attempting a write access using <untagged> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
+   |         this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/unaligned_pointers/intptrcast_alignment_check.rs
+++ b/tests/fail/unaligned_pointers/intptrcast_alignment_check.rs
@@ -13,7 +13,7 @@ fn main() {
     let base_addr_aligned = if base_addr % 2 == 0 { base_addr } else { base_addr + 1 };
     let u16_ptr = base_addr_aligned as *mut u16;
     unsafe {
-        *u16_ptr = 2;
-    } //~ERROR memory with alignment 1, but alignment 2 is required
+        *u16_ptr = 2; //~ERROR memory with alignment 1, but alignment 2 is required
+    }
     println!("{:?}", x);
 }

--- a/tests/fail/unaligned_pointers/intptrcast_alignment_check.rs
+++ b/tests/fail/unaligned_pointers/intptrcast_alignment_check.rs
@@ -10,8 +10,10 @@ fn main() {
     let x = &mut [0u8; 3];
     let base_addr = x as *mut _ as usize;
     // Manually make sure the pointer is properly aligned.
-    let base_addr_aligned = if base_addr % 2 == 0 { base_addr } else { base_addr+1 };
+    let base_addr_aligned = if base_addr % 2 == 0 { base_addr } else { base_addr + 1 };
     let u16_ptr = base_addr_aligned as *mut u16;
-    unsafe { *u16_ptr = 2; } //~ERROR memory with alignment 1, but alignment 2 is required
+    unsafe {
+        *u16_ptr = 2;
+    } //~ERROR memory with alignment 1, but alignment 2 is required
     println!("{:?}", x);
 }

--- a/tests/fail/unaligned_pointers/intptrcast_alignment_check.stderr
+++ b/tests/fail/unaligned_pointers/intptrcast_alignment_check.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: accessing memory with alignment ALIGN, but alignment ALIGN is required
   --> $DIR/intptrcast_alignment_check.rs:LL:CC
    |
-LL |     unsafe { *u16_ptr = 2; }
-   |              ^^^^^^^^^^^^ accessing memory with alignment ALIGN, but alignment ALIGN is required
+LL |         *u16_ptr = 2;
+   |         ^^^^^^^^^^^^ accessing memory with alignment ALIGN, but alignment ALIGN is required
    |
    = help: this usually indicates that your program performed an invalid operation and caused Undefined Behavior
    = help: but due to `-Zmiri-symbolic-alignment-check`, alignment errors can also be false positives

--- a/tests/fail/validity/transmute_through_ptr.rs
+++ b/tests/fail/validity/transmute_through_ptr.rs
@@ -7,8 +7,8 @@ enum Bool {
 fn evil(x: &mut Bool) {
     let x = x as *mut _ as *mut u32;
     unsafe {
-        *x = 44;
-    } // out-of-bounds enum tag
+        *x = 44; // out-of-bounds enum tag
+    }
 }
 
 #[rustfmt::skip] // rustfmt bug: https://github.com/rust-lang/rustfmt/issues/5391

--- a/tests/fail/validity/transmute_through_ptr.rs
+++ b/tests/fail/validity/transmute_through_ptr.rs
@@ -1,10 +1,14 @@
 #[repr(u32)]
 #[derive(Debug)]
-enum Bool { True }
+enum Bool {
+    True,
+}
 
 fn evil(x: &mut Bool) {
     let x = x as *mut _ as *mut u32;
-    unsafe { *x = 44; } // out-of-bounds enum tag
+    unsafe {
+        *x = 44;
+    } // out-of-bounds enum tag
 }
 
 #[rustfmt::skip] // rustfmt bug: https://github.com/rust-lang/rustfmt/issues/5391

--- a/tests/fail/zst2.rs
+++ b/tests/fail/zst2.rs
@@ -11,5 +11,7 @@ fn main() {
     let mut x_box = Box::new(1u8);
     let x = &mut *x_box as *mut _ as *mut [u8; 0];
     drop(x_box);
-    unsafe { *x = zst_val; } //~ ERROR dereferenced after this allocation got freed
+    unsafe {
+        *x = zst_val;
+    } //~ ERROR dereferenced after this allocation got freed
 }

--- a/tests/fail/zst2.rs
+++ b/tests/fail/zst2.rs
@@ -12,6 +12,6 @@ fn main() {
     let x = &mut *x_box as *mut _ as *mut [u8; 0];
     drop(x_box);
     unsafe {
-        *x = zst_val;
-    } //~ ERROR dereferenced after this allocation got freed
+        *x = zst_val; //~ ERROR dereferenced after this allocation got freed
+    }
 }

--- a/tests/fail/zst2.stderr
+++ b/tests/fail/zst2.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: pointer to ALLOC was dereferenced after this allocation got freed
   --> $DIR/zst2.rs:LL:CC
    |
-LL |     unsafe { *x = zst_val; }
-   |              ^^^^^^^^^^^^ pointer to ALLOC was dereferenced after this allocation got freed
+LL |         *x = zst_val;
+   |         ^^^^^^^^^^^^ pointer to ALLOC was dereferenced after this allocation got freed
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/zst3.rs
+++ b/tests/fail/zst3.rs
@@ -11,8 +11,12 @@ fn main() {
     let mut x_box = Box::new(1u8);
     let x = (&mut *x_box as *mut u8).wrapping_offset(1);
     // This one is just "at the edge", but still okay
-    unsafe { *(x as *mut [u8; 0]) = zst_val; }
+    unsafe {
+        *(x as *mut [u8; 0]) = zst_val;
+    }
     // One byte further is OOB.
     let x = x.wrapping_offset(1);
-    unsafe { *(x as *mut [u8; 0]) = zst_val; } //~ ERROR out-of-bounds
+    unsafe {
+        *(x as *mut [u8; 0]) = zst_val;
+    } //~ ERROR out-of-bounds
 }

--- a/tests/fail/zst3.rs
+++ b/tests/fail/zst3.rs
@@ -17,6 +17,6 @@ fn main() {
     // One byte further is OOB.
     let x = x.wrapping_offset(1);
     unsafe {
-        *(x as *mut [u8; 0]) = zst_val;
-    } //~ ERROR out-of-bounds
+        *(x as *mut [u8; 0]) = zst_val; //~ ERROR out-of-bounds
+    }
 }

--- a/tests/fail/zst3.stderr
+++ b/tests/fail/zst3.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: dereferencing pointer failed: ALLOC has size 1, so pointer at offset 2 is out-of-bounds
   --> $DIR/zst3.rs:LL:CC
    |
-LL |     unsafe { *(x as *mut [u8; 0]) = zst_val; }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ dereferencing pointer failed: ALLOC has size 1, so pointer at offset 2 is out-of-bounds
+LL |         *(x as *mut [u8; 0]) = zst_val;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ dereferencing pointer failed: ALLOC has size 1, so pointer at offset 2 is out-of-bounds
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information


### PR DESCRIPTION
Extracted from #2097.

These cases all involve a line comment at the end of a block that rustfmt has chosen to wrap.

```diff
- unsafe { (*ptr).set(20); } //~ ERROR does not exist in the borrow stack
+ unsafe {
+     (*ptr).set(20);
+ } //~ ERROR does not exist in the borrow stack
```

I have moved all of those comments back onto the same line as the content of the block instead, as was indicated being @RalfJung's preference in https://github.com/rust-lang/miri/pull/2097#discussion_r862436672.

```diff
+ unsafe {
+     (*ptr).set(20); //~ ERROR does not exist in the borrow stack
+ }
```