### PR TITLE
Format tests with rustfmt (276-287 of 299)

### DIFF
--- a/tests/fail/branchless-select-i128-pointer.rs
+++ b/tests/fail/branchless-select-i128-pointer.rs
@@ -11,8 +11,10 @@ fn main() {
         // This is branchless code to select one or the other pointer.
         // However, it drops provenance when transmuting to TwoPtrs, so this is UB.
         let val = unsafe {
-            transmute::<_, &str>( //~ERROR type validation failed: encountered a dangling reference
-                !mask & transmute::<_, TwoPtrs>("false !") | mask & transmute::<_, TwoPtrs>("true !"),
+            transmute::<_, &str>(
+                //~ERROR type validation failed: encountered a dangling reference
+                !mask & transmute::<_, TwoPtrs>("false !")
+                    | mask & transmute::<_, TwoPtrs>("true !"),
             )
         };
         println!("{}", val);

--- a/tests/fail/branchless-select-i128-pointer.rs
+++ b/tests/fail/branchless-select-i128-pointer.rs
@@ -12,7 +12,7 @@ fn main() {
         // However, it drops provenance when transmuting to TwoPtrs, so this is UB.
         let val = unsafe {
             transmute::<_, &str>(
-                //~ERROR type validation failed: encountered a dangling reference
+                //~^ ERROR type validation failed: encountered a dangling reference
                 !mask & transmute::<_, TwoPtrs>("false !")
                     | mask & transmute::<_, TwoPtrs>("true !"),
             )

--- a/tests/fail/branchless-select-i128-pointer.stderr
+++ b/tests/fail/branchless-select-i128-pointer.stderr
@@ -2,7 +2,9 @@ error: Undefined Behavior: type validation failed: encountered a dangling refere
   --> $DIR/branchless-select-i128-pointer.rs:LL:CC
    |
 LL | /             transmute::<_, &str>(
-LL | |                 !mask & transmute::<_, TwoPtrs>("false !") | mask & transmute::<_, TwoPtrs>("true !"),
+LL | |
+LL | |                 !mask & transmute::<_, TwoPtrs>("false !")
+LL | |                     | mask & transmute::<_, TwoPtrs>("true !"),
 LL | |             )
    | |_____________^ type validation failed: encountered a dangling reference (address $HEX is unallocated)
    |

--- a/tests/fail/data_race/dealloc_read_race1.rs
+++ b/tests/fail/data_race/dealloc_read_race1.rs
@@ -18,14 +18,17 @@ pub fn main() {
     let ptr = EvilSend(pointer);
 
     unsafe {
-        let j1 = spawn(move || *ptr.0);
+        let j1 = spawn(move || {
+            let _val = *ptr.0;
+        });
 
         let j2 = spawn(move || {
             __rust_dealloc(
+                //~^ ERROR Data race detected between Deallocate on Thread(id = 2) and Read on Thread(id = 1)
                 ptr.0 as *mut _,
                 std::mem::size_of::<usize>(),
                 std::mem::align_of::<usize>(),
-            ); //~ ERROR Data race detected between Deallocate on Thread(id = 2) and Read on Thread(id = 1)
+            );
         });
 
         j1.join().unwrap();

--- a/tests/fail/data_race/dealloc_read_race1.rs
+++ b/tests/fail/data_race/dealloc_read_race1.rs
@@ -18,12 +18,14 @@ pub fn main() {
     let ptr = EvilSend(pointer);
 
     unsafe {
-        let j1 = spawn(move || {
-            *ptr.0
-        });
+        let j1 = spawn(move || *ptr.0);
 
         let j2 = spawn(move || {
-            __rust_dealloc(ptr.0 as *mut _, std::mem::size_of::<usize>(), std::mem::align_of::<usize>());  //~ ERROR Data race detected between Deallocate on Thread(id = 2) and Read on Thread(id = 1)
+            __rust_dealloc(
+                ptr.0 as *mut _,
+                std::mem::size_of::<usize>(),
+                std::mem::align_of::<usize>(),
+            ); //~ ERROR Data race detected between Deallocate on Thread(id = 2) and Read on Thread(id = 1)
         });
 
         j1.join().unwrap();

--- a/tests/fail/data_race/dealloc_read_race1.stderr
+++ b/tests/fail/data_race/dealloc_read_race1.stderr
@@ -1,8 +1,13 @@
 error: Undefined Behavior: Data race detected between Deallocate on Thread(id = 2) and Read on Thread(id = 1) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
   --> $DIR/dealloc_read_race1.rs:LL:CC
    |
-LL |             __rust_dealloc(ptr.0 as *mut _, std::mem::size_of::<usize>(), std::mem::align_of::<usize>());
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Deallocate on Thread(id = 2) and Read on Thread(id = 1) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
+LL | /             __rust_dealloc(
+LL | |
+LL | |                 ptr.0 as *mut _,
+LL | |                 std::mem::size_of::<usize>(),
+LL | |                 std::mem::align_of::<usize>(),
+LL | |             );
+   | |_____________^ Data race detected between Deallocate on Thread(id = 2) and Read on Thread(id = 1) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/data_race/dealloc_write_race1.rs
+++ b/tests/fail/data_race/dealloc_write_race1.rs
@@ -22,7 +22,11 @@ pub fn main() {
         });
 
         let j2 = spawn(move || {
-            __rust_dealloc(ptr.0 as *mut _, std::mem::size_of::<usize>(), std::mem::align_of::<usize>());  //~ ERROR Data race detected between Deallocate on Thread(id = 2) and Write on Thread(id = 1)
+            __rust_dealloc(
+                ptr.0 as *mut _,
+                std::mem::size_of::<usize>(),
+                std::mem::align_of::<usize>(),
+            ); //~ ERROR Data race detected between Deallocate on Thread(id = 2) and Write on Thread(id = 1)
         });
 
         j1.join().unwrap();

--- a/tests/fail/data_race/dealloc_write_race1.rs
+++ b/tests/fail/data_race/dealloc_write_race1.rs
@@ -23,10 +23,11 @@ pub fn main() {
 
         let j2 = spawn(move || {
             __rust_dealloc(
+                //~^ ERROR Data race detected between Deallocate on Thread(id = 2) and Write on Thread(id = 1)
                 ptr.0 as *mut _,
                 std::mem::size_of::<usize>(),
                 std::mem::align_of::<usize>(),
-            ); //~ ERROR Data race detected between Deallocate on Thread(id = 2) and Write on Thread(id = 1)
+            );
         });
 
         j1.join().unwrap();

--- a/tests/fail/data_race/dealloc_write_race1.stderr
+++ b/tests/fail/data_race/dealloc_write_race1.stderr
@@ -1,8 +1,13 @@
 error: Undefined Behavior: Data race detected between Deallocate on Thread(id = 2) and Write on Thread(id = 1) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
   --> $DIR/dealloc_write_race1.rs:LL:CC
    |
-LL |             __rust_dealloc(ptr.0 as *mut _, std::mem::size_of::<usize>(), std::mem::align_of::<usize>());
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Deallocate on Thread(id = 2) and Write on Thread(id = 1) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
+LL | /             __rust_dealloc(
+LL | |
+LL | |                 ptr.0 as *mut _,
+LL | |                 std::mem::size_of::<usize>(),
+LL | |                 std::mem::align_of::<usize>(),
+LL | |             );
+   | |_____________^ Data race detected between Deallocate on Thread(id = 2) and Write on Thread(id = 1) at ALLOC (current vector clock = VClock, conflicting timestamp = VClock)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/function_calls/check_callback_abi.rs
+++ b/tests/fail/function_calls/check_callback_abi.rs
@@ -8,7 +8,8 @@ fn main() {
     unsafe {
         // Make sure we check the ABI when Miri itself invokes a function
         // as part of a shim implementation.
-        std::intrinsics::r#try( //~ ERROR calling a function with ABI C using caller ABI Rust
+        std::intrinsics::r#try(
+            //~ ERROR calling a function with ABI C using caller ABI Rust
             std::mem::transmute::<extern "C" fn(*mut u8), _>(try_fn),
             std::ptr::null_mut(),
             |_, _| unreachable!(),

--- a/tests/fail/function_calls/check_callback_abi.rs
+++ b/tests/fail/function_calls/check_callback_abi.rs
@@ -9,7 +9,7 @@ fn main() {
         // Make sure we check the ABI when Miri itself invokes a function
         // as part of a shim implementation.
         std::intrinsics::r#try(
-            //~ ERROR calling a function with ABI C using caller ABI Rust
+            //~^ ERROR calling a function with ABI C using caller ABI Rust
             std::mem::transmute::<extern "C" fn(*mut u8), _>(try_fn),
             std::ptr::null_mut(),
             |_, _| unreachable!(),

--- a/tests/fail/function_calls/check_callback_abi.stderr
+++ b/tests/fail/function_calls/check_callback_abi.stderr
@@ -2,6 +2,7 @@ error: Undefined Behavior: calling a function with ABI C using caller ABI Rust
   --> $DIR/check_callback_abi.rs:LL:CC
    |
 LL | /         std::intrinsics::r#try(
+LL | |
 LL | |             std::mem::transmute::<extern "C" fn(*mut u8), _>(try_fn),
 LL | |             std::ptr::null_mut(),
 LL | |             |_, _| unreachable!(),

--- a/tests/fail/function_calls/exported_symbol_abi_mismatch.cache.stderr
+++ b/tests/fail/function_calls/exported_symbol_abi_mismatch.cache.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: calling a function with calling convention Rust using calling convention C
   --> $DIR/exported_symbol_abi_mismatch.rs:LL:CC
    |
-LL |         unsafe { foo() }
-   |                  ^^^^^ calling a function with calling convention Rust using calling convention C
+LL |             foo();
+   |             ^^^^^ calling a function with calling convention Rust using calling convention C
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/function_calls/exported_symbol_abi_mismatch.fn_ptr.stderr
+++ b/tests/fail/function_calls/exported_symbol_abi_mismatch.fn_ptr.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: calling a function with calling convention Rust using calling convention C
   --> $DIR/exported_symbol_abi_mismatch.rs:LL:CC
    |
-LL |     unsafe { std::mem::transmute::<unsafe fn(), unsafe extern "C" fn()>(foo)() }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ calling a function with calling convention Rust using calling convention C
+LL |         std::mem::transmute::<unsafe fn(), unsafe extern "C" fn()>(foo)();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ calling a function with calling convention Rust using calling convention C
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/function_calls/exported_symbol_abi_mismatch.no_cache.stderr
+++ b/tests/fail/function_calls/exported_symbol_abi_mismatch.no_cache.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: calling a function with calling convention Rust using calling convention C
   --> $DIR/exported_symbol_abi_mismatch.rs:LL:CC
    |
-LL |         unsafe { foo() }
-   |                  ^^^^^ calling a function with calling convention Rust using calling convention C
+LL |             foo();
+   |             ^^^^^ calling a function with calling convention Rust using calling convention C
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/function_calls/exported_symbol_abi_mismatch.rs
+++ b/tests/fail/function_calls/exported_symbol_abi_mismatch.rs
@@ -11,14 +11,14 @@ fn main() {
 
     #[cfg(fn_ptr)]
     unsafe {
-        std::mem::transmute::<unsafe fn(), unsafe extern "C" fn()>(foo)()
+        std::mem::transmute::<unsafe fn(), unsafe extern "C" fn()>(foo)();
+        //[fn_ptr]~^ ERROR calling a function with calling convention Rust using calling convention C
     }
-    //[fn_ptr]~^ ERROR calling a function with calling convention Rust using calling convention C
 
     // `Instance` caching should not suppress ABI check.
     #[cfg(cache)]
     unsafe {
-        foo()
+        foo();
     }
 
     {
@@ -26,8 +26,10 @@ fn main() {
         extern "C" {
             fn foo();
         }
-        unsafe { foo() }
-        //[no_cache]~^ ERROR calling a function with calling convention Rust using calling convention C
-        //[cache]~^^ ERROR calling a function with calling convention Rust using calling convention C
+        unsafe {
+            foo();
+            //[no_cache]~^ ERROR calling a function with calling convention Rust using calling convention C
+            //[cache]~| ERROR calling a function with calling convention Rust using calling convention C
+        }
     }
 }

--- a/tests/fail/function_calls/exported_symbol_abi_mismatch.rs
+++ b/tests/fail/function_calls/exported_symbol_abi_mismatch.rs
@@ -10,12 +10,16 @@ fn main() {
     }
 
     #[cfg(fn_ptr)]
-    unsafe { std::mem::transmute::<unsafe fn(), unsafe extern "C" fn()>(foo)() }
+    unsafe {
+        std::mem::transmute::<unsafe fn(), unsafe extern "C" fn()>(foo)()
+    }
     //[fn_ptr]~^ ERROR calling a function with calling convention Rust using calling convention C
 
     // `Instance` caching should not suppress ABI check.
     #[cfg(cache)]
-    unsafe { foo() }
+    unsafe {
+        foo()
+    }
 
     {
         #[cfg_attr(any(cache, fn_ptr), allow(clashing_extern_declarations))]

--- a/tests/fail/type-too-large.rs
+++ b/tests/fail/type-too-large.rs
@@ -1,5 +1,6 @@
 // ignore-32bit
 
 fn main() {
-    let _fat: [u8; (1 << 61) + (1 << 31)] = [0; (1u64 << 61) as usize + (1u64 << 31) as usize]; //~ ERROR post-monomorphization error
+    let _fat: [u8; (1 << 61) + (1 << 31)];
+    _fat = [0; (1u64 << 61) as usize + (1u64 << 31) as usize]; //~ ERROR post-monomorphization error
 }

--- a/tests/fail/type-too-large.rs
+++ b/tests/fail/type-too-large.rs
@@ -1,6 +1,5 @@
 // ignore-32bit
 
 fn main() {
-    let _fat: [u8; (1<<61)+(1<<31)] =
-        [0; (1u64<<61) as usize +(1u64<<31) as usize]; //~ ERROR post-monomorphization error
+    let _fat: [u8; (1 << 61) + (1 << 31)] = [0; (1u64 << 61) as usize + (1u64 << 31) as usize]; //~ ERROR post-monomorphization error
 }

--- a/tests/fail/type-too-large.stderr
+++ b/tests/fail/type-too-large.stderr
@@ -1,8 +1,8 @@
 error: post-monomorphization error: values of the type `[u8; 2305843011361177600]` are too big for the current architecture
   --> $DIR/type-too-large.rs:LL:CC
    |
-LL |         [0; (1u64<<61) as usize +(1u64<<31) as usize];
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ values of the type `[u8; 2305843011361177600]` are too big for the current architecture
+LL |     _fat = [0; (1u64 << 61) as usize + (1u64 << 31) as usize];
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ values of the type `[u8; 2305843011361177600]` are too big for the current architecture
    |
    = note: inside `main` at $DIR/type-too-large.rs:LL:CC
 

--- a/tests/fail/validity/invalid_char.rs
+++ b/tests/fail/validity/invalid_char.rs
@@ -1,8 +1,9 @@
 fn main() {
     assert!(std::char::from_u32(-1_i32 as u32).is_none());
-    let _val = match unsafe { std::mem::transmute::<i32, char>(-1) } { //~ ERROR encountered 0xffffffff, but expected a valid unicode scalar value
-        'a' => {true},
-        'b' => {false},
-        _ => {true},
+    let _val = match unsafe { std::mem::transmute::<i32, char>(-1) } {
+        //~ ERROR encountered 0xffffffff, but expected a valid unicode scalar value
+        'a' => true,
+        'b' => false,
+        _ => true,
     };
 }

--- a/tests/fail/validity/invalid_char.rs
+++ b/tests/fail/validity/invalid_char.rs
@@ -1,7 +1,7 @@
 fn main() {
     assert!(std::char::from_u32(-1_i32 as u32).is_none());
     let _val = match unsafe { std::mem::transmute::<i32, char>(-1) } {
-        //~ ERROR encountered 0xffffffff, but expected a valid unicode scalar value
+        //~^ ERROR encountered 0xffffffff, but expected a valid unicode scalar value
         'a' => true,
         'b' => false,
         _ => true,

--- a/tests/pass/0weak_memory_consistency.rs
+++ b/tests/pass/0weak_memory_consistency.rs
@@ -60,7 +60,8 @@ fn test_corr() {
         r2 //                                        |                    |
     }); //                                           |                    |
     //                                               |synchronizes-with   |happens-before
-    let j3 = spawn(move || { //                      |                    |
+    let j3 = spawn(move || {
+        //                      |                    |
         acquires_value(&y, 1); // <------------------+                    |
         x.load(Relaxed) // <----------------------------------------------+
         // The two reads on x are ordered by hb, so they cannot observe values
@@ -84,12 +85,14 @@ fn test_wrc() {
         x.store(1, Release); // ---------------------+---------------------+
     }); //                                           |                     |
     //                                               |synchronizes-with    |
-    let j2 = spawn(move || { //                      |                     |
+    let j2 = spawn(move || {
+        //                      |                     |
         acquires_value(&x, 1); // <------------------+                     |
         y.store(1, Release); // ---------------------+                     |happens-before
     }); //                                           |                     |
     //                                               |synchronizes-with    |
-    let j3 = spawn(move || { //                      |                     |
+    let j3 = spawn(move || {
+        //                      |                     |
         acquires_value(&y, 1); // <------------------+                     |
         x.load(Relaxed) // <-----------------------------------------------+
     });
@@ -112,7 +115,8 @@ fn test_message_passing() {
         y.store(1, Release); // ---------------------+                   |
     }); //                                           |                   |
     //                                               |synchronizes-with  | happens-before
-    let j2 = spawn(move || { //                      |                   |
+    let j2 = spawn(move || {
+        //                      |                   |
         acquires_value(&y, 1); // <------------------+                   |
         unsafe { *x.0 } // <---------------------------------------------+
     });

--- a/tests/pass/0weak_memory_consistency.rs
+++ b/tests/pass/0weak_memory_consistency.rs
@@ -54,14 +54,14 @@ fn test_corr() {
         x.store(2, Relaxed);
     });
 
+    #[rustfmt::skip]
     let j2 = spawn(move || {
         let r2 = x.load(Relaxed); // -------------------------------------+
         y.store(1, Release); // ---------------------+                    |
         r2 //                                        |                    |
     }); //                                           |                    |
-    //                                               |synchronizes-with   |happens-before
-    let j3 = spawn(move || {
-        //                      |                    |
+    #[rustfmt::skip] //                              |synchronizes-with   |happens-before
+    let j3 = spawn(move || { //                      |                    |
         acquires_value(&y, 1); // <------------------+                    |
         x.load(Relaxed) // <----------------------------------------------+
         // The two reads on x are ordered by hb, so they cannot observe values
@@ -81,18 +81,17 @@ fn test_wrc() {
     let x = static_atomic(0);
     let y = static_atomic(0);
 
+    #[rustfmt::skip]
     let j1 = spawn(move || {
         x.store(1, Release); // ---------------------+---------------------+
     }); //                                           |                     |
-    //                                               |synchronizes-with    |
-    let j2 = spawn(move || {
-        //                      |                     |
+    #[rustfmt::skip] //                              |synchronizes-with    |
+    let j2 = spawn(move || { //                      |                     |
         acquires_value(&x, 1); // <------------------+                     |
         y.store(1, Release); // ---------------------+                     |happens-before
     }); //                                           |                     |
-    //                                               |synchronizes-with    |
-    let j3 = spawn(move || {
-        //                      |                     |
+    #[rustfmt::skip] //                              |synchronizes-with    |
+    let j3 = spawn(move || { //                      |                     |
         acquires_value(&y, 1); // <------------------+                     |
         x.load(Relaxed) // <-----------------------------------------------+
     });
@@ -110,13 +109,13 @@ fn test_message_passing() {
     let x = EvilSend(ptr);
     let y = static_atomic(0);
 
+    #[rustfmt::skip]
     let j1 = spawn(move || {
         unsafe { *x.0 = 1 }; // -----------------------------------------+
         y.store(1, Release); // ---------------------+                   |
     }); //                                           |                   |
-    //                                               |synchronizes-with  | happens-before
-    let j2 = spawn(move || {
-        //                      |                   |
+    #[rustfmt::skip] //                              |synchronizes-with  | happens-before
+    let j2 = spawn(move || { //                      |                   |
         acquires_value(&y, 1); // <------------------+                   |
         unsafe { *x.0 } // <---------------------------------------------+
     });

--- a/tests/pass/concurrency/linux-futex.rs
+++ b/tests/pass/concurrency/linux-futex.rs
@@ -16,7 +16,7 @@ fn wake_nobody() {
 
     // Wake 1 waiter. Expect zero waiters woken up, as nobody is waiting.
     unsafe {
-        assert_eq!(libc::syscall(libc::SYS_futex, &futex as *const i32, libc::FUTEX_WAKE, 1,), 0);
+        assert_eq!(libc::syscall(libc::SYS_futex, &futex as *const i32, libc::FUTEX_WAKE, 1), 0);
     }
 
     // Same, but without omitting the unused arguments.
@@ -31,7 +31,7 @@ fn wake_nobody() {
                 0usize,
                 0,
             ),
-            0
+            0,
         );
     }
 }
@@ -43,7 +43,7 @@ fn wake_dangling() {
 
     // Wake 1 waiter. Expect zero waiters woken up, as nobody is waiting.
     unsafe {
-        assert_eq!(libc::syscall(libc::SYS_futex, ptr, libc::FUTEX_WAKE, 1,), 0);
+        assert_eq!(libc::syscall(libc::SYS_futex, ptr, libc::FUTEX_WAKE, 1), 0);
     }
 }
 
@@ -60,7 +60,7 @@ fn wait_wrong_val() {
                 456,
                 ptr::null::<libc::timespec>(),
             ),
-            -1
+            -1,
         );
         assert_eq!(*libc::__errno_location(), libc::EAGAIN);
     }
@@ -81,7 +81,7 @@ fn wait_timeout() {
                 123,
                 &libc::timespec { tv_sec: 0, tv_nsec: 200_000_000 },
             ),
-            -1
+            -1,
         );
         assert_eq!(*libc::__errno_location(), libc::ETIMEDOUT);
     }
@@ -120,7 +120,7 @@ fn wait_absolute_timeout() {
                 0usize,
                 u32::MAX,
             ),
-            -1
+            -1,
         );
         assert_eq!(*libc::__errno_location(), libc::ETIMEDOUT);
     }
@@ -143,8 +143,8 @@ fn wait_wake() {
                     libc::FUTEX_WAKE,
                     10, // Wake up at most 10 threads.
                 ),
-                1
-            ); // Woken up one thread.
+                1, // Woken up one thread.
+            );
         }
     });
 
@@ -157,7 +157,7 @@ fn wait_wake() {
                 0,
                 ptr::null::<libc::timespec>(),
             ),
-            0
+            0,
         );
     }
 
@@ -183,8 +183,8 @@ fn wait_wake_bitset() {
                     0usize,
                     0b1001, // bitset
                 ),
-                0
-            ); // Didn't match any thread.
+                0, // Didn't match any thread.
+            );
         }
         thread::sleep(Duration::from_millis(200));
         unsafe {
@@ -198,8 +198,8 @@ fn wait_wake_bitset() {
                     0usize,
                     0b0110, // bitset
                 ),
-                1
-            ); // Woken up one thread.
+                1, // Woken up one thread.
+            );
         }
     });
 
@@ -214,7 +214,7 @@ fn wait_wake_bitset() {
                 0usize,
                 0b0100, // bitset
             ),
-            0
+            0,
         );
     }
 

--- a/tests/pass/concurrency/linux-futex.rs
+++ b/tests/pass/concurrency/linux-futex.rs
@@ -16,25 +16,23 @@ fn wake_nobody() {
 
     // Wake 1 waiter. Expect zero waiters woken up, as nobody is waiting.
     unsafe {
-        assert_eq!(libc::syscall(
-            libc::SYS_futex,
-            &futex as *const i32,
-            libc::FUTEX_WAKE,
-            1,
-        ), 0);
+        assert_eq!(libc::syscall(libc::SYS_futex, &futex as *const i32, libc::FUTEX_WAKE, 1,), 0);
     }
 
     // Same, but without omitting the unused arguments.
     unsafe {
-        assert_eq!(libc::syscall(
-            libc::SYS_futex,
-            &futex as *const i32,
-            libc::FUTEX_WAKE,
-            1,
-            ptr::null::<libc::timespec>(),
-            0usize,
-            0,
-        ), 0);
+        assert_eq!(
+            libc::syscall(
+                libc::SYS_futex,
+                &futex as *const i32,
+                libc::FUTEX_WAKE,
+                1,
+                ptr::null::<libc::timespec>(),
+                0usize,
+                0,
+            ),
+            0
+        );
     }
 }
 
@@ -45,12 +43,7 @@ fn wake_dangling() {
 
     // Wake 1 waiter. Expect zero waiters woken up, as nobody is waiting.
     unsafe {
-        assert_eq!(libc::syscall(
-            libc::SYS_futex,
-            ptr,
-            libc::FUTEX_WAKE,
-            1,
-        ), 0);
+        assert_eq!(libc::syscall(libc::SYS_futex, ptr, libc::FUTEX_WAKE, 1,), 0);
     }
 }
 
@@ -59,13 +52,16 @@ fn wait_wrong_val() {
 
     // Only wait if the futex value is 456.
     unsafe {
-        assert_eq!(libc::syscall(
-            libc::SYS_futex,
-            &futex as *const i32,
-            libc::FUTEX_WAIT,
-            456,
-            ptr::null::<libc::timespec>(),
-        ), -1);
+        assert_eq!(
+            libc::syscall(
+                libc::SYS_futex,
+                &futex as *const i32,
+                libc::FUTEX_WAIT,
+                456,
+                ptr::null::<libc::timespec>(),
+            ),
+            -1
+        );
         assert_eq!(*libc::__errno_location(), libc::EAGAIN);
     }
 }
@@ -77,16 +73,16 @@ fn wait_timeout() {
 
     // Wait for 200ms, with nobody waking us up early.
     unsafe {
-        assert_eq!(libc::syscall(
-            libc::SYS_futex,
-            &futex as *const i32,
-            libc::FUTEX_WAIT,
-            123,
-            &libc::timespec {
-                tv_sec: 0,
-                tv_nsec: 200_000_000,
-            },
-        ), -1);
+        assert_eq!(
+            libc::syscall(
+                libc::SYS_futex,
+                &futex as *const i32,
+                libc::FUTEX_WAIT,
+                123,
+                &libc::timespec { tv_sec: 0, tv_nsec: 200_000_000 },
+            ),
+            -1
+        );
         assert_eq!(*libc::__errno_location(), libc::ETIMEDOUT);
     }
 
@@ -114,15 +110,18 @@ fn wait_absolute_timeout() {
 
     // Wait for 200ms from now, with nobody waking us up early.
     unsafe {
-        assert_eq!(libc::syscall(
-            libc::SYS_futex,
-            &futex as *const i32,
-            libc::FUTEX_WAIT_BITSET,
-            123,
-            &timeout,
-            0usize,
-            u32::MAX,
-        ), -1);
+        assert_eq!(
+            libc::syscall(
+                libc::SYS_futex,
+                &futex as *const i32,
+                libc::FUTEX_WAIT_BITSET,
+                123,
+                &timeout,
+                0usize,
+                u32::MAX,
+            ),
+            -1
+        );
         assert_eq!(*libc::__errno_location(), libc::ETIMEDOUT);
     }
 
@@ -137,23 +136,29 @@ fn wait_wake() {
     let t = thread::spawn(move || {
         thread::sleep(Duration::from_millis(200));
         unsafe {
-            assert_eq!(libc::syscall(
-                libc::SYS_futex,
-                &FUTEX as *const i32,
-                libc::FUTEX_WAKE,
-                10, // Wake up at most 10 threads.
-            ), 1); // Woken up one thread.
+            assert_eq!(
+                libc::syscall(
+                    libc::SYS_futex,
+                    &FUTEX as *const i32,
+                    libc::FUTEX_WAKE,
+                    10, // Wake up at most 10 threads.
+                ),
+                1
+            ); // Woken up one thread.
         }
     });
 
     unsafe {
-        assert_eq!(libc::syscall(
-            libc::SYS_futex,
-            &FUTEX as *const i32,
-            libc::FUTEX_WAIT,
-            0,
-            ptr::null::<libc::timespec>(),
-        ), 0);
+        assert_eq!(
+            libc::syscall(
+                libc::SYS_futex,
+                &FUTEX as *const i32,
+                libc::FUTEX_WAIT,
+                0,
+                ptr::null::<libc::timespec>(),
+            ),
+            0
+        );
     }
 
     assert!((200..1000).contains(&start.elapsed().as_millis()));
@@ -168,40 +173,49 @@ fn wait_wake_bitset() {
     let t = thread::spawn(move || {
         thread::sleep(Duration::from_millis(200));
         unsafe {
-            assert_eq!(libc::syscall(
-                libc::SYS_futex,
-                &FUTEX as *const i32,
-                libc::FUTEX_WAKE_BITSET,
-                10, // Wake up at most 10 threads.
-                ptr::null::<libc::timespec>(),
-                0usize,
-                0b1001, // bitset
-            ), 0); // Didn't match any thread.
+            assert_eq!(
+                libc::syscall(
+                    libc::SYS_futex,
+                    &FUTEX as *const i32,
+                    libc::FUTEX_WAKE_BITSET,
+                    10, // Wake up at most 10 threads.
+                    ptr::null::<libc::timespec>(),
+                    0usize,
+                    0b1001, // bitset
+                ),
+                0
+            ); // Didn't match any thread.
         }
         thread::sleep(Duration::from_millis(200));
         unsafe {
-            assert_eq!(libc::syscall(
-                libc::SYS_futex,
-                &FUTEX as *const i32,
-                libc::FUTEX_WAKE_BITSET,
-                10, // Wake up at most 10 threads.
-                ptr::null::<libc::timespec>(),
-                0usize,
-                0b0110, // bitset
-            ), 1); // Woken up one thread.
+            assert_eq!(
+                libc::syscall(
+                    libc::SYS_futex,
+                    &FUTEX as *const i32,
+                    libc::FUTEX_WAKE_BITSET,
+                    10, // Wake up at most 10 threads.
+                    ptr::null::<libc::timespec>(),
+                    0usize,
+                    0b0110, // bitset
+                ),
+                1
+            ); // Woken up one thread.
         }
     });
 
     unsafe {
-        assert_eq!(libc::syscall(
-            libc::SYS_futex,
-            &FUTEX as *const i32,
-            libc::FUTEX_WAIT_BITSET,
-            0,
-            ptr::null::<libc::timespec>(),
-            0usize,
-            0b0100, // bitset
-        ), 0);
+        assert_eq!(
+            libc::syscall(
+                libc::SYS_futex,
+                &FUTEX as *const i32,
+                libc::FUTEX_WAIT_BITSET,
+                0,
+                ptr::null::<libc::timespec>(),
+                0usize,
+                0b0100, // bitset
+            ),
+            0
+        );
     }
 
     assert!((400..1000).contains(&start.elapsed().as_millis()));
@@ -237,12 +251,7 @@ fn concurrent_wait_wake() {
 
         FUTEX.store(FREE, Ordering::Relaxed);
         unsafe {
-            libc::syscall(
-                libc::SYS_futex,
-                &FUTEX as *const AtomicI32,
-                libc::FUTEX_WAKE,
-                1,
-            );
+            libc::syscall(libc::SYS_futex, &FUTEX as *const AtomicI32, libc::FUTEX_WAKE, 1);
         }
 
         t.join().unwrap();

--- a/tests/pass/deriving-associated-types.rs
+++ b/tests/pass/deriving-associated-types.rs
@@ -40,10 +40,15 @@ struct TupleStruct<A, B: DeclaredTrait, C>(
     <C as WhereTrait>::Type,
     Option<<C as WhereTrait>::Type>,
     <i32 as DeclaredTrait>::Type,
-) where C: WhereTrait;
+)
+where
+    C: WhereTrait;
 
 #[derive(PartialEq, Debug)]
-pub struct Struct<A, B: DeclaredTrait, C> where C: WhereTrait {
+pub struct Struct<A, B: DeclaredTrait, C>
+where
+    C: WhereTrait,
+{
     m1: module::Type,
     m2: Option<module::Type>,
     a1: A,
@@ -62,7 +67,10 @@ pub struct Struct<A, B: DeclaredTrait, C> where C: WhereTrait {
 }
 
 #[derive(PartialEq, Debug)]
-enum Enum<A, B: DeclaredTrait, C> where C: WhereTrait {
+enum Enum<A, B: DeclaredTrait, C>
+where
+    C: WhereTrait,
+{
     Unit,
     Seq(
         module::Type,
@@ -101,35 +109,11 @@ enum Enum<A, B: DeclaredTrait, C> where C: WhereTrait {
 }
 
 fn main() {
-
-    let e: Enum<
-        i32,
-        i32,
-        i32,
-    > = Enum::Seq(
-        0,
-        None,
-        0,
-        PrivateStruct(0),
-        0,
-        0,
-        None,
-        0,
-        None,
-        0,
-        0,
-        None,
-        0,
-        None,
-        0,
-    );
+    let e: Enum<i32, i32, i32> =
+        Enum::Seq(0, None, 0, PrivateStruct(0), 0, 0, None, 0, None, 0, 0, None, 0, None, 0);
     assert_eq!(e, e);
 
-    let e: Enum<
-        i32,
-        i32,
-        i32,
-    > = Enum::Map {
+    let e: Enum<i32, i32, i32> = Enum::Map {
         m1: 0,
         m2: None,
         a1: 0,
@@ -147,52 +131,29 @@ fn main() {
         d: 0,
     };
     assert_eq!(e, e);
-        let e: TupleStruct<
-            i32,
-            i32,
-            i32,
-        > = TupleStruct(
-            0,
-            None,
-            0,
-            PrivateStruct(0),
-            0,
-            0,
-            None,
-            0,
-            None,
-            0,
-            0,
-            None,
-            0,
-            None,
-            0,
-        );
-        assert_eq!(e, e);
+    let e: TupleStruct<i32, i32, i32> =
+        TupleStruct(0, None, 0, PrivateStruct(0), 0, 0, None, 0, None, 0, 0, None, 0, None, 0);
+    assert_eq!(e, e);
 
-        let e: Struct<
-            i32,
-            i32,
-            i32,
-        > = Struct {
-            m1: 0,
-            m2: None,
-            a1: 0,
-            a2: PrivateStruct(0),
-            b: 0,
-            b1: 0,
-            b2: None,
-            b3: 0,
-            b4: None,
-            c: 0,
-            c1: 0,
-            c2: None,
-            c3: 0,
-            c4: None,
-            d: 0,
-        };
-        assert_eq!(e, e);
+    let e: Struct<i32, i32, i32> = Struct {
+        m1: 0,
+        m2: None,
+        a1: 0,
+        a2: PrivateStruct(0),
+        b: 0,
+        b1: 0,
+        b2: None,
+        b3: 0,
+        b4: None,
+        c: 0,
+        c1: 0,
+        c2: None,
+        c3: 0,
+        c4: None,
+        d: 0,
+    };
+    assert_eq!(e, e);
 
-        let e = Enum::Unit::<i32, i32, i32>;
-        assert_eq!(e, e);
+    let e = Enum::Unit::<i32, i32, i32>;
+    assert_eq!(e, e);
 }

--- a/tests/pass/heap_allocator.rs
+++ b/tests/pass/heap_allocator.rs
@@ -1,58 +1,90 @@
 #![feature(allocator_api, slice_ptr_get)]
 
+use std::alloc::{Allocator, Global, Layout, System};
 use std::ptr::NonNull;
-use std::alloc::{Global, Allocator, Layout, System};
 use std::slice;
 
-fn check_alloc<T: Allocator>(allocator: T) { unsafe {
-    for &align in &[4, 8, 16, 32] {
-        let layout_20 = Layout::from_size_align(20, align).unwrap();
-        let layout_40 = Layout::from_size_align(40, 4*align).unwrap();
-        let layout_10 = Layout::from_size_align(10, align/2).unwrap();
+fn check_alloc<T: Allocator>(allocator: T) {
+    unsafe {
+        for &align in &[4, 8, 16, 32] {
+            let layout_20 = Layout::from_size_align(20, align).unwrap();
+            let layout_40 = Layout::from_size_align(40, 4 * align).unwrap();
+            let layout_10 = Layout::from_size_align(10, align / 2).unwrap();
 
-        for _ in 0..32 {
-            let a = allocator.allocate(layout_20).unwrap().as_non_null_ptr();
-            assert_eq!(a.as_ptr() as usize % layout_20.align(), 0, "pointer is incorrectly aligned");
-            allocator.deallocate(a, layout_20);
+            for _ in 0..32 {
+                let a = allocator.allocate(layout_20).unwrap().as_non_null_ptr();
+                assert_eq!(
+                    a.as_ptr() as usize % layout_20.align(),
+                    0,
+                    "pointer is incorrectly aligned"
+                );
+                allocator.deallocate(a, layout_20);
+            }
+
+            let p1 = allocator.allocate_zeroed(layout_20).unwrap().as_non_null_ptr();
+            assert_eq!(
+                p1.as_ptr() as usize % layout_20.align(),
+                0,
+                "pointer is incorrectly aligned"
+            );
+            assert_eq!(*p1.as_ptr(), 0);
+
+            // old size < new size
+            let p2 = allocator.grow(p1, layout_20, layout_40).unwrap().as_non_null_ptr();
+            assert_eq!(
+                p2.as_ptr() as usize % layout_40.align(),
+                0,
+                "pointer is incorrectly aligned"
+            );
+            let slice = slice::from_raw_parts(p2.as_ptr(), 20);
+            assert_eq!(&slice, &[0_u8; 20]);
+
+            // old size == new size
+            let p3 = allocator.grow(p2, layout_40, layout_40).unwrap().as_non_null_ptr();
+            assert_eq!(
+                p3.as_ptr() as usize % layout_40.align(),
+                0,
+                "pointer is incorrectly aligned"
+            );
+            let slice = slice::from_raw_parts(p3.as_ptr(), 20);
+            assert_eq!(&slice, &[0_u8; 20]);
+
+            // old size > new size
+            let p4 = allocator.shrink(p3, layout_40, layout_10).unwrap().as_non_null_ptr();
+            assert_eq!(
+                p4.as_ptr() as usize % layout_10.align(),
+                0,
+                "pointer is incorrectly aligned"
+            );
+            let slice = slice::from_raw_parts(p4.as_ptr(), 10);
+            assert_eq!(&slice, &[0_u8; 10]);
+
+            allocator.deallocate(p4, layout_10);
         }
-
-        let p1 = allocator.allocate_zeroed(layout_20).unwrap().as_non_null_ptr();
-        assert_eq!(p1.as_ptr() as usize % layout_20.align(), 0, "pointer is incorrectly aligned");
-        assert_eq!(*p1.as_ptr(), 0);
-
-        // old size < new size
-        let p2 = allocator.grow(p1, layout_20, layout_40).unwrap().as_non_null_ptr();
-        assert_eq!(p2.as_ptr() as usize % layout_40.align(), 0, "pointer is incorrectly aligned");
-        let slice = slice::from_raw_parts(p2.as_ptr(), 20);
-        assert_eq!(&slice, &[0_u8; 20]);
-
-        // old size == new size
-        let p3 = allocator.grow(p2, layout_40, layout_40).unwrap().as_non_null_ptr();
-        assert_eq!(p3.as_ptr() as usize % layout_40.align(), 0, "pointer is incorrectly aligned");
-        let slice = slice::from_raw_parts(p3.as_ptr(), 20);
-        assert_eq!(&slice, &[0_u8; 20]);
-
-        // old size > new size
-        let p4 = allocator.shrink(p3, layout_40, layout_10).unwrap().as_non_null_ptr();
-        assert_eq!(p4.as_ptr() as usize % layout_10.align(), 0, "pointer is incorrectly aligned");
-        let slice = slice::from_raw_parts(p4.as_ptr(), 10);
-        assert_eq!(&slice, &[0_u8; 10]);
-
-        allocator.deallocate(p4, layout_10);
     }
-} }
+}
 
 fn check_align_requests<T: Allocator>(allocator: T) {
-    for &size in &[2, 8, 64] { // size less than and bigger than alignment
-        for &align in &[4, 8, 16, 32] { // Be sure to cover less than and bigger than `MIN_ALIGN` for all architectures
+    for &size in &[2, 8, 64] {
+        // size less than and bigger than alignment
+        for &align in &[4, 8, 16, 32] {
+            // Be sure to cover less than and bigger than `MIN_ALIGN` for all architectures
             let iterations = 32;
             unsafe {
-                let pointers: Vec<_> = (0..iterations).map(|_| {
-                    allocator.allocate(Layout::from_size_align(size, align).unwrap()).unwrap().as_non_null_ptr()
-                }).collect();
+                let pointers: Vec<_> = (0..iterations)
+                    .map(|_| {
+                        allocator
+                            .allocate(Layout::from_size_align(size, align).unwrap())
+                            .unwrap()
+                            .as_non_null_ptr()
+                    })
+                    .collect();
                 for &ptr in &pointers {
-                    assert_eq!((ptr.as_ptr() as usize) % align, 0,
-                            "Got a pointer less aligned than requested")
+                    assert_eq!(
+                        (ptr.as_ptr() as usize) % align,
+                        0,
+                        "Got a pointer less aligned than requested"
+                    )
                 }
 
                 // Clean up.

--- a/tests/pass/heap_allocator.rs
+++ b/tests/pass/heap_allocator.rs
@@ -16,7 +16,7 @@ fn check_alloc<T: Allocator>(allocator: T) {
                 assert_eq!(
                     a.as_ptr() as usize % layout_20.align(),
                     0,
-                    "pointer is incorrectly aligned"
+                    "pointer is incorrectly aligned",
                 );
                 allocator.deallocate(a, layout_20);
             }
@@ -25,7 +25,7 @@ fn check_alloc<T: Allocator>(allocator: T) {
             assert_eq!(
                 p1.as_ptr() as usize % layout_20.align(),
                 0,
-                "pointer is incorrectly aligned"
+                "pointer is incorrectly aligned",
             );
             assert_eq!(*p1.as_ptr(), 0);
 
@@ -34,7 +34,7 @@ fn check_alloc<T: Allocator>(allocator: T) {
             assert_eq!(
                 p2.as_ptr() as usize % layout_40.align(),
                 0,
-                "pointer is incorrectly aligned"
+                "pointer is incorrectly aligned",
             );
             let slice = slice::from_raw_parts(p2.as_ptr(), 20);
             assert_eq!(&slice, &[0_u8; 20]);
@@ -44,7 +44,7 @@ fn check_alloc<T: Allocator>(allocator: T) {
             assert_eq!(
                 p3.as_ptr() as usize % layout_40.align(),
                 0,
-                "pointer is incorrectly aligned"
+                "pointer is incorrectly aligned",
             );
             let slice = slice::from_raw_parts(p3.as_ptr(), 20);
             assert_eq!(&slice, &[0_u8; 20]);
@@ -54,7 +54,7 @@ fn check_alloc<T: Allocator>(allocator: T) {
             assert_eq!(
                 p4.as_ptr() as usize % layout_10.align(),
                 0,
-                "pointer is incorrectly aligned"
+                "pointer is incorrectly aligned",
             );
             let slice = slice::from_raw_parts(p4.as_ptr(), 10);
             assert_eq!(&slice, &[0_u8; 10]);
@@ -65,10 +65,9 @@ fn check_alloc<T: Allocator>(allocator: T) {
 }
 
 fn check_align_requests<T: Allocator>(allocator: T) {
-    for &size in &[2, 8, 64] {
-        // size less than and bigger than alignment
-        for &align in &[4, 8, 16, 32] {
-            // Be sure to cover less than and bigger than `MIN_ALIGN` for all architectures
+    #[rustfmt::skip] // https://github.com/rust-lang/rustfmt/issues/3255
+    for &size in &[2, 8, 64] { // size less than and bigger than alignment
+        for &align in &[4, 8, 16, 32] { // Be sure to cover less than and bigger than `MIN_ALIGN` for all architectures
             let iterations = 32;
             unsafe {
                 let pointers: Vec<_> = (0..iterations)
@@ -83,7 +82,7 @@ fn check_align_requests<T: Allocator>(allocator: T) {
                     assert_eq!(
                         (ptr.as_ptr() as usize) % align,
                         0,
-                        "Got a pointer less aligned than requested"
+                        "Got a pointer less aligned than requested",
                     )
                 }
 
@@ -93,7 +92,7 @@ fn check_align_requests<T: Allocator>(allocator: T) {
                 }
             }
         }
-    }
+    };
 }
 
 fn global_to_box() {

--- a/tests/pass/iter.rs
+++ b/tests/pass/iter.rs
@@ -1,5 +1,6 @@
 fn iter_empty_and_zst() {
-    for _ in Vec::<u32>::new().iter() { // this iterates over a Unique::empty()
+    for _ in Vec::<u32>::new().iter() {
+        // this iterates over a Unique::empty()
         panic!("We should never be here.");
     }
 
@@ -21,13 +22,13 @@ fn test_iterator_step_by_nth() {
 }
 
 fn iter_any() {
-    let f = |x: &u8| { 10u8 == *x };
+    let f = |x: &u8| 10u8 == *x;
     f(&1u8);
 
-    let g = |(), x: &u8| { 10u8 == *x };
+    let g = |(), x: &u8| 10u8 == *x;
     g((), &1u8);
 
-    let h = |(), (), x: &u8| { 10u8 == *x };
+    let h = |(), (), x: &u8| 10u8 == *x;
     h((), (), &1u8);
 
     [1, 2, 3u8].iter().any(|elt| 10 == *elt);

--- a/tests/pass/iter.rs
+++ b/tests/pass/iter.rs
@@ -1,6 +1,6 @@
 fn iter_empty_and_zst() {
+    // Iterate over a Unique::empty()
     for _ in Vec::<u32>::new().iter() {
-        // this iterates over a Unique::empty()
         panic!("We should never be here.");
     }
 


### PR DESCRIPTION
Extracted from #2097.

This is one half of the last 24 files (left for last because they require more unique attention than the first 275 "easy" files).

I'll comment below to call attention to cases where I exercised my own judgement in how to format the test.

https://github.com/rust-lang/rustfmt/issues/3255 is especially annoying: rustfmt does not like `…( //` and `…{ //`.