### PR TITLE
Support no-std targets and test it in CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,16 @@ and you can (cross-)run the entire test suite using:
 MIRI_TEST_TARGET=i686-unknown-linux-gnu ./miri test
 ```
 
+If your target doesn't support libstd, you can run miri with
+
+```
+MIRI_NO_STD=1 MIRI_TEST_TARGET=thumbv7em-none-eabihf ./miri test tests/fail/alloc/no_global_allocator.rs
+MIRI_NO_STD=1 ./miri test tests/pass/no_std.rs --target thumbv7em-none-eabihf
+```
+
+to avoid attempting (and failing) to build libstd. Note that almost no tests will pass
+this way, but you can run individual tests.
+
 `./miri test FILTER` only runs those tests that contain `FILTER` in their
 filename (including the base directory, e.g. `./miri test fail` will run all
 compile-fail tests).

--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -398,11 +398,12 @@ fn setup(subcommand: MiriCommand) {
     if !dir.exists() {
         fs::create_dir_all(&dir).unwrap();
     }
-    // The interesting bit: Xargo.toml
-    File::create(dir.join("Xargo.toml"))
-        .unwrap()
-        .write_all(
-            br#"
+    let mut xargo_toml = File::create(dir.join("Xargo.toml")).unwrap();
+    if std::env::var_os("MIRI_NO_STD").is_none() {
+        // The interesting bit: Xargo.toml
+        xargo_toml
+            .write_all(
+                br#"
 [dependencies.std]
 default_features = false
 # We support unwinding, so enable that panic runtime.
@@ -410,8 +411,9 @@ features = ["panic_unwind", "backtrace"]
 
 [dependencies.test]
 "#,
-        )
-        .unwrap();
+            )
+            .unwrap();
+    }
     // The boring bits: a dummy project for xargo.
     // FIXME: With xargo-check, can we avoid doing this?
     File::create(dir.join("Cargo.toml"))
@@ -428,7 +430,7 @@ path = "lib.rs"
 "#,
         )
         .unwrap();
-    File::create(dir.join("lib.rs")).unwrap();
+    File::create(dir.join("lib.rs")).unwrap().write_all(b"#![no_std]").unwrap();
 
     // Determine architectures.
     // We always need to set a target so rustc bootstrap can tell apart host from target crates.

--- a/ci.sh
+++ b/ci.sh
@@ -65,6 +65,7 @@ case $HOST_TARGET in
   x86_64-apple-darwin)
     MIRI_TEST_TARGET=mips64-unknown-linux-gnuabi64 run_tests # big-endian architecture
     MIRI_TEST_TARGET=x86_64-pc-windows-msvc run_tests
+    MIRI_NO_STD=1 ./miri run tests/pass/no_std.rs --target thumbv7em-none-eabihf # no_std embedded architecture minimal test
     ;;
   i686-pc-windows-msvc)
     MIRI_TEST_TARGET=x86_64-unknown-linux-gnu run_tests

--- a/tests/pass/no_std.rs
+++ b/tests/pass/no_std.rs
@@ -1,0 +1,17 @@
+#![feature(lang_items, start)]
+#![no_std]
+
+#[start]
+fn start(_: isize, _: *const *const u8) -> isize {
+    for _ in 0..10 {}
+
+    0
+}
+
+#[panic_handler]
+fn panic_handler(_: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+#[lang = "eh_personality"]
+fn eh_personality() {}


### PR DESCRIPTION
cc @jamesmunns

This is a bit annoying as you need to have `MIRI_NO_STD=1` set at all times, but it works ™️

Once libstd's `restricted_std` feature becomes more usable, we can probably do away with that env var.

I also added a test to CI to make sure it keeps working. This test only builds libcore and runs a single test, so it's pretty fast.