### PR TITLE
revert --color=always changes

### DIFF
--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -952,17 +952,8 @@ fn phase_runner(binary: &Path, binary_args: env::Args, phase: RunnerPhase) {
             assert!(suffix.starts_with('='));
             // Drop this argument.
         } else if let Some(suffix) = arg.strip_prefix(json_flag) {
-            let suffix = suffix.strip_prefix('=').unwrap();
-            // This is how we pass through --color=always. We detect that Cargo is detecting rustc
-            // to emit the diagnostic structure that Cargo would consume from rustc to emit colored
-            // diagnostics, and ask rustc to emit them.
-            // See https://github.com/rust-lang/miri/issues/2037
-            // First skip over the leading `=`, then check for diagnostic-rendered-ansi in the
-            // comma-separated list
-            if suffix.split(',').any(|a| a == "diagnostic-rendered-ansi") {
-                cmd.arg("--color=always");
-            }
-            // But aside from remembering that colored output was requested, drop this argument.
+            assert!(suffix.starts_with('='));
+            // Drop this argument.
         } else {
             cmd.arg(arg);
         }


### PR DESCRIPTION
They [cause problems](https://github.com/rust-lang/miri/issues/2277) and they completely break rendering on the playground:
```
   Compiling playground v0.0.1 (/playground)
    Finished dev [unoptimized + debuginfo] target(s) in 0.47s
     Running `/playground/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/bin/cargo-miri target/miri/x86_64-unknown-linux-gnu/debug/playground`
[0m[1m[38;5;9merror[E0277][0m[0m[1m: `*mut std::sync::atomic::AtomicUsize` cannot be sent between threads safely[0m
[0m   [0m[0m[1m[38;5;12m--> [0m[0msrc/main.rs:17:18[0m
[0m    [0m[0m[1m[38;5;12m|[0m
[0m[1m[38;5;12m17[0m[0m  [0m[0m[1m[38;5;12m|[0m[0m   [0m[0m        let j1 = spawn(move || {[0m
[0m    [0m[0m[1m[38;5;12m| [0m[0m [0m[0m[1m[38;5;12m__________________[0m[0m[1m[38;5;9m^^^^^[0m[0m[1m[38;5;12m_-[0m
[0m    [0m[0m[1m[38;5;12m| [0m[0m[1m[38;5;12m|[0m[0m                  [0m[0m[1m[38;5;9m|[0m
[0m    [0m[0m[1m[38;5;12m| [0m[0m[1m[38;5;12m|[0m[0m                  [0m[0m[1m[38;5;9m`*mut std::sync::atomic::AtomicUsize` cannot be sent between threads safely[0m
[0m[1m[38;5;12m18[0m[0m  [0m[0m[1m[38;5;12m|[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m            *(c.0 as *mut usize) = 32;[0m
[0m[1m[38;5;12m19[0m[0m  [0m[0m[1m[38;5;12m|[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0m        });[0m
[0m    [0m[0m[1m[38;5;12m| [0m[0m[1m[38;5;12m|_________-[0m[0m [0m[0m[1m[38;5;12mwithin this `[closure@src/main.rs:17:24: 19:10]`[0m
[0m    [0m[0m[1m[38;5;12m|[0m
```

Sorry @saethlin, I think we need to go back to start here and consider another solution.

Fixes https://github.com/rust-lang/miri/issues/2277