### PR TITLE
Support `gettimeofday` on more than macos

### DIFF
--- a/src/shims/time.rs
+++ b/src/shims/time.rs
@@ -64,7 +64,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
     ) -> InterpResult<'tcx, i32> {
         let this = self.eval_context_mut();
 
-        this.assert_target_os("macos", "gettimeofday");
+        this.assert_target_os_is_unix("gettimeofday");
         this.check_no_isolation("`gettimeofday`")?;
 
         // Using tz is obsolete and should always be null

--- a/src/shims/unix/foreign_items.rs
+++ b/src/shims/unix/foreign_items.rs
@@ -139,6 +139,13 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_scalar(Scalar::from_machine_isize(result, this), dest)?;
             }
 
+            // Time related shims
+            "gettimeofday" => {
+                let [tv, tz] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let result = this.gettimeofday(tv, tz)?;
+                this.write_scalar(Scalar::from_i32(result), dest)?;
+            }
+
             // Allocation
             "posix_memalign" => {
                 let [ret, align, size] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;

--- a/src/shims/unix/macos/foreign_items.rs
+++ b/src/shims/unix/macos/foreign_items.rs
@@ -78,11 +78,6 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             }
 
             // Time related shims
-            "gettimeofday" => {
-                let [tv, tz] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
-                let result = this.gettimeofday(tv, tz)?;
-                this.write_scalar(Scalar::from_i32(result), dest)?;
-            }
             "mach_absolute_time" => {
                 let [] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.mach_absolute_time()?;


### PR DESCRIPTION
This appears to be in linux and in openbsd as well:

* https://github.com/torvalds/linux/blob/master/lib/vdso/gettimeofday.c
* https://github.com/openbsd/src/blob/master/sys/sys/time.h#L439

Note that std currently says [different syscalls are used on mac vs linux](https://doc.rust-lang.org/std/time/struct.SystemTime.html#platform-specific-behavior) but this is not part of[ std's contract](https://doc.rust-lang.org/std/io/index.html#platform-specific-behavior) and third party code could call the syscall directly on different platforms.