### PR TITLE
make -Zmiri-env-forward take precedence over -Zmiri-env-exclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,8 +285,9 @@ environment variable. We first document the most relevant and most commonly used
   harness](https://github.com/rust-lang/miri/issues/1702). This has no effect unless
   `-Zmiri-disable-isolation` is also set.
 * `-Zmiri-env-forward=<var>` forwards the `var` environment variable to the interpreted program. Can
-  be used multiple times to forward several variables. This has no effect if
-  `-Zmiri-disable-isolation` is set.
+  be used multiple times to forward several variables. This takes precedence over
+  `-Zmiri-env-exclude`: if a variable is both forwarded and exluced, it *will* get forwarded. This
+  means in particular `-Zmiri-env-forward=TERM` overwrites the default exclusion of `TERM`.
 * `-Zmiri-ignore-leaks` disables the memory leak checker, and also allows some
   remaining threads to exist when the main thread exits.
 * `-Zmiri-permissive-provenance` disables the warning for integer-to-pointer casts and

--- a/src/shims/env.rs
+++ b/src/shims/env.rs
@@ -50,10 +50,10 @@ impl<'tcx> EnvVars<'tcx> {
         // Skip the loop entirely if we don't want to forward anything.
         if ecx.machine.communicate() || !config.forwarded_env_vars.is_empty() {
             for (name, value) in env::vars_os() {
-                let forward = match ecx.machine.communicate() {
-                    true => !excluded_env_vars.iter().any(|v| **v == name),
-                    false => config.forwarded_env_vars.iter().any(|v| **v == name),
-                };
+                // Always forward what is in `forwarded_env_vars`; that list can take precedence over excluded_env_vars.
+                let forward = config.forwarded_env_vars.iter().any(|v| **v == name)
+                    || (ecx.machine.communicate()
+                        && !excluded_env_vars.iter().any(|v| **v == name));
                 if forward {
                     let var_ptr = match target_os {
                         target if target_os_is_unix(target) =>


### PR DESCRIPTION
Lets people experiment with the `TERM` env var.