### PR TITLE
Extend `environ` linux extern implementation to freebsd

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -60,7 +60,7 @@ case $HOST_TARGET in
     MIRI_TEST_TARGET=i686-unknown-linux-gnu run_tests
     MIRI_TEST_TARGET=aarch64-apple-darwin run_tests
     MIRI_TEST_TARGET=i686-pc-windows-msvc run_tests
-    MIRI_TEST_TARGET=x86_64-unknown-freebsd run_tests_minimal hello integer vec current_dir data_race
+    MIRI_TEST_TARGET=x86_64-unknown-freebsd run_tests_minimal hello integer vec current_dir data_race env
     MIRI_TEST_TARGET=thumbv7em-none-eabihf MIRI_NO_STD=1 run_tests_minimal no_std # no_std embedded architecture
     ;;
   x86_64-apple-darwin)

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -442,6 +442,14 @@ impl<'mir, 'tcx> Evaluator<'mir, 'tcx> {
                     Self::add_extern_static(this, name, place.ptr);
                 }
             }
+            "freebsd" => {
+                // "environ"
+                Self::add_extern_static(
+                    this,
+                    "environ",
+                    this.machine.env_vars.environ.unwrap().ptr,
+                );
+            }
             "windows" => {
                 // "_tls_used"
                 // This is some obscure hack that is part of the Windows TLS story. It's a `u8`.

--- a/tests/fail/environ-gets-deallocated.rs
+++ b/tests/fail/environ-gets-deallocated.rs
@@ -1,6 +1,6 @@
 // ignore-windows: Windows does not have a global environ list that the program can access directly
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
 fn get_environ() -> *const *const u8 {
     extern "C" {
         static mut environ: *const *const u8;


### PR DESCRIPTION
This fixes the `env` test on freebsd, and enables the CI test

Signed-off-by: InfRandomness <infrandomness@gmail.com>