### PR TITLE
Support (stat/fstat/lstat)64 on macos

### DIFF
--- a/src/shims/unix/macos/foreign_items.rs
+++ b/src/shims/unix/macos/foreign_items.rs
@@ -33,19 +33,19 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 let result = this.close(result)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
-            "stat" | "stat$INODE64" => {
+            "stat" | "stat64" | "stat$INODE64" => {
                 let [path, buf] =
                     this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.macos_stat(path, buf)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
-            "lstat" | "lstat$INODE64" => {
+            "lstat" | "lstat64" | "lstat$INODE64" => {
                 let [path, buf] =
                     this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.macos_lstat(path, buf)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;
             }
-            "fstat" | "fstat$INODE64" => {
+            "fstat" | "fstat64" | "fstat$INODE64" => {
                 let [fd, buf] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let result = this.macos_fstat(fd, buf)?;
                 this.write_scalar(Scalar::from_i32(result), dest)?;


### PR DESCRIPTION
"In order to accommodate advanced capabilities of newer file systems,
     the struct stat, struct statfs, and struct dirent data structures
     were updated in Mac OSX 10.5."

"TRANSITIONAL DESCRIPTION (NOW DEPRECATED)
     The fstat64, lstat64 and stat64 routines are equivalent to their
     corresponding non-64-suffixed routine, when 64-bit inodes are in
     effect.  They were added before there was support for the symbol
     variants, and so are now deprecated.  Instead of using these, set
     the _DARWIN_USE_64_BIT_INODE macro before including header files to
     force 64-bit inode support. The stat64 structure used by these deprecated routines is the same
     as the stat structure when 64-bit inodes are in effect (see above)."

"HISTORY
     An lstat() function call appeared in 4.2BSD.  The stat64(),
     fstat64(), and lstat64() system calls first appeared in Mac OS X
     10.5 (Leopard) and are now deprecated in favor of the corresponding
     symbol variants.  The fstatat() system call appeared in OS X 10.10"