### PR TITLE
pointer tag tracking: on creation, log the offsets it is created for

### DIFF
--- a/tests/fail/alloc/deallocate-bad-alignment.stderr
+++ b/tests/fail/alloc/deallocate-bad-alignment.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `std::alloc::dealloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
 note: inside `main` at $DIR/deallocate-bad-alignment.rs:LL:CC
   --> $DIR/deallocate-bad-alignment.rs:LL:CC

--- a/tests/fail/alloc/deallocate-bad-size.stderr
+++ b/tests/fail/alloc/deallocate-bad-size.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `std::alloc::dealloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
 note: inside `main` at $DIR/deallocate-bad-size.rs:LL:CC
   --> $DIR/deallocate-bad-size.rs:LL:CC

--- a/tests/fail/alloc/deallocate-twice.stderr
+++ b/tests/fail/alloc/deallocate-twice.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `std::alloc::dealloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
 note: inside `main` at $DIR/deallocate-twice.rs:LL:CC
   --> $DIR/deallocate-twice.rs:LL:CC

--- a/tests/fail/alloc/global_system_mixup.stderr
+++ b/tests/fail/alloc/global_system_mixup.stderr
@@ -6,7 +6,7 @@ LL |         FREE();
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `std::sys::PLATFORM::alloc::<impl std::alloc::GlobalAlloc for std::alloc::System>::dealloc` at RUSTLIB/std/src/sys/PLATFORM/alloc.rs:LL:CC
    = note: inside `<std::alloc::System as std::alloc::Allocator>::deallocate` at RUSTLIB/std/src/alloc.rs:LL:CC
 note: inside `main` at $DIR/global_system_mixup.rs:LL:CC

--- a/tests/fail/alloc/no_global_allocator.stderr
+++ b/tests/fail/alloc/no_global_allocator.stderr
@@ -5,7 +5,7 @@ LL |         __rust_alloc(1, 1);
    |         ^^^^^^^^^^^^^^^^^^ can't call foreign function: __rust_alloc
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
-           
+   = note: backtrace:
    = note: inside `start` at $DIR/no_global_allocator.rs:LL:CC
 
 error: aborting due to previous error

--- a/tests/fail/alloc/reallocate-bad-size.stderr
+++ b/tests/fail/alloc/reallocate-bad-size.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { __rust_realloc(ptr, layout.size(), layout.align(), new_size) }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `std::alloc::realloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
 note: inside `main` at $DIR/reallocate-bad-size.rs:LL:CC
   --> $DIR/reallocate-bad-size.rs:LL:CC

--- a/tests/fail/alloc/reallocate-change-alloc.stderr
+++ b/tests/fail/alloc/reallocate-change-alloc.stderr
@@ -6,7 +6,7 @@ LL |         let _z = *x;
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/reallocate-change-alloc.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/alloc/reallocate-dangling.stderr
+++ b/tests/fail/alloc/reallocate-dangling.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { __rust_realloc(ptr, layout.size(), layout.align(), new_size) }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `std::alloc::realloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
 note: inside `main` at $DIR/reallocate-dangling.rs:LL:CC
   --> $DIR/reallocate-dangling.rs:LL:CC

--- a/tests/fail/alloc/stack_free.stderr
+++ b/tests/fail/alloc/stack_free.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `std::alloc::dealloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
    = note: inside `<std::alloc::Global as std::alloc::Allocator>::deallocate` at RUSTLIB/alloc/src/alloc.rs:LL:CC
    = note: inside `alloc::alloc::box_free::<i32, std::alloc::Global>` at RUSTLIB/alloc/src/alloc.rs:LL:CC

--- a/tests/fail/backtrace/bad-backtrace-decl.stderr
+++ b/tests/fail/backtrace/bad-backtrace-decl.stderr
@@ -6,7 +6,7 @@ LL | ...   miri_resolve_frame(*frame, 0);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/bad-backtrace-decl.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/backtrace/bad-backtrace-flags.stderr
+++ b/tests/fail/backtrace/bad-backtrace-flags.stderr
@@ -5,7 +5,7 @@ LL |         miri_get_backtrace(2, std::ptr::null_mut());
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown `miri_get_backtrace` flags 2
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/bad-backtrace-flags.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/backtrace/bad-backtrace-ptr.stderr
+++ b/tests/fail/backtrace/bad-backtrace-ptr.stderr
@@ -6,7 +6,7 @@ LL |         miri_resolve_frame(std::ptr::null_mut(), 0);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/bad-backtrace-ptr.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/backtrace/bad-backtrace-resolve-flags.stderr
+++ b/tests/fail/backtrace/bad-backtrace-resolve-flags.stderr
@@ -5,7 +5,7 @@ LL |         miri_resolve_frame(buf[0], 2);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown `miri_resolve_frame` flags 2
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/bad-backtrace-resolve-flags.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/backtrace/bad-backtrace-resolve-names-flags.stderr
+++ b/tests/fail/backtrace/bad-backtrace-resolve-names-flags.stderr
@@ -5,7 +5,7 @@ LL | ...   miri_resolve_frame_names(buf[0], 2, std::ptr::null_mut(), std::ptr::n
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown `miri_resolve_frame_names` flags 2
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/bad-backtrace-resolve-names-flags.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/backtrace/bad-backtrace-size-flags.stderr
+++ b/tests/fail/backtrace/bad-backtrace-size-flags.stderr
@@ -5,7 +5,7 @@ LL |         miri_backtrace_size(2);
    |         ^^^^^^^^^^^^^^^^^^^^^^ unknown `miri_backtrace_size` flags 2
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/bad-backtrace-size-flags.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/box-cell-alias.stderr
+++ b/tests/fail/box-cell-alias.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x1]
    |
 LL |     let res = helper(val, ptr);
    |                      ^^^
+   = note: backtrace:
    = note: inside `helper` at $DIR/box-cell-alias.rs:LL:CC
 note: inside `main` at $DIR/box-cell-alias.rs:LL:CC
   --> $DIR/box-cell-alias.rs:LL:CC

--- a/tests/fail/branchless-select-i128-pointer.stderr
+++ b/tests/fail/branchless-select-i128-pointer.stderr
@@ -10,7 +10,7 @@ LL | |             )
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/branchless-select-i128-pointer.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/concurrency/libc_pthread_join_detached.stderr
+++ b/tests/fail/concurrency/libc_pthread_join_detached.stderr
@@ -6,7 +6,7 @@ LL | ...   assert_eq!(libc::pthread_join(native, ptr::null_mut()), 0);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/libc_pthread_join_detached.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/concurrency/libc_pthread_join_joined.stderr
+++ b/tests/fail/concurrency/libc_pthread_join_joined.stderr
@@ -6,7 +6,7 @@ LL | ...   assert_eq!(libc::pthread_join(native, ptr::null_mut()), 0);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/libc_pthread_join_joined.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/concurrency/libc_pthread_join_main.stderr
+++ b/tests/fail/concurrency/libc_pthread_join_main.stderr
@@ -6,7 +6,7 @@ LL | ...   assert_eq!(libc::pthread_join(thread_id, ptr::null_mut()), 0);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/libc_pthread_join_main.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/concurrency/libc_pthread_join_multiple.stderr
+++ b/tests/fail/concurrency/libc_pthread_join_multiple.stderr
@@ -6,7 +6,7 @@ LL | ...   assert_eq!(libc::pthread_join(native_copy, ptr::null_mut()), 0);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/libc_pthread_join_multiple.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/concurrency/libc_pthread_join_self.stderr
+++ b/tests/fail/concurrency/libc_pthread_join_self.stderr
@@ -6,7 +6,7 @@ LL |             assert_eq!(libc::pthread_join(native, ptr::null_mut()), 0);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/libc_pthread_join_self.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/concurrency/thread-spawn.stderr
+++ b/tests/fail/concurrency/thread-spawn.stderr
@@ -12,7 +12,7 @@ LL | |         );
    | |_________^ can't create threads on Windows
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
-           
+   = note: backtrace:
    = note: inside `std::sys::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/PLATFORM/thread.rs:LL:CC
    = note: inside `std::thread::Builder::spawn_unchecked_::<[closure@$DIR/thread-spawn.rs:LL:CC], ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
    = note: inside `std::thread::Builder::spawn_unchecked::<[closure@$DIR/thread-spawn.rs:LL:CC], ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC

--- a/tests/fail/concurrency/thread_local_static_dealloc.stderr
+++ b/tests/fail/concurrency/thread_local_static_dealloc.stderr
@@ -6,7 +6,7 @@ LL |         let _val = *dangling_ptr.0;
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/thread_local_static_dealloc.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/concurrency/too_few_args.stderr
+++ b/tests/fail/concurrency/too_few_args.stderr
@@ -6,7 +6,7 @@ LL |     panic!()
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `thread_start` at RUSTLIB/std/src/panic.rs:LL:CC
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/fail/concurrency/too_many_args.stderr
+++ b/tests/fail/concurrency/too_many_args.stderr
@@ -6,7 +6,7 @@ LL |     panic!()
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `thread_start` at RUSTLIB/std/src/panic.rs:LL:CC
    = note: this error originates in the macro `$crate::panic::panic_2015` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/fail/concurrency/unwind_top_of_stack.stderr
+++ b/tests/fail/concurrency/unwind_top_of_stack.stderr
@@ -11,7 +11,7 @@ LL | | }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `thread_start` at $DIR/unwind_top_of_stack.rs:LL:CC
 
 error: aborting due to previous error

--- a/tests/fail/dangling_pointers/dangling_pointer_addr_of.stderr
+++ b/tests/fail/dangling_pointers/dangling_pointer_addr_of.stderr
@@ -6,7 +6,7 @@ LL |     let x = unsafe { ptr::addr_of!(*p) };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at RUSTLIB/core/src/ptr/mod.rs:LL:CC
    = note: this error originates in the macro `ptr::addr_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/fail/dangling_pointers/dangling_pointer_deref.stderr
+++ b/tests/fail/dangling_pointers/dangling_pointer_deref.stderr
@@ -6,7 +6,7 @@ LL |     let x = unsafe { *p };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/dangling_pointer_deref.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/dangling_pointers/dangling_zst_deref.stderr
+++ b/tests/fail/dangling_pointers/dangling_zst_deref.stderr
@@ -6,7 +6,7 @@ LL |     let _x = unsafe { *p };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/dangling_zst_deref.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/dangling_pointers/deref-invalid-ptr.stderr
+++ b/tests/fail/dangling_pointers/deref-invalid-ptr.stderr
@@ -6,7 +6,7 @@ LL |     let _y = unsafe { &*x as *const u32 };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/deref-invalid-ptr.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/dangling_pointers/deref-partially-dangling.stderr
+++ b/tests/fail/dangling_pointers/deref-partially-dangling.stderr
@@ -6,7 +6,7 @@ LL |     let val = unsafe { (*xptr).1 };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/deref-partially-dangling.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/dangling_pointers/dyn_size.stderr
+++ b/tests/fail/dangling_pointers/dyn_size.stderr
@@ -6,7 +6,7 @@ LL |     let _ptr = unsafe { &*ptr };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/dyn_size.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/dangling_pointers/maybe_null_pointer_deref_zst.stderr
+++ b/tests/fail/dangling_pointers/maybe_null_pointer_deref_zst.stderr
@@ -6,7 +6,7 @@ LL |     let _x: () = unsafe { *ptr };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/maybe_null_pointer_deref_zst.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/dangling_pointers/maybe_null_pointer_write_zst.stderr
+++ b/tests/fail/dangling_pointers/maybe_null_pointer_write_zst.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { *ptr = zst_val };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/maybe_null_pointer_write_zst.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/dangling_pointers/null_pointer_deref.stderr
+++ b/tests/fail/dangling_pointers/null_pointer_deref.stderr
@@ -6,7 +6,7 @@ LL |     let x: i32 = unsafe { *std::ptr::null() };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/null_pointer_deref.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/dangling_pointers/null_pointer_deref_zst.stderr
+++ b/tests/fail/dangling_pointers/null_pointer_deref_zst.stderr
@@ -6,7 +6,7 @@ LL |     let x: () = unsafe { *std::ptr::null() };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/null_pointer_deref_zst.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/dangling_pointers/null_pointer_write.stderr
+++ b/tests/fail/dangling_pointers/null_pointer_write.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { *std::ptr::null_mut() = 0i32 };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/null_pointer_write.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/dangling_pointers/null_pointer_write_zst.stderr
+++ b/tests/fail/dangling_pointers/null_pointer_write_zst.stderr
@@ -6,7 +6,7 @@ LL |         copy_nonoverlapping(&src as *const T, dst, 1);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `std::ptr::write::<[u8; 0]>` at RUSTLIB/core/src/ptr/mod.rs:LL:CC
    = note: inside `std::ptr::mut_ptr::<impl *mut [u8; 0]>::write` at RUSTLIB/core/src/ptr/mut_ptr.rs:LL:CC
 note: inside `main` at $DIR/null_pointer_write_zst.rs:LL:CC

--- a/tests/fail/dangling_pointers/out_of_bounds_read1.stderr
+++ b/tests/fail/dangling_pointers/out_of_bounds_read1.stderr
@@ -6,7 +6,7 @@ LL |     let x = unsafe { *v.as_ptr().wrapping_offset(5) };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/out_of_bounds_read1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/dangling_pointers/out_of_bounds_read2.stderr
+++ b/tests/fail/dangling_pointers/out_of_bounds_read2.stderr
@@ -6,7 +6,7 @@ LL |     let x = unsafe { *v.as_ptr().wrapping_offset(5) };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/out_of_bounds_read2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/dangling_pointers/stack_temporary.stderr
+++ b/tests/fail/dangling_pointers/stack_temporary.stderr
@@ -6,7 +6,7 @@ LL |         let val = *x;
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/stack_temporary.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/dangling_pointers/storage_dead_dangling.stderr
+++ b/tests/fail/dangling_pointers/storage_dead_dangling.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { &mut *(LEAK as *mut i32) };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `evil` at $DIR/storage_dead_dangling.rs:LL:CC
 note: inside `main` at $DIR/storage_dead_dangling.rs:LL:CC
   --> $DIR/storage_dead_dangling.rs:LL:CC

--- a/tests/fail/dangling_pointers/wild_pointer_deref.stderr
+++ b/tests/fail/dangling_pointers/wild_pointer_deref.stderr
@@ -6,7 +6,7 @@ LL |     let x = unsafe { *p };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/wild_pointer_deref.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/alloc_read_race.stderr
+++ b/tests/fail/data_race/alloc_read_race.stderr
@@ -6,7 +6,7 @@ LL |             *pointer.load(Ordering::Relaxed)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/alloc_read_race.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/alloc_write_race.stderr
+++ b/tests/fail/data_race/alloc_write_race.stderr
@@ -6,7 +6,7 @@ LL |             *pointer.load(Ordering::Relaxed) = 2;
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/alloc_write_race.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/atomic_read_na_write_race1.stderr
+++ b/tests/fail/data_race/atomic_read_na_write_race1.stderr
@@ -6,7 +6,7 @@ LL |             intrinsics::atomic_load_seqcst(c.0 as *mut usize)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/atomic_read_na_write_race1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/atomic_read_na_write_race2.stderr
+++ b/tests/fail/data_race/atomic_read_na_write_race2.stderr
@@ -6,7 +6,7 @@ LL |             *atomic_ref.get_mut() = 32;
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/atomic_read_na_write_race2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/atomic_write_na_read_race1.stderr
+++ b/tests/fail/data_race/atomic_write_na_read_race1.stderr
@@ -6,7 +6,7 @@ LL |             *atomic_ref.get_mut()
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/atomic_write_na_read_race1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/atomic_write_na_read_race2.stderr
+++ b/tests/fail/data_race/atomic_write_na_read_race2.stderr
@@ -6,7 +6,7 @@ LL |             atomic_store(c.0 as *mut usize, 32);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/atomic_write_na_read_race2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/atomic_write_na_write_race1.stderr
+++ b/tests/fail/data_race/atomic_write_na_write_race1.stderr
@@ -6,7 +6,7 @@ LL |             atomic_store(c.0 as *mut usize, 64);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/atomic_write_na_write_race1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/atomic_write_na_write_race2.stderr
+++ b/tests/fail/data_race/atomic_write_na_write_race2.stderr
@@ -6,7 +6,7 @@ LL |             *atomic_ref.get_mut() = 32;
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/atomic_write_na_write_race2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/dangling_thread_async_race.stderr
+++ b/tests/fail/data_race/dangling_thread_async_race.stderr
@@ -6,7 +6,7 @@ LL |             *c.0 = 64;
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/dangling_thread_async_race.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/dangling_thread_race.stderr
+++ b/tests/fail/data_race/dangling_thread_race.stderr
@@ -6,7 +6,7 @@ LL |         *c.0 = 64;
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/dangling_thread_race.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/dealloc_read_race1.stderr
+++ b/tests/fail/data_race/dealloc_read_race1.stderr
@@ -11,7 +11,7 @@ LL | |             );
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/dealloc_read_race1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/dealloc_read_race2.stderr
+++ b/tests/fail/data_race/dealloc_read_race2.stderr
@@ -6,7 +6,7 @@ LL |             *ptr.0
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/dealloc_read_race2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/dealloc_read_race_stack.stderr
+++ b/tests/fail/data_race/dealloc_read_race_stack.stderr
@@ -6,7 +6,7 @@ LL |             }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/dealloc_read_race_stack.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/dealloc_write_race1.stderr
+++ b/tests/fail/data_race/dealloc_write_race1.stderr
@@ -11,7 +11,7 @@ LL | |             );
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/dealloc_write_race1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/dealloc_write_race2.stderr
+++ b/tests/fail/data_race/dealloc_write_race2.stderr
@@ -6,7 +6,7 @@ LL |             *ptr.0 = 2;
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/dealloc_write_race2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/dealloc_write_race_stack.stderr
+++ b/tests/fail/data_race/dealloc_write_race_stack.stderr
@@ -6,7 +6,7 @@ LL |             }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/dealloc_write_race_stack.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/enable_after_join_to_main.stderr
+++ b/tests/fail/data_race/enable_after_join_to_main.stderr
@@ -6,7 +6,7 @@ LL |             *c.0 = 64;
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/enable_after_join_to_main.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/fence_after_load.stderr
+++ b/tests/fail/data_race/fence_after_load.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { V = 2 }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/fence_after_load.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/read_write_race.stderr
+++ b/tests/fail/data_race/read_write_race.stderr
@@ -6,7 +6,7 @@ LL |             *c.0 = 64;
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/read_write_race.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/read_write_race_stack.stderr
+++ b/tests/fail/data_race/read_write_race_stack.stderr
@@ -6,7 +6,7 @@ LL |             stack_var
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/read_write_race_stack.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/relax_acquire_race.stderr
+++ b/tests/fail/data_race/relax_acquire_race.stderr
@@ -6,7 +6,7 @@ LL |                 *c.0
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/relax_acquire_race.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/release_seq_race.stderr
+++ b/tests/fail/data_race/release_seq_race.stderr
@@ -6,7 +6,7 @@ LL |                 *c.0
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/release_seq_race.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/release_seq_race_same_thread.stderr
+++ b/tests/fail/data_race/release_seq_race_same_thread.stderr
@@ -6,7 +6,7 @@ LL |                 *c.0
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/release_seq_race_same_thread.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/rmw_race.stderr
+++ b/tests/fail/data_race/rmw_race.stderr
@@ -6,7 +6,7 @@ LL |                 *c.0
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/rmw_race.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/write_write_race.stderr
+++ b/tests/fail/data_race/write_write_race.stderr
@@ -6,7 +6,7 @@ LL |             *c.0 = 64;
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/write_write_race.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/write_write_race_stack.stderr
+++ b/tests/fail/data_race/write_write_race_stack.stderr
@@ -6,7 +6,7 @@ LL |             stack_var = 1usize;
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/write_write_race_stack.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/environ-gets-deallocated.stderr
+++ b/tests/fail/environ-gets-deallocated.stderr
@@ -6,7 +6,7 @@ LL |     let _y = unsafe { *pointer };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/environ-gets-deallocated.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/extern_static.stderr
+++ b/tests/fail/extern_static.stderr
@@ -5,7 +5,7 @@ LL |     let _val = unsafe { std::ptr::addr_of!(FOO) };
    |                                            ^^^ `extern` static `FOO` from crate `extern_static` is not supported by Miri
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/extern_static.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/extern_static_in_const.stderr
+++ b/tests/fail/extern_static_in_const.stderr
@@ -5,7 +5,7 @@ LL |     let _val = X;
    |                ^ `extern` static `E` from crate `extern_static_in_const` is not supported by Miri
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/extern_static_in_const.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/fast_math_both.stderr
+++ b/tests/fail/fast_math_both.stderr
@@ -6,7 +6,7 @@ LL | ...: f32 = core::intrinsics::fsub_fast(f32::NAN, f32::NAN);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/fast_math_both.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/fast_math_first.stderr
+++ b/tests/fail/fast_math_first.stderr
@@ -6,7 +6,7 @@ LL | ...   let _x: f32 = core::intrinsics::frem_fast(f32::NAN, 3.2);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/fast_math_first.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/fast_math_second.stderr
+++ b/tests/fail/fast_math_second.stderr
@@ -6,7 +6,7 @@ LL | ...f32 = core::intrinsics::fmul_fast(3.4f32, f32::INFINITY);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/fast_math_second.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/fs/close_stdout.stderr
+++ b/tests/fail/fs/close_stdout.stderr
@@ -5,7 +5,7 @@ LL |         libc::close(1);
    |         ^^^^^^^^^^^^^^ stdout cannot be closed
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/close_stdout.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/fs/isolated_file.stderr
+++ b/tests/fail/fs/isolated_file.stderr
@@ -6,7 +6,7 @@ LL |         let fd = cvt_r(|| unsafe { open64(path.as_ptr(), flags, opts.mode a
    |
    = help: pass the flag `-Zmiri-disable-isolation` to disable isolation;
    = help: or pass `-Zmiri-isolation-error=warn` to configure Miri to return an error code from isolated operations (if supported for that operation) and continue with a warning
-           
+   = note: backtrace:
    = note: inside closure at RUSTLIB/std/src/sys/PLATFORM/fs.rs:LL:CC
    = note: inside `std::sys::PLATFORM::cvt_r::<i32, [closure@std::sys::PLATFORM::fs::File::open_c::{closure#0}]>` at RUSTLIB/std/src/sys/PLATFORM/mod.rs:LL:CC
    = note: inside `std::sys::PLATFORM::fs::File::open_c` at RUSTLIB/std/src/sys/PLATFORM/fs.rs:LL:CC

--- a/tests/fail/fs/isolated_stdin.stderr
+++ b/tests/fail/fs/isolated_stdin.stderr
@@ -6,7 +6,7 @@ LL |         libc::read(0, bytes.as_mut_ptr() as *mut libc::c_void, 512);
    |
    = help: pass the flag `-Zmiri-disable-isolation` to disable isolation;
    = help: or pass `-Zmiri-isolation-error=warn` to configure Miri to return an error code from isolated operations (if supported for that operation) and continue with a warning
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/isolated_stdin.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/fs/read_from_stdout.stderr
+++ b/tests/fail/fs/read_from_stdout.stderr
@@ -5,7 +5,7 @@ LL |         libc::read(1, bytes.as_mut_ptr() as *mut libc::c_void, 512);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot read from stdout
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/read_from_stdout.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/fs/unix_open_missing_required_mode.stderr
+++ b/tests/fail/fs/unix_open_missing_required_mode.stderr
@@ -6,7 +6,7 @@ LL | ...safe { libc::open(name_ptr, libc::O_CREAT) };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `test_file_open_missing_needed_mode` at $DIR/unix_open_missing_required_mode.rs:LL:CC
 note: inside `main` at $DIR/unix_open_missing_required_mode.rs:LL:CC
   --> $DIR/unix_open_missing_required_mode.rs:LL:CC

--- a/tests/fail/fs/write_to_stdin.stderr
+++ b/tests/fail/fs/write_to_stdin.stderr
@@ -5,7 +5,7 @@ LL |         libc::write(0, bytes.as_ptr() as *const libc::c_void, 5);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot write to stdin
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/write_to_stdin.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_calls/check_arg_abi.stderr
+++ b/tests/fail/function_calls/check_arg_abi.stderr
@@ -6,7 +6,7 @@ LL |         let _ = malloc(0);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/check_arg_abi.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_calls/check_arg_count_abort.stderr
+++ b/tests/fail/function_calls/check_arg_count_abort.stderr
@@ -6,7 +6,7 @@ LL |         abort(1);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/check_arg_count_abort.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_calls/check_arg_count_too_few_args.stderr
+++ b/tests/fail/function_calls/check_arg_count_too_few_args.stderr
@@ -6,7 +6,7 @@ LL |         let _ = malloc();
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/check_arg_count_too_few_args.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_calls/check_arg_count_too_many_args.stderr
+++ b/tests/fail/function_calls/check_arg_count_too_many_args.stderr
@@ -6,7 +6,7 @@ LL |         let _ = malloc(1, 2);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/check_arg_count_too_many_args.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_calls/check_callback_abi.stderr
+++ b/tests/fail/function_calls/check_callback_abi.stderr
@@ -11,7 +11,7 @@ LL | |         );
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/check_callback_abi.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_calls/exported_symbol_abi_mismatch.cache.stderr
+++ b/tests/fail/function_calls/exported_symbol_abi_mismatch.cache.stderr
@@ -6,7 +6,7 @@ LL |             foo();
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/exported_symbol_abi_mismatch.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_calls/exported_symbol_abi_mismatch.fn_ptr.stderr
+++ b/tests/fail/function_calls/exported_symbol_abi_mismatch.fn_ptr.stderr
@@ -6,7 +6,7 @@ LL |         std::mem::transmute::<unsafe fn(), unsafe extern "C" fn()>(foo)();
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/exported_symbol_abi_mismatch.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_calls/exported_symbol_abi_mismatch.no_cache.stderr
+++ b/tests/fail/function_calls/exported_symbol_abi_mismatch.no_cache.stderr
@@ -6,7 +6,7 @@ LL |             foo();
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/exported_symbol_abi_mismatch.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_calls/exported_symbol_bad_unwind1.stderr
+++ b/tests/fail/function_calls/exported_symbol_bad_unwind1.stderr
@@ -8,7 +8,7 @@ LL |     unsafe { unwind() }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/exported_symbol_bad_unwind1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_calls/exported_symbol_bad_unwind2.extern_block.stderr
+++ b/tests/fail/function_calls/exported_symbol_bad_unwind2.extern_block.stderr
@@ -8,7 +8,7 @@ LL |     unsafe { nounwind() }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/exported_symbol_bad_unwind2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_calls/exported_symbol_clashing.stderr
+++ b/tests/fail/function_calls/exported_symbol_clashing.stderr
@@ -14,6 +14,7 @@ help: then it's defined here again, in crate `exported_symbol_clashing`
    |
 LL | fn bar() {}
    | ^^^^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/exported_symbol_clashing.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_calls/exported_symbol_shim_clashing.stderr
+++ b/tests/fail/function_calls/exported_symbol_shim_clashing.stderr
@@ -12,6 +12,7 @@ LL | |
 LL | |     unreachable!()
 LL | | }
    | |_^
+   = note: backtrace:
    = note: inside `main` at $DIR/exported_symbol_shim_clashing.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_calls/exported_symbol_wrong_arguments.stderr
+++ b/tests/fail/function_calls/exported_symbol_wrong_arguments.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { foo(1) }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/exported_symbol_wrong_arguments.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_calls/exported_symbol_wrong_type.stderr
+++ b/tests/fail/function_calls/exported_symbol_wrong_type.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { FOO() }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/exported_symbol_wrong_type.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_pointers/cast_box_int_to_fn_ptr.stderr
+++ b/tests/fail/function_pointers/cast_box_int_to_fn_ptr.stderr
@@ -6,7 +6,7 @@ LL |     (*g)(42)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/cast_box_int_to_fn_ptr.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_pointers/cast_fn_ptr1.stderr
+++ b/tests/fail/function_pointers/cast_fn_ptr1.stderr
@@ -6,7 +6,7 @@ LL |     g(42)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/cast_fn_ptr1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_pointers/cast_fn_ptr2.stderr
+++ b/tests/fail/function_pointers/cast_fn_ptr2.stderr
@@ -6,7 +6,7 @@ LL |     g(42)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/cast_fn_ptr2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_pointers/cast_fn_ptr3.stderr
+++ b/tests/fail/function_pointers/cast_fn_ptr3.stderr
@@ -6,7 +6,7 @@ LL |     g()
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/cast_fn_ptr3.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_pointers/cast_fn_ptr4.stderr
+++ b/tests/fail/function_pointers/cast_fn_ptr4.stderr
@@ -6,7 +6,7 @@ LL |     g(&42 as *const i32)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/cast_fn_ptr4.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_pointers/cast_fn_ptr5.stderr
+++ b/tests/fail/function_pointers/cast_fn_ptr5.stderr
@@ -6,7 +6,7 @@ LL |     g()
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/cast_fn_ptr5.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_pointers/cast_int_to_fn_ptr.stderr
+++ b/tests/fail/function_pointers/cast_int_to_fn_ptr.stderr
@@ -6,7 +6,7 @@ LL |     g(42)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/cast_int_to_fn_ptr.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_pointers/deref_fn_ptr.stderr
+++ b/tests/fail/function_pointers/deref_fn_ptr.stderr
@@ -6,7 +6,7 @@ LL |         *std::mem::transmute::<fn(), *const u8>(f)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/deref_fn_ptr.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_pointers/execute_memory.stderr
+++ b/tests/fail/function_pointers/execute_memory.stderr
@@ -6,7 +6,7 @@ LL |         f()
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/execute_memory.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_pointers/fn_ptr_offset.stderr
+++ b/tests/fail/function_pointers/fn_ptr_offset.stderr
@@ -6,7 +6,7 @@ LL |     x();
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/fn_ptr_offset.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/generator-pinned-moved.stderr
+++ b/tests/fail/generator-pinned-moved.stderr
@@ -6,7 +6,7 @@ LL |         *num += 1;
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/generator-pinned-moved.rs:LL:CC
 note: inside `<GeneratorIteratorAdapter<[static generator@$DIR/generator-pinned-moved.rs:LL:CC]> as std::iter::Iterator>::next` at $DIR/generator-pinned-moved.rs:LL:CC
   --> $DIR/generator-pinned-moved.rs:LL:CC

--- a/tests/fail/intrinsics/assume.stderr
+++ b/tests/fail/intrinsics/assume.stderr
@@ -6,7 +6,7 @@ LL |         std::intrinsics::assume(x > 42);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/assume.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/copy_null.stderr
+++ b/tests/fail/intrinsics/copy_null.stderr
@@ -6,7 +6,7 @@ LL |         copy_nonoverlapping(std::ptr::null(), ptr, 0);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/copy_null.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/copy_overflow.stderr
+++ b/tests/fail/intrinsics/copy_overflow.stderr
@@ -6,7 +6,7 @@ LL |         copy(src, dst, count)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `std::intrinsics::copy::<i32>` at RUSTLIB/core/src/intrinsics.rs:LL:CC
    = note: inside `std::ptr::mut_ptr::<impl *mut i32>::copy_from` at RUSTLIB/core/src/ptr/mut_ptr.rs:LL:CC
 note: inside `main` at $DIR/copy_overflow.rs:LL:CC

--- a/tests/fail/intrinsics/copy_overlapping.stderr
+++ b/tests/fail/intrinsics/copy_overlapping.stderr
@@ -6,7 +6,7 @@ LL |         copy_nonoverlapping(a, b, 2);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/copy_overlapping.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/copy_unaligned.stderr
+++ b/tests/fail/intrinsics/copy_unaligned.stderr
@@ -6,7 +6,7 @@ LL |         copy_nonoverlapping(&data[5], ptr, 0);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/copy_unaligned.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/ctlz_nonzero.stderr
+++ b/tests/fail/intrinsics/ctlz_nonzero.stderr
@@ -6,7 +6,7 @@ LL |         ctlz_nonzero(0u8);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/ctlz_nonzero.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/cttz_nonzero.stderr
+++ b/tests/fail/intrinsics/cttz_nonzero.stderr
@@ -6,7 +6,7 @@ LL |         cttz_nonzero(0u8);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/cttz_nonzero.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/div-by-zero.stderr
+++ b/tests/fail/intrinsics/div-by-zero.stderr
@@ -6,7 +6,7 @@ LL |         let _n = unchecked_div(1i64, 0);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/div-by-zero.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/exact_div1.stderr
+++ b/tests/fail/intrinsics/exact_div1.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { std::intrinsics::exact_div(2, 0) };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/exact_div1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/exact_div2.stderr
+++ b/tests/fail/intrinsics/exact_div2.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { std::intrinsics::exact_div(2u16, 3) };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/exact_div2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/exact_div3.stderr
+++ b/tests/fail/intrinsics/exact_div3.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { std::intrinsics::exact_div(-19i8, 2) };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/exact_div3.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/exact_div4.stderr
+++ b/tests/fail/intrinsics/exact_div4.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { std::intrinsics::exact_div(i64::MIN, -1) };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/exact_div4.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/float_to_int_32_inf1.stderr
+++ b/tests/fail/intrinsics/float_to_int_32_inf1.stderr
@@ -6,7 +6,7 @@ LL |         float_to_int_unchecked::<f32, i32>(f32::INFINITY);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/float_to_int_32_inf1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/float_to_int_32_infneg1.stderr
+++ b/tests/fail/intrinsics/float_to_int_32_infneg1.stderr
@@ -6,7 +6,7 @@ LL |         float_to_int_unchecked::<f32, i32>(f32::NEG_INFINITY);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/float_to_int_32_infneg1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/float_to_int_32_nan.stderr
+++ b/tests/fail/intrinsics/float_to_int_32_nan.stderr
@@ -6,7 +6,7 @@ LL |         float_to_int_unchecked::<f32, u32>(f32::NAN);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/float_to_int_32_nan.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/float_to_int_32_nanneg.stderr
+++ b/tests/fail/intrinsics/float_to_int_32_nanneg.stderr
@@ -6,7 +6,7 @@ LL |         float_to_int_unchecked::<f32, u32>(-f32::NAN);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/float_to_int_32_nanneg.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/float_to_int_32_neg.stderr
+++ b/tests/fail/intrinsics/float_to_int_32_neg.stderr
@@ -6,7 +6,7 @@ LL |         float_to_int_unchecked::<f32, u32>(-1.000000001f32);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/float_to_int_32_neg.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/float_to_int_32_too_big1.stderr
+++ b/tests/fail/intrinsics/float_to_int_32_too_big1.stderr
@@ -6,7 +6,7 @@ LL |         float_to_int_unchecked::<f32, i32>(2147483648.0f32);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/float_to_int_32_too_big1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/float_to_int_32_too_big2.stderr
+++ b/tests/fail/intrinsics/float_to_int_32_too_big2.stderr
@@ -6,7 +6,7 @@ LL |         float_to_int_unchecked::<f32, u32>((u32::MAX - 127) as f32);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/float_to_int_32_too_big2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/float_to_int_32_too_small1.stderr
+++ b/tests/fail/intrinsics/float_to_int_32_too_small1.stderr
@@ -6,7 +6,7 @@ LL |         float_to_int_unchecked::<f32, i32>(-2147483904.0f32);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/float_to_int_32_too_small1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/float_to_int_64_inf1.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_inf1.stderr
@@ -6,7 +6,7 @@ LL |         float_to_int_unchecked::<f64, u128>(f64::INFINITY);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/float_to_int_64_inf1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/float_to_int_64_infneg1.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_infneg1.stderr
@@ -6,7 +6,7 @@ LL |         float_to_int_unchecked::<f64, u128>(f64::NEG_INFINITY);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/float_to_int_64_infneg1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/float_to_int_64_infneg2.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_infneg2.stderr
@@ -6,7 +6,7 @@ LL |         float_to_int_unchecked::<f64, i128>(f64::NEG_INFINITY);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/float_to_int_64_infneg2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/float_to_int_64_nan.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_nan.stderr
@@ -6,7 +6,7 @@ LL |         float_to_int_unchecked::<f64, u32>(f64::NAN);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/float_to_int_64_nan.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/float_to_int_64_neg.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_neg.stderr
@@ -6,7 +6,7 @@ LL |         float_to_int_unchecked::<f64, u128>(-1.0000000000001f64);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/float_to_int_64_neg.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/float_to_int_64_too_big1.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_big1.stderr
@@ -6,7 +6,7 @@ LL |         float_to_int_unchecked::<f64, i32>(2147483648.0f64);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/float_to_int_64_too_big1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/float_to_int_64_too_big2.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_big2.stderr
@@ -6,7 +6,7 @@ LL |         float_to_int_unchecked::<f64, i64>(9223372036854775808.0f64);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/float_to_int_64_too_big2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/float_to_int_64_too_big3.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_big3.stderr
@@ -6,7 +6,7 @@ LL |         float_to_int_unchecked::<f64, u64>(18446744073709551616.0f64);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/float_to_int_64_too_big3.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/float_to_int_64_too_big4.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_big4.stderr
@@ -6,7 +6,7 @@ LL |         float_to_int_unchecked::<f64, u128>(u128::MAX as f64);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/float_to_int_64_too_big4.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/float_to_int_64_too_big5.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_big5.stderr
@@ -6,7 +6,7 @@ LL |         float_to_int_unchecked::<f64, i128>(2402823669209384634633746074317
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/float_to_int_64_too_big5.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/float_to_int_64_too_big6.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_big6.stderr
@@ -6,7 +6,7 @@ LL |         float_to_int_unchecked::<f64, u128>(f64::MAX);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/float_to_int_64_too_big6.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/float_to_int_64_too_big7.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_big7.stderr
@@ -6,7 +6,7 @@ LL |         float_to_int_unchecked::<f64, i128>(f64::MIN);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/float_to_int_64_too_big7.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/float_to_int_64_too_small1.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_small1.stderr
@@ -6,7 +6,7 @@ LL |         float_to_int_unchecked::<f64, i32>(-2147483649.0f64);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/float_to_int_64_too_small1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/float_to_int_64_too_small2.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_small2.stderr
@@ -6,7 +6,7 @@ LL |         float_to_int_unchecked::<f64, i64>(-9223372036854777856.0f64);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/float_to_int_64_too_small2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/float_to_int_64_too_small3.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_small3.stderr
@@ -6,7 +6,7 @@ LL |         float_to_int_unchecked::<f64, i128>(-240282366920938463463374607431
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/float_to_int_64_too_small3.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/out_of_bounds_ptr_1.stderr
+++ b/tests/fail/intrinsics/out_of_bounds_ptr_1.stderr
@@ -6,7 +6,7 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `std::ptr::const_ptr::<impl *const i8>::offset` at RUSTLIB/core/src/ptr/const_ptr.rs:LL:CC
 note: inside `main` at $DIR/out_of_bounds_ptr_1.rs:LL:CC
   --> $DIR/out_of_bounds_ptr_1.rs:LL:CC

--- a/tests/fail/intrinsics/out_of_bounds_ptr_2.stderr
+++ b/tests/fail/intrinsics/out_of_bounds_ptr_2.stderr
@@ -6,7 +6,7 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `std::ptr::const_ptr::<impl *const i8>::offset` at RUSTLIB/core/src/ptr/const_ptr.rs:LL:CC
 note: inside `main` at $DIR/out_of_bounds_ptr_2.rs:LL:CC
   --> $DIR/out_of_bounds_ptr_2.rs:LL:CC

--- a/tests/fail/intrinsics/out_of_bounds_ptr_3.stderr
+++ b/tests/fail/intrinsics/out_of_bounds_ptr_3.stderr
@@ -6,7 +6,7 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `std::ptr::const_ptr::<impl *const i8>::offset` at RUSTLIB/core/src/ptr/const_ptr.rs:LL:CC
 note: inside `main` at $DIR/out_of_bounds_ptr_3.rs:LL:CC
   --> $DIR/out_of_bounds_ptr_3.rs:LL:CC

--- a/tests/fail/intrinsics/overflowing-unchecked-rsh.stderr
+++ b/tests/fail/intrinsics/overflowing-unchecked-rsh.stderr
@@ -6,7 +6,7 @@ LL |         let _n = unchecked_shr(1i64, 64);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/overflowing-unchecked-rsh.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/ptr_offset_0_plus_0.stderr
+++ b/tests/fail/intrinsics/ptr_offset_0_plus_0.stderr
@@ -6,7 +6,7 @@ LL |         unsafe { intrinsics::offset(self, count) as *mut T }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `std::ptr::mut_ptr::<impl *mut i32>::offset` at RUSTLIB/core/src/ptr/mut_ptr.rs:LL:CC
 note: inside `main` at $DIR/ptr_offset_0_plus_0.rs:LL:CC
   --> $DIR/ptr_offset_0_plus_0.rs:LL:CC

--- a/tests/fail/intrinsics/ptr_offset_from_oob.stderr
+++ b/tests/fail/intrinsics/ptr_offset_from_oob.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { ptr_offset_from(end_ptr, end_ptr) };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/ptr_offset_from_oob.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/ptr_offset_int_plus_int.stderr
+++ b/tests/fail/intrinsics/ptr_offset_int_plus_int.stderr
@@ -6,7 +6,7 @@ LL |         unsafe { intrinsics::offset(self, count) as *mut T }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `std::ptr::mut_ptr::<impl *mut u8>::offset` at RUSTLIB/core/src/ptr/mut_ptr.rs:LL:CC
 note: inside `main` at $DIR/ptr_offset_int_plus_int.rs:LL:CC
   --> $DIR/ptr_offset_int_plus_int.rs:LL:CC

--- a/tests/fail/intrinsics/ptr_offset_int_plus_ptr.stderr
+++ b/tests/fail/intrinsics/ptr_offset_int_plus_ptr.stderr
@@ -6,7 +6,7 @@ LL |         unsafe { intrinsics::offset(self, count) as *mut T }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `std::ptr::mut_ptr::<impl *mut u8>::offset` at RUSTLIB/core/src/ptr/mut_ptr.rs:LL:CC
 note: inside `main` at $DIR/ptr_offset_int_plus_ptr.rs:LL:CC
   --> $DIR/ptr_offset_int_plus_ptr.rs:LL:CC

--- a/tests/fail/intrinsics/ptr_offset_overflow.stderr
+++ b/tests/fail/intrinsics/ptr_offset_overflow.stderr
@@ -6,7 +6,7 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `std::ptr::const_ptr::<impl *const i8>::offset` at RUSTLIB/core/src/ptr/const_ptr.rs:LL:CC
 note: inside `main` at $DIR/ptr_offset_overflow.rs:LL:CC
   --> $DIR/ptr_offset_overflow.rs:LL:CC

--- a/tests/fail/intrinsics/ptr_offset_ptr_plus_0.stderr
+++ b/tests/fail/intrinsics/ptr_offset_ptr_plus_0.stderr
@@ -6,7 +6,7 @@ LL |         unsafe { intrinsics::offset(self, count) as *mut T }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `std::ptr::mut_ptr::<impl *mut u32>::offset` at RUSTLIB/core/src/ptr/mut_ptr.rs:LL:CC
 note: inside `main` at $DIR/ptr_offset_ptr_plus_0.rs:LL:CC
   --> $DIR/ptr_offset_ptr_plus_0.rs:LL:CC

--- a/tests/fail/intrinsics/rem-by-zero.stderr
+++ b/tests/fail/intrinsics/rem-by-zero.stderr
@@ -6,7 +6,7 @@ LL |         let _n = unchecked_rem(3u32, 0);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/rem-by-zero.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/simd-div-by-zero.stderr
+++ b/tests/fail/intrinsics/simd-div-by-zero.stderr
@@ -6,7 +6,7 @@ LL |         simd_div(x, y);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/simd-div-by-zero.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/simd-div-overflow.stderr
+++ b/tests/fail/intrinsics/simd-div-overflow.stderr
@@ -6,7 +6,7 @@ LL |         simd_div(x, y);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/simd-div-overflow.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/simd-float-to-int.stderr
+++ b/tests/fail/intrinsics/simd-float-to-int.stderr
@@ -6,7 +6,7 @@ LL | implement! { f32 }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `core::core_simd::round::<impl std::simd::Simd<f32, 2_usize>>::to_int_unchecked::<i32>` at RUSTLIB/core/src/../../portable-simd/crates/core_simd/src/round.rs:LL:CC
 note: inside `main` at $DIR/simd-float-to-int.rs:LL:CC
   --> $DIR/simd-float-to-int.rs:LL:CC

--- a/tests/fail/intrinsics/simd-gather.stderr
+++ b/tests/fail/intrinsics/simd-gather.stderr
@@ -6,7 +6,7 @@ LL |         unsafe { intrinsics::simd_gather(or, ptrs, enable.to_int()) }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `std::simd::Simd::<i8, 4_usize>::gather_select_unchecked` at RUSTLIB/core/src/../../portable-simd/crates/core_simd/src/vector.rs:LL:CC
 note: inside `main` at $DIR/simd-gather.rs:LL:CC
   --> $DIR/simd-gather.rs:LL:CC

--- a/tests/fail/intrinsics/simd-reduce-invalid-bool.stderr
+++ b/tests/fail/intrinsics/simd-reduce-invalid-bool.stderr
@@ -6,7 +6,7 @@ LL |         simd_reduce_any(x);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/simd-reduce-invalid-bool.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/simd-rem-by-zero.stderr
+++ b/tests/fail/intrinsics/simd-rem-by-zero.stderr
@@ -6,7 +6,7 @@ LL |         simd_rem(x, y);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/simd-rem-by-zero.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/simd-scatter.stderr
+++ b/tests/fail/intrinsics/simd-scatter.stderr
@@ -6,7 +6,7 @@ LL |             intrinsics::simd_scatter(self, ptrs, enable.to_int())
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `std::simd::Simd::<i8, 4_usize>::scatter_select_unchecked` at RUSTLIB/core/src/../../portable-simd/crates/core_simd/src/vector.rs:LL:CC
 note: inside `main` at $DIR/simd-scatter.rs:LL:CC
   --> $DIR/simd-scatter.rs:LL:CC

--- a/tests/fail/intrinsics/simd-select-bitmask-invalid.stderr
+++ b/tests/fail/intrinsics/simd-select-bitmask-invalid.stderr
@@ -6,7 +6,7 @@ LL |         simd_select_bitmask(0b11111111u8, x, x);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/simd-select-bitmask-invalid.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/simd-select-invalid-bool.stderr
+++ b/tests/fail/intrinsics/simd-select-invalid-bool.stderr
@@ -6,7 +6,7 @@ LL |         simd_select(x, x, x);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/simd-select-invalid-bool.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/simd-shl-too-far.stderr
+++ b/tests/fail/intrinsics/simd-shl-too-far.stderr
@@ -6,7 +6,7 @@ LL |         simd_shl(x, y);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/simd-shl-too-far.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/simd-shr-too-far.stderr
+++ b/tests/fail/intrinsics/simd-shr-too-far.stderr
@@ -6,7 +6,7 @@ LL |         simd_shr(x, y);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/simd-shr-too-far.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/unchecked_add1.stderr
+++ b/tests/fail/intrinsics/unchecked_add1.stderr
@@ -6,7 +6,7 @@ LL |         std::intrinsics::unchecked_add(40000u16, 30000);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/unchecked_add1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/unchecked_add2.stderr
+++ b/tests/fail/intrinsics/unchecked_add2.stderr
@@ -6,7 +6,7 @@ LL |         std::intrinsics::unchecked_add(-30000i16, -8000);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/unchecked_add2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/unchecked_div1.stderr
+++ b/tests/fail/intrinsics/unchecked_div1.stderr
@@ -6,7 +6,7 @@ LL |         std::intrinsics::unchecked_div(i16::MIN, -1);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/unchecked_div1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/unchecked_mul1.stderr
+++ b/tests/fail/intrinsics/unchecked_mul1.stderr
@@ -6,7 +6,7 @@ LL |         std::intrinsics::unchecked_mul(300u16, 250u16);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/unchecked_mul1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/unchecked_mul2.stderr
+++ b/tests/fail/intrinsics/unchecked_mul2.stderr
@@ -6,7 +6,7 @@ LL |         std::intrinsics::unchecked_mul(1_000_000_000i32, -4);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/unchecked_mul2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/unchecked_sub1.stderr
+++ b/tests/fail/intrinsics/unchecked_sub1.stderr
@@ -6,7 +6,7 @@ LL |         std::intrinsics::unchecked_sub(14u32, 22);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/unchecked_sub1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/unchecked_sub2.stderr
+++ b/tests/fail/intrinsics/unchecked_sub2.stderr
@@ -6,7 +6,7 @@ LL |         std::intrinsics::unchecked_sub(30000i16, -7000);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/unchecked_sub2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/write_bytes_null.stderr
+++ b/tests/fail/intrinsics/write_bytes_null.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { write_bytes::<u8>(std::ptr::null_mut(), 0, 0) };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/write_bytes_null.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/write_bytes_overflow.stderr
+++ b/tests/fail/intrinsics/write_bytes_overflow.stderr
@@ -6,7 +6,7 @@ LL |         write_bytes(dst, val, count)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `std::intrinsics::write_bytes::<i32>` at RUSTLIB/core/src/intrinsics.rs:LL:CC
    = note: inside `std::ptr::mut_ptr::<impl *mut i32>::write_bytes` at RUSTLIB/core/src/ptr/mut_ptr.rs:LL:CC
 note: inside `main` at $DIR/write_bytes_overflow.rs:LL:CC

--- a/tests/fail/invalid_bool.stderr
+++ b/tests/fail/invalid_bool.stderr
@@ -6,7 +6,7 @@ LL |     let _x = b == std::hint::black_box(true);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/invalid_bool.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/invalid_char.stderr
+++ b/tests/fail/invalid_char.stderr
@@ -6,7 +6,7 @@ LL |     let _x = c == 'x';
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/invalid_char.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/invalid_enum_tag.stderr
+++ b/tests/fail/invalid_enum_tag.stderr
@@ -6,7 +6,7 @@ LL |     Discriminant(intrinsics::discriminant_value(v))
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `std::mem::discriminant::<Foo>` at RUSTLIB/core/src/mem/mod.rs:LL:CC
 note: inside `main` at $DIR/invalid_enum_tag.rs:LL:CC
   --> $DIR/invalid_enum_tag.rs:LL:CC

--- a/tests/fail/invalid_int.stderr
+++ b/tests/fail/invalid_int.stderr
@@ -6,7 +6,7 @@ LL |     let _x = i + 0;
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/invalid_int.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/issue-miri-1112.stderr
+++ b/tests/fail/issue-miri-1112.stderr
@@ -6,7 +6,7 @@ LL |         let obj = std::mem::transmute::<FatPointer, *mut FunnyPointer>(obj)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `FunnyPointer::from_data_ptr` at $DIR/issue-miri-1112.rs:LL:CC
 note: inside `main` at $DIR/issue-miri-1112.rs:LL:CC
   --> $DIR/issue-miri-1112.rs:LL:CC

--- a/tests/fail/modifying_constants.stderr
+++ b/tests/fail/modifying_constants.stderr
@@ -6,7 +6,7 @@ LL |     *y = 42;
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/modifying_constants.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/never_say_never.stderr
+++ b/tests/fail/never_say_never.stderr
@@ -6,7 +6,7 @@ LL |         *(y as *const _ as *const !)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/never_say_never.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/never_transmute_humans.stderr
+++ b/tests/fail/never_transmute_humans.stderr
@@ -6,7 +6,7 @@ LL |         std::mem::transmute::<Human, !>(Human)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/never_transmute_humans.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/never_transmute_void.stderr
+++ b/tests/fail/never_transmute_void.stderr
@@ -6,7 +6,7 @@ LL |         match v.0 {}
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `m::f` at $DIR/never_transmute_void.rs:LL:CC
 note: inside `main` at $DIR/never_transmute_void.rs:LL:CC
   --> $DIR/never_transmute_void.rs:LL:CC

--- a/tests/fail/panic/bad_miri_start_panic.stderr
+++ b/tests/fail/panic/bad_miri_start_panic.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { miri_start_panic(&mut 0) }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/bad_miri_start_panic.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/panic/bad_unwind.stderr
+++ b/tests/fail/panic/bad_unwind.stderr
@@ -8,7 +8,7 @@ LL |     std::panic::catch_unwind(|| unwind()).unwrap_err();
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/bad_unwind.rs:LL:CC
    = note: inside `std::panicking::r#try::do_call::<[closure@$DIR/bad_unwind.rs:LL:CC], ()>` at RUSTLIB/std/src/panicking.rs:LL:CC
    = note: inside `std::panicking::r#try::<(), [closure@$DIR/bad_unwind.rs:LL:CC]>` at RUSTLIB/std/src/panicking.rs:LL:CC

--- a/tests/fail/panic/unwind_panic_abort.stderr
+++ b/tests/fail/panic/unwind_panic_abort.stderr
@@ -6,7 +6,7 @@ LL |         miri_start_panic(&mut 0);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/unwind_panic_abort.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/pointer_partial_overwrite.stderr
+++ b/tests/fail/pointer_partial_overwrite.stderr
@@ -6,7 +6,7 @@ LL |     let x = *p;
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/pointer_partial_overwrite.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/provenance/provenance_transmute.stderr
+++ b/tests/fail/provenance/provenance_transmute.stderr
@@ -6,7 +6,7 @@ LL |         let _val = *left_ptr;
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `deref` at $DIR/provenance_transmute.rs:LL:CC
 note: inside `main` at $DIR/provenance_transmute.rs:LL:CC
   --> $DIR/provenance_transmute.rs:LL:CC

--- a/tests/fail/provenance/ptr_int_unexposed.stderr
+++ b/tests/fail/provenance/ptr_int_unexposed.stderr
@@ -6,7 +6,7 @@ LL |     assert_eq!(unsafe { *ptr }, 3);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/ptr_int_unexposed.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/provenance/ptr_invalid.stderr
+++ b/tests/fail/provenance/ptr_invalid.stderr
@@ -6,7 +6,7 @@ LL |     let _val = unsafe { *xptr_invalid };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/ptr_invalid.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/provenance/ptr_invalid_offset.stderr
+++ b/tests/fail/provenance/ptr_invalid_offset.stderr
@@ -6,7 +6,7 @@ LL |         unsafe { intrinsics::offset(self, count) }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `std::ptr::const_ptr::<impl *const u8>::offset` at RUSTLIB/core/src/ptr/const_ptr.rs:LL:CC
 note: inside `main` at $DIR/ptr_invalid_offset.rs:LL:CC
   --> $DIR/ptr_invalid_offset.rs:LL:CC

--- a/tests/fail/provenance/strict_provenance_cast.stderr
+++ b/tests/fail/provenance/strict_provenance_cast.stderr
@@ -5,7 +5,7 @@ LL |     let _ptr = addr as *const i32;
    |                ^^^^^^^^^^^^^^^^^^ integer-to-pointer casts and `ptr::from_exposed_addr` are not supported with `-Zmiri-strict-provenance`
    |
    = help: use Strict Provenance APIs (https://doc.rust-lang.org/nightly/std/ptr/index.html#strict-provenance, https://crates.io/crates/sptr) instead
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/strict_provenance_cast.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/rc_as_ptr.stderr
+++ b/tests/fail/rc_as_ptr.stderr
@@ -6,7 +6,7 @@ LL |     assert_eq!(42, **unsafe { &*Weak::as_ptr(&weak) });
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at RUSTLIB/core/src/macros/mod.rs:LL:CC
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/fail/reading_half_a_pointer.stderr
+++ b/tests/fail/reading_half_a_pointer.stderr
@@ -5,7 +5,7 @@ LL |         let _x = *d_alias;
    |                  ^^^^^^^^ unable to turn pointer into raw bytes
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/reading_half_a_pointer.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/shim_arg_size.32bit.stderr
+++ b/tests/fail/shim_arg_size.32bit.stderr
@@ -6,7 +6,7 @@ LL |         let _p1 = malloc(42);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/shim_arg_size.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/shim_arg_size.64bit.stderr
+++ b/tests/fail/shim_arg_size.64bit.stderr
@@ -6,7 +6,7 @@ LL |         let _p1 = malloc(42);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/shim_arg_size.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/should-pass/cpp20_rwc_syncs.stderr
+++ b/tests/fail/should-pass/cpp20_rwc_syncs.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { intrinsics::unreachable() }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `std::hint::unreachable_unchecked` at RUSTLIB/core/src/hint.rs:LL:CC
 note: inside `test_cpp20_rwc_syncs` at $DIR/cpp20_rwc_syncs.rs:LL:CC
   --> $DIR/cpp20_rwc_syncs.rs:LL:CC

--- a/tests/fail/stacked_borrows/alias_through_mutation.stderr
+++ b/tests/fail/stacked_borrows/alias_through_mutation.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4]
    |
 LL |     *target = 13;
    |     ^^^^^^^^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/alias_through_mutation.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/aliasing_mut1.stderr
+++ b/tests/fail/stacked_borrows/aliasing_mut1.stderr
@@ -21,6 +21,7 @@ help: this protector is live for this call
    |
 LL | pub fn safe(_x: &mut i32, _y: &mut i32) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: backtrace:
    = note: inside `safe` at $DIR/aliasing_mut1.rs:LL:CC
 note: inside `main` at $DIR/aliasing_mut1.rs:LL:CC
   --> $DIR/aliasing_mut1.rs:LL:CC

--- a/tests/fail/stacked_borrows/aliasing_mut2.stderr
+++ b/tests/fail/stacked_borrows/aliasing_mut2.stderr
@@ -21,6 +21,7 @@ help: this protector is live for this call
    |
 LL | pub fn safe(_x: &i32, _y: &mut i32) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: backtrace:
    = note: inside `safe` at $DIR/aliasing_mut2.rs:LL:CC
 note: inside `main` at $DIR/aliasing_mut2.rs:LL:CC
   --> $DIR/aliasing_mut2.rs:LL:CC

--- a/tests/fail/stacked_borrows/aliasing_mut3.stderr
+++ b/tests/fail/stacked_borrows/aliasing_mut3.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4]
    |
 LL | pub fn safe(_x: &mut i32, _y: &i32) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: backtrace:
    = note: inside `safe` at $DIR/aliasing_mut3.rs:LL:CC
 note: inside `main` at $DIR/aliasing_mut3.rs:LL:CC
   --> $DIR/aliasing_mut3.rs:LL:CC

--- a/tests/fail/stacked_borrows/aliasing_mut4.stderr
+++ b/tests/fail/stacked_borrows/aliasing_mut4.stderr
@@ -21,6 +21,7 @@ help: this protector is live for this call
    |
 LL | pub fn safe(_x: &i32, _y: &mut Cell<i32>) {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: backtrace:
    = note: inside `safe` at $DIR/aliasing_mut4.rs:LL:CC
 note: inside `main` at $DIR/aliasing_mut4.rs:LL:CC
   --> $DIR/aliasing_mut4.rs:LL:CC

--- a/tests/fail/stacked_borrows/box_exclusive_violation1.stderr
+++ b/tests/fail/stacked_borrows/box_exclusive_violation1.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4]
    |
 LL |     *our = 5;
    |     ^^^^^^^^
+   = note: backtrace:
    = note: inside `unknown_code_2` at $DIR/box_exclusive_violation1.rs:LL:CC
 note: inside `demo_mut_advanced_unique` at $DIR/box_exclusive_violation1.rs:LL:CC
   --> $DIR/box_exclusive_violation1.rs:LL:CC

--- a/tests/fail/stacked_borrows/buggy_as_mut_slice.stderr
+++ b/tests/fail/stacked_borrows/buggy_as_mut_slice.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0xc]
    |
 LL |         unsafe { from_raw_parts_mut(self_.as_ptr() as *mut T, self_.len()) }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/buggy_as_mut_slice.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/buggy_split_at_mut.stderr
+++ b/tests/fail/stacked_borrows/buggy_split_at_mut.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x10]
    |
 LL |                 from_raw_parts_mut(ptr.offset(mid as isize), len - mid),
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/buggy_split_at_mut.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/deallocate_against_barrier1.stderr
+++ b/tests/fail/stacked_borrows/deallocate_against_barrier1.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
-           
+   = note: backtrace:
    = note: inside `std::alloc::dealloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
    = note: inside `<std::alloc::Global as std::alloc::Allocator>::deallocate` at RUSTLIB/alloc/src/alloc.rs:LL:CC
    = note: inside `alloc::alloc::box_free::<i32, std::alloc::Global>` at RUSTLIB/alloc/src/alloc.rs:LL:CC

--- a/tests/fail/stacked_borrows/deallocate_against_barrier2.stderr
+++ b/tests/fail/stacked_borrows/deallocate_against_barrier2.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
-           
+   = note: backtrace:
    = note: inside `std::alloc::dealloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
    = note: inside `<std::alloc::Global as std::alloc::Allocator>::deallocate` at RUSTLIB/alloc/src/alloc.rs:LL:CC
    = note: inside `alloc::alloc::box_free::<NotUnpin, std::alloc::Global>` at RUSTLIB/alloc/src/alloc.rs:LL:CC

--- a/tests/fail/stacked_borrows/exposed_only_ro.stderr
+++ b/tests/fail/stacked_borrows/exposed_only_ro.stderr
@@ -9,7 +9,7 @@ LL |     unsafe { *ptr = 0 };
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/exposed_only_ro.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_read1.stderr
+++ b/tests/fail/stacked_borrows/illegal_read1.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4]
    |
 LL |     let _val = unsafe { *xraw };
    |                         ^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/illegal_read1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_read2.stderr
+++ b/tests/fail/stacked_borrows/illegal_read2.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4]
    |
 LL |     let shr = unsafe { &*xraw };
    |                        ^^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/illegal_read2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_read3.stderr
+++ b/tests/fail/stacked_borrows/illegal_read3.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4]
    |
 LL |     let _val = unsafe { *xref1.r };
    |                         ^^^^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/illegal_read3.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_read4.stderr
+++ b/tests/fail/stacked_borrows/illegal_read4.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4]
    |
 LL |     let _val = unsafe { *xraw }; // use the raw again, this invalidates xref2 *even* with the special read except for uniq refs
    |                         ^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/illegal_read4.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_read5.stderr
+++ b/tests/fail/stacked_borrows/illegal_read5.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [$HEX..$HEX]
    |
 LL |     mem::forget(unsafe { ptr::read(xshr) }); // but after reading through the shared ref
    |                          ^^^^^^^^^^^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/illegal_read5.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_read6.stderr
+++ b/tests/fail/stacked_borrows/illegal_read6.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4]
    |
 LL |         let x = &mut *x; // kill `raw`
    |                 ^^^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/illegal_read6.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_read7.stderr
+++ b/tests/fail/stacked_borrows/illegal_read7.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4]
    |
 LL |         let _val = ptr::read(raw);
    |                    ^^^^^^^^^^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/illegal_read7.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_read8.stderr
+++ b/tests/fail/stacked_borrows/illegal_read8.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4]
    |
 LL |         *y2 += 1;
    |         ^^^^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/illegal_read8.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_read_despite_exposed1.stderr
+++ b/tests/fail/stacked_borrows/illegal_read_despite_exposed1.stderr
@@ -9,7 +9,7 @@ LL |         let _val = *root2;
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/illegal_read_despite_exposed1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_read_despite_exposed2.stderr
+++ b/tests/fail/stacked_borrows/illegal_read_despite_exposed2.stderr
@@ -9,7 +9,7 @@ LL |         let _val = *root2;
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/illegal_read_despite_exposed2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_write1.stderr
+++ b/tests/fail/stacked_borrows/illegal_write1.stderr
@@ -14,6 +14,7 @@ help: <TAG> was created by a retag at offsets [0x0..0x4]
    |
 LL |         let x: *mut u32 = xref as *const _ as *mut _;
    |                           ^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/illegal_write1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_write2.stderr
+++ b/tests/fail/stacked_borrows/illegal_write2.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4]
    |
 LL |     drop(&mut *target); // reborrow
    |          ^^^^^^^^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/illegal_write2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_write3.stderr
+++ b/tests/fail/stacked_borrows/illegal_write3.stderr
@@ -14,6 +14,7 @@ help: <TAG> was created by a retag at offsets [0x0..0x4]
    |
 LL |     let ptr = r#ref as *const _ as *mut _; // raw ptr, with raw tag
    |               ^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/illegal_write3.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_write4.stderr
+++ b/tests/fail/stacked_borrows/illegal_write4.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4]
    |
 LL |     let _mut_ref: &mut i32 = unsafe { mem::transmute(raw) }; // &mut, with raw tag
    |                                       ^^^^^^^^^^^^^^^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/illegal_write4.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_write5.stderr
+++ b/tests/fail/stacked_borrows/illegal_write5.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4]
    |
 LL |     unsafe { *xraw = 15 };
    |              ^^^^^^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/illegal_write5.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_write6.stderr
+++ b/tests/fail/stacked_borrows/illegal_write6.stderr
@@ -26,6 +26,7 @@ LL | |     unsafe { *y = 2 };
 LL | |     return *a;
 LL | | }
    | |_^
+   = note: backtrace:
    = note: inside `foo` at $DIR/illegal_write6.rs:LL:CC
 note: inside `main` at $DIR/illegal_write6.rs:LL:CC
   --> $DIR/illegal_write6.rs:LL:CC

--- a/tests/fail/stacked_borrows/illegal_write_despite_exposed1.stderr
+++ b/tests/fail/stacked_borrows/illegal_write_despite_exposed1.stderr
@@ -9,7 +9,7 @@ LL |         let _val = *root2;
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/illegal_write_despite_exposed1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/interior_mut1.stderr
+++ b/tests/fail/stacked_borrows/interior_mut1.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4]
    |
 LL |         *c.get() = UnsafeCell::new(1); // invalidates inner_shr
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/interior_mut1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/interior_mut2.stderr
+++ b/tests/fail/stacked_borrows/interior_mut2.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4]
    |
 LL |         *c.get() = UnsafeCell::new(0); // now inner_shr gets invalidated
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/interior_mut2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/invalidate_against_barrier1.stderr
+++ b/tests/fail/stacked_borrows/invalidate_against_barrier1.stderr
@@ -26,6 +26,7 @@ LL | |     // unique for the duration of this call.
 LL | |     let _val = unsafe { *x };
 LL | | }
    | |_^
+   = note: backtrace:
    = note: inside `inner` at $DIR/invalidate_against_barrier1.rs:LL:CC
 note: inside `main` at $DIR/invalidate_against_barrier1.rs:LL:CC
   --> $DIR/invalidate_against_barrier1.rs:LL:CC

--- a/tests/fail/stacked_borrows/invalidate_against_barrier2.stderr
+++ b/tests/fail/stacked_borrows/invalidate_against_barrier2.stderr
@@ -26,6 +26,7 @@ LL | |     // immutable for the duration of this call.
 LL | |     unsafe { *x = 0 };
 LL | | }
    | |_^
+   = note: backtrace:
    = note: inside `inner` at $DIR/invalidate_against_barrier2.rs:LL:CC
 note: inside `main` at $DIR/invalidate_against_barrier2.rs:LL:CC
   --> $DIR/invalidate_against_barrier2.rs:LL:CC

--- a/tests/fail/stacked_borrows/issue-miri-1050-1.stderr
+++ b/tests/fail/stacked_borrows/issue-miri-1050-1.stderr
@@ -6,7 +6,7 @@ LL |         Box(unsafe { Unique::new_unchecked(raw) }, alloc)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `std::boxed::Box::<u32>::from_raw_in` at RUSTLIB/alloc/src/boxed.rs:LL:CC
    = note: inside `std::boxed::Box::<u32>::from_raw` at RUSTLIB/alloc/src/boxed.rs:LL:CC
 note: inside `main` at $DIR/issue-miri-1050-1.rs:LL:CC

--- a/tests/fail/stacked_borrows/issue-miri-1050-2.stderr
+++ b/tests/fail/stacked_borrows/issue-miri-1050-2.stderr
@@ -6,7 +6,7 @@ LL |         Box(unsafe { Unique::new_unchecked(raw) }, alloc)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `std::boxed::Box::<i32>::from_raw_in` at RUSTLIB/alloc/src/boxed.rs:LL:CC
    = note: inside `std::boxed::Box::<i32>::from_raw` at RUSTLIB/alloc/src/boxed.rs:LL:CC
 note: inside `main` at $DIR/issue-miri-1050-2.rs:LL:CC

--- a/tests/fail/stacked_borrows/load_invalid_mut.stderr
+++ b/tests/fail/stacked_borrows/load_invalid_mut.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4]
    |
 LL |     let _val = unsafe { *xraw }; // invalidate xref
    |                         ^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/load_invalid_mut.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/load_invalid_shr.stderr
+++ b/tests/fail/stacked_borrows/load_invalid_shr.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4]
    |
 LL |     unsafe { *xraw = 42 }; // unfreeze
    |              ^^^^^^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/load_invalid_shr.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/mut_exclusive_violation1.stderr
+++ b/tests/fail/stacked_borrows/mut_exclusive_violation1.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4]
    |
 LL |     *our = 5;
    |     ^^^^^^^^
+   = note: backtrace:
    = note: inside `unknown_code_2` at $DIR/mut_exclusive_violation1.rs:LL:CC
 note: inside `demo_mut_advanced_unique` at $DIR/mut_exclusive_violation1.rs:LL:CC
   --> $DIR/mut_exclusive_violation1.rs:LL:CC

--- a/tests/fail/stacked_borrows/mut_exclusive_violation2.stderr
+++ b/tests/fail/stacked_borrows/mut_exclusive_violation2.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4]
    |
 LL |         let _raw2 = ptr2.as_mut();
    |                     ^^^^^^^^^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/mut_exclusive_violation2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/newtype_retagging.stderr
+++ b/tests/fail/stacked_borrows/newtype_retagging.stderr
@@ -23,6 +23,7 @@ LL | / fn dealloc_while_running(_n: Newtype<'_>, dealloc: impl FnOnce()) {
 LL | |     dealloc();
 LL | | }
    | |_^
+   = note: backtrace:
    = note: inside `std::boxed::Box::<i32>::from_raw_in` at RUSTLIB/alloc/src/boxed.rs:LL:CC
    = note: inside `std::boxed::Box::<i32>::from_raw` at RUSTLIB/alloc/src/boxed.rs:LL:CC
 note: inside closure at $DIR/newtype_retagging.rs:LL:CC

--- a/tests/fail/stacked_borrows/outdated_local.stderr
+++ b/tests/fail/stacked_borrows/outdated_local.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4]
    |
 LL |     x = 1; // this invalidates y by reactivating the lowermost uniq borrow for this local
    |     ^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/outdated_local.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/pass_invalid_mut.stderr
+++ b/tests/fail/stacked_borrows/pass_invalid_mut.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4]
    |
 LL |     let _val = unsafe { *xraw }; // invalidate xref
    |                         ^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/pass_invalid_mut.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/pass_invalid_shr.stderr
+++ b/tests/fail/stacked_borrows/pass_invalid_shr.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4]
    |
 LL |     unsafe { *xraw = 42 }; // unfreeze
    |              ^^^^^^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/pass_invalid_shr.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/pointer_smuggling.stderr
+++ b/tests/fail/stacked_borrows/pointer_smuggling.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x1]
    |
 LL |     *val = 2; // this invalidates any raw ptrs `fun1` might have created.
    |     ^^^^^^^^
+   = note: backtrace:
    = note: inside `fun2` at $DIR/pointer_smuggling.rs:LL:CC
 note: inside `main` at $DIR/pointer_smuggling.rs:LL:CC
   --> $DIR/pointer_smuggling.rs:LL:CC

--- a/tests/fail/stacked_borrows/raw_tracking.stderr
+++ b/tests/fail/stacked_borrows/raw_tracking.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4]
    |
 LL |     let raw2 = &mut l as *mut _; // invalidates raw1
    |                ^^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/raw_tracking.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/return_invalid_mut.stderr
+++ b/tests/fail/stacked_borrows/return_invalid_mut.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x8]
    |
 LL |     let _val = unsafe { *xraw }; // invalidate xref
    |                         ^^^^^
+   = note: backtrace:
    = note: inside `foo` at $DIR/return_invalid_mut.rs:LL:CC
 note: inside `main` at $DIR/return_invalid_mut.rs:LL:CC
   --> $DIR/return_invalid_mut.rs:LL:CC

--- a/tests/fail/stacked_borrows/return_invalid_mut_option.stderr
+++ b/tests/fail/stacked_borrows/return_invalid_mut_option.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x8]
    |
 LL |     let _val = unsafe { *xraw }; // invalidate xref
    |                         ^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/return_invalid_mut_option.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/return_invalid_mut_tuple.stderr
+++ b/tests/fail/stacked_borrows/return_invalid_mut_tuple.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x8]
    |
 LL |     let _val = unsafe { *xraw }; // invalidate xref
    |                         ^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/return_invalid_mut_tuple.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/return_invalid_shr.stderr
+++ b/tests/fail/stacked_borrows/return_invalid_shr.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x8]
    |
 LL |     unsafe { *xraw = (42, 23) }; // unfreeze
    |              ^^^^^^^^^^^^^^^^
+   = note: backtrace:
    = note: inside `foo` at $DIR/return_invalid_shr.rs:LL:CC
 note: inside `main` at $DIR/return_invalid_shr.rs:LL:CC
   --> $DIR/return_invalid_shr.rs:LL:CC

--- a/tests/fail/stacked_borrows/return_invalid_shr_option.stderr
+++ b/tests/fail/stacked_borrows/return_invalid_shr_option.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x8]
    |
 LL |     unsafe { *xraw = (42, 23) }; // unfreeze
    |              ^^^^^^^^^^^^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/return_invalid_shr_option.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/return_invalid_shr_tuple.stderr
+++ b/tests/fail/stacked_borrows/return_invalid_shr_tuple.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x8]
    |
 LL |     unsafe { *xraw = (42, 23) }; // unfreeze
    |              ^^^^^^^^^^^^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/return_invalid_shr_tuple.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/shared_rw_borrows_are_weak1.stderr
+++ b/tests/fail/stacked_borrows/shared_rw_borrows_are_weak1.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4]
    |
 LL |         shr_rw.set(1);
    |         ^^^^^^^^^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/shared_rw_borrows_are_weak1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/shared_rw_borrows_are_weak2.stderr
+++ b/tests/fail/stacked_borrows/shared_rw_borrows_are_weak2.stderr
@@ -19,6 +19,7 @@ help: <TAG> was later invalidated at offsets [$HEX..$HEX]
    |
 LL |         shr_rw.replace(1);
    |         ^^^^^^^^^^^^^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/shared_rw_borrows_are_weak2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/shr_frozen_violation1.stderr
+++ b/tests/fail/stacked_borrows/shr_frozen_violation1.stderr
@@ -14,6 +14,7 @@ help: <TAG> was created by a retag at offsets [0x0..0x4]
    |
 LL |         *(x as *const i32 as *mut i32) = 7;
    |           ^
+   = note: backtrace:
    = note: inside `unknown_code` at $DIR/shr_frozen_violation1.rs:LL:CC
 note: inside `foo` at $DIR/shr_frozen_violation1.rs:LL:CC
   --> $DIR/shr_frozen_violation1.rs:LL:CC

--- a/tests/fail/stacked_borrows/static_memory_modification.stderr
+++ b/tests/fail/stacked_borrows/static_memory_modification.stderr
@@ -6,7 +6,7 @@ LL |         std::mem::transmute::<&usize, &mut usize>(&X)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/static_memory_modification.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/transmute-is-no-escape.stderr
+++ b/tests/fail/stacked_borrows/transmute-is-no-escape.stderr
@@ -14,6 +14,7 @@ help: <TAG> was created by a retag at offsets [0x4..0x8]
    |
 LL |     let raw = (&mut x[1] as *mut i32).wrapping_offset(-1);
    |                ^^^^^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/transmute-is-no-escape.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/unescaped_local.stderr
+++ b/tests/fail/stacked_borrows/unescaped_local.stderr
@@ -9,7 +9,7 @@ LL |         *raw = 13;
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/unescaped_local.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/unescaped_static.stderr
+++ b/tests/fail/stacked_borrows/unescaped_static.stderr
@@ -14,6 +14,7 @@ help: <TAG> was created by a retag at offsets [0x0..0x1]
    |
 LL |     let ptr_to_first = &ARRAY[0] as *const u8;
    |                        ^^^^^^^^^
+   = note: backtrace:
    = note: inside `main` at $DIR/unescaped_static.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/vtable.stderr
+++ b/tests/fail/stacked_borrows/vtable.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { PtrRepr { components: PtrComponents { data_address, metadata }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `std::ptr::from_raw_parts::<dyn Foo>` at RUSTLIB/core/src/ptr/metadata.rs:LL:CC
 note: inside `uwu` at $DIR/vtable.rs:LL:CC
   --> $DIR/vtable.rs:LL:CC

--- a/tests/fail/stacked_borrows/zst_slice.stderr
+++ b/tests/fail/stacked_borrows/zst_slice.stderr
@@ -14,6 +14,7 @@ help: <TAG> was created by a retag at offsets [0x0..0x0]
    |
 LL |         assert_eq!(*s.get_unchecked(1), 2);
    |                     ^^^^^^^^^^^^^^^^^^
+   = note: backtrace:
    = note: inside `core::slice::<impl [i32]>::get_unchecked::<usize>` at RUSTLIB/core/src/slice/mod.rs:LL:CC
 note: inside `main` at $DIR/zst_slice.rs:LL:CC
   --> $DIR/zst_slice.rs:LL:CC

--- a/tests/fail/static_memory_modification1.stderr
+++ b/tests/fail/static_memory_modification1.stderr
@@ -6,7 +6,7 @@ LL |         *std::mem::transmute::<&usize, &mut usize>(&X) = 6;
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/static_memory_modification1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/static_memory_modification2.stderr
+++ b/tests/fail/static_memory_modification2.stderr
@@ -6,7 +6,7 @@ LL |         transmute::<&[u8], &mut [u8]>(s.as_bytes())[4] = 42;
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/static_memory_modification2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/static_memory_modification3.stderr
+++ b/tests/fail/static_memory_modification3.stderr
@@ -6,7 +6,7 @@ LL |         transmute::<&[u8], &mut [u8]>(bs)[4] = 42;
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/static_memory_modification3.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/sync/libc_pthread_cond_double_destroy.stderr
+++ b/tests/fail/sync/libc_pthread_cond_double_destroy.stderr
@@ -6,7 +6,7 @@ LL |         libc::pthread_cond_destroy(cond.as_mut_ptr());
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/libc_pthread_cond_double_destroy.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/sync/libc_pthread_condattr_double_destroy.stderr
+++ b/tests/fail/sync/libc_pthread_condattr_double_destroy.stderr
@@ -6,7 +6,7 @@ LL |         libc::pthread_condattr_destroy(attr.as_mut_ptr());
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/libc_pthread_condattr_double_destroy.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/sync/libc_pthread_mutex_NULL_deadlock.stderr
+++ b/tests/fail/sync/libc_pthread_mutex_NULL_deadlock.stderr
@@ -6,7 +6,7 @@ LL |         libc::pthread_mutex_lock(&mut mutex as *mut _);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/libc_pthread_mutex_NULL_deadlock.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/sync/libc_pthread_mutex_default_deadlock.stderr
+++ b/tests/fail/sync/libc_pthread_mutex_default_deadlock.stderr
@@ -6,7 +6,7 @@ LL |         libc::pthread_mutex_lock(&mut mutex as *mut _);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/libc_pthread_mutex_default_deadlock.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/sync/libc_pthread_mutex_destroy_locked.stderr
+++ b/tests/fail/sync/libc_pthread_mutex_destroy_locked.stderr
@@ -6,7 +6,7 @@ LL |         libc::pthread_mutex_destroy(&mut mutex as *mut _);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/libc_pthread_mutex_destroy_locked.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/sync/libc_pthread_mutex_double_destroy.stderr
+++ b/tests/fail/sync/libc_pthread_mutex_double_destroy.stderr
@@ -6,7 +6,7 @@ LL |         libc::pthread_mutex_destroy(mutex.as_mut_ptr());
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/libc_pthread_mutex_double_destroy.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/sync/libc_pthread_mutex_normal_unlock_unlocked.stderr
+++ b/tests/fail/sync/libc_pthread_mutex_normal_unlock_unlocked.stderr
@@ -6,7 +6,7 @@ LL |         libc::pthread_mutex_unlock(&mut mutex as *mut _);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/libc_pthread_mutex_normal_unlock_unlocked.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/sync/libc_pthread_mutex_wrong_owner.stderr
+++ b/tests/fail/sync/libc_pthread_mutex_wrong_owner.stderr
@@ -6,7 +6,7 @@ LL | ...t_eq!(libc::pthread_mutex_unlock(lock_copy.0.get() as *mut _), 0);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/libc_pthread_mutex_wrong_owner.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/sync/libc_pthread_mutexattr_double_destroy.stderr
+++ b/tests/fail/sync/libc_pthread_mutexattr_double_destroy.stderr
@@ -6,7 +6,7 @@ LL |         libc::pthread_mutexattr_destroy(attr.as_mut_ptr());
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/libc_pthread_mutexattr_double_destroy.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/sync/libc_pthread_rwlock_destroy_read_locked.stderr
+++ b/tests/fail/sync/libc_pthread_rwlock_destroy_read_locked.stderr
@@ -6,7 +6,7 @@ LL |         libc::pthread_rwlock_destroy(rw.get());
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/libc_pthread_rwlock_destroy_read_locked.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/sync/libc_pthread_rwlock_destroy_write_locked.stderr
+++ b/tests/fail/sync/libc_pthread_rwlock_destroy_write_locked.stderr
@@ -6,7 +6,7 @@ LL |         libc::pthread_rwlock_destroy(rw.get());
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/libc_pthread_rwlock_destroy_write_locked.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/sync/libc_pthread_rwlock_double_destroy.stderr
+++ b/tests/fail/sync/libc_pthread_rwlock_double_destroy.stderr
@@ -6,7 +6,7 @@ LL |         libc::pthread_rwlock_destroy(&mut lock);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/libc_pthread_rwlock_double_destroy.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/sync/libc_pthread_rwlock_read_wrong_owner.stderr
+++ b/tests/fail/sync/libc_pthread_rwlock_read_wrong_owner.stderr
@@ -6,7 +6,7 @@ LL | ...   assert_eq!(libc::pthread_rwlock_unlock(lock_copy.0.get() as *mut _), 
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/libc_pthread_rwlock_read_wrong_owner.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/sync/libc_pthread_rwlock_unlock_unlocked.stderr
+++ b/tests/fail/sync/libc_pthread_rwlock_unlock_unlocked.stderr
@@ -6,7 +6,7 @@ LL |         libc::pthread_rwlock_unlock(rw.get());
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/libc_pthread_rwlock_unlock_unlocked.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/sync/libc_pthread_rwlock_write_wrong_owner.stderr
+++ b/tests/fail/sync/libc_pthread_rwlock_write_wrong_owner.stderr
@@ -6,7 +6,7 @@ LL | ...   assert_eq!(libc::pthread_rwlock_unlock(lock_copy.0.get() as *mut _), 
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside closure at $DIR/libc_pthread_rwlock_write_wrong_owner.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/transmute-pair-uninit.stderr
+++ b/tests/fail/transmute-pair-uninit.stderr
@@ -6,7 +6,7 @@ LL |     let v = unsafe { *z.offset(first_undef) };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/transmute-pair-uninit.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/transmute_fat1.stderr
+++ b/tests/fail/transmute_fat1.stderr
@@ -6,7 +6,7 @@ LL |         std::mem::transmute::<&[u8], [u8; N]>(&[1u8])
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/transmute_fat1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/unaligned_pointers/alignment.stderr
+++ b/tests/fail/unaligned_pointers/alignment.stderr
@@ -6,7 +6,7 @@ LL |         *(x_ptr as *mut u32) = 42; *(x_ptr.add(1) as *mut u32) = 42;
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/alignment.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/unaligned_pointers/atomic_unaligned.stderr
+++ b/tests/fail/unaligned_pointers/atomic_unaligned.stderr
@@ -6,7 +6,7 @@ LL |         ::std::intrinsics::atomic_load_seqcst(zptr);
    |
    = help: this usually indicates that your program performed an invalid operation and caused Undefined Behavior
    = help: but due to `-Zmiri-symbolic-alignment-check`, alignment errors can also be false positives
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/atomic_unaligned.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/unaligned_pointers/dyn_alignment.stderr
+++ b/tests/fail/unaligned_pointers/dyn_alignment.stderr
@@ -6,7 +6,7 @@ LL |         let _ptr = &*ptr;
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/dyn_alignment.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/unaligned_pointers/intptrcast_alignment_check.stderr
+++ b/tests/fail/unaligned_pointers/intptrcast_alignment_check.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { *u16_ptr = 2 };
    |
    = help: this usually indicates that your program performed an invalid operation and caused Undefined Behavior
    = help: but due to `-Zmiri-symbolic-alignment-check`, alignment errors can also be false positives
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/intptrcast_alignment_check.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/unaligned_pointers/reference_to_packed.stderr
+++ b/tests/fail/unaligned_pointers/reference_to_packed.stderr
@@ -6,7 +6,7 @@ LL |         let i = *p;
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/reference_to_packed.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/unaligned_pointers/unaligned_ptr1.stderr
+++ b/tests/fail/unaligned_pointers/unaligned_ptr1.stderr
@@ -6,7 +6,7 @@ LL |         let _x = unsafe { *x };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/unaligned_ptr1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/unaligned_pointers/unaligned_ptr2.stderr
+++ b/tests/fail/unaligned_pointers/unaligned_ptr2.stderr
@@ -6,7 +6,7 @@ LL |     let _x = unsafe { *x };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/unaligned_ptr2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/unaligned_pointers/unaligned_ptr3.stderr
+++ b/tests/fail/unaligned_pointers/unaligned_ptr3.stderr
@@ -6,7 +6,7 @@ LL |         let _x = unsafe { *x };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/unaligned_ptr3.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/unaligned_pointers/unaligned_ptr4.stderr
+++ b/tests/fail/unaligned_pointers/unaligned_ptr4.stderr
@@ -6,7 +6,7 @@ LL |         let _val = unsafe { *ptr };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/unaligned_ptr4.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/unaligned_pointers/unaligned_ptr_addr_of.stderr
+++ b/tests/fail/unaligned_pointers/unaligned_ptr_addr_of.stderr
@@ -6,7 +6,7 @@ LL |         let _x = unsafe { ptr::addr_of!(*x) };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at RUSTLIB/core/src/ptr/mod.rs:LL:CC
    = note: this error originates in the macro `ptr::addr_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/fail/unaligned_pointers/unaligned_ptr_zst.stderr
+++ b/tests/fail/unaligned_pointers/unaligned_ptr_zst.stderr
@@ -6,7 +6,7 @@ LL |         let _x = unsafe { *x };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/unaligned_ptr_zst.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/uninit_buffer.stderr
+++ b/tests/fail/uninit_buffer.stderr
@@ -6,7 +6,7 @@ LL |         let mut order = unsafe { memcmp(left.as_ptr(), right.as_ptr(), len)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `<u8 as core::slice::cmp::SliceOrd>::compare` at RUSTLIB/core/src/slice/cmp.rs:LL:CC
    = note: inside `core::slice::cmp::<impl std::cmp::Ord for [u8]>::cmp` at RUSTLIB/core/src/slice/cmp.rs:LL:CC
 note: inside `main` at $DIR/uninit_buffer.rs:LL:CC

--- a/tests/fail/uninit_byte_read.stderr
+++ b/tests/fail/uninit_byte_read.stderr
@@ -6,7 +6,7 @@ LL |     let undef = unsafe { *v.get_unchecked(5) };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/uninit_byte_read.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/uninit_raw_ptr.stderr
+++ b/tests/fail/uninit_raw_ptr.stderr
@@ -6,7 +6,7 @@ LL |     let _val = unsafe { std::mem::MaybeUninit::<*const u8>::uninit().assume
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/uninit_raw_ptr.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/unreachable.stderr
+++ b/tests/fail/unreachable.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { intrinsics::unreachable() }
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `std::hint::unreachable_unchecked` at RUSTLIB/core/src/hint.rs:LL:CC
 note: inside `main` at $DIR/unreachable.rs:LL:CC
   --> $DIR/unreachable.rs:LL:CC

--- a/tests/fail/unsupported_foreign_function.stderr
+++ b/tests/fail/unsupported_foreign_function.stderr
@@ -5,7 +5,7 @@ LL |         foo();
    |         ^^^^^ can't call foreign function: foo
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/unsupported_foreign_function.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/unsupported_signal.stderr
+++ b/tests/fail/unsupported_signal.stderr
@@ -5,7 +5,7 @@ LL |         libc::signal(libc::SIGPIPE, libc::SIG_IGN);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't call foreign function: signal
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/unsupported_signal.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/validity/cast_fn_ptr1.stderr
+++ b/tests/fail/validity/cast_fn_ptr1.stderr
@@ -6,7 +6,7 @@ LL |     g(0usize as *const i32)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/cast_fn_ptr1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/validity/cast_fn_ptr2.stderr
+++ b/tests/fail/validity/cast_fn_ptr2.stderr
@@ -6,7 +6,7 @@ LL |     let _x = g();
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/cast_fn_ptr2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/validity/dangling_ref1.stderr
+++ b/tests/fail/validity/dangling_ref1.stderr
@@ -6,7 +6,7 @@ LL |     let _x: &i32 = unsafe { mem::transmute(16usize) };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/dangling_ref1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/validity/dangling_ref2.stderr
+++ b/tests/fail/validity/dangling_ref2.stderr
@@ -6,7 +6,7 @@ LL |     let _x: &i32 = unsafe { mem::transmute(ptr) };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/dangling_ref2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/validity/dangling_ref3.stderr
+++ b/tests/fail/validity/dangling_ref3.stderr
@@ -6,7 +6,7 @@ LL |     let _x: &i32 = unsafe { mem::transmute(dangling()) };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/dangling_ref3.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/validity/invalid_bool.stderr
+++ b/tests/fail/validity/invalid_bool.stderr
@@ -6,7 +6,7 @@ LL |     let _b = unsafe { std::mem::transmute::<u8, bool>(2) };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/invalid_bool.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/validity/invalid_bool_uninit.stderr
+++ b/tests/fail/validity/invalid_bool_uninit.stderr
@@ -6,7 +6,7 @@ LL |     let _b = unsafe { MyUninit { init: () }.uninit };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/invalid_bool_uninit.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/validity/invalid_char.stderr
+++ b/tests/fail/validity/invalid_char.stderr
@@ -6,7 +6,7 @@ LL |     let _val = match unsafe { std::mem::transmute::<i32, char>(-1) } {
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/invalid_char.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/validity/invalid_char_uninit.stderr
+++ b/tests/fail/validity/invalid_char_uninit.stderr
@@ -6,7 +6,7 @@ LL |     let _b = unsafe { MyUninit { init: () }.uninit };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/invalid_char_uninit.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/validity/invalid_enum_tag.stderr
+++ b/tests/fail/validity/invalid_enum_tag.stderr
@@ -6,7 +6,7 @@ LL |     let _f = unsafe { std::mem::transmute::<i32, Foo>(42) };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/invalid_enum_tag.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/validity/invalid_enum_tag_256variants_uninit.stderr
+++ b/tests/fail/validity/invalid_enum_tag_256variants_uninit.stderr
@@ -7,7 +7,7 @@ LL |     let _a = unsafe { MyUninit { init: () }.uninit };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/invalid_enum_tag_256variants_uninit.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/validity/invalid_fnptr_null.stderr
+++ b/tests/fail/validity/invalid_fnptr_null.stderr
@@ -6,7 +6,7 @@ LL |     let _b: fn() = unsafe { std::mem::transmute(0usize) };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/invalid_fnptr_null.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/validity/invalid_fnptr_uninit.stderr
+++ b/tests/fail/validity/invalid_fnptr_uninit.stderr
@@ -6,7 +6,7 @@ LL |     let _b = unsafe { MyUninit { init: () }.uninit };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/invalid_fnptr_uninit.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/validity/invalid_wide_raw.stderr
+++ b/tests/fail/validity/invalid_wide_raw.stderr
@@ -6,7 +6,7 @@ LL |     dbg!(S { x: unsafe { std::mem::transmute((0usize, 0usize)) } });
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/invalid_wide_raw.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/validity/nonzero.stderr
+++ b/tests/fail/validity/nonzero.stderr
@@ -6,7 +6,7 @@ LL |     let _x = Some(unsafe { NonZero(0) });
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/nonzero.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/validity/ptr_integer_array_transmute.stderr
+++ b/tests/fail/validity/ptr_integer_array_transmute.stderr
@@ -6,7 +6,7 @@ LL |     let _i: [usize; 1] = unsafe { std::mem::transmute(r) };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/ptr_integer_array_transmute.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/validity/ref_to_uninhabited1.stderr
+++ b/tests/fail/validity/ref_to_uninhabited1.stderr
@@ -6,7 +6,7 @@ LL |         let x: Box<!> = transmute(&mut 42);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/ref_to_uninhabited1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/validity/ref_to_uninhabited2.stderr
+++ b/tests/fail/validity/ref_to_uninhabited2.stderr
@@ -6,7 +6,7 @@ LL |         let _x: &(i32, Void) = transmute(&42);
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/ref_to_uninhabited2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/validity/too-big-slice.stderr
+++ b/tests/fail/validity/too-big-slice.stderr
@@ -6,7 +6,7 @@ LL |         let _x: &[u8] = mem::transmute((ptr, usize::MAX));
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/too-big-slice.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/validity/too-big-unsized.stderr
+++ b/tests/fail/validity/too-big-unsized.stderr
@@ -6,7 +6,7 @@ LL |         let _x: &MySlice = mem::transmute((ptr, isize::MAX as usize));
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/too-big-unsized.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/validity/transmute_through_ptr.stderr
+++ b/tests/fail/validity/transmute_through_ptr.stderr
@@ -6,7 +6,7 @@ LL |     let y = x; // reading this ought to be enough to trigger validation
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/transmute_through_ptr.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/validity/uninit_float.stderr
+++ b/tests/fail/validity/uninit_float.stderr
@@ -6,7 +6,7 @@ LL |     let _val = unsafe { std::mem::MaybeUninit::<f32>::uninit().assume_init(
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/uninit_float.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/validity/uninit_integer.stderr
+++ b/tests/fail/validity/uninit_integer.stderr
@@ -6,7 +6,7 @@ LL |     let _val = unsafe { std::mem::MaybeUninit::<usize>::uninit().assume_ini
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/uninit_integer.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/validity/uninit_integer_signed.stderr
+++ b/tests/fail/validity/uninit_integer_signed.stderr
@@ -6,7 +6,7 @@ LL |     let _val = unsafe { std::mem::MaybeUninit::<i32>::uninit().assume_init(
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/uninit_integer_signed.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/weak_memory/racing_mixed_size.stderr
+++ b/tests/fail/weak_memory/racing_mixed_size.stderr
@@ -5,7 +5,7 @@ LL |             std::intrinsics::atomic_load_relaxed(hi);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ racy imperfectly overlapping atomic access is not possible in the C++20 memory model, and not supported by Miri's weak memory emulation
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
-           
+   = note: backtrace:
    = note: inside closure at $DIR/racing_mixed_size.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/weak_memory/racing_mixed_size_read.stderr
+++ b/tests/fail/weak_memory/racing_mixed_size_read.stderr
@@ -5,7 +5,7 @@ LL |             std::intrinsics::atomic_load_relaxed(hi);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ racy imperfectly overlapping atomic access is not possible in the C++20 memory model, and not supported by Miri's weak memory emulation
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
-           
+   = note: backtrace:
    = note: inside closure at $DIR/racing_mixed_size_read.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/zst1.stderr
+++ b/tests/fail/zst1.stderr
@@ -6,7 +6,7 @@ LL |     let _val = unsafe { *x };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/zst1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/zst2.stderr
+++ b/tests/fail/zst2.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { *x = zst_val };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/zst2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/zst3.stderr
+++ b/tests/fail/zst3.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { *(x as *mut [u8; 0]) = zst_val };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/zst3.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/pass/box.stderr
+++ b/tests/pass/box.stderr
@@ -10,7 +10,7 @@ LL |         let r2 = ((r as usize) + 0) as *mut i32;
    = help: To ensure that Miri does not miss bugs in your program, use Strict Provenance APIs (https://doc.rust-lang.org/nightly/std/ptr/index.html#strict-provenance, https://crates.io/crates/sptr) instead.
    = help: You can then pass the `-Zmiri-strict-provenance` flag to Miri, to ensure you are not relying on `from_exposed_addr` semantics.
    = help: Alternatively, the `-Zmiri-permissive-provenance` flag disables this warning.
-           
+   = note: backtrace:
    = note: inside `into_raw` at $DIR/box.rs:LL:CC
 note: inside `main` at $DIR/box.rs:LL:CC
   --> $DIR/box.rs:LL:CC

--- a/tests/pass/extern_types.stderr
+++ b/tests/pass/extern_types.stderr
@@ -10,6 +10,6 @@ LL |     let x: &Foo = unsafe { &*(16 as *const Foo) };
    = help: To ensure that Miri does not miss bugs in your program, use Strict Provenance APIs (https://doc.rust-lang.org/nightly/std/ptr/index.html#strict-provenance, https://crates.io/crates/sptr) instead.
    = help: You can then pass the `-Zmiri-strict-provenance` flag to Miri, to ensure you are not relying on `from_exposed_addr` semantics.
    = help: Alternatively, the `-Zmiri-permissive-provenance` flag disables this warning.
-           
+   = note: backtrace:
    = note: inside `main` at $DIR/extern_types.rs:LL:CC
 


### PR DESCRIPTION
Hopefully this makes things like https://github.com/Manishearth/triomphe/issues/38 easier to diagnose.