### PR TITLE
Optimizing Stacked Borrows (part 2): Shrink Item

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,8 +90,8 @@ pub use crate::mono_hash_map::MonoHashMap;
 pub use crate::operator::EvalContextExt as OperatorEvalContextExt;
 pub use crate::range_map::RangeMap;
 pub use crate::stacked_borrows::{
-    stack::Stack, CallId, EvalContextExt as StackedBorEvalContextExt, Item, Permission, SbTag,
-    SbTagExtra, Stacks,
+    CallId, EvalContextExt as StackedBorEvalContextExt, Item, Permission, SbTag, SbTagExtra, Stack,
+    Stacks,
 };
 pub use crate::sync::{CondvarId, EvalContextExt as SyncEvalContextExt, MutexId, RwLockId};
 pub use crate::thread::{

--- a/src/stacked_borrows/diagnostics.rs
+++ b/src/stacked_borrows/diagnostics.rs
@@ -141,7 +141,7 @@ impl AllocHistory {
     ) -> InterpError<'tcx> {
         let action = format!(
             "trying to reborrow {derived_from:?} for {new_perm:?} permission at {alloc_id:?}[{offset:#x}]",
-            new_perm = new.perm,
+            new_perm = new.perm(),
             offset = error_offset.bytes(),
         );
         err_sb_ub(
@@ -185,7 +185,7 @@ fn error_cause(stack: &Stack, tag: SbTagExtra) -> &'static str {
     if let SbTagExtra::Concrete(tag) = tag {
         if (0..stack.len())
             .map(|i| stack.get(i).unwrap())
-            .any(|item| item.tag == tag && item.perm != Permission::Disabled)
+            .any(|item| item.tag() == tag && item.perm() != Permission::Disabled)
         {
             ", but that tag only grants SharedReadOnly permission for this location"
         } else {

--- a/src/stacked_borrows/item.rs
+++ b/src/stacked_borrows/item.rs
@@ -1,0 +1,104 @@
+use crate::stacked_borrows::SbTag;
+use std::fmt;
+use std::num::NonZeroU64;
+
+/// An item in the per-location borrow stack.
+#[derive(Copy, Clone, Hash, PartialEq, Eq)]
+pub struct Item(u64);
+
+// An Item contains 3 bitfields:
+// * Bits 0-61 store an SbTag
+// * Bits 61-63 store a Permission
+// * Bit 64 stores a flag which indicates if we have a protector
+const TAG_MASK: u64 = u64::MAX >> 3;
+const PERM_MASK: u64 = 0x3 << 61;
+const PROTECTED_MASK: u64 = 0x1 << 63;
+
+const PERM_SHIFT: u64 = 61;
+const PROTECTED_SHIFT: u64 = 63;
+
+impl Item {
+    pub fn new(tag: SbTag, perm: Permission, protected: bool) -> Self {
+        assert!(tag.0.get() <= TAG_MASK);
+        let packed_tag = tag.0.get();
+        let packed_perm = perm.to_bits() << PERM_SHIFT;
+        let packed_protected = (protected as u64) << PROTECTED_SHIFT;
+
+        let new = Self(packed_tag | packed_perm | packed_protected);
+
+        debug_assert!(new.tag() == tag);
+        debug_assert!(new.perm() == perm);
+        debug_assert!(new.protected() == protected);
+
+        new
+    }
+
+    /// The pointers the permission is granted to.
+    pub fn tag(self) -> SbTag {
+        SbTag(NonZeroU64::new(self.0 & TAG_MASK).unwrap())
+    }
+
+    /// The permission this item grants.
+    pub fn perm(self) -> Permission {
+        Permission::from_bits((self.0 & PERM_MASK) >> PERM_SHIFT)
+    }
+
+    /// Whether or not there is a protector for this tag
+    pub fn protected(self) -> bool {
+        self.0 & PROTECTED_MASK > 0
+    }
+
+    /// Set the Permission stored in this Item
+    pub fn set_permission(&mut self, perm: Permission) {
+        // Clear the current set permission
+        self.0 &= !PERM_MASK;
+        // Write Permission::Disabled to the Permission bits
+        self.0 |= perm.to_bits() << PERM_SHIFT;
+    }
+}
+
+impl fmt::Debug for Item {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[{:?} for {:?}]", self.perm(), self.tag())
+    }
+}
+
+/// Indicates which permission is granted (by this item to some pointers)
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+pub enum Permission {
+    /// Grants unique mutable access.
+    Unique,
+    /// Grants shared mutable access.
+    SharedReadWrite,
+    /// Grants shared read-only access.
+    SharedReadOnly,
+    /// Grants no access, but separates two groups of SharedReadWrite so they are not
+    /// all considered mutually compatible.
+    Disabled,
+}
+
+impl Permission {
+    const UNIQUE: u64 = 0;
+    const SHARED_READ_WRITE: u64 = 1;
+    const SHARED_READ_ONLY: u64 = 2;
+    const DISABLED: u64 = 3;
+
+    fn to_bits(self) -> u64 {
+        match self {
+            Permission::Unique => Self::UNIQUE,
+            Permission::SharedReadWrite => Self::SHARED_READ_WRITE,
+            Permission::SharedReadOnly => Self::SHARED_READ_ONLY,
+            Permission::Disabled => Self::DISABLED,
+        }
+    }
+
+    fn from_bits(perm: u64) -> Self {
+        match perm {
+            Self::UNIQUE => Permission::Unique,
+            Self::SHARED_READ_WRITE => Permission::SharedReadWrite,
+            Self::SHARED_READ_ONLY => Permission::SharedReadOnly,
+            Self::DISABLED => Permission::Disabled,
+            _ => unreachable!(),
+        }
+    }
+}

--- a/src/stacked_borrows/stack.rs
+++ b/src/stacked_borrows/stack.rs
@@ -303,10 +303,11 @@ impl<'tcx> Stack {
                 if item.perm() == Permission::Unique {
                     log::trace!("access: disabling item {:?}", item);
                     visitor(*item)?;
-                    item.set_disabled();
-                    for t in &mut self.cache.items {
-                        if t.tag() == item.tag() {
-                            t.set_disabled();
+                    item.set_permission(Permission::Disabled);
+                    // Also update all copies of this item in the cache.
+                    for it in &mut self.cache.items {
+                        if it.tag() == item.tag() {
+                            it.set_permission(Permission::Disabled);
                         }
                     }
                 }

--- a/src/stacked_borrows/stack.rs
+++ b/src/stacked_borrows/stack.rs
@@ -37,7 +37,7 @@ pub struct Stack {
 }
 
 /// A very small cache of searches of the borrow stack
-/// This maps tags to locations in the borrow stack. Any use of this still needs to do a
+/// This maps items to locations in the borrow stack. Any use of this still needs to do a
 /// probably-cold random access into the borrow stack to figure out what `Permission` an
 /// `SbTag` grants. We could avoid this by also storing the `Permission` in the cache, but
 /// most lookups into the cache are immediately followed by access of the full borrow stack anyway.
@@ -48,7 +48,7 @@ pub struct Stack {
 #[cfg(feature = "stack-cache")]
 #[derive(Clone, Debug)]
 struct StackCache {
-    tags: [SbTag; CACHE_LEN], // Hot in find_granting
+    items: [Item; CACHE_LEN], // Hot in find_granting
     idx: [usize; CACHE_LEN],  // Hot in grant
 }
 
@@ -59,11 +59,11 @@ impl StackCache {
     /// We use the position in the cache to represent how recently a tag was used; the first position
     /// is the most recently used tag. So an add shifts every element towards the end, and inserts
     /// the new element at the start. We lose the last element.
-    /// This strategy is effective at keeping the most-accessed tags in the cache, but it costs a
+    /// This strategy is effective at keeping the most-accessed items in the cache, but it costs a
     /// linear shift across the entire cache when we add a new tag.
-    fn add(&mut self, idx: usize, tag: SbTag) {
-        self.tags.copy_within(0..CACHE_LEN - 1, 1);
-        self.tags[0] = tag;
+    fn add(&mut self, idx: usize, item: Item) {
+        self.items.copy_within(0..CACHE_LEN - 1, 1);
+        self.items[0] = item;
         self.idx.copy_within(0..CACHE_LEN - 1, 1);
         self.idx[0] = idx;
     }
@@ -80,20 +80,20 @@ impl Eq for Stack {}
 
 impl<'tcx> Stack {
     /// Panics if any of the caching mechanisms have broken,
-    /// - The StackCache indices don't refer to the parallel tags,
-    /// - There are no Unique tags outside of first_unique..last_unique
+    /// - The StackCache indices don't refer to the parallel items,
+    /// - There are no Unique items outside of first_unique..last_unique
     #[cfg(feature = "expensive-debug-assertions")]
     fn verify_cache_consistency(&self) {
         // Only a full cache needs to be valid. Also see the comments in find_granting_cache
         // and set_unknown_bottom.
         if self.borrows.len() >= CACHE_LEN {
-            for (tag, stack_idx) in self.cache.tags.iter().zip(self.cache.idx.iter()) {
-                assert_eq!(self.borrows[*stack_idx].tag, *tag);
+            for (tag, stack_idx) in self.cache.items.iter().zip(self.cache.idx.iter()) {
+                assert_eq!(self.borrows[*stack_idx], *tag);
             }
         }
 
         for (idx, item) in self.borrows.iter().enumerate() {
-            if item.perm == Permission::Unique {
+            if item.perm() == Permission::Unique {
                 assert!(
                     self.unique_range.contains(&idx),
                     "{:?} {:?}",
@@ -128,7 +128,7 @@ impl<'tcx> Stack {
                     .rev() // search top-to-bottom
                     .find_map(|(idx, item)| {
                         // If the item fits and *might* be this wildcard, use it.
-                        if item.perm.grants(access) && exposed_tags.contains(&item.tag) {
+                        if item.perm().grants(access) && exposed_tags.contains(&item.tag()) {
                             Some(idx)
                         } else {
                             None
@@ -161,9 +161,9 @@ impl<'tcx> Stack {
         // If we didn't find the tag in the cache, fall back to a linear search of the
         // whole stack, and add the tag to the cache.
         for (stack_idx, item) in self.borrows.iter().enumerate().rev() {
-            if tag == item.tag && item.perm.grants(access) {
+            if tag == item.tag() && item.perm().grants(access) {
                 #[cfg(feature = "stack-cache")]
-                self.cache.add(stack_idx, tag);
+                self.cache.add(stack_idx, *item);
                 return Some(stack_idx);
             }
         }
@@ -175,7 +175,7 @@ impl<'tcx> Stack {
         // This looks like a common-sense optimization; we're going to do a linear search of the
         // cache or the borrow stack to scan the shorter of the two. This optimization is miniscule
         // and this check actually ensures we do not access an invalid cache.
-        // When a stack is created and when tags are removed from the top of the borrow stack, we
+        // When a stack is created and when items are removed from the top of the borrow stack, we
         // need some valid value to populate the cache. In both cases, we try to use the bottom
         // item. But when the stack is cleared in `set_unknown_bottom` there is nothing we could
         // place in the cache that is correct. But due to the way we populate the cache in
@@ -185,21 +185,23 @@ impl<'tcx> Stack {
             return None;
         }
         // Search the cache for the tag we're looking up
-        let cache_idx = self.cache.tags.iter().position(|t| *t == tag)?;
+        let cache_idx = self.cache.items.iter().position(|t| t.tag() == tag)?;
         let stack_idx = self.cache.idx[cache_idx];
         // If we found the tag, look up its position in the stack to see if it grants
         // the required permission
-        if self.borrows[stack_idx].perm.grants(access) {
+        if self.cache.items[cache_idx].perm().grants(access) {
             // If it does, and it's not already in the most-recently-used position, re-insert it at
             // the most-recently-used position. This technically reduces the efficiency of the
             // cache by duplicating elements, but current benchmarks do not seem to benefit from
             // avoiding this duplication.
             // But if the tag is in position 1, avoiding the duplicating add is trivial.
+            // If it does, and it's not already in the most-recently-used position, move it there.
+            // Except if the tag is in position 1, this is equivalent to just a swap, so do that.
             if cache_idx == 1 {
-                self.cache.tags.swap(0, 1);
+                self.cache.items.swap(0, 1);
                 self.cache.idx.swap(0, 1);
             } else if cache_idx > 1 {
-                self.cache.add(stack_idx, tag);
+                self.cache.add(stack_idx, self.cache.items[cache_idx]);
             }
             Some(stack_idx)
         } else {
@@ -224,7 +226,7 @@ impl<'tcx> Stack {
         if self.unique_range.end >= new_idx {
             self.unique_range.end += 1;
         }
-        if new.perm == Permission::Unique {
+        if new.perm() == Permission::Unique {
             // Make sure the possibly-unique range contains the new borrow
             self.unique_range.start = self.unique_range.start.min(new_idx);
             self.unique_range.end = self.unique_range.end.max(new_idx + 1);
@@ -233,7 +235,7 @@ impl<'tcx> Stack {
         // The above insert changes the meaning of every index in the cache >= new_idx, so now
         // we need to find every one of those indexes and increment it.
         // But if the insert is at the end (equivalent to a push), we can skip this step because
-        // it didn't change the position of any other tags.
+        // it didn't change the position of any other items.
         if new_idx != self.borrows.len() - 1 {
             for idx in &mut self.cache.idx {
                 if *idx >= new_idx {
@@ -243,7 +245,7 @@ impl<'tcx> Stack {
         }
 
         // This primes the cache for the next access, which is almost always the just-added tag.
-        self.cache.add(new_idx, new.tag);
+        self.cache.add(new_idx, new);
 
         #[cfg(feature = "expensive-debug-assertions")]
         self.verify_cache_consistency();
@@ -255,9 +257,9 @@ impl<'tcx> Stack {
             borrows: vec![item],
             unknown_bottom: None,
             #[cfg(feature = "stack-cache")]
-            cache: StackCache { idx: [0; CACHE_LEN], tags: [item.tag; CACHE_LEN] },
+            cache: StackCache { idx: [0; CACHE_LEN], items: [item; CACHE_LEN] },
             #[cfg(feature = "stack-cache")]
-            unique_range: if item.perm == Permission::Unique { 0..1 } else { 0..0 },
+            unique_range: if item.perm() == Permission::Unique { 0..1 } else { 0..0 },
         }
     }
 
@@ -298,10 +300,15 @@ impl<'tcx> Stack {
             let lower = unique_range.start.max(disable_start);
             let upper = (unique_range.end + 1).min(self.borrows.len());
             for item in &mut self.borrows[lower..upper] {
-                if item.perm == Permission::Unique {
+                if item.perm() == Permission::Unique {
                     log::trace!("access: disabling item {:?}", item);
                     visitor(*item)?;
-                    item.perm = Permission::Disabled;
+                    item.set_disabled();
+                    for t in &mut self.cache.items {
+                        if t.tag() == item.tag() {
+                            t.set_disabled();
+                        }
+                    }
                 }
             }
         }
@@ -341,7 +348,7 @@ impl<'tcx> Stack {
             // also possible that the whole cache is still valid. So we call this method to repair what
             // aspects of the cache are now invalid, instead of resetting the whole thing to a trivially
             // valid default state.
-            let base_tag = self.borrows[0].tag;
+            let base_tag = self.borrows[0];
             let mut removed = 0;
             let mut cursor = 0;
             // Remove invalid entries from the cache by rotating them to the end of the cache, then
@@ -350,7 +357,7 @@ impl<'tcx> Stack {
             for _ in 0..CACHE_LEN - 1 {
                 if self.cache.idx[cursor] >= start {
                     self.cache.idx[cursor..CACHE_LEN - removed].rotate_left(1);
-                    self.cache.tags[cursor..CACHE_LEN - removed].rotate_left(1);
+                    self.cache.items[cursor..CACHE_LEN - removed].rotate_left(1);
                     removed += 1;
                 } else {
                     cursor += 1;
@@ -358,7 +365,7 @@ impl<'tcx> Stack {
             }
             for i in CACHE_LEN - removed - 1..CACHE_LEN {
                 self.cache.idx[i] = 0;
-                self.cache.tags[i] = base_tag;
+                self.cache.items[i] = base_tag;
             }
 
             if start < self.unique_range.start.saturating_sub(1) {

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -281,6 +281,10 @@ impl<'mir, 'tcx: 'mir> ThreadManager<'mir, 'tcx> {
         &mut self.threads[self.active_thread].stack
     }
 
+    pub fn all_stacks(&self) -> impl Iterator<Item = &[Frame<'mir, 'tcx, Tag, FrameData<'tcx>>]> {
+        self.threads.iter().map(|t| &t.stack[..])
+    }
+
     /// Create a new thread and returns its id.
     fn create_thread(&mut self) -> ThreadId {
         let new_thread_id = ThreadId::new(self.threads.len());

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -97,7 +97,7 @@ regexes! {
     // erase specific alignments
     "alignment [0-9]+"               => "alignment ALIGN",
     // erase thread caller ids
-    r"\(call [0-9]+\)"              => "(call ID)",
+    r"call [0-9]+"                  => "call ID",
     // erase platform module paths
     "sys::[a-z]+::"                  => "sys::PLATFORM::",
     // Windows file paths

--- a/tests/fail/stacked_borrows/aliasing_mut1.stderr
+++ b/tests/fail/stacked_borrows/aliasing_mut1.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because incompatible item is protected: [Unique for <TAG> (call ID)]
+error: Undefined Behavior: not granting access to tag <TAG> because incompatible item is protected: [Unique for <TAG>] (call ID)
   --> $DIR/aliasing_mut1.rs:LL:CC
    |
 LL | pub fn safe(_x: &mut i32, _y: &mut i32) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <TAG> because incompatible item is protected: [Unique for <TAG> (call ID)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <TAG> because incompatible item is protected: [Unique for <TAG>] (call ID)
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/aliasing_mut1.stderr
+++ b/tests/fail/stacked_borrows/aliasing_mut1.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because incompatible item is protected: [Unique for <TAG>] (call ID)
+error: Undefined Behavior: not granting access to tag <TAG> because incompatible item [Unique for <TAG>] is protected by call ID
   --> $DIR/aliasing_mut1.rs:LL:CC
    |
 LL | pub fn safe(_x: &mut i32, _y: &mut i32) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <TAG> because incompatible item is protected: [Unique for <TAG>] (call ID)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <TAG> because incompatible item [Unique for <TAG>] is protected by call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/aliasing_mut2.stderr
+++ b/tests/fail/stacked_borrows/aliasing_mut2.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because incompatible item is protected: [SharedReadOnly for <TAG> (call ID)]
+error: Undefined Behavior: not granting access to tag <TAG> because incompatible item is protected: [SharedReadOnly for <TAG>] (call ID)
   --> $DIR/aliasing_mut2.rs:LL:CC
    |
 LL | pub fn safe(_x: &i32, _y: &mut i32) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <TAG> because incompatible item is protected: [SharedReadOnly for <TAG> (call ID)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <TAG> because incompatible item is protected: [SharedReadOnly for <TAG>] (call ID)
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/aliasing_mut2.stderr
+++ b/tests/fail/stacked_borrows/aliasing_mut2.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because incompatible item is protected: [SharedReadOnly for <TAG>] (call ID)
+error: Undefined Behavior: not granting access to tag <TAG> because incompatible item [SharedReadOnly for <TAG>] is protected by call ID
   --> $DIR/aliasing_mut2.rs:LL:CC
    |
 LL | pub fn safe(_x: &i32, _y: &mut i32) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <TAG> because incompatible item is protected: [SharedReadOnly for <TAG>] (call ID)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <TAG> because incompatible item [SharedReadOnly for <TAG>] is protected by call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/aliasing_mut4.stderr
+++ b/tests/fail/stacked_borrows/aliasing_mut4.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because incompatible item is protected: [SharedReadOnly for <TAG>] (call ID)
+error: Undefined Behavior: not granting access to tag <TAG> because incompatible item [SharedReadOnly for <TAG>] is protected by call ID
   --> $DIR/aliasing_mut4.rs:LL:CC
    |
 LL | pub fn safe(_x: &i32, _y: &mut Cell<i32>) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <TAG> because incompatible item is protected: [SharedReadOnly for <TAG>] (call ID)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <TAG> because incompatible item [SharedReadOnly for <TAG>] is protected by call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/aliasing_mut4.stderr
+++ b/tests/fail/stacked_borrows/aliasing_mut4.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because incompatible item is protected: [SharedReadOnly for <TAG> (call ID)]
+error: Undefined Behavior: not granting access to tag <TAG> because incompatible item is protected: [SharedReadOnly for <TAG>] (call ID)
   --> $DIR/aliasing_mut4.rs:LL:CC
    |
 LL | pub fn safe(_x: &i32, _y: &mut Cell<i32>) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <TAG> because incompatible item is protected: [SharedReadOnly for <TAG> (call ID)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <TAG> because incompatible item is protected: [SharedReadOnly for <TAG>] (call ID)
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/deallocate_against_barrier1.rs
+++ b/tests/fail/stacked_borrows/deallocate_against_barrier1.rs
@@ -1,4 +1,4 @@
-//@error-pattern: deallocating while item is protected
+//@error-pattern: deallocating while item
 
 fn inner(x: &mut i32, f: fn(&mut i32)) {
     // `f` may mutate, but it may not deallocate!

--- a/tests/fail/stacked_borrows/deallocate_against_barrier1.stderr
+++ b/tests/fail/stacked_borrows/deallocate_against_barrier1.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: deallocating while item is protected: [Unique for <TAG>] (call ID)
+error: Undefined Behavior: deallocating while item [Unique for <TAG>] is protected by call ID
   --> RUSTLIB/alloc/src/alloc.rs:LL:CC
    |
 LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocating while item is protected: [Unique for <TAG>] (call ID)
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocating while item [Unique for <TAG>] is protected by call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/deallocate_against_barrier1.stderr
+++ b/tests/fail/stacked_borrows/deallocate_against_barrier1.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: deallocating while item is protected: [Unique for <TAG> (call ID)]
+error: Undefined Behavior: deallocating while item is protected: [Unique for <TAG>] (call ID)
   --> RUSTLIB/alloc/src/alloc.rs:LL:CC
    |
 LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocating while item is protected: [Unique for <TAG> (call ID)]
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocating while item is protected: [Unique for <TAG>] (call ID)
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/deallocate_against_barrier2.rs
+++ b/tests/fail/stacked_borrows/deallocate_against_barrier2.rs
@@ -1,4 +1,4 @@
-//@error-pattern: deallocating while item is protected
+//@error-pattern: deallocating while item
 use std::marker::PhantomPinned;
 
 pub struct NotUnpin(i32, PhantomPinned);

--- a/tests/fail/stacked_borrows/deallocate_against_barrier2.stderr
+++ b/tests/fail/stacked_borrows/deallocate_against_barrier2.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: deallocating while item is protected: [SharedReadWrite for <TAG>] (call ID)
+error: Undefined Behavior: deallocating while item [SharedReadWrite for <TAG>] is protected by call ID
   --> RUSTLIB/alloc/src/alloc.rs:LL:CC
    |
 LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocating while item is protected: [SharedReadWrite for <TAG>] (call ID)
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocating while item [SharedReadWrite for <TAG>] is protected by call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/deallocate_against_barrier2.stderr
+++ b/tests/fail/stacked_borrows/deallocate_against_barrier2.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: deallocating while item is protected: [SharedReadWrite for <TAG> (call ID)]
+error: Undefined Behavior: deallocating while item is protected: [SharedReadWrite for <TAG>] (call ID)
   --> RUSTLIB/alloc/src/alloc.rs:LL:CC
    |
 LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocating while item is protected: [SharedReadWrite for <TAG> (call ID)]
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocating while item is protected: [SharedReadWrite for <TAG>] (call ID)
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/illegal_write6.stderr
+++ b/tests/fail/stacked_borrows/illegal_write6.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because incompatible item is protected: [Unique for <TAG>] (call ID)
+error: Undefined Behavior: not granting access to tag <TAG> because incompatible item [Unique for <TAG>] is protected by call ID
   --> $DIR/illegal_write6.rs:LL:CC
    |
 LL |     unsafe { *y = 2 };
-   |              ^^^^^^ not granting access to tag <TAG> because incompatible item is protected: [Unique for <TAG>] (call ID)
+   |              ^^^^^^ not granting access to tag <TAG> because incompatible item [Unique for <TAG>] is protected by call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/illegal_write6.stderr
+++ b/tests/fail/stacked_borrows/illegal_write6.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because incompatible item is protected: [Unique for <TAG> (call ID)]
+error: Undefined Behavior: not granting access to tag <TAG> because incompatible item is protected: [Unique for <TAG>] (call ID)
   --> $DIR/illegal_write6.rs:LL:CC
    |
 LL |     unsafe { *y = 2 };
-   |              ^^^^^^ not granting access to tag <TAG> because incompatible item is protected: [Unique for <TAG> (call ID)]
+   |              ^^^^^^ not granting access to tag <TAG> because incompatible item is protected: [Unique for <TAG>] (call ID)
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/invalidate_against_barrier1.stderr
+++ b/tests/fail/stacked_borrows/invalidate_against_barrier1.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because incompatible item is protected: [Unique for <TAG> (call ID)]
+error: Undefined Behavior: not granting access to tag <TAG> because incompatible item is protected: [Unique for <TAG>] (call ID)
   --> $DIR/invalidate_against_barrier1.rs:LL:CC
    |
 LL |     let _val = unsafe { *x };
-   |                         ^^ not granting access to tag <TAG> because incompatible item is protected: [Unique for <TAG> (call ID)]
+   |                         ^^ not granting access to tag <TAG> because incompatible item is protected: [Unique for <TAG>] (call ID)
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/invalidate_against_barrier1.stderr
+++ b/tests/fail/stacked_borrows/invalidate_against_barrier1.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because incompatible item is protected: [Unique for <TAG>] (call ID)
+error: Undefined Behavior: not granting access to tag <TAG> because incompatible item [Unique for <TAG>] is protected by call ID
   --> $DIR/invalidate_against_barrier1.rs:LL:CC
    |
 LL |     let _val = unsafe { *x };
-   |                         ^^ not granting access to tag <TAG> because incompatible item is protected: [Unique for <TAG>] (call ID)
+   |                         ^^ not granting access to tag <TAG> because incompatible item [Unique for <TAG>] is protected by call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/invalidate_against_barrier2.stderr
+++ b/tests/fail/stacked_borrows/invalidate_against_barrier2.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because incompatible item is protected: [SharedReadOnly for <TAG>] (call ID)
+error: Undefined Behavior: not granting access to tag <TAG> because incompatible item [SharedReadOnly for <TAG>] is protected by call ID
   --> $DIR/invalidate_against_barrier2.rs:LL:CC
    |
 LL |     unsafe { *x = 0 };
-   |              ^^^^^^ not granting access to tag <TAG> because incompatible item is protected: [SharedReadOnly for <TAG>] (call ID)
+   |              ^^^^^^ not granting access to tag <TAG> because incompatible item [SharedReadOnly for <TAG>] is protected by call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/invalidate_against_barrier2.stderr
+++ b/tests/fail/stacked_borrows/invalidate_against_barrier2.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because incompatible item is protected: [SharedReadOnly for <TAG> (call ID)]
+error: Undefined Behavior: not granting access to tag <TAG> because incompatible item is protected: [SharedReadOnly for <TAG>] (call ID)
   --> $DIR/invalidate_against_barrier2.rs:LL:CC
    |
 LL |     unsafe { *x = 0 };
-   |              ^^^^^^ not granting access to tag <TAG> because incompatible item is protected: [SharedReadOnly for <TAG> (call ID)]
+   |              ^^^^^^ not granting access to tag <TAG> because incompatible item is protected: [SharedReadOnly for <TAG>] (call ID)
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/newtype_retagging.rs
+++ b/tests/fail/stacked_borrows/newtype_retagging.rs
@@ -1,5 +1,5 @@
 //@compile-flags: -Zmiri-retag-fields
-//@error-pattern: incompatible item is protected
+//@error-pattern: is protected by call
 struct Newtype<'a>(&'a mut i32);
 
 fn dealloc_while_running(_n: Newtype<'_>, dealloc: impl FnOnce()) {

--- a/tests/fail/stacked_borrows/newtype_retagging.stderr
+++ b/tests/fail/stacked_borrows/newtype_retagging.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because incompatible item is protected: [Unique for <TAG> (call ID)]
+error: Undefined Behavior: not granting access to tag <TAG> because incompatible item is protected: [Unique for <TAG>] (call ID)
   --> RUSTLIB/alloc/src/boxed.rs:LL:CC
    |
 LL |         Box(unsafe { Unique::new_unchecked(raw) }, alloc)
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <TAG> because incompatible item is protected: [Unique for <TAG> (call ID)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <TAG> because incompatible item is protected: [Unique for <TAG>] (call ID)
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/newtype_retagging.stderr
+++ b/tests/fail/stacked_borrows/newtype_retagging.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because incompatible item is protected: [Unique for <TAG>] (call ID)
+error: Undefined Behavior: not granting access to tag <TAG> because incompatible item [Unique for <TAG>] is protected by call ID
   --> RUSTLIB/alloc/src/boxed.rs:LL:CC
    |
 LL |         Box(unsafe { Unique::new_unchecked(raw) }, alloc)
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <TAG> because incompatible item is protected: [Unique for <TAG>] (call ID)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <TAG> because incompatible item [Unique for <TAG>] is protected by call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information


### PR DESCRIPTION
This moves protectors out of `Item`, storing them both in a global `HashSet` which contains all currently-protected tags as well as a `Vec<SbTag>` on each `Frame` so that when we return from a function we know which tags to remove from the protected set.

This also bit-packs the 64-bit tag and the 2-bit permission together when they are stored in memory. This means we theoretically run out of tags sooner, but I doubt that limit will ever be hit.

Together these optimizations reduce the memory footprint of Miri when executing programs which stress Stacked Borrows by ~66%. For example, running a test with isolation off which only panics currently peaks at ~19 GB, with this PR it peaks at ~6.2 GB.

To-do
- [x] Enforce the 62-bit limit
- [x] Decide if there is a better order to pack the tag and permission in
- [x] Wait for `UnsafeCell` to become infectious, or express offsets + tags in the global protector set

Benchmarks before:
```
Benchmark 1: cargo +miri miri run --manifest-path bench-cargo-miri/backtraces/Cargo.toml
  Time (mean ± σ):      8.948 s ±  0.253 s    [User: 8.752 s, System: 0.158 s]
  Range (min … max):    8.619 s …  9.279 s    5 runs
 
Benchmark 1: cargo +miri miri run --manifest-path bench-cargo-miri/mse/Cargo.toml
  Time (mean ± σ):      2.129 s ±  0.037 s    [User: 1.849 s, System: 0.248 s]
  Range (min … max):    2.086 s …  2.176 s    5 runs
 
Benchmark 1: cargo +miri miri run --manifest-path bench-cargo-miri/serde1/Cargo.toml
  Time (mean ± σ):      3.334 s ±  0.017 s    [User: 3.211 s, System: 0.103 s]
  Range (min … max):    3.315 s …  3.352 s    5 runs
 
Benchmark 1: cargo +miri miri run --manifest-path bench-cargo-miri/serde2/Cargo.toml
  Time (mean ± σ):      3.316 s ±  0.038 s    [User: 3.207 s, System: 0.095 s]
  Range (min … max):    3.282 s …  3.375 s    5 runs
 
Benchmark 1: cargo +miri miri run --manifest-path bench-cargo-miri/unicode/Cargo.toml
  Time (mean ± σ):      6.391 s ±  0.323 s    [User: 5.928 s, System: 0.412 s]
  Range (min … max):    6.090 s …  6.917 s    5 runs
 ```
 After:
 ```
Benchmark 1: cargo +miri miri run --manifest-path bench-cargo-miri/backtraces/Cargo.toml
  Time (mean ± σ):      6.955 s ±  0.051 s    [User: 6.807 s, System: 0.132 s]
  Range (min … max):    6.900 s …  7.038 s    5 runs
 
Benchmark 1: cargo +miri miri run --manifest-path bench-cargo-miri/mse/Cargo.toml
  Time (mean ± σ):      1.784 s ±  0.012 s    [User: 1.627 s, System: 0.156 s]
  Range (min … max):    1.772 s …  1.797 s    5 runs
 
Benchmark 1: cargo +miri miri run --manifest-path bench-cargo-miri/serde1/Cargo.toml
  Time (mean ± σ):      2.505 s ±  0.095 s    [User: 2.311 s, System: 0.096 s]
  Range (min … max):    2.405 s …  2.603 s    5 runs
 
Benchmark 1: cargo +miri miri run --manifest-path bench-cargo-miri/serde2/Cargo.toml
  Time (mean ± σ):      2.449 s ±  0.031 s    [User: 2.306 s, System: 0.100 s]
  Range (min … max):    2.395 s …  2.467 s    5 runs
 
Benchmark 1: cargo +miri miri run --manifest-path bench-cargo-miri/unicode/Cargo.toml
  Time (mean ± σ):      3.667 s ±  0.110 s    [User: 3.498 s, System: 0.140 s]
  Range (min … max):    3.564 s …  3.814 s    5 runs
 ```
 The decrease in system time is probably due to spending less time in the page fault handler.