### PR TITLE
there are no doctests in ui_test

### DIFF
--- a/ui_test/Cargo.toml
+++ b/ui_test/Cargo.toml
@@ -3,7 +3,9 @@ name = "ui_test"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+test = true # we have unit tests
+doctest = false # but no doc tests
 
 [dependencies]
 rustc_version = "0.4"


### PR DESCRIPTION
It tries to run doctests which leads to an error when testing against a locally built rustc (that has no rustdoc).