### PR TITLE
More robust comment parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,16 +53,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backtrace"
+version = "0.3.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "color-eyre"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ebf286c900a6d5867aeff75cfee3192857bb7f24b547d4f0df2ed6baa812c90"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba75b3d9449ecdccb27ecbc479fdc0b87fa2dd43d2f8298f9bf0e59aacc8dce"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
 
 [[package]]
 name = "colored"
@@ -159,6 +222,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +241,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "hermit-abi"
@@ -183,6 +262,12 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "instant"
@@ -268,6 +353,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "miri"
 version = "0.1.0"
 dependencies = [
@@ -287,6 +381,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.28.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+
+[[package]]
 name = "output_vt100"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +403,12 @@ checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "decf7381921fea4dcb2549c5667eda59b3ec297ab7e2b5fc33eac69d2e7da87b"
 
 [[package]]
 name = "parking_lot"
@@ -328,6 +443,12 @@ checksum = "ce9bedf5da2c234fdf2391ede2b90fabf585355f33100689bc364a3ea558561a"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "ppv-lite86"
@@ -432,6 +553,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +629,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-escape"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,9 +670,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a713421342a5a666b7577783721d3117f1b69a393df803ee17bb73b1e122a59"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
+]
+
+[[package]]
 name = "ui_test"
 version = "0.1.0"
 dependencies = [
+ "color-eyre",
  "colored",
  "crossbeam",
  "lazy_static",
@@ -552,6 +740,12 @@ name = "unicode-ident"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "wasi"

--- a/miri
+++ b/miri
@@ -181,8 +181,8 @@ test|test-debug|bless|bless-debug)
     esac
     # Then test, and let caller control flags.
     # Only in root project and ui_test as `cargo-miri` has no tests.
-    $CARGO test $CARGO_BUILD_FLAGS --manifest-path "$MIRIDIR"/Cargo.toml "$@"
     $CARGO test $CARGO_BUILD_FLAGS --manifest-path "$MIRIDIR"/ui_test/Cargo.toml "$@"
+    $CARGO test $CARGO_BUILD_FLAGS --manifest-path "$MIRIDIR"/Cargo.toml "$@"
     ;;
 run|run-debug)
     # Scan for "--target" to overwrite the "MIRI_TEST_TARGET" env var so

--- a/miri
+++ b/miri
@@ -181,8 +181,8 @@ test|test-debug|bless|bless-debug)
     esac
     # Then test, and let caller control flags.
     # Only in root project and ui_test as `cargo-miri` has no tests.
-    $CARGO test $CARGO_BUILD_FLAGS --manifest-path "$MIRIDIR"/ui_test/Cargo.toml "$@"
     $CARGO test $CARGO_BUILD_FLAGS --manifest-path "$MIRIDIR"/Cargo.toml "$@"
+    $CARGO test $CARGO_BUILD_FLAGS --manifest-path "$MIRIDIR"/ui_test/Cargo.toml "$@"
     ;;
 run|run-debug)
     # Scan for "--target" to overwrite the "MIRI_TEST_TARGET" env var so

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -2,7 +2,7 @@ use colored::*;
 use regex::Regex;
 use std::env;
 use std::path::PathBuf;
-use ui_test::{Config, Mode, OutputConflictHandling, color_eyre::Result};
+use ui_test::{color_eyre::Result, Config, Mode, OutputConflictHandling};
 
 fn miri_path() -> PathBuf {
     PathBuf::from(option_env!("MIRI").unwrap_or(env!("CARGO_BIN_EXE_miri")))

--- a/tests/fail/alloc/deallocate-bad-alignment.rs
+++ b/tests/fail/alloc/deallocate-bad-alignment.rs
@@ -1,6 +1,6 @@
 use std::alloc::{alloc, dealloc, Layout};
 
-// error-pattern: has size 1 and alignment 1, but gave size 1 and alignment 2
+//@error-pattern: has size 1 and alignment 1, but gave size 1 and alignment 2
 
 fn main() {
     unsafe {

--- a/tests/fail/alloc/deallocate-bad-size.rs
+++ b/tests/fail/alloc/deallocate-bad-size.rs
@@ -1,6 +1,6 @@
 use std::alloc::{alloc, dealloc, Layout};
 
-// error-pattern: has size 1 and alignment 1, but gave size 2 and alignment 1
+//@error-pattern: has size 1 and alignment 1, but gave size 2 and alignment 1
 
 fn main() {
     unsafe {

--- a/tests/fail/alloc/deallocate-twice.rs
+++ b/tests/fail/alloc/deallocate-twice.rs
@@ -1,6 +1,6 @@
 use std::alloc::{alloc, dealloc, Layout};
 
-// error-pattern: dereferenced after this allocation got freed
+//@error-pattern: dereferenced after this allocation got freed
 
 fn main() {
     unsafe {

--- a/tests/fail/alloc/global_system_mixup.rs
+++ b/tests/fail/alloc/global_system_mixup.rs
@@ -1,10 +1,10 @@
 // Make sure we detect when the `Global` and `System` allocators are mixed
 // (even when the default `Global` uses `System`).
-// error-pattern: which is Rust heap memory, using
+//@error-pattern: which is Rust heap memory, using
 
-// normalize-stderr-test: "using [A-Za-z]+ heap deallocation operation" -> "using PLATFORM heap deallocation operation"
-// normalize-stderr-test: "\| +\^+" -> "| ^"
-// normalize-stderr-test: "libc::free\([^()]*\)|unsafe \{ HeapFree\([^()]*\) \};" -> "FREE();"
+//@normalize-stderr-test: "using [A-Za-z]+ heap deallocation operation" -> "using PLATFORM heap deallocation operation"
+//@normalize-stderr-test: "\| +\^+" -> "| ^"
+//@normalize-stderr-test: "libc::free\([^()]*\)|unsafe \{ HeapFree\([^()]*\) \};" -> "FREE();"
 
 #![feature(allocator_api, slice_ptr_get)]
 

--- a/tests/fail/alloc/reallocate-bad-size.rs
+++ b/tests/fail/alloc/reallocate-bad-size.rs
@@ -1,6 +1,6 @@
 use std::alloc::{alloc, realloc, Layout};
 
-// error-pattern: has size 1 and alignment 1, but gave size 2 and alignment 1
+//@error-pattern: has size 1 and alignment 1, but gave size 2 and alignment 1
 
 fn main() {
     unsafe {

--- a/tests/fail/alloc/reallocate-dangling.rs
+++ b/tests/fail/alloc/reallocate-dangling.rs
@@ -1,6 +1,6 @@
 use std::alloc::{alloc, dealloc, realloc, Layout};
 
-// error-pattern: dereferenced after this allocation got freed
+//@error-pattern: dereferenced after this allocation got freed
 
 fn main() {
     unsafe {

--- a/tests/fail/alloc/stack_free.rs
+++ b/tests/fail/alloc/stack_free.rs
@@ -1,7 +1,7 @@
 // Validation/SB changes why we fail
-// compile-flags: -Zmiri-disable-validation -Zmiri-disable-stacked-borrows
+//@compile-flags: -Zmiri-disable-validation -Zmiri-disable-stacked-borrows
 
-// error-pattern: which is stack variable memory, using Rust heap deallocation operation
+//@error-pattern: which is stack variable memory, using Rust heap deallocation operation
 
 fn main() {
     let x = 42;

--- a/tests/fail/box-cell-alias.rs
+++ b/tests/fail/box-cell-alias.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-strict-provenance
+//@compile-flags: -Zmiri-strict-provenance
 
 // Taken from <https://github.com/rust-lang/unsafe-code-guidelines/issues/194#issuecomment-520934222>.
 

--- a/tests/fail/concurrency/libc_pthread_create_main_terminate.rs
+++ b/tests/fail/concurrency/libc_pthread_create_main_terminate.rs
@@ -1,5 +1,5 @@
-// ignore-windows: No libc on Windows
-// error-pattern: the main thread terminated without waiting for all remaining threads
+//@ignore-windows: No libc on Windows
+//@error-pattern: the main thread terminated without waiting for all remaining threads
 
 // Check that we terminate the program when the main thread terminates.
 

--- a/tests/fail/concurrency/libc_pthread_join_detached.rs
+++ b/tests/fail/concurrency/libc_pthread_join_detached.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 
 // Joining a detached thread is undefined behavior.
 

--- a/tests/fail/concurrency/libc_pthread_join_joined.rs
+++ b/tests/fail/concurrency/libc_pthread_join_joined.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 
 // Joining an already joined thread is undefined behavior.
 

--- a/tests/fail/concurrency/libc_pthread_join_main.rs
+++ b/tests/fail/concurrency/libc_pthread_join_main.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 
 // Joining the main thread is undefined behavior.
 

--- a/tests/fail/concurrency/libc_pthread_join_multiple.rs
+++ b/tests/fail/concurrency/libc_pthread_join_multiple.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 
 // Joining the same thread from multiple threads is undefined behavior.
 

--- a/tests/fail/concurrency/libc_pthread_join_self.rs
+++ b/tests/fail/concurrency/libc_pthread_join_self.rs
@@ -1,6 +1,6 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 // We are making scheduler assumptions here.
-// compile-flags: -Zmiri-preemption-rate=0
+//@compile-flags: -Zmiri-preemption-rate=0
 
 // Joining itself is undefined behavior.
 

--- a/tests/fail/concurrency/thread-spawn.rs
+++ b/tests/fail/concurrency/thread-spawn.rs
@@ -1,8 +1,8 @@
-// only-windows: Only Windows is not supported.
+//@only-windows: Only Windows is not supported.
 
 use std::thread;
 
-// error-pattern: can't create threads on Windows
+//@error-pattern: can't create threads on Windows
 
 fn main() {
     thread::spawn(|| {});

--- a/tests/fail/concurrency/thread_local_static_dealloc.rs
+++ b/tests/fail/concurrency/thread_local_static_dealloc.rs
@@ -1,4 +1,4 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-windows: Concurrency on Windows is not supported yet.
 
 //! Ensure that thread-local statics get deallocated when the thread dies.
 

--- a/tests/fail/concurrency/too_few_args.rs
+++ b/tests/fail/concurrency/too_few_args.rs
@@ -1,4 +1,4 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-windows: Concurrency on Windows is not supported yet.
 
 //! The thread function must have exactly one argument.
 

--- a/tests/fail/concurrency/too_many_args.rs
+++ b/tests/fail/concurrency/too_many_args.rs
@@ -1,4 +1,4 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-windows: Concurrency on Windows is not supported yet.
 
 //! The thread function must have exactly one argument.
 

--- a/tests/fail/concurrency/unwind_top_of_stack.rs
+++ b/tests/fail/concurrency/unwind_top_of_stack.rs
@@ -1,5 +1,5 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-abi-check
+//@ignore-windows: Concurrency on Windows is not supported yet.
+//@compile-flags: -Zmiri-disable-abi-check
 
 //! Unwinding past the top frame of a stack is Undefined Behavior.
 

--- a/tests/fail/dangling_pointers/dangling_pointer_addr_of.rs
+++ b/tests/fail/dangling_pointers/dangling_pointer_addr_of.rs
@@ -1,5 +1,5 @@
 // Make sure we find these even with many checks disabled.
-// compile-flags: -Zmiri-disable-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-disable-validation
+//@compile-flags: -Zmiri-disable-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-disable-validation
 use std::ptr;
 
 fn main() {

--- a/tests/fail/dangling_pointers/dangling_pointer_deref.rs
+++ b/tests/fail/dangling_pointers/dangling_pointer_deref.rs
@@ -1,5 +1,5 @@
 // Make sure we find these even with many checks disabled.
-// compile-flags: -Zmiri-disable-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-disable-validation
+//@compile-flags: -Zmiri-disable-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-disable-validation
 
 fn main() {
     let p = {

--- a/tests/fail/dangling_pointers/dangling_zst_deref.rs
+++ b/tests/fail/dangling_pointers/dangling_zst_deref.rs
@@ -1,6 +1,6 @@
 // Make sure we find these even with many checks disabled.
 // Some optimizations remove ZST accesses, thus masking this UB.
-// compile-flags: -Zmir-opt-level=0 -Zmiri-disable-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-disable-validation
+//@compile-flags: -Zmir-opt-level=0 -Zmiri-disable-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-disable-validation
 
 fn main() {
     let p = {

--- a/tests/fail/dangling_pointers/deref-invalid-ptr.rs
+++ b/tests/fail/dangling_pointers/deref-invalid-ptr.rs
@@ -1,5 +1,5 @@
 // This should fail even without validation.
-// compile-flags: -Zmiri-disable-validation -Zmiri-permissive-provenance
+//@compile-flags: -Zmiri-disable-validation -Zmiri-permissive-provenance
 
 fn main() {
     let x = 16usize as *const u32;

--- a/tests/fail/dangling_pointers/dyn_size.rs
+++ b/tests/fail/dangling_pointers/dyn_size.rs
@@ -1,5 +1,5 @@
 // should find the bug even without these, but gets masked by optimizations
-// compile-flags: -Zmiri-disable-validation -Zmiri-disable-stacked-borrows -Zmir-opt-level=0
+//@compile-flags: -Zmiri-disable-validation -Zmiri-disable-stacked-borrows -Zmir-opt-level=0
 
 struct SliceWithHead(u8, [u8]);
 

--- a/tests/fail/dangling_pointers/maybe_null_pointer_deref_zst.rs
+++ b/tests/fail/dangling_pointers/maybe_null_pointer_deref_zst.rs
@@ -1,5 +1,5 @@
 // Some optimizations remove ZST accesses, thus masking this UB.
-// compile-flags: -Zmir-opt-level=0
+//@compile-flags: -Zmir-opt-level=0
 
 fn main() {
     // This pointer *could* be NULL so we cannot load from it, not even at ZST

--- a/tests/fail/dangling_pointers/maybe_null_pointer_write_zst.rs
+++ b/tests/fail/dangling_pointers/maybe_null_pointer_write_zst.rs
@@ -1,5 +1,5 @@
 // Some optimizations remove ZST accesses, thus masking this UB.
-// compile-flags: -Zmir-opt-level=0
+//@compile-flags: -Zmir-opt-level=0
 
 fn main() {
     // This pointer *could* be NULL so we cannot load from it, not even at ZST.

--- a/tests/fail/dangling_pointers/null_pointer_deref_zst.rs
+++ b/tests/fail/dangling_pointers/null_pointer_deref_zst.rs
@@ -1,5 +1,5 @@
 // Some optimizations remove ZST accesses, thus masking this UB.
-// compile-flags: -Zmir-opt-level=0
+//@compile-flags: -Zmir-opt-level=0
 
 #[allow(deref_nullptr)]
 fn main() {

--- a/tests/fail/dangling_pointers/null_pointer_write_zst.rs
+++ b/tests/fail/dangling_pointers/null_pointer_write_zst.rs
@@ -1,6 +1,6 @@
 // Some optimizations remove ZST accesses, thus masking this UB.
-// compile-flags: -Zmir-opt-level=0
-// error-pattern: memory access failed: null pointer is a dangling pointer
+//@compile-flags: -Zmir-opt-level=0
+//@error-pattern: memory access failed: null pointer is a dangling pointer
 
 #[allow(deref_nullptr)]
 fn main() {

--- a/tests/fail/dangling_pointers/stack_temporary.rs
+++ b/tests/fail/dangling_pointers/stack_temporary.rs
@@ -1,5 +1,5 @@
 // This should fail even without validation, but some MIR opts mask the error
-// compile-flags: -Zmiri-disable-validation -Zmir-opt-level=0
+//@compile-flags: -Zmiri-disable-validation -Zmir-opt-level=0
 
 unsafe fn make_ref<'a>(x: *mut i32) -> &'a mut i32 {
     &mut *x

--- a/tests/fail/dangling_pointers/storage_dead_dangling.rs
+++ b/tests/fail/dangling_pointers/storage_dead_dangling.rs
@@ -1,5 +1,5 @@
 // This should fail even without validation, but some MIR opts mask the error
-// compile-flags: -Zmiri-disable-validation -Zmir-opt-level=0 -Zmiri-permissive-provenance
+//@compile-flags: -Zmiri-disable-validation -Zmir-opt-level=0 -Zmiri-permissive-provenance
 
 static mut LEAK: usize = 0;
 

--- a/tests/fail/dangling_pointers/wild_pointer_deref.rs
+++ b/tests/fail/dangling_pointers/wild_pointer_deref.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-permissive-provenance
+//@compile-flags: -Zmiri-permissive-provenance
 
 fn main() {
     let p = 44 as *const i32;

--- a/tests/fail/data_race/alloc_read_race.rs
+++ b/tests/fail/data_race/alloc_read_race.rs
@@ -1,5 +1,5 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
+//@ignore-windows: Concurrency on Windows is not supported yet.
+//@compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 #![feature(new_uninit)]
 
 use std::mem::MaybeUninit;

--- a/tests/fail/data_race/alloc_write_race.rs
+++ b/tests/fail/data_race/alloc_write_race.rs
@@ -1,5 +1,5 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
+//@ignore-windows: Concurrency on Windows is not supported yet.
+//@compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 #![feature(new_uninit)]
 
 use std::ptr::null_mut;

--- a/tests/fail/data_race/atomic_read_na_write_race1.rs
+++ b/tests/fail/data_race/atomic_read_na_write_race1.rs
@@ -1,4 +1,4 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-windows: Concurrency on Windows is not supported yet.
 #![feature(core_intrinsics)]
 
 use std::intrinsics;

--- a/tests/fail/data_race/atomic_read_na_write_race2.rs
+++ b/tests/fail/data_race/atomic_read_na_write_race2.rs
@@ -1,4 +1,4 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-windows: Concurrency on Windows is not supported yet.
 
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;

--- a/tests/fail/data_race/atomic_write_na_read_race1.rs
+++ b/tests/fail/data_race/atomic_write_na_read_race1.rs
@@ -1,4 +1,4 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-windows: Concurrency on Windows is not supported yet.
 
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;

--- a/tests/fail/data_race/atomic_write_na_read_race2.rs
+++ b/tests/fail/data_race/atomic_write_na_read_race2.rs
@@ -1,4 +1,4 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-windows: Concurrency on Windows is not supported yet.
 #![feature(core_intrinsics)]
 
 use std::intrinsics::atomic_store;

--- a/tests/fail/data_race/atomic_write_na_write_race1.rs
+++ b/tests/fail/data_race/atomic_write_na_write_race1.rs
@@ -1,4 +1,4 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-windows: Concurrency on Windows is not supported yet.
 #![feature(core_intrinsics)]
 
 use std::intrinsics::atomic_store;

--- a/tests/fail/data_race/atomic_write_na_write_race2.rs
+++ b/tests/fail/data_race/atomic_write_na_write_race2.rs
@@ -1,4 +1,4 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-windows: Concurrency on Windows is not supported yet.
 
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;

--- a/tests/fail/data_race/dangling_thread_async_race.rs
+++ b/tests/fail/data_race/dangling_thread_async_race.rs
@@ -1,5 +1,5 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-isolation
+//@ignore-windows: Concurrency on Windows is not supported yet.
+//@compile-flags: -Zmiri-disable-isolation
 
 use std::mem;
 use std::thread::{sleep, spawn};

--- a/tests/fail/data_race/dangling_thread_race.rs
+++ b/tests/fail/data_race/dangling_thread_race.rs
@@ -1,5 +1,5 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-isolation
+//@ignore-windows: Concurrency on Windows is not supported yet.
+//@compile-flags: -Zmiri-disable-isolation
 
 use std::mem;
 use std::thread::{sleep, spawn};

--- a/tests/fail/data_race/dealloc_read_race1.rs
+++ b/tests/fail/data_race/dealloc_read_race1.rs
@@ -1,4 +1,4 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-windows: Concurrency on Windows is not supported yet.
 
 use std::thread::spawn;
 

--- a/tests/fail/data_race/dealloc_read_race2.rs
+++ b/tests/fail/data_race/dealloc_read_race2.rs
@@ -1,4 +1,4 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-windows: Concurrency on Windows is not supported yet.
 
 use std::thread::spawn;
 

--- a/tests/fail/data_race/dealloc_read_race_stack.rs
+++ b/tests/fail/data_race/dealloc_read_race_stack.rs
@@ -1,5 +1,5 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
+//@ignore-windows: Concurrency on Windows is not supported yet.
+//@compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
 use std::ptr::null_mut;
 use std::sync::atomic::{AtomicPtr, Ordering};

--- a/tests/fail/data_race/dealloc_write_race1.rs
+++ b/tests/fail/data_race/dealloc_write_race1.rs
@@ -1,4 +1,4 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-windows: Concurrency on Windows is not supported yet.
 
 use std::thread::spawn;
 

--- a/tests/fail/data_race/dealloc_write_race2.rs
+++ b/tests/fail/data_race/dealloc_write_race2.rs
@@ -1,4 +1,4 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-windows: Concurrency on Windows is not supported yet.
 
 use std::thread::spawn;
 

--- a/tests/fail/data_race/dealloc_write_race_stack.rs
+++ b/tests/fail/data_race/dealloc_write_race_stack.rs
@@ -1,5 +1,5 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
+//@ignore-windows: Concurrency on Windows is not supported yet.
+//@compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
 use std::ptr::null_mut;
 use std::sync::atomic::{AtomicPtr, Ordering};

--- a/tests/fail/data_race/enable_after_join_to_main.rs
+++ b/tests/fail/data_race/enable_after_join_to_main.rs
@@ -1,4 +1,4 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-windows: Concurrency on Windows is not supported yet.
 
 use std::thread::spawn;
 

--- a/tests/fail/data_race/fence_after_load.rs
+++ b/tests/fail/data_race/fence_after_load.rs
@@ -1,6 +1,6 @@
 // We want to control preemption here.
-// compile-flags: -Zmiri-disable-isolation -Zmiri-preemption-rate=0
-// ignore-windows: Concurrency on Windows is not supported yet.
+//@compile-flags: -Zmiri-disable-isolation -Zmiri-preemption-rate=0
+//@ignore-windows: Concurrency on Windows is not supported yet.
 use std::sync::atomic::{fence, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread;

--- a/tests/fail/data_race/read_write_race.rs
+++ b/tests/fail/data_race/read_write_race.rs
@@ -1,4 +1,4 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-windows: Concurrency on Windows is not supported yet.
 
 use std::thread::spawn;
 

--- a/tests/fail/data_race/read_write_race_stack.rs
+++ b/tests/fail/data_race/read_write_race_stack.rs
@@ -1,5 +1,5 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-isolation -Zmir-opt-level=0 -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
+//@ignore-windows: Concurrency on Windows is not supported yet.
+//@compile-flags: -Zmiri-disable-isolation -Zmir-opt-level=0 -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
 // Note: mir-opt-level set to 0 to prevent the read of stack_var in thread 1
 // from being optimized away and preventing the detection of the data-race.

--- a/tests/fail/data_race/relax_acquire_race.rs
+++ b/tests/fail/data_race/relax_acquire_race.rs
@@ -1,5 +1,5 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
+//@ignore-windows: Concurrency on Windows is not supported yet.
+//@compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread::spawn;

--- a/tests/fail/data_race/release_seq_race.rs
+++ b/tests/fail/data_race/release_seq_race.rs
@@ -1,5 +1,5 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
+//@ignore-windows: Concurrency on Windows is not supported yet.
+//@compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread::{sleep, spawn};

--- a/tests/fail/data_race/release_seq_race_same_thread.rs
+++ b/tests/fail/data_race/release_seq_race_same_thread.rs
@@ -1,5 +1,5 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
+//@ignore-windows: Concurrency on Windows is not supported yet.
+//@compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread::spawn;

--- a/tests/fail/data_race/rmw_race.rs
+++ b/tests/fail/data_race/rmw_race.rs
@@ -1,5 +1,5 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
+//@ignore-windows: Concurrency on Windows is not supported yet.
+//@compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread::spawn;

--- a/tests/fail/data_race/stack_pop_race.rs
+++ b/tests/fail/data_race/stack_pop_race.rs
@@ -1,5 +1,5 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-preemption-rate=0
+//@ignore-windows: Concurrency on Windows is not supported yet.
+//@compile-flags: -Zmiri-preemption-rate=0
 use std::thread;
 
 #[derive(Copy, Clone)]

--- a/tests/fail/data_race/write_write_race.rs
+++ b/tests/fail/data_race/write_write_race.rs
@@ -1,4 +1,4 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-windows: Concurrency on Windows is not supported yet.
 
 use std::thread::spawn;
 

--- a/tests/fail/data_race/write_write_race_stack.rs
+++ b/tests/fail/data_race/write_write_race_stack.rs
@@ -1,5 +1,5 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
+//@ignore-windows: Concurrency on Windows is not supported yet.
+//@compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
 use std::ptr::null_mut;
 use std::sync::atomic::{AtomicPtr, Ordering};

--- a/tests/fail/environ-gets-deallocated.rs
+++ b/tests/fail/environ-gets-deallocated.rs
@@ -1,4 +1,4 @@
-// ignore-windows: Windows does not have a global environ list that the program can access directly
+//@ignore-windows: Windows does not have a global environ list that the program can access directly
 
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 fn get_environ() -> *const *const u8 {

--- a/tests/fail/erroneous_const.rs
+++ b/tests/fail/erroneous_const.rs
@@ -1,7 +1,7 @@
 //! Make sure we detect erroneous constants post-monomorphization even when they are unused.
 //! (https://github.com/rust-lang/miri/issues/1382)
 // Inlining changes the error location
-// compile-flags: -Zmir-opt-level=0
+//@compile-flags: -Zmir-opt-level=0
 #![feature(never_type)]
 #![warn(warnings, const_err)]
 

--- a/tests/fail/fs/close_stdout.rs
+++ b/tests/fail/fs/close_stdout.rs
@@ -1,5 +1,5 @@
-// ignore-windows: No libc on Windows
-// compile-flags: -Zmiri-disable-isolation
+//@ignore-windows: No libc on Windows
+//@compile-flags: -Zmiri-disable-isolation
 
 // FIXME: standard handles cannot be closed (https://github.com/rust-lang/rust/issues/40032)
 

--- a/tests/fail/fs/isolated_file.rs
+++ b/tests/fail/fs/isolated_file.rs
@@ -1,5 +1,5 @@
-// ignore-windows: File handling is not implemented yet
-// error-pattern: `open` not available when isolation is enabled
+//@ignore-windows: File handling is not implemented yet
+//@error-pattern: `open` not available when isolation is enabled
 
 fn main() {
     let _file = std::fs::File::open("file.txt").unwrap();

--- a/tests/fail/fs/isolated_stdin.rs
+++ b/tests/fail/fs/isolated_stdin.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/fs/read_from_stdout.rs
+++ b/tests/fail/fs/read_from_stdout.rs
@@ -1,5 +1,5 @@
-// compile-flags: -Zmiri-disable-isolation
-// ignore-windows: No libc on Windows
+//@compile-flags: -Zmiri-disable-isolation
+//@ignore-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/fs/unix_open_missing_required_mode.rs
+++ b/tests/fail/fs/unix_open_missing_required_mode.rs
@@ -1,5 +1,5 @@
-// ignore-windows: No libc on Windows
-// compile-flags: -Zmiri-disable-isolation
+//@ignore-windows: No libc on Windows
+//@compile-flags: -Zmiri-disable-isolation
 
 #![feature(rustc_private)]
 

--- a/tests/fail/fs/write_to_stdin.rs
+++ b/tests/fail/fs/write_to_stdin.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/function_calls/exported_symbol_abi_mismatch.rs
+++ b/tests/fail/function_calls/exported_symbol_abi_mismatch.rs
@@ -1,4 +1,4 @@
-// revisions: no_cache cache fn_ptr
+//@revisions: no_cache cache fn_ptr
 
 #[no_mangle]
 fn foo() {}

--- a/tests/fail/function_calls/exported_symbol_bad_unwind1.rs
+++ b/tests/fail/function_calls/exported_symbol_bad_unwind1.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-disable-abi-check
+//@compile-flags: -Zmiri-disable-abi-check
 #![feature(c_unwind)]
 
 #[no_mangle]

--- a/tests/fail/function_calls/exported_symbol_bad_unwind2.rs
+++ b/tests/fail/function_calls/exported_symbol_bad_unwind2.rs
@@ -1,4 +1,4 @@
-// revisions: extern_block definition both
+//@revisions: extern_block definition both
 #![feature(rustc_attrs, c_unwind)]
 
 #[cfg_attr(any(definition, both), rustc_allocator_nounwind)]

--- a/tests/fail/function_pointers/cast_box_int_to_fn_ptr.rs
+++ b/tests/fail/function_pointers/cast_box_int_to_fn_ptr.rs
@@ -1,5 +1,5 @@
 // Validation makes this fail in the wrong place
-// compile-flags: -Zmiri-disable-validation
+//@compile-flags: -Zmiri-disable-validation
 
 fn main() {
     let b = Box::new(42);

--- a/tests/fail/function_pointers/cast_int_to_fn_ptr.rs
+++ b/tests/fail/function_pointers/cast_int_to_fn_ptr.rs
@@ -1,5 +1,5 @@
 // Validation makes this fail in the wrong place
-// compile-flags: -Zmiri-disable-validation
+//@compile-flags: -Zmiri-disable-validation
 
 fn main() {
     let g = unsafe { std::mem::transmute::<usize, fn(i32)>(42) };

--- a/tests/fail/function_pointers/execute_memory.rs
+++ b/tests/fail/function_pointers/execute_memory.rs
@@ -1,5 +1,5 @@
 // Validation makes this fail in the wrong place
-// compile-flags: -Zmiri-disable-validation
+//@compile-flags: -Zmiri-disable-validation
 
 #![feature(box_syntax)]
 

--- a/tests/fail/function_pointers/fn_ptr_offset.rs
+++ b/tests/fail/function_pointers/fn_ptr_offset.rs
@@ -1,5 +1,5 @@
 // Validation makes this fail in the wrong place
-// compile-flags: -Zmiri-disable-validation
+//@compile-flags: -Zmiri-disable-validation
 
 use std::mem;
 

--- a/tests/fail/generator-pinned-moved.rs
+++ b/tests/fail/generator-pinned-moved.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-disable-validation
+//@compile-flags: -Zmiri-disable-validation
 #![feature(generators, generator_trait)]
 
 use std::{

--- a/tests/fail/intrinsics/copy_overflow.rs
+++ b/tests/fail/intrinsics/copy_overflow.rs
@@ -1,4 +1,4 @@
-// error-pattern: overflow computing total size
+//@error-pattern: overflow computing total size
 use std::mem;
 
 fn main() {

--- a/tests/fail/intrinsics/out_of_bounds_ptr_1.rs
+++ b/tests/fail/intrinsics/out_of_bounds_ptr_1.rs
@@ -1,4 +1,4 @@
-// error-pattern: pointer to 5 bytes starting at offset 0 is out-of-bounds
+//@error-pattern: pointer to 5 bytes starting at offset 0 is out-of-bounds
 fn main() {
     let v = [0i8; 4];
     let x = &v as *const i8;

--- a/tests/fail/intrinsics/out_of_bounds_ptr_2.rs
+++ b/tests/fail/intrinsics/out_of_bounds_ptr_2.rs
@@ -1,4 +1,4 @@
-// error-pattern: overflowing in-bounds pointer arithmetic
+//@error-pattern: overflowing in-bounds pointer arithmetic
 fn main() {
     let v = [0i8; 4];
     let x = &v as *const i8;

--- a/tests/fail/intrinsics/out_of_bounds_ptr_3.rs
+++ b/tests/fail/intrinsics/out_of_bounds_ptr_3.rs
@@ -1,4 +1,4 @@
-// error-pattern: pointer to 1 byte starting at offset -1 is out-of-bounds
+//@error-pattern: pointer to 1 byte starting at offset -1 is out-of-bounds
 fn main() {
     let v = [0i8; 4];
     let x = &v as *const i8;

--- a/tests/fail/intrinsics/ptr_offset_0_plus_0.rs
+++ b/tests/fail/intrinsics/ptr_offset_0_plus_0.rs
@@ -1,5 +1,5 @@
-// error-pattern: null pointer is a dangling pointer
-// compile-flags: -Zmiri-permissive-provenance
+//@error-pattern: null pointer is a dangling pointer
+//@compile-flags: -Zmiri-permissive-provenance
 
 fn main() {
     let x = 0 as *mut i32;

--- a/tests/fail/intrinsics/ptr_offset_int_plus_int.rs
+++ b/tests/fail/intrinsics/ptr_offset_int_plus_int.rs
@@ -1,5 +1,5 @@
-// error-pattern: is a dangling pointer
-// compile-flags: -Zmiri-permissive-provenance
+//@error-pattern: is a dangling pointer
+//@compile-flags: -Zmiri-permissive-provenance
 
 fn main() {
     // Can't offset an integer pointer by non-zero offset.

--- a/tests/fail/intrinsics/ptr_offset_int_plus_ptr.rs
+++ b/tests/fail/intrinsics/ptr_offset_int_plus_ptr.rs
@@ -1,5 +1,5 @@
-// error-pattern: is a dangling pointer
-// compile-flags: -Zmiri-permissive-provenance
+//@error-pattern: is a dangling pointer
+//@compile-flags: -Zmiri-permissive-provenance
 
 fn main() {
     let ptr = Box::into_raw(Box::new(0u32));

--- a/tests/fail/intrinsics/ptr_offset_overflow.rs
+++ b/tests/fail/intrinsics/ptr_offset_overflow.rs
@@ -1,4 +1,4 @@
-// error-pattern: overflowing in-bounds pointer arithmetic
+//@error-pattern: overflowing in-bounds pointer arithmetic
 fn main() {
     let v = [1i8, 2];
     let x = &v[1] as *const i8;

--- a/tests/fail/intrinsics/ptr_offset_ptr_plus_0.rs
+++ b/tests/fail/intrinsics/ptr_offset_ptr_plus_0.rs
@@ -1,4 +1,4 @@
-// error-pattern: pointer at offset 32 is out-of-bounds
+//@error-pattern: pointer at offset 32 is out-of-bounds
 
 fn main() {
     let x = Box::into_raw(Box::new(0u32));

--- a/tests/fail/intrinsics/simd-float-to-int.rs
+++ b/tests/fail/intrinsics/simd-float-to-int.rs
@@ -1,4 +1,4 @@
-// error-pattern: cannot be represented in target type `i32`
+//@error-pattern: cannot be represented in target type `i32`
 #![feature(portable_simd)]
 use std::simd::*;
 

--- a/tests/fail/intrinsics/simd-gather.rs
+++ b/tests/fail/intrinsics/simd-gather.rs
@@ -1,4 +1,4 @@
-// error-pattern: pointer to 1 byte starting at offset 9 is out-of-bounds
+//@error-pattern: pointer to 1 byte starting at offset 9 is out-of-bounds
 #![feature(portable_simd)]
 use std::simd::*;
 

--- a/tests/fail/intrinsics/simd-scatter.rs
+++ b/tests/fail/intrinsics/simd-scatter.rs
@@ -1,4 +1,4 @@
-// error-pattern: pointer to 1 byte starting at offset 9 is out-of-bounds
+//@error-pattern: pointer to 1 byte starting at offset 9 is out-of-bounds
 #![feature(portable_simd)]
 use std::simd::*;
 

--- a/tests/fail/intrinsics/write_bytes_overflow.rs
+++ b/tests/fail/intrinsics/write_bytes_overflow.rs
@@ -1,4 +1,4 @@
-// error-pattern: overflow computing total size of `write_bytes`
+//@error-pattern: overflow computing total size of `write_bytes`
 use std::mem;
 
 fn main() {

--- a/tests/fail/invalid_bool.rs
+++ b/tests/fail/invalid_bool.rs
@@ -1,6 +1,6 @@
 // Validation makes this fail in the wrong place
 // Make sure we find these even with many checks disabled.
-// compile-flags: -Zmiri-disable-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-disable-validation
+//@compile-flags: -Zmiri-disable-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-disable-validation
 #![feature(bench_black_box)]
 
 fn main() {

--- a/tests/fail/invalid_char.rs
+++ b/tests/fail/invalid_char.rs
@@ -1,6 +1,6 @@
 // Validation makes this fail in the wrong place
 // Make sure we find these even with many checks disabled.
-// compile-flags: -Zmiri-disable-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-disable-validation
+//@compile-flags: -Zmiri-disable-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-disable-validation
 
 fn main() {
     let c = 0xFFFFFFu32;

--- a/tests/fail/invalid_enum_tag.rs
+++ b/tests/fail/invalid_enum_tag.rs
@@ -1,8 +1,8 @@
 // Validation makes this fail in the wrong place
 // Make sure we find these even with many checks disabled.
-// compile-flags: -Zmiri-disable-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-disable-validation
+//@compile-flags: -Zmiri-disable-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-disable-validation
 
-// error-pattern: enum value has invalid tag
+//@error-pattern: enum value has invalid tag
 
 use std::mem;
 

--- a/tests/fail/invalid_int.rs
+++ b/tests/fail/invalid_int.rs
@@ -1,6 +1,6 @@
 // Validation makes this fail in the wrong place
 // Make sure we find these even with many checks disabled.
-// compile-flags: -Zmiri-disable-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-disable-validation
+//@compile-flags: -Zmiri-disable-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-disable-validation
 
 fn main() {
     let i = unsafe { std::mem::MaybeUninit::<i32>::uninit().assume_init() };

--- a/tests/fail/memleak.rs
+++ b/tests/fail/memleak.rs
@@ -1,5 +1,5 @@
-// error-pattern: the evaluated program leaked memory
-// normalize-stderr-test: ".*│.*" -> "$$stripped$$"
+//@error-pattern: the evaluated program leaked memory
+//@normalize-stderr-test: ".*│.*" -> "$$stripped$$"
 
 fn main() {
     std::mem::forget(Box::new(42));

--- a/tests/fail/memleak_rc.rs
+++ b/tests/fail/memleak_rc.rs
@@ -1,6 +1,6 @@
-// error-pattern: the evaluated program leaked memory
-// stderr-per-bitwidth
-// normalize-stderr-test: ".*│.*" -> "$$stripped$$"
+//@error-pattern: the evaluated program leaked memory
+//@stderr-per-bitwidth
+//@normalize-stderr-test: ".*│.*" -> "$$stripped$$"
 
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/tests/fail/memleak_rc.stderr
+++ b/tests/fail/memleak_rc.stderr
@@ -1,0 +1,11 @@
+The following memory was leaked: ALLOC (Rust heap, size: 32, align: 8) {
+    0x00 │ 01 00 00 00 00 00 00 00 01 00 00 00 00 00 00 00 │ ................
+    0x10 │ 00 00 00 00 00 00 00 00 ╾$HEX[a1765]<TAG>─╼ │ ........╾──────╼
+}
+
+error: the evaluated program leaked memory
+
+note: pass `-Zmiri-ignore-leaks` to disable this check
+
+error: aborting due to previous error
+

--- a/tests/fail/modifying_constants.rs
+++ b/tests/fail/modifying_constants.rs
@@ -1,5 +1,5 @@
 // This should fail even without validation/SB
-// compile-flags: -Zmiri-disable-validation -Zmiri-disable-stacked-borrows
+//@compile-flags: -Zmiri-disable-validation -Zmiri-disable-stacked-borrows
 
 fn main() {
     let x = &1; // the `&1` is promoted to a constant, but it used to be that only the pointer is marked static, not the pointee

--- a/tests/fail/never_say_never.rs
+++ b/tests/fail/never_say_never.rs
@@ -1,5 +1,5 @@
 // This should fail even without validation
-// compile-flags: -Zmiri-disable-validation
+//@compile-flags: -Zmiri-disable-validation
 
 #![feature(never_type)]
 #![allow(unreachable_code)]

--- a/tests/fail/never_transmute_humans.rs
+++ b/tests/fail/never_transmute_humans.rs
@@ -1,5 +1,5 @@
 // This should fail even without validation
-// compile-flags: -Zmiri-disable-validation
+//@compile-flags: -Zmiri-disable-validation
 
 #![feature(never_type)]
 

--- a/tests/fail/never_transmute_void.rs
+++ b/tests/fail/never_transmute_void.rs
@@ -1,5 +1,5 @@
 // This should fail even without validation
-// compile-flags: -Zmiri-disable-validation
+//@compile-flags: -Zmiri-disable-validation
 
 #![feature(never_type)]
 #![allow(unused, invalid_value)]

--- a/tests/fail/no_main.rs
+++ b/tests/fail/no_main.rs
@@ -1,2 +1,2 @@
-// error-pattern: miri can only run programs that have a main function
+//@error-pattern: miri can only run programs that have a main function
 #![no_main]

--- a/tests/fail/panic/bad_miri_start_panic.rs
+++ b/tests/fail/panic/bad_miri_start_panic.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-disable-abi-check
+//@compile-flags: -Zmiri-disable-abi-check
 // This feature is required to trigger the error using the "C" ABI.
 #![feature(c_unwind)]
 

--- a/tests/fail/panic/double_panic.rs
+++ b/tests/fail/panic/double_panic.rs
@@ -1,6 +1,6 @@
-// error-pattern: the program aborted
-// normalize-stderr-test: "\| +\^+" -> "| ^"
-// normalize-stderr-test: "unsafe \{ libc::abort\(\) \}|crate::intrinsics::abort\(\);" -> "ABORT();"
+//@error-pattern: the program aborted
+//@normalize-stderr-test: "\| +\^+" -> "| ^"
+//@normalize-stderr-test: "unsafe \{ libc::abort\(\) \}|crate::intrinsics::abort\(\);" -> "ABORT();"
 
 struct Foo;
 impl Drop for Foo {

--- a/tests/fail/panic/panic_abort1.rs
+++ b/tests/fail/panic/panic_abort1.rs
@@ -1,7 +1,7 @@
-// error-pattern: the program aborted execution
-// normalize-stderr-test: "\| +\^+" -> "| ^"
-// normalize-stderr-test: "libc::abort\(\);|core::intrinsics::abort\(\);" -> "ABORT();"
-// compile-flags: -C panic=abort
+//@error-pattern: the program aborted execution
+//@normalize-stderr-test: "\| +\^+" -> "| ^"
+//@normalize-stderr-test: "libc::abort\(\);|core::intrinsics::abort\(\);" -> "ABORT();"
+//@compile-flags: -C panic=abort
 
 fn main() {
     std::panic!("panicking from libstd");

--- a/tests/fail/panic/panic_abort2.rs
+++ b/tests/fail/panic/panic_abort2.rs
@@ -1,7 +1,7 @@
-// error-pattern: the program aborted execution
-// normalize-stderr-test: "\| +\^+" -> "| ^"
-// normalize-stderr-test: "libc::abort\(\);|core::intrinsics::abort\(\);" -> "ABORT();"
-// compile-flags: -C panic=abort
+//@error-pattern: the program aborted execution
+//@normalize-stderr-test: "\| +\^+" -> "| ^"
+//@normalize-stderr-test: "libc::abort\(\);|core::intrinsics::abort\(\);" -> "ABORT();"
+//@compile-flags: -C panic=abort
 
 fn main() {
     std::panic!("{}-panicking from libstd", 42);

--- a/tests/fail/panic/panic_abort3.rs
+++ b/tests/fail/panic/panic_abort3.rs
@@ -1,7 +1,7 @@
-// error-pattern: the program aborted execution
-// normalize-stderr-test: "\| +\^+" -> "| ^"
-// normalize-stderr-test: "libc::abort\(\);|core::intrinsics::abort\(\);" -> "ABORT();"
-// compile-flags: -C panic=abort
+//@error-pattern: the program aborted execution
+//@normalize-stderr-test: "\| +\^+" -> "| ^"
+//@normalize-stderr-test: "libc::abort\(\);|core::intrinsics::abort\(\);" -> "ABORT();"
+//@compile-flags: -C panic=abort
 
 fn main() {
     core::panic!("panicking from libcore");

--- a/tests/fail/panic/panic_abort4.rs
+++ b/tests/fail/panic/panic_abort4.rs
@@ -1,7 +1,7 @@
-// error-pattern: the program aborted execution
-// normalize-stderr-test: "\| +\^+" -> "| ^"
-// normalize-stderr-test: "libc::abort\(\);|core::intrinsics::abort\(\);" -> "ABORT();"
-// compile-flags: -C panic=abort
+//@error-pattern: the program aborted execution
+//@normalize-stderr-test: "\| +\^+" -> "| ^"
+//@normalize-stderr-test: "libc::abort\(\);|core::intrinsics::abort\(\);" -> "ABORT();"
+//@compile-flags: -C panic=abort
 
 fn main() {
     core::panic!("{}-panicking from libcore", 42);

--- a/tests/fail/panic/unwind_panic_abort.rs
+++ b/tests/fail/panic/unwind_panic_abort.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Cpanic=abort
+//@compile-flags: -Cpanic=abort
 
 //! Unwinding despite `-C panic=abort` is an error.
 

--- a/tests/fail/pointer_partial_overwrite.rs
+++ b/tests/fail/pointer_partial_overwrite.rs
@@ -1,5 +1,5 @@
 // Make sure we find these even with many checks disabled.
-// compile-flags: -Zmiri-disable-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-disable-validation
+//@compile-flags: -Zmiri-disable-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-disable-validation
 
 // Test what happens when we overwrite parts of a pointer.
 // Also see <https://github.com/rust-lang/miri/issues/2181>.

--- a/tests/fail/provenance/provenance_transmute.rs
+++ b/tests/fail/provenance/provenance_transmute.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-permissive-provenance
+//@compile-flags: -Zmiri-permissive-provenance
 #![feature(strict_provenance)]
 
 use std::mem;

--- a/tests/fail/provenance/ptr_int_unexposed.rs
+++ b/tests/fail/provenance/ptr_int_unexposed.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-permissive-provenance
+//@compile-flags: -Zmiri-permissive-provenance
 #![feature(strict_provenance)]
 
 fn main() {

--- a/tests/fail/provenance/ptr_invalid_offset.rs
+++ b/tests/fail/provenance/ptr_invalid_offset.rs
@@ -1,5 +1,5 @@
-// compile-flags: -Zmiri-strict-provenance
-// error-pattern: is a dangling pointer
+//@compile-flags: -Zmiri-strict-provenance
+//@error-pattern: is a dangling pointer
 #![feature(strict_provenance)]
 
 fn main() {

--- a/tests/fail/provenance/strict_provenance_cast.rs
+++ b/tests/fail/provenance/strict_provenance_cast.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-strict-provenance
+//@compile-flags: -Zmiri-strict-provenance
 
 fn main() {
     let addr = &0 as *const i32 as usize;

--- a/tests/fail/rc_as_ptr.rs
+++ b/tests/fail/rc_as_ptr.rs
@@ -1,5 +1,5 @@
 // This should fail even without validation
-// compile-flags: -Zmiri-disable-validation
+//@compile-flags: -Zmiri-disable-validation
 
 use std::ptr;
 use std::rc::{Rc, Weak};

--- a/tests/fail/shim_arg_size.rs
+++ b/tests/fail/shim_arg_size.rs
@@ -1,4 +1,4 @@
-// stderr-per-bitwidth
+//@stderr-per-bitwidth
 
 fn main() {
     extern "C" {

--- a/tests/fail/should-pass/cpp20_rwc_syncs.rs
+++ b/tests/fail/should-pass/cpp20_rwc_syncs.rs
@@ -1,6 +1,6 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-ignore-leaks
-// error-pattern: unreachable
+//@ignore-windows: Concurrency on Windows is not supported yet.
+//@compile-flags: -Zmiri-ignore-leaks
+//@error-pattern: unreachable
 
 // https://plv.mpi-sws.org/scfix/paper.pdf
 // 2.2 Second Problem: SC Fences are Too Weak

--- a/tests/fail/stacked_borrows/deallocate_against_barrier1.rs
+++ b/tests/fail/stacked_borrows/deallocate_against_barrier1.rs
@@ -1,4 +1,4 @@
-// error-pattern: deallocating while item is protected
+//@error-pattern: deallocating while item is protected
 
 fn inner(x: &mut i32, f: fn(&mut i32)) {
     // `f` may mutate, but it may not deallocate!

--- a/tests/fail/stacked_borrows/deallocate_against_barrier2.rs
+++ b/tests/fail/stacked_borrows/deallocate_against_barrier2.rs
@@ -1,4 +1,4 @@
-// error-pattern: deallocating while item is protected
+//@error-pattern: deallocating while item is protected
 use std::marker::PhantomPinned;
 
 pub struct NotUnpin(i32, PhantomPinned);

--- a/tests/fail/stacked_borrows/exposed_only_ro.rs
+++ b/tests/fail/stacked_borrows/exposed_only_ro.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-permissive-provenance
+//@compile-flags: -Zmiri-permissive-provenance
 #![feature(strict_provenance)]
 
 // If we have only exposed read-only pointers, doing a write through a wildcard ptr should fail.

--- a/tests/fail/stacked_borrows/illegal_read5.rs
+++ b/tests/fail/stacked_borrows/illegal_read5.rs
@@ -1,6 +1,6 @@
 // We *can* have aliasing &RefCell<T> and &mut T, but we cannot read through the former.
 // Else we couldn't optimize based on the assumption that `xref` below is truly unique.
-// normalize-stderr-test: "0x[0-9a-fA-F]+" -> "$$HEX"
+//@normalize-stderr-test: "0x[0-9a-fA-F]+" -> "$$HEX"
 
 use std::cell::RefCell;
 use std::{mem, ptr};

--- a/tests/fail/stacked_borrows/illegal_read_despite_exposed1.rs
+++ b/tests/fail/stacked_borrows/illegal_read_despite_exposed1.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-permissive-provenance
+//@compile-flags: -Zmiri-permissive-provenance
 
 fn main() {
     unsafe {

--- a/tests/fail/stacked_borrows/illegal_read_despite_exposed2.rs
+++ b/tests/fail/stacked_borrows/illegal_read_despite_exposed2.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-permissive-provenance
+//@compile-flags: -Zmiri-permissive-provenance
 
 fn main() {
     unsafe {

--- a/tests/fail/stacked_borrows/illegal_write_despite_exposed1.rs
+++ b/tests/fail/stacked_borrows/illegal_write_despite_exposed1.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-permissive-provenance
+//@compile-flags: -Zmiri-permissive-provenance
 
 fn main() {
     unsafe {

--- a/tests/fail/stacked_borrows/issue-miri-1050-1.rs
+++ b/tests/fail/stacked_borrows/issue-miri-1050-1.rs
@@ -1,4 +1,4 @@
-// error-pattern: pointer to 4 bytes starting at offset 0 is out-of-bounds
+//@error-pattern: pointer to 4 bytes starting at offset 0 is out-of-bounds
 
 fn main() {
     unsafe {

--- a/tests/fail/stacked_borrows/issue-miri-1050-2.rs
+++ b/tests/fail/stacked_borrows/issue-miri-1050-2.rs
@@ -1,4 +1,4 @@
-// error-pattern: is a dangling pointer
+//@error-pattern: is a dangling pointer
 use std::ptr::NonNull;
 
 fn main() {

--- a/tests/fail/stacked_borrows/load_invalid_mut.rs
+++ b/tests/fail/stacked_borrows/load_invalid_mut.rs
@@ -1,5 +1,5 @@
 // Make sure we catch this even without validation
-// compile-flags: -Zmiri-disable-validation
+//@compile-flags: -Zmiri-disable-validation
 
 // Make sure that we cannot load from memory a `&mut` that got already invalidated.
 fn main() {

--- a/tests/fail/stacked_borrows/load_invalid_shr.rs
+++ b/tests/fail/stacked_borrows/load_invalid_shr.rs
@@ -1,5 +1,5 @@
 // Make sure we catch this even without validation
-// compile-flags: -Zmiri-disable-validation
+//@compile-flags: -Zmiri-disable-validation
 
 // Make sure that we cannot load from memory a `&` that got already invalidated.
 fn main() {

--- a/tests/fail/stacked_borrows/newtype_retagging.rs
+++ b/tests/fail/stacked_borrows/newtype_retagging.rs
@@ -1,5 +1,5 @@
-// compile-flags: -Zmiri-retag-fields
-// error-pattern: incompatible item is protected
+//@compile-flags: -Zmiri-retag-fields
+//@error-pattern: incompatible item is protected
 struct Newtype<'a>(&'a mut i32);
 
 fn dealloc_while_running(_n: Newtype<'_>, dealloc: impl FnOnce()) {

--- a/tests/fail/stacked_borrows/shared_rw_borrows_are_weak2.rs
+++ b/tests/fail/stacked_borrows/shared_rw_borrows_are_weak2.rs
@@ -1,7 +1,7 @@
 // We want to test that granting a SharedReadWrite will be added
 // *below* an already granted SharedReadWrite -- so writing to
 // the SharedReadWrite will invalidate the SharedReadWrite.
-// normalize-stderr-test: "0x[0-9a-fA-F]+" -> "$$HEX"
+//@normalize-stderr-test: "0x[0-9a-fA-F]+" -> "$$HEX"
 
 use std::cell::RefCell;
 use std::mem;

--- a/tests/fail/stacked_borrows/unescaped_local.rs
+++ b/tests/fail/stacked_borrows/unescaped_local.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-permissive-provenance
+//@compile-flags: -Zmiri-permissive-provenance
 
 // Make sure we cannot use raw ptrs to access a local that
 // we took the direct address of.

--- a/tests/fail/stacked_borrows/vtable.rs
+++ b/tests/fail/stacked_borrows/vtable.rs
@@ -1,4 +1,4 @@
-// error-pattern: vtable pointer does not have permission
+//@error-pattern: vtable pointer does not have permission
 #![feature(ptr_metadata)]
 
 trait Foo {}

--- a/tests/fail/stacked_borrows/zst_slice.rs
+++ b/tests/fail/stacked_borrows/zst_slice.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-strict-provenance
+//@compile-flags: -Zmiri-strict-provenance
 //@error-pattern: does not exist in the borrow stack
 
 fn main() {

--- a/tests/fail/stacked_borrows/zst_slice.rs
+++ b/tests/fail/stacked_borrows/zst_slice.rs
@@ -1,5 +1,5 @@
 // compile-flags: -Zmiri-strict-provenance
-// error-pattern: does not exist in the borrow stack
+//@error-pattern: does not exist in the borrow stack
 
 fn main() {
     unsafe {

--- a/tests/fail/static_memory_modification1.rs
+++ b/tests/fail/static_memory_modification1.rs
@@ -1,5 +1,5 @@
 // Stacked Borrows detects that we are casting & to &mut and so it changes why we fail
-// compile-flags: -Zmiri-disable-stacked-borrows
+//@compile-flags: -Zmiri-disable-stacked-borrows
 
 static X: usize = 5;
 

--- a/tests/fail/static_memory_modification2.rs
+++ b/tests/fail/static_memory_modification2.rs
@@ -1,5 +1,5 @@
 // Stacked Borrows detects that we are casting & to &mut and so it changes why we fail
-// compile-flags: -Zmiri-disable-stacked-borrows
+//@compile-flags: -Zmiri-disable-stacked-borrows
 
 use std::mem::transmute;
 

--- a/tests/fail/static_memory_modification3.rs
+++ b/tests/fail/static_memory_modification3.rs
@@ -1,5 +1,5 @@
 // Stacked Borrows detects that we are casting & to &mut and so it changes why we fail
-// compile-flags: -Zmiri-disable-stacked-borrows
+//@compile-flags: -Zmiri-disable-stacked-borrows
 
 use std::mem::transmute;
 

--- a/tests/fail/sync/libc_pthread_cond_double_destroy.rs
+++ b/tests/fail/sync/libc_pthread_cond_double_destroy.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 #![feature(rustc_private)]
 
 /// Test that destroying a pthread_cond twice fails, even without a check for number validity

--- a/tests/fail/sync/libc_pthread_condattr_double_destroy.rs
+++ b/tests/fail/sync/libc_pthread_condattr_double_destroy.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 #![feature(rustc_private)]
 
 /// Test that destroying a pthread_condattr twice fails, even without a check for number validity

--- a/tests/fail/sync/libc_pthread_mutex_NULL_deadlock.rs
+++ b/tests/fail/sync/libc_pthread_mutex_NULL_deadlock.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 //
 // Check that if we pass NULL attribute, then we get the default mutex type.
 

--- a/tests/fail/sync/libc_pthread_mutex_deadlock.rs
+++ b/tests/fail/sync/libc_pthread_mutex_deadlock.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/sync/libc_pthread_mutex_default_deadlock.rs
+++ b/tests/fail/sync/libc_pthread_mutex_default_deadlock.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 //
 // Check that if we do not set the mutex type, it is the default.
 

--- a/tests/fail/sync/libc_pthread_mutex_destroy_locked.rs
+++ b/tests/fail/sync/libc_pthread_mutex_destroy_locked.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/sync/libc_pthread_mutex_double_destroy.rs
+++ b/tests/fail/sync/libc_pthread_mutex_double_destroy.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 #![feature(rustc_private)]
 
 /// Test that destroying a pthread_mutex twice fails, even without a check for number validity

--- a/tests/fail/sync/libc_pthread_mutex_normal_deadlock.rs
+++ b/tests/fail/sync/libc_pthread_mutex_normal_deadlock.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/sync/libc_pthread_mutex_normal_unlock_unlocked.rs
+++ b/tests/fail/sync/libc_pthread_mutex_normal_unlock_unlocked.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/sync/libc_pthread_mutex_wrong_owner.rs
+++ b/tests/fail/sync/libc_pthread_mutex_wrong_owner.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/sync/libc_pthread_mutexattr_double_destroy.rs
+++ b/tests/fail/sync/libc_pthread_mutexattr_double_destroy.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 #![feature(rustc_private)]
 
 /// Test that destroying a pthread_mutexattr twice fails, even without a check for number validity

--- a/tests/fail/sync/libc_pthread_rwlock_destroy_read_locked.rs
+++ b/tests/fail/sync/libc_pthread_rwlock_destroy_read_locked.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/sync/libc_pthread_rwlock_destroy_write_locked.rs
+++ b/tests/fail/sync/libc_pthread_rwlock_destroy_write_locked.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/sync/libc_pthread_rwlock_double_destroy.rs
+++ b/tests/fail/sync/libc_pthread_rwlock_double_destroy.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 #![feature(rustc_private)]
 
 /// Test that destroying a pthread_rwlock twice fails, even without a check for number validity

--- a/tests/fail/sync/libc_pthread_rwlock_read_write_deadlock_single_thread.rs
+++ b/tests/fail/sync/libc_pthread_rwlock_read_write_deadlock_single_thread.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/sync/libc_pthread_rwlock_read_wrong_owner.rs
+++ b/tests/fail/sync/libc_pthread_rwlock_read_wrong_owner.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/sync/libc_pthread_rwlock_unlock_unlocked.rs
+++ b/tests/fail/sync/libc_pthread_rwlock_unlock_unlocked.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/sync/libc_pthread_rwlock_write_read_deadlock.rs
+++ b/tests/fail/sync/libc_pthread_rwlock_write_read_deadlock.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/sync/libc_pthread_rwlock_write_read_deadlock_single_thread.rs
+++ b/tests/fail/sync/libc_pthread_rwlock_write_read_deadlock_single_thread.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/sync/libc_pthread_rwlock_write_write_deadlock.rs
+++ b/tests/fail/sync/libc_pthread_rwlock_write_write_deadlock.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/sync/libc_pthread_rwlock_write_write_deadlock_single_thread.rs
+++ b/tests/fail/sync/libc_pthread_rwlock_write_write_deadlock_single_thread.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/sync/libc_pthread_rwlock_write_wrong_owner.rs
+++ b/tests/fail/sync/libc_pthread_rwlock_write_wrong_owner.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/type-too-large.rs
+++ b/tests/fail/type-too-large.rs
@@ -1,4 +1,4 @@
-// ignore-32bit
+//@ignore-32bit
 
 fn main() {
     let _fat: [u8; (1 << 61) + (1 << 31)];

--- a/tests/fail/unaligned_pointers/alignment.rs
+++ b/tests/fail/unaligned_pointers/alignment.rs
@@ -1,4 +1,4 @@
-// normalize-stderr-test: "\| +\^+" -> "| ^"
+//@normalize-stderr-test: "\| +\^+" -> "| ^"
 
 fn main() {
     // No retry needed, this fails reliably.

--- a/tests/fail/unaligned_pointers/atomic_unaligned.rs
+++ b/tests/fail/unaligned_pointers/atomic_unaligned.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-symbolic-alignment-check
+//@compile-flags: -Zmiri-symbolic-alignment-check
 #![feature(core_intrinsics)]
 
 fn main() {

--- a/tests/fail/unaligned_pointers/dyn_alignment.rs
+++ b/tests/fail/unaligned_pointers/dyn_alignment.rs
@@ -1,5 +1,5 @@
 // should find the bug even without validation and stacked borrows, but gets masked by optimizations
-// compile-flags: -Zmiri-disable-validation -Zmiri-disable-stacked-borrows -Zmir-opt-level=0
+//@compile-flags: -Zmiri-disable-validation -Zmiri-disable-stacked-borrows -Zmir-opt-level=0
 
 #[repr(align(256))]
 #[derive(Debug)]

--- a/tests/fail/unaligned_pointers/intptrcast_alignment_check.rs
+++ b/tests/fail/unaligned_pointers/intptrcast_alignment_check.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-symbolic-alignment-check -Zmiri-permissive-provenance
+//@compile-flags: -Zmiri-symbolic-alignment-check -Zmiri-permissive-provenance
 // With the symbolic alignment check, even with intptrcast and without
 // validation, we want to be *sure* to catch bugs that arise from pointers being
 // insufficiently aligned. The only way to achieve that is not not let programs

--- a/tests/fail/unaligned_pointers/reference_to_packed.rs
+++ b/tests/fail/unaligned_pointers/reference_to_packed.rs
@@ -1,5 +1,5 @@
 // This should fail even without validation/SB
-// compile-flags: -Zmiri-disable-validation -Zmiri-disable-stacked-borrows
+//@compile-flags: -Zmiri-disable-validation -Zmiri-disable-stacked-borrows
 
 #![allow(dead_code, unused_variables, unaligned_references)]
 

--- a/tests/fail/unaligned_pointers/unaligned_ptr1.rs
+++ b/tests/fail/unaligned_pointers/unaligned_ptr1.rs
@@ -1,5 +1,5 @@
 // This should fail even without validation or Stacked Borrows.
-// compile-flags: -Zmiri-disable-validation -Zmiri-disable-stacked-borrows
+//@compile-flags: -Zmiri-disable-validation -Zmiri-disable-stacked-borrows
 
 fn main() {
     // Try many times as this might work by chance.

--- a/tests/fail/unaligned_pointers/unaligned_ptr2.rs
+++ b/tests/fail/unaligned_pointers/unaligned_ptr2.rs
@@ -1,5 +1,5 @@
 // This should fail even without validation or Stacked Borrows.
-// compile-flags: -Zmiri-disable-validation -Zmiri-disable-stacked-borrows
+//@compile-flags: -Zmiri-disable-validation -Zmiri-disable-stacked-borrows
 
 fn main() {
     // No retry needed, this fails reliably.

--- a/tests/fail/unaligned_pointers/unaligned_ptr3.rs
+++ b/tests/fail/unaligned_pointers/unaligned_ptr3.rs
@@ -1,5 +1,5 @@
 // This should fail even without validation or Stacked Borrows.
-// compile-flags: -Zmiri-disable-validation -Zmiri-disable-stacked-borrows
+//@compile-flags: -Zmiri-disable-validation -Zmiri-disable-stacked-borrows
 
 fn main() {
     // Try many times as this might work by chance.

--- a/tests/fail/unaligned_pointers/unaligned_ptr4.rs
+++ b/tests/fail/unaligned_pointers/unaligned_ptr4.rs
@@ -1,5 +1,5 @@
 // This should fail even without validation or Stacked Borrows.
-// compile-flags: -Zmiri-disable-validation -Zmiri-disable-stacked-borrows
+//@compile-flags: -Zmiri-disable-validation -Zmiri-disable-stacked-borrows
 
 fn main() {
     // Make sure we notice when a u16 is loaded at offset 1 into a u8 allocation.

--- a/tests/fail/unaligned_pointers/unaligned_ptr_addr_of.rs
+++ b/tests/fail/unaligned_pointers/unaligned_ptr_addr_of.rs
@@ -1,5 +1,5 @@
 // This should fail even without validation or Stacked Borrows.
-// compile-flags: -Zmiri-disable-validation -Zmiri-disable-stacked-borrows
+//@compile-flags: -Zmiri-disable-validation -Zmiri-disable-stacked-borrows
 use std::ptr;
 
 fn main() {

--- a/tests/fail/unaligned_pointers/unaligned_ptr_zst.rs
+++ b/tests/fail/unaligned_pointers/unaligned_ptr_zst.rs
@@ -1,6 +1,6 @@
 // This should fail even without validation
 // Some optimizations remove ZST accesses, thus masking this UB.
-// compile-flags: -Zmir-opt-level=0 -Zmiri-disable-validation
+//@compile-flags: -Zmir-opt-level=0 -Zmiri-disable-validation
 
 fn main() {
     // Try many times as this might work by chance.

--- a/tests/fail/uninit_buffer.rs
+++ b/tests/fail/uninit_buffer.rs
@@ -1,4 +1,4 @@
-// error-pattern: memory is uninitialized at [0x4..0x10]
+//@error-pattern: memory is uninitialized at [0x4..0x10]
 
 use std::alloc::{alloc, dealloc, Layout};
 use std::slice::from_raw_parts;

--- a/tests/fail/uninit_byte_read.rs
+++ b/tests/fail/uninit_byte_read.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-disable-stacked-borrows
+//@compile-flags: -Zmiri-disable-stacked-borrows
 fn main() {
     let v: Vec<u8> = Vec::with_capacity(10);
     let undef = unsafe { *v.get_unchecked(5) }; //~ ERROR uninitialized

--- a/tests/fail/unreachable.rs
+++ b/tests/fail/unreachable.rs
@@ -1,4 +1,4 @@
-// error-pattern: entering unreachable code
+//@error-pattern: entering unreachable code
 fn main() {
     unsafe { std::hint::unreachable_unchecked() }
 }

--- a/tests/fail/unsupported_signal.rs
+++ b/tests/fail/unsupported_signal.rs
@@ -1,6 +1,6 @@
 //! `signal()` is special on Linux and macOS that it's only supported within libstd.
 //! The implementation is not complete enough to permit user code to call it.
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 #![feature(rustc_private)]
 
 extern crate libc;

--- a/tests/fail/validity/cast_fn_ptr1.rs
+++ b/tests/fail/validity/cast_fn_ptr1.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-permissive-provenance
+//@compile-flags: -Zmiri-permissive-provenance
 
 fn main() {
     // Cast a function pointer such that on a call, the argument gets transmuted

--- a/tests/fail/validity/cast_fn_ptr2.rs
+++ b/tests/fail/validity/cast_fn_ptr2.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-permissive-provenance
+//@compile-flags: -Zmiri-permissive-provenance
 
 fn main() {
     // Cast a function pointer such that when returning, the return value gets transmuted

--- a/tests/fail/validity/dangling_ref1.rs
+++ b/tests/fail/validity/dangling_ref1.rs
@@ -1,5 +1,5 @@
 // Make sure we catch this even without Stacked Borrows
-// compile-flags: -Zmiri-disable-stacked-borrows
+//@compile-flags: -Zmiri-disable-stacked-borrows
 use std::mem;
 
 fn main() {

--- a/tests/fail/validity/dangling_ref2.rs
+++ b/tests/fail/validity/dangling_ref2.rs
@@ -1,5 +1,5 @@
 // Make sure we catch this even without Stacked Borrows
-// compile-flags: -Zmiri-disable-stacked-borrows
+//@compile-flags: -Zmiri-disable-stacked-borrows
 use std::mem;
 
 fn main() {

--- a/tests/fail/validity/dangling_ref3.rs
+++ b/tests/fail/validity/dangling_ref3.rs
@@ -1,5 +1,5 @@
 // Make sure we catch this even without Stacked Borrows
-// compile-flags: -Zmiri-disable-stacked-borrows
+//@compile-flags: -Zmiri-disable-stacked-borrows
 use std::mem;
 
 fn dangling() -> *const u8 {

--- a/tests/fail/validity/invalid_enum_tag_256variants_uninit.rs
+++ b/tests/fail/validity/invalid_enum_tag_256variants_uninit.rs
@@ -1,5 +1,5 @@
 // Even when uninit numbers are allowed, this enum is not.
-// compile-flags: -Zmiri-allow-uninit-numbers
+//@compile-flags: -Zmiri-allow-uninit-numbers
 #![allow(unused, deprecated, invalid_value)]
 
 #[derive(Copy, Clone)]

--- a/tests/fail/validity/nonzero.rs
+++ b/tests/fail/validity/nonzero.rs
@@ -1,5 +1,5 @@
 // gets masked by optimizations
-// compile-flags: -Zmir-opt-level=0
+//@compile-flags: -Zmir-opt-level=0
 #![feature(rustc_attrs)]
 #![allow(unused_attributes)]
 

--- a/tests/fail/weak_memory/racing_mixed_size.rs
+++ b/tests/fail/weak_memory/racing_mixed_size.rs
@@ -1,4 +1,4 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-windows: Concurrency on Windows is not supported yet.
 
 #![feature(core_intrinsics)]
 

--- a/tests/fail/weak_memory/racing_mixed_size_read.rs
+++ b/tests/fail/weak_memory/racing_mixed_size_read.rs
@@ -1,4 +1,4 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-windows: Concurrency on Windows is not supported yet.
 
 #![feature(core_intrinsics)]
 

--- a/tests/fail/zst2.rs
+++ b/tests/fail/zst2.rs
@@ -1,5 +1,5 @@
 // Some optimizations remove ZST accesses, thus masking this UB.
-// compile-flags: -Zmir-opt-level=0
+//@compile-flags: -Zmir-opt-level=0
 
 fn main() {
     // Not using the () type here, as writes of that type do not even have MIR generated.

--- a/tests/fail/zst3.rs
+++ b/tests/fail/zst3.rs
@@ -1,5 +1,5 @@
 // Some optimizations remove ZST accesses, thus masking this UB.
-// compile-flags: -Zmir-opt-level=0
+//@compile-flags: -Zmir-opt-level=0
 
 fn main() {
     // Not using the () type here, as writes of that type do not even have MIR generated.

--- a/tests/panic/panic/panic1.rs
+++ b/tests/panic/panic/panic1.rs
@@ -1,5 +1,5 @@
-// rustc-env: RUST_BACKTRACE=1
-// compile-flags: -Zmiri-disable-isolation
+//@rustc-env: RUST_BACKTRACE=1
+//@compile-flags: -Zmiri-disable-isolation
 
 fn main() {
     std::panic!("panicking from libstd");

--- a/tests/panic/panic/unsupported_foreign_function.rs
+++ b/tests/panic/panic/unsupported_foreign_function.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-panic-on-unsupported
+//@compile-flags: -Zmiri-panic-on-unsupported
 
 fn main() {
     extern "Rust" {

--- a/tests/panic/panic/unsupported_syscall.rs
+++ b/tests/panic/panic/unsupported_syscall.rs
@@ -1,6 +1,6 @@
-// ignore-windows: No libc on Windows
-// ignore-apple: `syscall` is not supported on macOS
-// compile-flags: -Zmiri-panic-on-unsupported
+//@ignore-windows: No libc on Windows
+//@ignore-apple: `syscall` is not supported on macOS
+//@compile-flags: -Zmiri-panic-on-unsupported
 #![feature(rustc_private)]
 
 extern crate libc;

--- a/tests/pass/0weak_memory_consistency.rs
+++ b/tests/pass/0weak_memory_consistency.rs
@@ -1,5 +1,5 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-ignore-leaks -Zmiri-disable-stacked-borrows
+//@ignore-windows: Concurrency on Windows is not supported yet.
+//@compile-flags: -Zmiri-ignore-leaks -Zmiri-disable-stacked-borrows
 
 // The following tests check whether our weak memory emulation produces
 // any inconsistent execution outcomes

--- a/tests/pass/adjacent-allocs.rs
+++ b/tests/pass/adjacent-allocs.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-permissive-provenance
+//@compile-flags: -Zmiri-permissive-provenance
 
 fn ensure_allocs_can_be_adjacent() {
     for _ in 0..512 {

--- a/tests/pass/align.rs
+++ b/tests/pass/align.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-permissive-provenance
+//@compile-flags: -Zmiri-permissive-provenance
 
 /// This manually makes sure that we have a pointer with the proper alignment.
 fn manual_alignment() {

--- a/tests/pass/align_offset_symbolic.rs
+++ b/tests/pass/align_offset_symbolic.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-symbolic-alignment-check
+//@compile-flags: -Zmiri-symbolic-alignment-check
 
 fn test_align_offset() {
     let d = Box::new([0u32; 4]);

--- a/tests/pass/atomic-compare-exchange-weak-never-fail.rs
+++ b/tests/pass/atomic-compare-exchange-weak-never-fail.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-compare-exchange-weak-failure-rate=0.0
+//@compile-flags: -Zmiri-compare-exchange-weak-failure-rate=0.0
 use std::sync::atomic::{AtomicBool, Ordering::*};
 
 // Ensure that compare_exchange_weak never fails.

--- a/tests/pass/atomic.rs
+++ b/tests/pass/atomic.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-strict-provenance
+//@compile-flags: -Zmiri-strict-provenance
 #![feature(strict_provenance, strict_provenance_atomic_ptr)]
 use std::sync::atomic::{
     compiler_fence, fence, AtomicBool, AtomicIsize, AtomicPtr, AtomicU64, Ordering::*,

--- a/tests/pass/backtrace/backtrace-api-v0.rs
+++ b/tests/pass/backtrace/backtrace-api-v0.rs
@@ -1,4 +1,4 @@
-// normalize-stderr-test: "::<.*>" -> ""
+//@normalize-stderr-test: "::<.*>" -> ""
 
 #[inline(never)]
 fn func_a() -> Box<[*mut ()]> {

--- a/tests/pass/backtrace/backtrace-api-v1.rs
+++ b/tests/pass/backtrace/backtrace-api-v1.rs
@@ -1,4 +1,4 @@
-// normalize-stderr-test: "::<.*>" -> ""
+//@normalize-stderr-test: "::<.*>" -> ""
 
 #[inline(never)]
 fn func_a() -> Box<[*mut ()]> {

--- a/tests/pass/backtrace/backtrace-global-alloc.rs
+++ b/tests/pass/backtrace/backtrace-global-alloc.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-disable-isolation
+//@compile-flags: -Zmiri-disable-isolation
 
 #![feature(backtrace)]
 

--- a/tests/pass/backtrace/backtrace-std.rs
+++ b/tests/pass/backtrace/backtrace-std.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-disable-isolation
+//@compile-flags: -Zmiri-disable-isolation
 
 #![feature(backtrace)]
 

--- a/tests/pass/btreemap.rs
+++ b/tests/pass/btreemap.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-strict-provenance
+//@compile-flags: -Zmiri-strict-provenance
 #![feature(btree_drain_filter)]
 use std::collections::{BTreeMap, BTreeSet};
 use std::mem;

--- a/tests/pass/calloc.rs
+++ b/tests/pass/calloc.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/pass/concurrency/channels.rs
+++ b/tests/pass/concurrency/channels.rs
@@ -1,5 +1,5 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-strict-provenance
+//@ignore-windows: Concurrency on Windows is not supported yet.
+//@compile-flags: -Zmiri-strict-provenance
 
 use std::sync::mpsc::{channel, sync_channel};
 use std::thread;

--- a/tests/pass/concurrency/concurrent_caller_location.rs
+++ b/tests/pass/concurrency/concurrent_caller_location.rs
@@ -1,4 +1,4 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-windows: Concurrency on Windows is not supported yet.
 
 use std::panic::Location;
 use std::thread::spawn;

--- a/tests/pass/concurrency/data_race.rs
+++ b/tests/pass/concurrency/data_race.rs
@@ -1,5 +1,5 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-weak-memory-emulation
+//@ignore-windows: Concurrency on Windows is not supported yet.
+//@compile-flags: -Zmiri-disable-weak-memory-emulation
 
 use std::sync::atomic::{fence, AtomicUsize, Ordering};
 use std::thread::spawn;

--- a/tests/pass/concurrency/disable_data_race_detector.rs
+++ b/tests/pass/concurrency/disable_data_race_detector.rs
@@ -1,5 +1,5 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-data-race-detector
+//@ignore-windows: Concurrency on Windows is not supported yet.
+//@compile-flags: -Zmiri-disable-data-race-detector
 
 use std::thread::spawn;
 

--- a/tests/pass/concurrency/issue1643.rs
+++ b/tests/pass/concurrency/issue1643.rs
@@ -1,4 +1,4 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-windows: Concurrency on Windows is not supported yet.
 
 use std::thread::spawn;
 

--- a/tests/pass/concurrency/libc_pthread_cond.rs
+++ b/tests/pass/concurrency/libc_pthread_cond.rs
@@ -1,6 +1,6 @@
-// ignore-windows: No libc on Windows
-// ignore-apple: pthread_condattr_setclock is not supported on MacOS.
-// compile-flags: -Zmiri-disable-isolation
+//@ignore-windows: No libc on Windows
+//@ignore-apple: pthread_condattr_setclock is not supported on MacOS.
+//@compile-flags: -Zmiri-disable-isolation
 
 #![feature(rustc_private)]
 

--- a/tests/pass/concurrency/linux-futex.rs
+++ b/tests/pass/concurrency/linux-futex.rs
@@ -1,5 +1,5 @@
-// only-linux
-// compile-flags: -Zmiri-disable-isolation
+//@only-linux
+//@compile-flags: -Zmiri-disable-isolation
 
 #![feature(rustc_private)]
 extern crate libc;

--- a/tests/pass/concurrency/mutex_leak.rs
+++ b/tests/pass/concurrency/mutex_leak.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-ignore-leaks
+//@compile-flags: -Zmiri-ignore-leaks
 use std::mem;
 use std::sync::Mutex;
 

--- a/tests/pass/concurrency/simple.rs
+++ b/tests/pass/concurrency/simple.rs
@@ -1,5 +1,5 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-strict-provenance
+//@ignore-windows: Concurrency on Windows is not supported yet.
+//@compile-flags: -Zmiri-strict-provenance
 
 use std::thread;
 

--- a/tests/pass/concurrency/spin_loop.rs
+++ b/tests/pass/concurrency/spin_loop.rs
@@ -1,4 +1,4 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-windows: Concurrency on Windows is not supported yet.
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
 

--- a/tests/pass/concurrency/spin_loops_nopreempt.rs
+++ b/tests/pass/concurrency/spin_loops_nopreempt.rs
@@ -1,6 +1,6 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-windows: Concurrency on Windows is not supported yet.
 // This specifically tests behavior *without* preemption.
-// compile-flags: -Zmiri-preemption-rate=0
+//@compile-flags: -Zmiri-preemption-rate=0
 
 use std::cell::Cell;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};

--- a/tests/pass/concurrency/sync.rs
+++ b/tests/pass/concurrency/sync.rs
@@ -1,5 +1,5 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-disable-isolation -Zmiri-strict-provenance
+//@ignore-windows: Concurrency on Windows is not supported yet.
+//@compile-flags: -Zmiri-disable-isolation -Zmiri-strict-provenance
 
 use std::sync::{Arc, Barrier, Condvar, Mutex, Once, RwLock};
 use std::thread;

--- a/tests/pass/concurrency/sync_nopreempt.rs
+++ b/tests/pass/concurrency/sync_nopreempt.rs
@@ -1,6 +1,6 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-windows: Concurrency on Windows is not supported yet.
 // We are making scheduler assumptions here.
-// compile-flags: -Zmiri-strict-provenance -Zmiri-preemption-rate=0
+//@compile-flags: -Zmiri-strict-provenance -Zmiri-preemption-rate=0
 
 use std::sync::{Arc, Condvar, Mutex, RwLock};
 use std::thread;

--- a/tests/pass/concurrency/thread_locals.rs
+++ b/tests/pass/concurrency/thread_locals.rs
@@ -1,5 +1,5 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-strict-provenance
+//@ignore-windows: Concurrency on Windows is not supported yet.
+//@compile-flags: -Zmiri-strict-provenance
 
 //! The main purpose of this test is to check that if we take a pointer to
 //! thread's `t1` thread-local `A` and send it to another thread `t2`,

--- a/tests/pass/concurrency/tls_lib_drop.rs
+++ b/tests/pass/concurrency/tls_lib_drop.rs
@@ -1,4 +1,4 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-windows: Concurrency on Windows is not supported yet.
 
 use std::cell::RefCell;
 use std::thread;

--- a/tests/pass/concurrency/tls_pthread_drop_order.rs
+++ b/tests/pass/concurrency/tls_pthread_drop_order.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 
 #![feature(rustc_private)]
 extern crate libc;

--- a/tests/pass/current_dir.rs
+++ b/tests/pass/current_dir.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-disable-isolation
+//@compile-flags: -Zmiri-disable-isolation
 use std::env;
 use std::io::ErrorKind;
 

--- a/tests/pass/current_dir_with_isolation.rs
+++ b/tests/pass/current_dir_with_isolation.rs
@@ -1,6 +1,6 @@
-// compile-flags: -Zmiri-isolation-error=warn-nobacktrace
-// normalize-stderr-test: "(getcwd|GetCurrentDirectoryW)" -> "$$GETCWD"
-// normalize-stderr-test: "(chdir|SetCurrentDirectoryW)" -> "$$SETCWD"
+//@compile-flags: -Zmiri-isolation-error=warn-nobacktrace
+//@normalize-stderr-test: "(getcwd|GetCurrentDirectoryW)" -> "$$GETCWD"
+//@normalize-stderr-test: "(chdir|SetCurrentDirectoryW)" -> "$$SETCWD"
 
 use std::env;
 use std::io::ErrorKind;

--- a/tests/pass/disable-alignment-check.rs
+++ b/tests/pass/disable-alignment-check.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-disable-alignment-check
+//@compile-flags: -Zmiri-disable-alignment-check
 
 fn main() {
     let mut x = [0u8; 20];

--- a/tests/pass/enum_discriminant_ptr_value.rs
+++ b/tests/pass/enum_discriminant_ptr_value.rs
@@ -1,6 +1,6 @@
 // A niche-optimized enum where the discriminant is a pointer value -- relies on ptr-to-int casts in
 // the niche handling code.
-// compile-flags: -Zmiri-disable-stacked-borrows -Zmiri-disable-validation
+//@compile-flags: -Zmiri-disable-stacked-borrows -Zmiri-disable-validation
 
 fn main() {
     let x = 42;

--- a/tests/pass/env-exclude.rs
+++ b/tests/pass/env-exclude.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-disable-isolation -Zmiri-env-exclude=MIRI_ENV_VAR_TEST
+//@compile-flags: -Zmiri-disable-isolation -Zmiri-env-exclude=MIRI_ENV_VAR_TEST
 
 fn main() {
     assert!(std::env::var("MIRI_ENV_VAR_TEST").is_err());

--- a/tests/pass/env-forward.rs
+++ b/tests/pass/env-forward.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-env-forward=MIRI_ENV_VAR_TEST
+//@compile-flags: -Zmiri-env-forward=MIRI_ENV_VAR_TEST
 
 fn main() {
     assert_eq!(std::env::var("MIRI_ENV_VAR_TEST"), Ok("0".to_owned()));

--- a/tests/pass/env-without-isolation.rs
+++ b/tests/pass/env-without-isolation.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-disable-isolation
+//@compile-flags: -Zmiri-disable-isolation
 
 fn main() {
     assert_eq!(std::env::var("MIRI_ENV_VAR_TEST"), Ok("0".to_owned()));

--- a/tests/pass/fs.rs
+++ b/tests/pass/fs.rs
@@ -1,5 +1,5 @@
-// ignore-windows: File handling is not implemented yet
-// compile-flags: -Zmiri-disable-isolation
+//@ignore-windows: File handling is not implemented yet
+//@compile-flags: -Zmiri-disable-isolation
 
 #![feature(rustc_private)]
 #![feature(io_error_more)]

--- a/tests/pass/fs_with_isolation.rs
+++ b/tests/pass/fs_with_isolation.rs
@@ -1,6 +1,6 @@
-// ignore-windows: File handling is not implemented yet
-// compile-flags: -Zmiri-isolation-error=warn-nobacktrace
-// normalize-stderr-test: "(stat(x)?)" -> "$$STAT"
+//@ignore-windows: File handling is not implemented yet
+//@compile-flags: -Zmiri-isolation-error=warn-nobacktrace
+//@normalize-stderr-test: "(stat(x)?)" -> "$$STAT"
 
 #![feature(rustc_private)]
 

--- a/tests/pass/function_calls/disable_abi_check.rs
+++ b/tests/pass/function_calls/disable_abi_check.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-disable-abi-check
+//@compile-flags: -Zmiri-disable-abi-check
 #![feature(core_intrinsics)]
 
 fn main() {

--- a/tests/pass/getpid.rs
+++ b/tests/pass/getpid.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-disable-isolation
+//@compile-flags: -Zmiri-disable-isolation
 
 fn getpid() -> u32 {
     std::process::id()

--- a/tests/pass/hide_stdout.rs
+++ b/tests/pass/hide_stdout.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-mute-stdout-stderr
+//@compile-flags: -Zmiri-mute-stdout-stderr
 
 fn main() {
     println!("print to stdout");

--- a/tests/pass/integer-ops.rs
+++ b/tests/pass/integer-ops.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Coverflow-checks=off
+//@compile-flags: -Coverflow-checks=off
 #![feature(int_log)]
 #![allow(arithmetic_overflow)]
 

--- a/tests/pass/intptrcast.rs
+++ b/tests/pass/intptrcast.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-permissive-provenance
+//@compile-flags: -Zmiri-permissive-provenance
 
 use std::mem;
 

--- a/tests/pass/intrinsics.rs
+++ b/tests/pass/intrinsics.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-permissive-provenance
+//@compile-flags: -Zmiri-permissive-provenance
 #![feature(core_intrinsics, const_raw_ptr_comparison)]
 #![feature(layout_for_ptr)]
 

--- a/tests/pass/issues/issue-miri-1925.rs
+++ b/tests/pass/issues/issue-miri-1925.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-symbolic-alignment-check
+//@compile-flags: -Zmiri-symbolic-alignment-check
 
 use std::mem::size_of;
 

--- a/tests/pass/issues/issue-miri-2068-2.rs
+++ b/tests/pass/issues/issue-miri-2068-2.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-disable-validation
+//@compile-flags: -Zmiri-disable-validation
 
 use std::mem::MaybeUninit;
 

--- a/tests/pass/libc.rs
+++ b/tests/pass/libc.rs
@@ -1,5 +1,5 @@
-// ignore-windows: No libc on Windows
-// compile-flags: -Zmiri-disable-isolation
+//@ignore-windows: No libc on Windows
+//@compile-flags: -Zmiri-disable-isolation
 
 #![feature(rustc_private)]
 

--- a/tests/pass/linux-getrandom-without-isolation.rs
+++ b/tests/pass/linux-getrandom-without-isolation.rs
@@ -1,5 +1,5 @@
-// only-linux
-// compile-flags: -Zmiri-disable-isolation
+//@only-linux
+//@compile-flags: -Zmiri-disable-isolation
 #![feature(rustc_private)]
 extern crate libc;
 

--- a/tests/pass/linux-getrandom.rs
+++ b/tests/pass/linux-getrandom.rs
@@ -1,4 +1,4 @@
-// only-linux
+//@only-linux
 #![feature(rustc_private)]
 extern crate libc;
 

--- a/tests/pass/malloc.rs
+++ b/tests/pass/malloc.rs
@@ -1,4 +1,4 @@
-// ignore-windows: No libc on Windows
+//@ignore-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/pass/memleak_ignored.rs
+++ b/tests/pass/memleak_ignored.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-ignore-leaks
+//@compile-flags: -Zmiri-ignore-leaks
 
 fn main() {
     std::mem::forget(Box::new(42));

--- a/tests/pass/move-uninit-primval.rs
+++ b/tests/pass/move-uninit-primval.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-allow-uninit-numbers
+//@compile-flags: -Zmiri-allow-uninit-numbers
 #![allow(deprecated)]
 
 struct Foo {

--- a/tests/pass/no_std.rs
+++ b/tests/pass/no_std.rs
@@ -3,7 +3,7 @@
 // windows tls dtors go through libstd right now, thus this test
 // cannot pass. When windows tls dtors go through the special magic
 // windows linker section, we can run this test on windows again.
-// ignore-windows
+//@ignore-windows
 
 #[start]
 fn start(_: isize, _: *const *const u8) -> isize {

--- a/tests/pass/observed_local_mut.rs
+++ b/tests/pass/observed_local_mut.rs
@@ -1,5 +1,5 @@
 // Stacked Borrows catches this (correctly) as UB.
-// compile-flags: -Zmiri-disable-stacked-borrows
+//@compile-flags: -Zmiri-disable-stacked-borrows
 
 // This test is intended to guard against the problem described in commit
 // 39bb1254d1eaf74f45a4e741097e33fc942168d5.

--- a/tests/pass/overflow_checks_off.rs
+++ b/tests/pass/overflow_checks_off.rs
@@ -1,4 +1,4 @@
-// compile-flags: -C overflow-checks=off
+//@compile-flags: -C overflow-checks=off
 
 // Check that we correctly implement the intended behavior of these operators
 // when they are not being overflow-checked.

--- a/tests/pass/panic/catch_panic.rs
+++ b/tests/pass/panic/catch_panic.rs
@@ -1,5 +1,5 @@
 // We test the `align_offset` panic below, make sure we test the interpreter impl and not the "real" one.
-// compile-flags: -Zmiri-symbolic-alignment-check -Zmiri-permissive-provenance
+//@compile-flags: -Zmiri-symbolic-alignment-check -Zmiri-permissive-provenance
 #![feature(never_type)]
 #![allow(unconditional_panic, non_fmt_panics)]
 

--- a/tests/pass/panic/concurrent-panic.rs
+++ b/tests/pass/panic/concurrent-panic.rs
@@ -1,6 +1,6 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-windows: Concurrency on Windows is not supported yet.
 // We are making scheduler assumptions here.
-// compile-flags: -Zmiri-preemption-rate=0
+//@compile-flags: -Zmiri-preemption-rate=0
 
 //! Cause a panic in one thread while another thread is unwinding. This checks
 //! that separate threads have their own panicking state.

--- a/tests/pass/portable-simd.rs
+++ b/tests/pass/portable-simd.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-strict-provenance
+//@compile-flags: -Zmiri-strict-provenance
 #![feature(portable_simd, platform_intrinsics)]
 use std::simd::*;
 

--- a/tests/pass/ptr_int_casts.rs
+++ b/tests/pass/ptr_int_casts.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-permissive-provenance
+//@compile-flags: -Zmiri-permissive-provenance
 use std::mem;
 use std::ptr;
 

--- a/tests/pass/ptr_int_from_exposed.rs
+++ b/tests/pass/ptr_int_from_exposed.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-permissive-provenance
+//@compile-flags: -Zmiri-permissive-provenance
 #![feature(strict_provenance)]
 
 use std::ptr;

--- a/tests/pass/ptr_offset.rs
+++ b/tests/pass/ptr_offset.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-permissive-provenance
+//@compile-flags: -Zmiri-permissive-provenance
 use std::{mem, ptr};
 
 fn main() {

--- a/tests/pass/rc.rs
+++ b/tests/pass/rc.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-strict-provenance
+//@compile-flags: -Zmiri-strict-provenance
 #![feature(new_uninit)]
 #![feature(get_mut_unchecked)]
 

--- a/tests/pass/slices.rs
+++ b/tests/pass/slices.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-strict-provenance
+//@compile-flags: -Zmiri-strict-provenance
 #![feature(new_uninit)]
 #![feature(slice_as_chunks)]
 #![feature(slice_partition_dedup)]

--- a/tests/pass/stacked-borrows/int-to-ptr.rs
+++ b/tests/pass/stacked-borrows/int-to-ptr.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-permissive-provenance
+//@compile-flags: -Zmiri-permissive-provenance
 #![feature(strict_provenance)]
 use std::ptr;
 

--- a/tests/pass/stacked-borrows/interior_mutability.rs
+++ b/tests/pass/stacked-borrows/interior_mutability.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-retag-fields
+//@compile-flags: -Zmiri-retag-fields
 use std::cell::{Cell, Ref, RefCell, RefMut, UnsafeCell};
 use std::mem::{self, MaybeUninit};
 

--- a/tests/pass/stacked-borrows/stacked-borrows.rs
+++ b/tests/pass/stacked-borrows/stacked-borrows.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-retag-fields
+//@compile-flags: -Zmiri-retag-fields
 #![feature(allocator_api)]
 use std::ptr;
 

--- a/tests/pass/strings.rs
+++ b/tests/pass/strings.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-strict-provenance
+//@compile-flags: -Zmiri-strict-provenance
 
 fn empty() -> &'static str {
     ""

--- a/tests/pass/threadleak_ignored.rs
+++ b/tests/pass/threadleak_ignored.rs
@@ -1,6 +1,6 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-windows: Concurrency on Windows is not supported yet.
 // FIXME: disallow preemption to work around https://github.com/rust-lang/rust/issues/55005
-// compile-flags: -Zmiri-ignore-leaks -Zmiri-preemption-rate=0
+//@compile-flags: -Zmiri-ignore-leaks -Zmiri-preemption-rate=0
 
 //! Test that leaking threads works, and that their destructors are not executed.
 

--- a/tests/pass/time.rs
+++ b/tests/pass/time.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-disable-isolation
+//@compile-flags: -Zmiri-disable-isolation
 
 use std::time::{Duration, Instant, SystemTime};
 

--- a/tests/pass/track-alloc-1.rs
+++ b/tests/pass/track-alloc-1.rs
@@ -1,6 +1,6 @@
 // Ensure that tracking early allocations doesn't ICE Miri.
 // Early allocations are probably part of the runtime and therefore uninteresting, but they
 // shouldn't cause a crash.
-// compile-flags: -Zmiri-track-alloc-id=1
-// normalize-stderr-test: "[48] bytes" -> "SIZE bytes"
+//@compile-flags: -Zmiri-track-alloc-id=1
+//@normalize-stderr-test: "[48] bytes" -> "SIZE bytes"
 fn main() {}

--- a/tests/pass/transmute_fat.rs
+++ b/tests/pass/transmute_fat.rs
@@ -1,5 +1,5 @@
 // Stacked Borrows disallows this becuase the reference is never cast to a raw pointer.
-// compile-flags: -Zmiri-disable-stacked-borrows
+//@compile-flags: -Zmiri-disable-stacked-borrows
 
 fn main() {
     // If we are careful, we can exploit data layout...

--- a/tests/pass/uninit_number_ignored.rs
+++ b/tests/pass/uninit_number_ignored.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-allow-uninit-numbers
+//@compile-flags: -Zmiri-allow-uninit-numbers
 // This test is adapted from https://github.com/rust-lang/miri/issues/1340#issue-600900312.
 
 fn main() {

--- a/tests/pass/vec.rs
+++ b/tests/pass/vec.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-strict-provenance
+//@compile-flags: -Zmiri-strict-provenance
 // Gather all references from a mutable iterator and make sure Miri notices if
 // using them is dangerous.
 fn test_all_refs<'a, T: 'a>(dummy: &mut T, iter: impl Iterator<Item = &'a mut T>) {

--- a/tests/pass/vecdeque.rs
+++ b/tests/pass/vecdeque.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-strict-provenance
+//@compile-flags: -Zmiri-strict-provenance
 use std::collections::VecDeque;
 
 fn test_all_refs<'a, T: 'a>(dummy: &mut T, iter: impl Iterator<Item = &'a mut T>) {

--- a/tests/pass/weak_memory/extra_cpp.rs
+++ b/tests/pass/weak_memory/extra_cpp.rs
@@ -1,5 +1,5 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-ignore-leaks
+//@ignore-windows: Concurrency on Windows is not supported yet.
+//@compile-flags: -Zmiri-ignore-leaks
 
 // Tests operations not perfomable through C++'s atomic API
 // but doable in safe (at least sound) Rust.

--- a/tests/pass/weak_memory/extra_cpp_unsafe.rs
+++ b/tests/pass/weak_memory/extra_cpp_unsafe.rs
@@ -1,5 +1,5 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-ignore-leaks
+//@ignore-windows: Concurrency on Windows is not supported yet.
+//@compile-flags: -Zmiri-ignore-leaks
 
 // Tests operations not perfomable through C++'s atomic API
 // but doable in unsafe Rust which we think *should* be fine.

--- a/tests/pass/weak_memory/weak.rs
+++ b/tests/pass/weak_memory/weak.rs
@@ -1,5 +1,5 @@
-// ignore-windows: Concurrency on Windows is not supported yet.
-// compile-flags: -Zmiri-ignore-leaks -Zmiri-preemption-rate=0
+//@ignore-windows: Concurrency on Windows is not supported yet.
+//@compile-flags: -Zmiri-ignore-leaks -Zmiri-preemption-rate=0
 
 // Tests showing weak memory behaviours are exhibited. All tests
 // return true when the desired behaviour is seen.

--- a/tests/pass/without-validation.rs
+++ b/tests/pass/without-validation.rs
@@ -1,5 +1,5 @@
 // When we notice something breaks only without validation, we add a test here.
-// compile-flags: -Zmiri-disable-validation
+//@compile-flags: -Zmiri-disable-validation
 use std::cell::*;
 
 fn refcell_unsize() {

--- a/tests/pass/wtf8.rs
+++ b/tests/pass/wtf8.rs
@@ -1,4 +1,4 @@
-// only-windows
+//@only-windows
 
 use std::ffi::{OsStr, OsString};
 use std::os::windows::ffi::{OsStrExt, OsStringExt};

--- a/tests/pass/zst.rs
+++ b/tests/pass/zst.rs
@@ -1,4 +1,4 @@
-// compile-flags: -Zmiri-permissive-provenance
+//@compile-flags: -Zmiri-permissive-provenance
 #[derive(PartialEq, Debug)]
 struct A;
 

--- a/ui_test/Cargo.lock
+++ b/ui_test/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,10 +53,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backtrace"
+version = "0.3.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "color-eyre"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ebf286c900a6d5867aeff75cfee3192857bb7f24b547d4f0df2ed6baa812c90"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba75b3d9449ecdccb27ecbc479fdc0b87fa2dd43d2f8298f9bf0e59aacc8dce"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
 
 [[package]]
 name = "colored"
@@ -140,6 +203,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
+name = "gimli"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,6 +226,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "itoa"
@@ -182,6 +267,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "object"
+version = "0.28.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+
+[[package]]
 name = "output_vt100"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +298,18 @@ checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "decf7381921fea4dcb2549c5667eda59b3ec297ab7e2b5fc33eac69d2e7da87b"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "pretty_assertions"
@@ -236,6 +357,12 @@ name = "regex-syntax"
 version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc_version"
@@ -296,6 +423,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,9 +443,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a713421342a5a666b7577783721d3117f1b69a393df803ee17bb73b1e122a59"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
+]
+
+[[package]]
 name = "ui_test"
 version = "0.1.0"
 dependencies = [
+ "color-eyre",
  "colored",
  "crossbeam",
  "lazy_static",
@@ -325,6 +513,12 @@ name = "unicode-ident"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "winapi"

--- a/ui_test/Cargo.toml
+++ b/ui_test/Cargo.toml
@@ -17,5 +17,5 @@ crossbeam = "0.8.1"
 lazy_static = "1.4.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-color-eyre = "0.6.1"
+color-eyre = { version = "0.6.1", default-features = false, features = ["capture-spantrace"] }
 

--- a/ui_test/Cargo.toml
+++ b/ui_test/Cargo.toml
@@ -17,3 +17,5 @@ crossbeam = "0.8.1"
 lazy_static = "1.4.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+color-eyre = "0.6.1"
+

--- a/ui_test/README.md
+++ b/ui_test/README.md
@@ -7,14 +7,12 @@ A smaller version of compiletest-rs
 
 ## Supported magic comment annotations
 
-Note that the space after `//`, when it is present, is *not* optional -- it must be exactly one.
-
 * `// ignore-XXX` avoids running the test on targets whose triple contains `XXX`
     * `XXX` can also be one of `64bit`, `32bit` or `16bit`
 * `// only-XXX` avoids running the test on targets whose triple **does not** contain `XXX`
     * `XXX` can also be one of `64bit`, `32bit` or `16bit`
 * `// stderr-per-bitwidth` produces one stderr file per bitwidth, as they may differ significantly sometimes
-* `// error-pattern: XXX` make sure the stderr output contains `XXX`
+* `//@error-pattern: XXX` make sure the stderr output contains `XXX`
 * `//~ ERROR: XXX` make sure the stderr output contains `XXX` for an error in the line where this comment is written
     * Also supports `HELP`, `WARN` or `NOTE` for different kind of message
         * if one of those levels is specified explicitly, *all* diagnostics of this level or higher need an annotation. If you want to avoid this, just leave out the all caps level note entirely.

--- a/ui_test/README.md
+++ b/ui_test/README.md
@@ -7,25 +7,37 @@ A smaller version of compiletest-rs
 
 ## Supported magic comment annotations
 
-* `// ignore-XXX` avoids running the test on targets whose triple contains `XXX`
+If your test tests for failure, you need to add a `//~` annotation where the error is happening
+to make sure that the test will always keep failing with a specific message at the annotated line.
+
+`//~ ERROR: XXX` make sure the stderr output contains `XXX` for an error in the line where this comment is written
+
+* Also supports `HELP`, `WARN` or `NOTE` for different kind of message
+    * if one of those levels is specified explicitly, *all* diagnostics of this level or higher need an annotation. If you want to avoid this, just leave out the all caps level note entirely.
+* If the all caps note is left out, a message of any level is matched. Leaving it out is not allowed for `ERROR` levels.
+* This checks the output *before* normalization, so you can check things that get normalized away, but need to
+    be careful not to accidentally have a pattern that differs between platforms.
+
+In order to change how a single test is tested, you can add various `//@` comments to the test.
+Any other comments will be ignored, and all `//@` comments must be formatted precisely as
+their command specifies, or the test will fail without even being run.
+
+* `//@ignore-XXX` avoids running the test on targets whose triple contains `XXX`
     * `XXX` can also be one of `64bit`, `32bit` or `16bit`
-* `// only-XXX` avoids running the test on targets whose triple **does not** contain `XXX`
+* `//@only-XXX` avoids running the test on targets whose triple **does not** contain `XXX`
     * `XXX` can also be one of `64bit`, `32bit` or `16bit`
-* `// stderr-per-bitwidth` produces one stderr file per bitwidth, as they may differ significantly sometimes
+* `//@stderr-per-bitwidth` produces one stderr file per bitwidth, as they may differ significantly sometimes
 * `//@error-pattern: XXX` make sure the stderr output contains `XXX`
-* `//~ ERROR: XXX` make sure the stderr output contains `XXX` for an error in the line where this comment is written
-    * Also supports `HELP`, `WARN` or `NOTE` for different kind of message
-        * if one of those levels is specified explicitly, *all* diagnostics of this level or higher need an annotation. If you want to avoid this, just leave out the all caps level note entirely.
-    * If the all caps note is left out, a message of any level is matched. Leaving it out is not allowed for `ERROR` levels.
-    * This checks the output *before* normalization, so you can check things that get normalized away, but need to
-      be careful not to accidentally have a pattern that differs between platforms.
-* `// revisions: XXX YYY` runs the test once for each space separated name in the list
+* `//@revisions: XXX YYY` runs the test once for each space separated name in the list
     * emits one stderr file per revision
     * `//~` comments can be restricted to specific revisions by adding the revision name before the `~` in square brackets: `//[XXX]~`
-* `// compile-flags: XXX` appends `XXX` to the command line arguments passed to the rustc driver
-* `// rustc-env: XXX=YYY` sets the env var `XXX` to `YYY` for the rustc driver execution.
+* `//@compile-flags: XXX` appends `XXX` to the command line arguments passed to the rustc driver
+    * you can specify this multiple times, and all the flags will accumulate
+* `//@rustc-env: XXX=YYY` sets the env var `XXX` to `YYY` for the rustc driver execution.
     * for Miri these env vars are used during compilation via rustc and during the emulation of the program
-* `// normalize-stderr-test: "REGEX" -> "REPLACEMENT"` replaces all matches of `REGEX` in the stderr with `REPLACEMENT`. The replacement may specify `$1` and similar backreferences to paste captures.
+    * you can specify this multiple times, accumulating all the env vars
+* `//@normalize-stderr-test: "REGEX" -> "REPLACEMENT"` replaces all matches of `REGEX` in the stderr with `REPLACEMENT`. The replacement may specify `$1` and similar backreferences to paste captures.
+    * you can specify multiple such commands, there is no need to create a single regex that handles multiple replacements that you want to perform.
 
 ## Significant differences to compiletest-rs
 

--- a/ui_test/src/comments.rs
+++ b/ui_test/src/comments.rs
@@ -80,8 +80,7 @@ impl Comments {
     fn parse_checked(path: &Path, content: &str) -> Result<Self> {
         let mut this = Self::default();
 
-        // The line that a `|` will refer to
-        let mut fallthrough_to = None;
+        let mut fallthrough_to = None; // The line that a `|` will refer to.
         for (l, line) in content.lines().enumerate() {
             let l = l + 1; // enumerate starts at 0, but line numbers start at 1
             this.parse_checked_line(l, &mut fallthrough_to, line).map_err(|err| {
@@ -190,6 +189,7 @@ impl Comments {
                 Some(i) => {
                     let (command, args) = command.split_at(i);
                     let mut args = args.chars();
+                    // Commands are separated from their arguments by ':' or ' '
                     let next = args
                         .next()
                         .expect("the `position` above guarantees that there is at least one char");

--- a/ui_test/src/comments.rs
+++ b/ui_test/src/comments.rs
@@ -75,7 +75,7 @@ impl Comments {
     /// Parse comments in `content`.
     /// `path` is only used to emit diagnostics if parsing fails.
     ///
-    /// This function will only parse `//@` and `//~` style comments
+    /// This function will only parse `//@` and `//~` style comments (and the `//[xxx]~` variant)
     /// and ignore all others
     fn parse_checked(path: &Path, content: &str) -> Result<Self> {
         let mut this = Self::default();

--- a/ui_test/src/comments.rs
+++ b/ui_test/src/comments.rs
@@ -218,6 +218,9 @@ impl Comments {
                     self.env_vars.push((k.to_string(), v.to_string()));
                 },
             "normalize-stderr-test" => {
+                /// Parses a string literal. `s` has to start with `"`; everything until the next `"` is
+                /// returned in the first component. `\` can be used to escape arbitrary character.
+                /// Second return component is the rest of the string with leading whitespace removed.
                 fn parse_str(s: &str) -> Result<(&str, &str)> {
                     let mut chars = s.char_indices();
                     match chars.next().ok_or_else(|| eyre!("missing arguments"))?.1 {
@@ -226,6 +229,7 @@ impl Comments {
                             let mut escaped = false;
                             for (i, c) in chars {
                                 if escaped {
+                                    // Accept any character as literal after a `\`.
                                     escaped = false;
                                 } else if c == '"' {
                                     return Ok((&s[..(i - 1)], s[i..].trim_start()));

--- a/ui_test/src/comments.rs
+++ b/ui_test/src/comments.rs
@@ -184,19 +184,22 @@ impl Comments {
 
     fn parse_command(&mut self, command: &str, l: usize) -> Result<()> {
         // Commands are letters or dashes, grab everything until the first character that is neither of those.
-        let (command, args) = match command.chars().position(|c: char| !c.is_alphabetic() && c != '-') {
-            None => (command, ""),
-            Some(i) => {
-                let (command, args) = command.split_at(i);
-                let mut args = args.chars();
-                let next = args.next().expect("the `position` above guarantees that there is at least one char");
-                let args = match next {
-                    ':' | ' ' => args.as_str(),
-                    _ => bail!("expected space or `:`, got `{next}`"),
-                };
-                (command, args)
-            }
-        };
+        let (command, args) =
+            match command.chars().position(|c: char| !c.is_alphabetic() && c != '-') {
+                None => (command, ""),
+                Some(i) => {
+                    let (command, args) = command.split_at(i);
+                    let mut args = args.chars();
+                    let next = args
+                        .next()
+                        .expect("the `position` above guarantees that there is at least one char");
+                    let args = match next {
+                        ':' | ' ' => args.as_str(),
+                        _ => bail!("expected space or `:`, got `{next}`"),
+                    };
+                    (command, args)
+                }
+            };
 
         match command {
             "revisions" => {

--- a/ui_test/src/comments.rs
+++ b/ui_test/src/comments.rs
@@ -286,8 +286,6 @@ impl Comments {
         revision: Option<String>,
         l: usize,
     ) -> Result<()> {
-        // FIXME: check that the error happens on the marked line
-
         let (match_line, pattern) =
             match pattern.chars().next().ok_or_else(|| eyre!("no pattern specified"))? {
                 '|' =>

--- a/ui_test/src/comments.rs
+++ b/ui_test/src/comments.rs
@@ -193,6 +193,7 @@ impl Comments {
                     let next = args
                         .next()
                         .expect("the `position` above guarantees that there is at least one char");
+                    // FIXME: this replicates the existing flexibility in our syntax. Consider requiring the colon.
                     let args = match next {
                         ':' | ' ' => args.as_str(),
                         _ => bail!("expected space or `:`, got `{next}`"),

--- a/ui_test/src/comments.rs
+++ b/ui_test/src/comments.rs
@@ -227,7 +227,7 @@ impl Comments {
                                 if escaped {
                                     escaped = false;
                                 } else if c == '"' {
-                                    return Ok((&s[..(i - 1)], s[i..].trim_start()))
+                                    return Ok((&s[..(i - 1)], s[i..].trim_start()));
                                 } else {
                                     escaped = c == '\\';
                                 }

--- a/ui_test/src/comments.rs
+++ b/ui_test/src/comments.rs
@@ -246,7 +246,8 @@ impl Comments {
                 );
                 self.error_pattern = Some((args.trim().to_string(), l));
             }
-            _ => exit!("unknown command {command} with args {args}"),
+            // Maybe the user just left a comment explaining a command without arguments
+            _ => self.parse_command(command, path, l),
         }
     }
 
@@ -292,14 +293,8 @@ impl Comments {
         checked!(path, l);
         let (revision, pattern) =
             unwrap!(pattern.split_once(']'), "`//[` without corresponding `]`");
-        if pattern.starts_with('~') {
-            self.parse_pattern_inner(
-                &pattern[1..],
-                fallthrough_to,
-                Some(revision.to_owned()),
-                path,
-                l,
-            )
+        if let Some(pattern) = pattern.strip_prefix('~') {
+            self.parse_pattern_inner(pattern, fallthrough_to, Some(revision.to_owned()), path, l)
         } else {
             exit!("revisioned pattern must have `~` following the `]`");
         }

--- a/ui_test/src/comments/tests.rs
+++ b/ui_test/src/comments/tests.rs
@@ -1,9 +1,9 @@
-use std::{path::Path, panic::catch_unwind};
+use std::path::Path;
 
 use super::Comments;
 
-use color_eyre::eyre::{Result, bail};
 use crate::tests::init;
+use color_eyre::eyre::{bail, Result};
 
 #[test]
 fn parse_simple_comment() -> Result<()> {
@@ -48,8 +48,8 @@ fn parse_slash_slash_at_fail() -> Result<()> {
 use std::mem;
 
     ";
-    match catch_unwind(|| Comments::parse(Path::new("<dummy>"), s)) {
-        Ok(_) => bail!("expected parsing to panic"),
+    match Comments::parse(Path::new("<dummy>"), s) {
+        Ok(_) => bail!("expected parsing to fail"),
         Err(_) => Ok(()),
     }
 }

--- a/ui_test/src/comments/tests.rs
+++ b/ui_test/src/comments/tests.rs
@@ -1,9 +1,13 @@
-use std::path::Path;
+use std::{path::Path, panic::catch_unwind};
 
 use super::Comments;
 
+use color_eyre::eyre::{Result, bail};
+use crate::tests::init;
+
 #[test]
-fn parse_simple_comment() {
+fn parse_simple_comment() -> Result<()> {
+    init();
     let s = r"
 use std::mem;
 
@@ -11,7 +15,7 @@ fn main() {
     let _x: &i32 = unsafe { mem::transmute(16usize) }; //~ ERROR encountered a dangling reference (address $HEX is unallocated)
 }
     ";
-    let comments = Comments::parse(Path::new("<dummy>"), s);
+    let comments = Comments::parse(Path::new("<dummy>"), s)?;
     println!("parsed comments: {:#?}", comments);
     assert_eq!(comments.error_matches[0].definition_line, 5);
     assert_eq!(comments.error_matches[0].revision, None);
@@ -19,29 +23,33 @@ fn main() {
         comments.error_matches[0].matched,
         "encountered a dangling reference (address $HEX is unallocated)"
     );
+    Ok(())
 }
 
 #[test]
-fn parse_slash_slash_at() {
+fn parse_slash_slash_at() -> Result<()> {
+    init();
     let s = r"
 //@  error-pattern:  foomp
 use std::mem;
 
     ";
-    let comments = Comments::parse(Path::new("<dummy>"), s);
+    let comments = Comments::parse(Path::new("<dummy>"), s)?;
     println!("parsed comments: {:#?}", comments);
     assert_eq!(comments.error_pattern, Some(("foomp".to_string(), 2)));
+    Ok(())
 }
 
 #[test]
-#[should_panic]
-fn parse_slash_slash_at_fail() {
+fn parse_slash_slash_at_fail() -> Result<()> {
+    init();
     let s = r"
 //@  error-pattern  foomp
 use std::mem;
 
     ";
-    let comments = Comments::parse(Path::new("<dummy>"), s);
-    println!("parsed comments: {:#?}", comments);
-    assert_eq!(comments.error_pattern, Some(("foomp".to_string(), 2)));
+    match catch_unwind(|| Comments::parse(Path::new("<dummy>"), s)) {
+        Ok(_) => bail!("expected parsing to panic"),
+        Err(_) => Ok(()),
+    }
 }

--- a/ui_test/src/comments/tests.rs
+++ b/ui_test/src/comments/tests.rs
@@ -20,3 +20,28 @@ fn main() {
         "encountered a dangling reference (address $HEX is unallocated)"
     );
 }
+
+#[test]
+fn parse_slash_slash_at() {
+    let s = r"
+//@  error-pattern:  foomp
+use std::mem;
+
+    ";
+    let comments = Comments::parse(Path::new("<dummy>"), s);
+    println!("parsed comments: {:#?}", comments);
+    assert_eq!(comments.error_pattern, Some(("foomp".to_string(), 2)));
+}
+
+#[test]
+#[should_panic]
+fn parse_slash_slash_at_fail() {
+    let s = r"
+//@  error-pattern  foomp
+use std::mem;
+
+    ";
+    let comments = Comments::parse(Path::new("<dummy>"), s);
+    println!("parsed comments: {:#?}", comments);
+    assert_eq!(comments.error_pattern, Some(("foomp".to_string(), 2)));
+}

--- a/ui_test/src/comments/tests.rs
+++ b/ui_test/src/comments/tests.rs
@@ -44,7 +44,7 @@ use std::mem;
 fn parse_slash_slash_at_fail() -> Result<()> {
     init();
     let s = r"
-//@  error-pattern  foomp
+//@  error-patttern  foomp
 use std::mem;
 
     ";

--- a/ui_test/src/lib.rs
+++ b/ui_test/src/lib.rs
@@ -377,7 +377,7 @@ fn check_annotations(
 ) {
     if let Some((ref error_pattern, definition_line)) = comments.error_pattern {
         // first check the diagnostics messages outside of our file. We check this first, so that
-        // you can mix in-file annotations with // error-pattern annotations, even if there is overlap
+        // you can mix in-file annotations with //@error-pattern annotations, even if there is overlap
         // in the messages.
         if let Some(i) = messages_from_unknown_file_or_line
             .iter()

--- a/ui_test/src/tests.rs
+++ b/ui_test/src/tests.rs
@@ -329,8 +329,8 @@ fn main() {
     }
 }
 
-static INIT: std::sync::Once = std::sync::Once::new();
-
+/// Call this from every test to initialize eyre only once across all tests.
 pub fn init() {
+    static INIT: std::sync::Once = std::sync::Once::new();
     INIT.call_once(|| color_eyre::install().unwrap());
 }


### PR DESCRIPTION
fixes #2170

I haven't ported the entire test suite yet. Once we've done that, I will remove the old parsing system (or in fact, turn them into errors so that accidental usage of old-style comments will be detected)