### PR TITLE
Add a `rustup` subcommand to `./miri`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,15 @@ contact us (`oli-obk` and `RalfJ`) on the [Rust Zulip].
 
 [Rust Zulip]: https://rust-lang.zulipchat.com
 
+## The `miri` script
+
+Building and invoking Miri requires getting a bunch of flags right and setting
+up a custom sysroot with xargo. The `miri` script located at the root of the
+repository takes care of that for you.
+
+Run `./miri` without arguments to see the commands our build tool
+supports.
+
 ## Preparing the build environment
 
 Miri heavily relies on internal and unstable rustc interfaces to execute MIR,
@@ -23,25 +32,23 @@ tested against. Other versions will likely not work. After installing
 [`rustup-toolchain-install-master`], you can run the following command to
 install that exact version of rustc as a toolchain:
 ```
-./rustup-toolchain
+./miri toolchain
 ```
-This will set up a rustup toolchain called `miri` and set it as an override for
-the current directory.
+This will set up a rustup toolchain called `miri` and set it as an override.
+
+For more advanced build environment configuration, run the `rust-toolchain`
+script located at the root of the repository.
 
 [`rustup-toolchain-install-master`]: https://github.com/kennytm/rustup-toolchain-install-master
 
-## Building and testing Miri
+## Building Miri
 
-Invoking Miri requires getting a bunch of flags right and setting up a custom
-sysroot with xargo. The `miri` script takes care of that for you. With the
-build environment prepared, compiling Miri is just one command away:
+ Once the build environment is prepared, compiling Miri is just one command
+ away:
 
 ```
 ./miri build
 ```
-
-Run `./miri` without arguments to see the other commands our build tool
-supports.
 
 ### Testing the Miri driver
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,11 +28,6 @@ install that exact version of rustc as a toolchain:
 This will set up a rustup toolchain called `miri` and set it as an override for
 the current directory.
 
-If you want to also have `clippy` installed, you need to run this:
-```
-./rustup-toolchain "" -c clippy
-```
-
 [`rustup-toolchain-install-master`]: https://github.com/kennytm/rustup-toolchain-install-master
 
 ## Building and testing Miri

--- a/miri
+++ b/miri
@@ -32,10 +32,10 @@ Format all sources and tests. <flags> are passed to `rustfmt`.
 ./miri clippy <flags>:
 Runs clippy on all sources. <flags> are passed to `cargo clippy`.
 
-./miri rustup <flags>:
+./miri toolchain <flags>:
 Set up a rustup toolchain called `miri` and set it as an override.
 Requires <https://github.com/kennytm/rustup-toolchain-install-master> to be installed.
-<flags> are passed to `rustup-toolchain`.
+<flags> are passed to `./rustup-toolchain`.
 
 ./miri many-seeds <command>:
 Runs <command> over and over again with different seeds for Miri. The MIRIFLAGS
@@ -159,6 +159,9 @@ find_sysroot() {
 
 # Run command.
 case "$COMMAND" in
+toolchain)
+    "$MIRIDIR/rustup-toolchain" "$@"
+    ;;
 install|install-debug)
     # "--locked" to respect the Cargo.lock file if it exists,
     # "--offline" to avoid querying the registry (for yanked packages).
@@ -215,9 +218,6 @@ run|run-debug)
 fmt)
     find "$MIRIDIR" -not \( -name target -prune \) -name '*.rs' \
         | xargs rustfmt +$TOOLCHAIN --edition=2021 --config-path "$MIRIDIR/rustfmt.toml" "$@"
-    ;;
-rustup)
-    "$MIRIDIR/rustup-toolchain" "$@"
     ;;
 clippy)
     $CARGO clippy $CARGO_BUILD_FLAGS --manifest-path "$MIRIDIR"/Cargo.toml --all-targets "$@"

--- a/miri
+++ b/miri
@@ -32,6 +32,11 @@ Format all sources and tests. <flags> are passed to `rustfmt`.
 ./miri clippy <flags>:
 Runs clippy on all sources. <flags> are passed to `cargo clippy`.
 
+./miri rustup <flags>:
+Set up a rustup toolchain called `miri` and set it as an override.
+Requires <https://github.com/kennytm/rustup-toolchain-install-master> to be installed.
+<flags> are passed to `rustup-toolchain`.
+
 ./miri many-seeds <command>:
 Runs <command> over and over again with different seeds for Miri. The MIRIFLAGS
 variable is set to its original value appended with ` -Zmiri-seed=$SEED` for
@@ -210,6 +215,9 @@ run|run-debug)
 fmt)
     find "$MIRIDIR" -not \( -name target -prune \) -name '*.rs' \
         | xargs rustfmt +$TOOLCHAIN --edition=2021 --config-path "$MIRIDIR/rustfmt.toml" "$@"
+    ;;
+rustup)
+    "$MIRIDIR/rustup-toolchain" "$@"
     ;;
 clippy)
     $CARGO clippy $CARGO_BUILD_FLAGS --manifest-path "$MIRIDIR"/Cargo.toml --all-targets "$@"

--- a/rustup-toolchain
+++ b/rustup-toolchain
@@ -21,22 +21,32 @@ if ! which rustup-toolchain-install-master >/dev/null; then
     exit 1
 fi
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
 # Determine new commit.
 if [[ "$1" == "" ]]; then
-    NEW_COMMIT=$(cat rust-version)
+    NEW_COMMIT=$(cat "$SCRIPT_DIR/rust-version")
 elif [[ "$1" == "HEAD" ]]; then
     NEW_COMMIT=$(git ls-remote https://github.com/rust-lang/rust/ HEAD | cut -f 1)
 else
     NEW_COMMIT="$1"
 fi
-echo "$NEW_COMMIT" > rust-version
+echo "$NEW_COMMIT" > "$SCRIPT_DIR/rust-version"
 shift || true # don't fail if shifting fails
+
+# Save the working directory.
+pushd .;
+
+# Go to where this script is located.
+cd $SCRIPT_DIR;
 
 # Check if we already are at that commit.
 CUR_COMMIT=$(rustc +miri --version -v 2>/dev/null | egrep "^commit-hash: " | cut -d " " -f 2)
 if [[ "$CUR_COMMIT" == "$NEW_COMMIT" ]]; then
     echo "miri toolchain is already at commit $CUR_COMMIT."
     rustup override set miri
+    # Return to the original working directory.
+    popd;
     exit 0
 fi
 
@@ -51,3 +61,6 @@ cargo clean
 # Call 'cargo metadata' on the sources in case that changes the lockfile
 # (which fails under some setups when it is done from inside vscode).
 cargo metadata --format-version 1 --manifest-path "$(rustc --print sysroot)/lib/rustlib/rustc-src/rust/compiler/rustc/Cargo.toml" >/dev/null
+
+# Return to the original working directory.
+popd;


### PR DESCRIPTION
All dev commands run through `./miri` except for updating the miri toolchain,
which uses `./rustup-toolchain`. This change makes the experience more
consistent for contributors.

I also removed the clippy suggestion in `CONTRIBUTING.md`, as it appears
we are installing it already by default...`rustup-toolchain` calls `rustup-toolchain-install-master` with `-c clippy`.