### PR TITLE
ui_test: more robust syntax for target filtering

### DIFF
--- a/tests/fail/concurrency/libc_pthread_create_main_terminate.rs
+++ b/tests/fail/concurrency/libc_pthread_create_main_terminate.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 //@error-pattern: the main thread terminated without waiting for all remaining threads
 
 // Check that we terminate the program when the main thread terminates.

--- a/tests/fail/concurrency/libc_pthread_join_detached.rs
+++ b/tests/fail/concurrency/libc_pthread_join_detached.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 
 // Joining a detached thread is undefined behavior.
 

--- a/tests/fail/concurrency/libc_pthread_join_joined.rs
+++ b/tests/fail/concurrency/libc_pthread_join_joined.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 
 // Joining an already joined thread is undefined behavior.
 

--- a/tests/fail/concurrency/libc_pthread_join_main.rs
+++ b/tests/fail/concurrency/libc_pthread_join_main.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 
 // Joining the main thread is undefined behavior.
 

--- a/tests/fail/concurrency/libc_pthread_join_multiple.rs
+++ b/tests/fail/concurrency/libc_pthread_join_multiple.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 
 // Joining the same thread from multiple threads is undefined behavior.
 

--- a/tests/fail/concurrency/libc_pthread_join_self.rs
+++ b/tests/fail/concurrency/libc_pthread_join_self.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 // We are making scheduler assumptions here.
 //@compile-flags: -Zmiri-preemption-rate=0
 

--- a/tests/fail/concurrency/thread-spawn.rs
+++ b/tests/fail/concurrency/thread-spawn.rs
@@ -1,4 +1,4 @@
-//@only-windows: Only Windows is not supported.
+//@only-target-windows: Only Windows is not supported.
 
 use std::thread;
 

--- a/tests/fail/concurrency/thread_local_static_dealloc.rs
+++ b/tests/fail/concurrency/thread_local_static_dealloc.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 
 //! Ensure that thread-local statics get deallocated when the thread dies.
 

--- a/tests/fail/concurrency/too_few_args.rs
+++ b/tests/fail/concurrency/too_few_args.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 
 //! The thread function must have exactly one argument.
 

--- a/tests/fail/concurrency/too_many_args.rs
+++ b/tests/fail/concurrency/too_many_args.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 
 //! The thread function must have exactly one argument.
 

--- a/tests/fail/concurrency/unwind_top_of_stack.rs
+++ b/tests/fail/concurrency/unwind_top_of_stack.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 //@compile-flags: -Zmiri-disable-abi-check
 
 //! Unwinding past the top frame of a stack is Undefined Behavior.

--- a/tests/fail/data_race/alloc_read_race.rs
+++ b/tests/fail/data_race/alloc_read_race.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 //@compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 #![feature(new_uninit)]
 

--- a/tests/fail/data_race/alloc_write_race.rs
+++ b/tests/fail/data_race/alloc_write_race.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 //@compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 #![feature(new_uninit)]
 

--- a/tests/fail/data_race/atomic_read_na_write_race1.rs
+++ b/tests/fail/data_race/atomic_read_na_write_race1.rs
@@ -1,6 +1,6 @@
 // We want to control preemption here.
 //@compile-flags: -Zmiri-preemption-rate=0
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 #![feature(core_intrinsics)]
 
 use std::intrinsics;

--- a/tests/fail/data_race/atomic_read_na_write_race2.rs
+++ b/tests/fail/data_race/atomic_read_na_write_race2.rs
@@ -1,6 +1,6 @@
 // We want to control preemption here.
 //@compile-flags: -Zmiri-preemption-rate=0
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;

--- a/tests/fail/data_race/atomic_write_na_read_race1.rs
+++ b/tests/fail/data_race/atomic_write_na_read_race1.rs
@@ -1,6 +1,6 @@
 // We want to control preemption here.
 //@compile-flags: -Zmiri-preemption-rate=0
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;

--- a/tests/fail/data_race/atomic_write_na_read_race2.rs
+++ b/tests/fail/data_race/atomic_write_na_read_race2.rs
@@ -1,6 +1,6 @@
 // We want to control preemption here.
 //@compile-flags: -Zmiri-preemption-rate=0
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 #![feature(core_intrinsics)]
 
 use std::intrinsics::atomic_store;

--- a/tests/fail/data_race/atomic_write_na_write_race1.rs
+++ b/tests/fail/data_race/atomic_write_na_write_race1.rs
@@ -1,6 +1,6 @@
 // We want to control preemption here.
 //@compile-flags: -Zmiri-preemption-rate=0
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 #![feature(core_intrinsics)]
 
 use std::intrinsics::atomic_store;

--- a/tests/fail/data_race/atomic_write_na_write_race2.rs
+++ b/tests/fail/data_race/atomic_write_na_write_race2.rs
@@ -1,6 +1,6 @@
 // We want to control preemption here.
 //@compile-flags: -Zmiri-preemption-rate=0
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;

--- a/tests/fail/data_race/dangling_thread_async_race.rs
+++ b/tests/fail/data_race/dangling_thread_async_race.rs
@@ -1,6 +1,6 @@
 // We want to control preemption here.
 //@compile-flags: -Zmiri-disable-isolation -Zmiri-preemption-rate=0
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 
 use std::mem;
 use std::thread::{sleep, spawn};

--- a/tests/fail/data_race/dangling_thread_race.rs
+++ b/tests/fail/data_race/dangling_thread_race.rs
@@ -1,6 +1,6 @@
 // We want to control preemption here.
 //@compile-flags: -Zmiri-disable-isolation -Zmiri-preemption-rate=0
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 
 use std::mem;
 use std::thread::{sleep, spawn};

--- a/tests/fail/data_race/dealloc_read_race1.rs
+++ b/tests/fail/data_race/dealloc_read_race1.rs
@@ -1,6 +1,6 @@
 // We want to control preemption here.
 //@compile-flags: -Zmiri-preemption-rate=0
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 
 use std::thread::spawn;
 

--- a/tests/fail/data_race/dealloc_read_race2.rs
+++ b/tests/fail/data_race/dealloc_read_race2.rs
@@ -1,6 +1,6 @@
 // We want to control preemption here.
 //@compile-flags: -Zmiri-preemption-rate=0
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 
 use std::thread::spawn;
 

--- a/tests/fail/data_race/dealloc_read_race_stack.rs
+++ b/tests/fail/data_race/dealloc_read_race_stack.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 //@compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
 use std::ptr::null_mut;

--- a/tests/fail/data_race/dealloc_write_race1.rs
+++ b/tests/fail/data_race/dealloc_write_race1.rs
@@ -1,6 +1,6 @@
 // We want to control preemption here.
 //@compile-flags: -Zmiri-preemption-rate=0
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 
 use std::thread::spawn;
 

--- a/tests/fail/data_race/dealloc_write_race2.rs
+++ b/tests/fail/data_race/dealloc_write_race2.rs
@@ -1,6 +1,6 @@
 // We want to control preemption here.
 //@compile-flags: -Zmiri-preemption-rate=0
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 
 use std::thread::spawn;
 

--- a/tests/fail/data_race/dealloc_write_race_stack.rs
+++ b/tests/fail/data_race/dealloc_write_race_stack.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 //@compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
 use std::ptr::null_mut;

--- a/tests/fail/data_race/enable_after_join_to_main.rs
+++ b/tests/fail/data_race/enable_after_join_to_main.rs
@@ -1,6 +1,6 @@
 // We want to control preemption here.
 //@compile-flags: -Zmiri-preemption-rate=0
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 
 use std::thread::spawn;
 

--- a/tests/fail/data_race/fence_after_load.rs
+++ b/tests/fail/data_race/fence_after_load.rs
@@ -1,6 +1,6 @@
 // We want to control preemption here.
 //@compile-flags: -Zmiri-disable-isolation -Zmiri-preemption-rate=0
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 use std::sync::atomic::{fence, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread;

--- a/tests/fail/data_race/read_write_race.rs
+++ b/tests/fail/data_race/read_write_race.rs
@@ -1,6 +1,6 @@
 // We want to control preemption here.
 //@compile-flags: -Zmiri-preemption-rate=0
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 
 use std::thread::spawn;
 

--- a/tests/fail/data_race/read_write_race_stack.rs
+++ b/tests/fail/data_race/read_write_race_stack.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 //@compile-flags: -Zmiri-disable-isolation -Zmir-opt-level=0 -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
 // Note: mir-opt-level set to 0 to prevent the read of stack_var in thread 1

--- a/tests/fail/data_race/relax_acquire_race.rs
+++ b/tests/fail/data_race/relax_acquire_race.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 //@compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/tests/fail/data_race/release_seq_race.rs
+++ b/tests/fail/data_race/release_seq_race.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 //@compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/tests/fail/data_race/release_seq_race_same_thread.rs
+++ b/tests/fail/data_race/release_seq_race_same_thread.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 //@compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/tests/fail/data_race/rmw_race.rs
+++ b/tests/fail/data_race/rmw_race.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 //@compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/tests/fail/data_race/stack_pop_race.rs
+++ b/tests/fail/data_race/stack_pop_race.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 //@compile-flags: -Zmiri-preemption-rate=0
 use std::thread;
 

--- a/tests/fail/data_race/write_write_race.rs
+++ b/tests/fail/data_race/write_write_race.rs
@@ -1,6 +1,6 @@
 // We want to control preemption here.
 //@compile-flags: -Zmiri-preemption-rate=0
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 
 use std::thread::spawn;
 

--- a/tests/fail/data_race/write_write_race_stack.rs
+++ b/tests/fail/data_race/write_write_race_stack.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 //@compile-flags: -Zmiri-disable-isolation -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
 
 use std::ptr::null_mut;

--- a/tests/fail/environ-gets-deallocated.rs
+++ b/tests/fail/environ-gets-deallocated.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Windows does not have a global environ list that the program can access directly
+//@ignore-target-windows: Windows does not have a global environ list that the program can access directly
 
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 fn get_environ() -> *const *const u8 {

--- a/tests/fail/fs/close_stdout.rs
+++ b/tests/fail/fs/close_stdout.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 //@compile-flags: -Zmiri-disable-isolation
 
 // FIXME: standard handles cannot be closed (https://github.com/rust-lang/rust/issues/40032)

--- a/tests/fail/fs/isolated_file.rs
+++ b/tests/fail/fs/isolated_file.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: File handling is not implemented yet
+//@ignore-target-windows: File handling is not implemented yet
 //@error-pattern: `open` not available when isolation is enabled
 
 fn main() {

--- a/tests/fail/fs/isolated_stdin.rs
+++ b/tests/fail/fs/isolated_stdin.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/fs/read_from_stdout.rs
+++ b/tests/fail/fs/read_from_stdout.rs
@@ -1,5 +1,5 @@
 //@compile-flags: -Zmiri-disable-isolation
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/fs/unix_open_missing_required_mode.rs
+++ b/tests/fail/fs/unix_open_missing_required_mode.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 //@compile-flags: -Zmiri-disable-isolation
 
 #![feature(rustc_private)]

--- a/tests/fail/fs/write_to_stdin.rs
+++ b/tests/fail/fs/write_to_stdin.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/should-pass/cpp20_rwc_syncs.rs
+++ b/tests/fail/should-pass/cpp20_rwc_syncs.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 //@compile-flags: -Zmiri-ignore-leaks
 //@error-pattern: unreachable
 

--- a/tests/fail/sync/libc_pthread_cond_double_destroy.rs
+++ b/tests/fail/sync/libc_pthread_cond_double_destroy.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 #![feature(rustc_private)]
 
 /// Test that destroying a pthread_cond twice fails, even without a check for number validity

--- a/tests/fail/sync/libc_pthread_condattr_double_destroy.rs
+++ b/tests/fail/sync/libc_pthread_condattr_double_destroy.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 #![feature(rustc_private)]
 
 /// Test that destroying a pthread_condattr twice fails, even without a check for number validity

--- a/tests/fail/sync/libc_pthread_mutex_NULL_deadlock.rs
+++ b/tests/fail/sync/libc_pthread_mutex_NULL_deadlock.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 //
 // Check that if we pass NULL attribute, then we get the default mutex type.
 

--- a/tests/fail/sync/libc_pthread_mutex_deadlock.rs
+++ b/tests/fail/sync/libc_pthread_mutex_deadlock.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/sync/libc_pthread_mutex_default_deadlock.rs
+++ b/tests/fail/sync/libc_pthread_mutex_default_deadlock.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 //
 // Check that if we do not set the mutex type, it is the default.
 

--- a/tests/fail/sync/libc_pthread_mutex_destroy_locked.rs
+++ b/tests/fail/sync/libc_pthread_mutex_destroy_locked.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/sync/libc_pthread_mutex_double_destroy.rs
+++ b/tests/fail/sync/libc_pthread_mutex_double_destroy.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 #![feature(rustc_private)]
 
 /// Test that destroying a pthread_mutex twice fails, even without a check for number validity

--- a/tests/fail/sync/libc_pthread_mutex_normal_deadlock.rs
+++ b/tests/fail/sync/libc_pthread_mutex_normal_deadlock.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/sync/libc_pthread_mutex_normal_unlock_unlocked.rs
+++ b/tests/fail/sync/libc_pthread_mutex_normal_unlock_unlocked.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/sync/libc_pthread_mutex_wrong_owner.rs
+++ b/tests/fail/sync/libc_pthread_mutex_wrong_owner.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/sync/libc_pthread_mutexattr_double_destroy.rs
+++ b/tests/fail/sync/libc_pthread_mutexattr_double_destroy.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 #![feature(rustc_private)]
 
 /// Test that destroying a pthread_mutexattr twice fails, even without a check for number validity

--- a/tests/fail/sync/libc_pthread_rwlock_destroy_read_locked.rs
+++ b/tests/fail/sync/libc_pthread_rwlock_destroy_read_locked.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/sync/libc_pthread_rwlock_destroy_write_locked.rs
+++ b/tests/fail/sync/libc_pthread_rwlock_destroy_write_locked.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/sync/libc_pthread_rwlock_double_destroy.rs
+++ b/tests/fail/sync/libc_pthread_rwlock_double_destroy.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 #![feature(rustc_private)]
 
 /// Test that destroying a pthread_rwlock twice fails, even without a check for number validity

--- a/tests/fail/sync/libc_pthread_rwlock_read_write_deadlock_single_thread.rs
+++ b/tests/fail/sync/libc_pthread_rwlock_read_write_deadlock_single_thread.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/sync/libc_pthread_rwlock_read_wrong_owner.rs
+++ b/tests/fail/sync/libc_pthread_rwlock_read_wrong_owner.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/sync/libc_pthread_rwlock_unlock_unlocked.rs
+++ b/tests/fail/sync/libc_pthread_rwlock_unlock_unlocked.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/sync/libc_pthread_rwlock_write_read_deadlock.rs
+++ b/tests/fail/sync/libc_pthread_rwlock_write_read_deadlock.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/sync/libc_pthread_rwlock_write_read_deadlock_single_thread.rs
+++ b/tests/fail/sync/libc_pthread_rwlock_write_read_deadlock_single_thread.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/sync/libc_pthread_rwlock_write_write_deadlock.rs
+++ b/tests/fail/sync/libc_pthread_rwlock_write_write_deadlock.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/sync/libc_pthread_rwlock_write_write_deadlock_single_thread.rs
+++ b/tests/fail/sync/libc_pthread_rwlock_write_write_deadlock_single_thread.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/sync/libc_pthread_rwlock_write_wrong_owner.rs
+++ b/tests/fail/sync/libc_pthread_rwlock_write_wrong_owner.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/fail/unsupported_signal.rs
+++ b/tests/fail/unsupported_signal.rs
@@ -1,6 +1,6 @@
 //! `signal()` is special on Linux and macOS that it's only supported within libstd.
 //! The implementation is not complete enough to permit user code to call it.
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 #![feature(rustc_private)]
 
 extern crate libc;

--- a/tests/fail/weak_memory/racing_mixed_size.rs
+++ b/tests/fail/weak_memory/racing_mixed_size.rs
@@ -1,6 +1,6 @@
 // We want to control preemption here.
 //@compile-flags: -Zmiri-preemption-rate=0
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 
 #![feature(core_intrinsics)]
 

--- a/tests/fail/weak_memory/racing_mixed_size_read.rs
+++ b/tests/fail/weak_memory/racing_mixed_size_read.rs
@@ -1,6 +1,6 @@
 // We want to control preemption here.
 //@compile-flags: -Zmiri-preemption-rate=0
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 
 #![feature(core_intrinsics)]
 

--- a/tests/panic/panic/unsupported_syscall.rs
+++ b/tests/panic/panic/unsupported_syscall.rs
@@ -1,5 +1,5 @@
-//@ignore-windows: No libc on Windows
-//@ignore-apple: `syscall` is not supported on macOS
+//@ignore-target-windows: No libc on Windows
+//@ignore-target-apple: `syscall` is not supported on macOS
 //@compile-flags: -Zmiri-panic-on-unsupported
 #![feature(rustc_private)]
 

--- a/tests/pass/0weak_memory_consistency.rs
+++ b/tests/pass/0weak_memory_consistency.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 //@compile-flags: -Zmiri-ignore-leaks -Zmiri-disable-stacked-borrows
 
 // The following tests check whether our weak memory emulation produces

--- a/tests/pass/calloc.rs
+++ b/tests/pass/calloc.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/pass/concurrency/channels.rs
+++ b/tests/pass/concurrency/channels.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 //@compile-flags: -Zmiri-strict-provenance
 
 use std::sync::mpsc::{channel, sync_channel};

--- a/tests/pass/concurrency/concurrent_caller_location.rs
+++ b/tests/pass/concurrency/concurrent_caller_location.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 
 use std::panic::Location;
 use std::thread::spawn;

--- a/tests/pass/concurrency/data_race.rs
+++ b/tests/pass/concurrency/data_race.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 //@compile-flags: -Zmiri-disable-weak-memory-emulation
 
 use std::sync::atomic::{fence, AtomicUsize, Ordering};

--- a/tests/pass/concurrency/disable_data_race_detector.rs
+++ b/tests/pass/concurrency/disable_data_race_detector.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 //@compile-flags: -Zmiri-disable-data-race-detector
 
 use std::thread::spawn;

--- a/tests/pass/concurrency/issue1643.rs
+++ b/tests/pass/concurrency/issue1643.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 
 use std::thread::spawn;
 

--- a/tests/pass/concurrency/libc_pthread_cond.rs
+++ b/tests/pass/concurrency/libc_pthread_cond.rs
@@ -1,5 +1,5 @@
-//@ignore-windows: No libc on Windows
-//@ignore-apple: pthread_condattr_setclock is not supported on MacOS.
+//@ignore-target-windows: No libc on Windows
+//@ignore-target-apple: pthread_condattr_setclock is not supported on MacOS.
 //@compile-flags: -Zmiri-disable-isolation
 
 #![feature(rustc_private)]

--- a/tests/pass/concurrency/linux-futex.rs
+++ b/tests/pass/concurrency/linux-futex.rs
@@ -1,4 +1,4 @@
-//@only-linux
+//@only-target-linux
 //@compile-flags: -Zmiri-disable-isolation
 
 #![feature(rustc_private)]

--- a/tests/pass/concurrency/simple.rs
+++ b/tests/pass/concurrency/simple.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 //@compile-flags: -Zmiri-strict-provenance
 
 use std::thread;

--- a/tests/pass/concurrency/spin_loop.rs
+++ b/tests/pass/concurrency/spin_loop.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
 

--- a/tests/pass/concurrency/spin_loops_nopreempt.rs
+++ b/tests/pass/concurrency/spin_loops_nopreempt.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 // This specifically tests behavior *without* preemption.
 //@compile-flags: -Zmiri-preemption-rate=0
 

--- a/tests/pass/concurrency/sync.rs
+++ b/tests/pass/concurrency/sync.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 //@compile-flags: -Zmiri-disable-isolation -Zmiri-strict-provenance
 
 use std::sync::{Arc, Barrier, Condvar, Mutex, Once, RwLock};

--- a/tests/pass/concurrency/sync_nopreempt.rs
+++ b/tests/pass/concurrency/sync_nopreempt.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 // We are making scheduler assumptions here.
 //@compile-flags: -Zmiri-strict-provenance -Zmiri-preemption-rate=0
 

--- a/tests/pass/concurrency/thread_locals.rs
+++ b/tests/pass/concurrency/thread_locals.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 //@compile-flags: -Zmiri-strict-provenance
 
 //! The main purpose of this test is to check that if we take a pointer to

--- a/tests/pass/concurrency/tls_lib_drop.rs
+++ b/tests/pass/concurrency/tls_lib_drop.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 
 use std::cell::RefCell;
 use std::thread;

--- a/tests/pass/concurrency/tls_pthread_drop_order.rs
+++ b/tests/pass/concurrency/tls_pthread_drop_order.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 
 #![feature(rustc_private)]
 extern crate libc;

--- a/tests/pass/fs.rs
+++ b/tests/pass/fs.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: File handling is not implemented yet
+//@ignore-target-windows: File handling is not implemented yet
 //@compile-flags: -Zmiri-disable-isolation
 
 #![feature(rustc_private)]

--- a/tests/pass/fs_with_isolation.rs
+++ b/tests/pass/fs_with_isolation.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: File handling is not implemented yet
+//@ignore-target-windows: File handling is not implemented yet
 //@compile-flags: -Zmiri-isolation-error=warn-nobacktrace
 //@normalize-stderr-test: "(stat(x)?)" -> "$$STAT"
 

--- a/tests/pass/libc.rs
+++ b/tests/pass/libc.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 //@compile-flags: -Zmiri-disable-isolation
 
 #![feature(rustc_private)]

--- a/tests/pass/linux-getrandom-without-isolation.rs
+++ b/tests/pass/linux-getrandom-without-isolation.rs
@@ -1,4 +1,4 @@
-//@only-linux
+//@only-target-linux
 //@compile-flags: -Zmiri-disable-isolation
 #![feature(rustc_private)]
 extern crate libc;

--- a/tests/pass/linux-getrandom.rs
+++ b/tests/pass/linux-getrandom.rs
@@ -1,4 +1,4 @@
-//@only-linux
+//@only-target-linux
 #![feature(rustc_private)]
 extern crate libc;
 

--- a/tests/pass/malloc.rs
+++ b/tests/pass/malloc.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: No libc on Windows
+//@ignore-target-windows: No libc on Windows
 
 #![feature(rustc_private)]
 

--- a/tests/pass/no_std.rs
+++ b/tests/pass/no_std.rs
@@ -3,7 +3,7 @@
 // windows tls dtors go through libstd right now, thus this test
 // cannot pass. When windows tls dtors go through the special magic
 // windows linker section, we can run this test on windows again.
-//@ignore-windows
+//@ignore-target-windows
 
 #[start]
 fn start(_: isize, _: *const *const u8) -> isize {

--- a/tests/pass/panic/concurrent-panic.rs
+++ b/tests/pass/panic/concurrent-panic.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 // We are making scheduler assumptions here.
 //@compile-flags: -Zmiri-preemption-rate=0
 

--- a/tests/pass/threadleak_ignored.rs
+++ b/tests/pass/threadleak_ignored.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 // FIXME: disallow preemption to work around https://github.com/rust-lang/rust/issues/55005
 //@compile-flags: -Zmiri-ignore-leaks -Zmiri-preemption-rate=0
 

--- a/tests/pass/weak_memory/extra_cpp.rs
+++ b/tests/pass/weak_memory/extra_cpp.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 //@compile-flags: -Zmiri-ignore-leaks
 
 // Tests operations not perfomable through C++'s atomic API

--- a/tests/pass/weak_memory/extra_cpp_unsafe.rs
+++ b/tests/pass/weak_memory/extra_cpp_unsafe.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 //@compile-flags: -Zmiri-ignore-leaks
 
 // Tests operations not perfomable through C++'s atomic API

--- a/tests/pass/weak_memory/weak.rs
+++ b/tests/pass/weak_memory/weak.rs
@@ -1,4 +1,4 @@
-//@ignore-windows: Concurrency on Windows is not supported yet.
+//@ignore-target-windows: Concurrency on Windows is not supported yet.
 //@compile-flags: -Zmiri-ignore-leaks -Zmiri-preemption-rate=0
 
 // Tests showing weak memory behaviours are exhibited. All tests

--- a/tests/pass/wtf8.rs
+++ b/tests/pass/wtf8.rs
@@ -1,4 +1,4 @@
-//@only-windows
+//@only-target-windows
 
 use std::ffi::{OsStr, OsString};
 use std::os::windows::ffi::{OsStrExt, OsStringExt};

--- a/ui_test/src/parser.rs
+++ b/ui_test/src/parser.rs
@@ -69,9 +69,9 @@ impl Condition {
         if c == "on-host" {
             Ok(Condition::OnHost)
         } else if let Some(bits) = c.strip_suffix("bit") {
-            let bits: u8 = bits.parse().expect(
-                "ignore/only filter ending in 'bit' must be of the form 'Nbit' for some integer N",
-            );
+            let bits: u8 = bits.parse().map_err(|_err| {
+                eyre!("invalid ignore/only filter ending in 'bit': {c:?} is not a valid bitwdith")
+            })?;
             Ok(Condition::Bitwidth(bits))
         } else if let Some(target) = c.strip_prefix("target-") {
             Ok(Condition::Target(target.to_owned()))


### PR DESCRIPTION
Implicit fallbacks are always fragile and prone to typos, so let's be explicit.