### PR TITLE
Add a scheme for always using the default toolchain, running clippy and fmt before running any other command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tex/*/out
 perf.data
 perf.data.old
 flamegraph.svg
+.auto-*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,11 @@ install that exact version of rustc as a toolchain:
 This will set up a rustup toolchain called `miri` and set it as an override for
 the current directory.
 
+You can also create a `.auto-everything` file (contents don't matter, can be empty), which
+will cause any `./miri` command to automatically call `rustup-toolchain`, `clippy` and `rustfmt`
+for you. If you don't want all of these to happen, you can add individual `.auto-toolchain`,
+`.auto-clippy` and `.auto-fmt` files respectively.
+
 [`rustup-toolchain-install-master`]: https://github.com/kennytm/rustup-toolchain-install-master
 
 ## Building and testing Miri
@@ -242,6 +247,14 @@ cd rustc
 rustup toolchain link stage2 build/x86_64-unknown-linux-gnu/stage2
 # Now cd to your Miri directory, then configure rustup
 rustup override set stage2
+```
+
+Note: When you are working with a locally built rustc or any other toolchain that
+is not the same as the one in `rust-version`, you should not have `.auto-everything` or
+`.auto-toolchain` as that will keep resetting your toolchain.
+
+```
+rm -f .auto-everything .auto-toolchain
 ```
 
 Important: You need to delete the Miri cache when you change the stdlib; otherwise the

--- a/miri
+++ b/miri
@@ -48,33 +48,34 @@ Pass extra flags to all cargo invocations.
 EOF
 )
 
-## Run the subcommands that the user requested to always run first
+## We need to know where we are.
+# macOS does not have a useful readlink/realpath so we have to use Python instead...
+MIRIDIR=$(python3 -c 'import os, sys; print(os.path.dirname(os.path.realpath(sys.argv[1])))' "$0")
+
+## Run the auto-things.
 if [ -z "$AUTO_OPS" ]; then
     export AUTO_OPS=42
 
     # Run this first, so that the toolchain doesn't change after
     # other code has run.
-    if [ -f ".auto-everything" ] || [ -f ".auto-toolchain" ] ; then
+    if [ -f "$MIRIDIR/.auto-everything" ] || [ -f "$MIRIDIR/.auto-toolchain" ] ; then
         "$MIRIDIR"/rustup-toolchain
     fi
 
-    if [ -f ".auto-everything" ] || [ -f ".auto-fmt" ] ; then
+    if [ -f "$MIRIDIR/.auto-everything" ] || [ -f "$MIRIDIR/.auto-fmt" ] ; then
         $0 fmt
     fi
 
-    if [ -f ".auto-everything" ] || [ -f ".auto-clippy" ] ; then
+    if [ -f "$MIRIDIR/.auto-everything" ] || [ -f "$MIRIDIR/.auto-clippy" ] ; then
         $0 clippy -- -D warnings
     fi
 fi
 
-## Preparation
-# macOS does not have a useful readlink/realpath so we have to use Python instead...
-MIRIDIR=$(python3 -c 'import os, sys; print(os.path.dirname(os.path.realpath(sys.argv[1])))' "$0")
-TOOLCHAIN=$(cd "$MIRIDIR"; rustup show active-toolchain | head -n 1 | cut -d ' ' -f 1)
-
-# Determine command.
+## Determine command and toolchain.
 COMMAND="$1"
 [ $# -gt 0 ] && shift
+# Doing this *after* auto-toolchain logic above, since that might change the toolchain.
+TOOLCHAIN=$(cd "$MIRIDIR"; rustup show active-toolchain | head -n 1 | cut -d ' ' -f 1)
 
 ## Handle some commands early, since they should *not* alter the environment.
 case "$COMMAND" in

--- a/miri
+++ b/miri
@@ -48,6 +48,25 @@ Pass extra flags to all cargo invocations.
 EOF
 )
 
+## Run the subcommands that the user requested to always run first
+if [ -z "$AUTO_OPS" ]; then
+    export AUTO_OPS=42
+
+    # Run this first, so that the toolchain doesn't change after
+    # other code has run.
+    if [ -f ".auto-everything" ] || [ -f ".auto-toolchain" ] ; then
+        "$MIRIDIR"/rustup-toolchain
+    fi
+
+    if [ -f ".auto-everything" ] || [ -f ".auto-fmt" ] ; then
+        $0 fmt
+    fi
+
+    if [ -f ".auto-everything" ] || [ -f ".auto-clippy" ] ; then
+        $0 clippy -- -D warnings
+    fi
+fi
+
 ## Preparation
 # macOS does not have a useful readlink/realpath so we have to use Python instead...
 MIRIDIR=$(python3 -c 'import os, sys; print(os.path.dirname(os.path.realpath(sys.argv[1])))' "$0")


### PR DESCRIPTION
I keep forgetting to run rustup-toolchain on rebases across toolchain updates

I also keep forgetting to run rustfmt and clippy. The former isn't run by vscode if I don't explicitly save (I have autosave on).