### PR TITLE
Print one . character per test instead of one line

### DIFF
--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -48,8 +48,17 @@ fn run_tests(mode: Mode, path: &str, target: Option<String>) -> Result<()> {
         (true, true) => panic!("cannot use MIRI_BLESS and MIRI_SKIP_UI_CHECKS at the same time"),
     };
 
-    // Pass on all arguments as filters.
-    let path_filter = std::env::args().skip(1);
+    // Pass on all unknown arguments as filters.
+    let mut quiet = false;
+    let path_filter = std::env::args().skip(1).filter(|arg| {
+        match &**arg {
+            "--quiet" => {
+                quiet = true;
+                false
+            }
+            _ => true,
+        }
+    });
 
     let use_std = env::var_os("MIRI_NO_STD").is_none();
 
@@ -76,6 +85,7 @@ fn run_tests(mode: Mode, path: &str, target: Option<String>) -> Result<()> {
             ],
             envs: vec![],
         }),
+        quiet,
     };
     ui_test::run_tests(config)
 }

--- a/ui_test/src/tests.rs
+++ b/ui_test/src/tests.rs
@@ -18,6 +18,7 @@ fn config() -> Config {
         output_conflict_handling: OutputConflictHandling::Error,
         dependencies_crate_manifest_path: None,
         dependency_builder: None,
+        quiet: false,
     }
 }
 


### PR DESCRIPTION
`./miri bless -- --quiet` now prints a dot per test, along with the regular Rust unit tests that listen to this flag