### PR TITLE
use env vars, not Cargo.toml, to configure out dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,5 +56,6 @@ harness = false
 default = ["stack-cache"]
 stack-cache = []
 
-[profile.dev]
-opt-level = 2 # because it's too slow otherwise
+# Be aware that this file is inside a workspace when used via the
+# submodule in the rustc repo. That means there are many cargo features
+# we cannot use, such as profiles.

--- a/miri
+++ b/miri
@@ -96,9 +96,13 @@ fi
 
 # Prepare flags for cargo and rustc.
 CARGO="cargo +$TOOLCHAIN"
+# Share target dir between `miri` and `cargo-miri`.
 if [ -z "$CARGO_TARGET_DIR" ]; then
-    # Share target dir between `miri` and `cargo-miri`.
     export CARGO_TARGET_DIR="$MIRIDIR/target"
+fi
+# We configure dev builds to not be unusably slow.
+if [ -z "$CARGO_PROFILE_DEV_OPT_LEVEL" ]; then
+    export CARGO_PROFILE_DEV_OPT_LEVEL=2
 fi
 # We set the rpath so that Miri finds the private rustc libraries it needs.
 export RUSTFLAGS="-C link-args=-Wl,-rpath,$LIBDIR $RUSTFLAGS"


### PR DESCRIPTION
This should fix the cargo warnings we are seeing in rustc.