### PR TITLE
fix some debugging papercuts

### DIFF
--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -374,12 +374,15 @@ fn setup(subcommand: MiriCommand) {
         }
         None => {
             // Check for `rust-src` rustup component.
-            let sysroot = miri()
-                .args(&["--print", "sysroot"])
-                .output()
-                .expect("failed to determine sysroot")
-                .stdout;
-            let sysroot = std::str::from_utf8(&sysroot).unwrap();
+            let output =
+                miri().args(&["--print", "sysroot"]).output().expect("failed to determine sysroot");
+            if !output.status.success() {
+                show_error(format!(
+                    "Failed to determine sysroot; Miri said:\n{}",
+                    String::from_utf8_lossy(&output.stderr).trim_end()
+                ));
+            }
+            let sysroot = std::str::from_utf8(&output.stdout).unwrap();
             let sysroot = Path::new(sysroot.trim_end_matches('\n'));
             // Check for `$SYSROOT/lib/rustlib/src/rust/library`; test if that contains `std/Cargo.toml`.
             let rustup_src =

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -505,4 +505,22 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             }
         });
     }
+
+    /// We had a panic in Miri itself, try to print something useful.
+    fn handle_ice(&self) {
+        eprintln!();
+        eprintln!(
+            "Miri caused an ICE during evaluation. Here's the interpreter backtrace at the time of the panic:"
+        );
+        let this = self.eval_context_ref();
+        let stacktrace = this.generate_stacktrace();
+        report_msg(
+            this,
+            DiagLevel::Note,
+            "the place in the program where the ICE was triggered",
+            vec![],
+            vec![],
+            &stacktrace,
+        );
+    }
 }


### PR DESCRIPTION
- detect when Miri got locally installed and is being run with the wrong toolchain
- when an ICE occurs, print a backtrace of where the interpreter was at the time