### PR TITLE
on an error, always print the unnormalized stderr

### DIFF
--- a/ui_test/src/lib.rs
+++ b/ui_test/src/lib.rs
@@ -164,11 +164,11 @@ pub fn run_tests(config: Config) -> Result<()> {
     if !failures.is_empty() {
         for (path, miri, revision, errors, stderr) in &failures {
             eprintln!();
-            eprint!("{}", path.display().to_string().underline());
+            eprint!("{}", path.display().to_string().underline().bold());
             if !revision.is_empty() {
                 eprint!(" (revision `{}`)", revision);
             }
-            eprint!(" {}", "FAILED".red());
+            eprint!(" {}", "FAILED:".red().bold());
             eprintln!();
             eprintln!("command: {:?}", miri);
             eprintln!();
@@ -223,7 +223,7 @@ pub fn run_tests(config: Config) -> Result<()> {
             eprintln!("{}", stderr);
             eprintln!();
         }
-        eprintln!("{}", "failures:".red().underline());
+        eprintln!("{}", "FAILURES:".red().underline().bold());
         for (path, _miri, _revision, _errors, _stderr) in &failures {
             eprintln!("    {}", path.display());
         }

--- a/ui_test/src/lib.rs
+++ b/ui_test/src/lib.rs
@@ -172,7 +172,6 @@ pub fn run_tests(config: Config) -> Result<()> {
             eprintln!();
             eprintln!("command: {:?}", miri);
             eprintln!();
-            let mut dump_stderr = true;
             for error in errors {
                 match error {
                     Error::ExitStatus(mode, exit_status) => eprintln!("{mode:?} got {exit_status}"),
@@ -194,9 +193,6 @@ pub fn run_tests(config: Config) -> Result<()> {
                     Error::PatternFoundInPassTest =>
                         eprintln!("{}", "error pattern found in success test".red()),
                     Error::OutputDiffers { path, actual, expected } => {
-                        if path.extension().unwrap() == "stderr" {
-                            dump_stderr = false;
-                        }
                         eprintln!("actual output differed from expected {}", path.display());
                         eprintln!("{}", pretty_assertions::StrComparison::new(expected, actual));
                         eprintln!()
@@ -223,12 +219,9 @@ pub fn run_tests(config: Config) -> Result<()> {
                 }
                 eprintln!();
             }
-            // Unless we already dumped the stderr via an OutputDiffers diff, let's dump it here.
-            if dump_stderr {
-                eprintln!("actual stderr:");
-                eprintln!("{}", stderr);
-                eprintln!();
-            }
+            eprintln!("full stderr:");
+            eprintln!("{}", stderr);
+            eprintln!();
         }
         eprintln!("{}", "failures:".red().underline());
         for (path, _miri, _revision, _errors, _stderr) in &failures {


### PR DESCRIPTION
Currently we skip this if a stderr diff was printed, but the stderr diff is normalized, so e.g. one cannot learn line numbers from it.

Is there a way to get the diff to only print the parts the differ, like a usual `diff -u`? Currently it always seems to print the full output, so with a long stderr we now get doubly long test results even if the diff is actually rather small.