### PR TITLE
[cargo-miri] support nextest

### DIFF
--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -27,6 +27,7 @@ Usage:
 Subcommands:
     run, r                   Run binaries
     test, t                  Run tests
+    nextest                  Run tests with nextest (requires cargo-nextest installed)
     setup                    Only perform automatic setup, but without asking questions (for getting a proper libstd)
 
 The cargo options are exactly the same as for `cargo run` and `cargo test`, respectively.
@@ -586,11 +587,10 @@ fn phase_cargo_miri(mut args: env::Args) {
     };
     let subcommand = match &*subcommand {
         "setup" => MiriCommand::Setup,
-        "test" | "t" | "run" | "r" => MiriCommand::Forward(subcommand),
-        // Invalid command.
+        "test" | "t" | "run" | "r" | "nextest" => MiriCommand::Forward(subcommand),
         _ =>
             show_error(format!(
-                "`cargo miri` supports the following subcommands: `run`, `test`, and `setup`."
+                "`cargo miri` supports the following subcommands: `run`, `test`, `nextest`, and `setup`."
             )),
     };
     let verbose = num_arg_flag("-v");


### PR DESCRIPTION
Add the ability to run `cargo miri nextest list` and `cargo miri nextest run`.

[cargo-nextest](https://nexte.st) is a new test runner for Rust maintained mostly by myself. It has several new features, but the most relevant to miri is the fact that it runs [each test in its own process](https://nexte.st/book/how-it-works.html#the-nextest-model). This gives miri users better leak detection (https://github.com/rust-lang/miri/issues/1481) for free, for example.

See https://github.com/nextest-rs/nextest/issues/181 for discussion, including comments by @eddyb and @RalfJung.

Future work might be to have miri read [the list of tests](https://docs.rs/nextest-metadata/latest/nextest_metadata/struct.TestListSummary.html) (or [test binaries](https://docs.rs/nextest-metadata/latest/nextest_metadata/struct.BinaryListSummary.html)) generated by `nextest list`. @eddyb thinks that might be useful.

I tested `cargo miri nextest run` against smallvec, and it worked great.

Note: Running tests out of archives is currently broken, as the comment in run-test.py explains.