### PR TITLE
fix auto-toolchain pwd

### DIFF
--- a/miri
+++ b/miri
@@ -59,7 +59,7 @@ if [ -z "$AUTO_OPS" ]; then
     # Run this first, so that the toolchain doesn't change after
     # other code has run.
     if [ -f "$MIRIDIR/.auto-everything" ] || [ -f "$MIRIDIR/.auto-toolchain" ] ; then
-        "$MIRIDIR"/rustup-toolchain
+        (cd "$MIRIDIR" && ./rustup-toolchain)
     fi
 
     if [ -f "$MIRIDIR/.auto-everything" ] || [ -f "$MIRIDIR/.auto-fmt" ] ; then


### PR DESCRIPTION
`rustup-toolchain` needs to be called in the right directory