### PR TITLE
fix ./x.py test miri

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,11 +168,15 @@ to `.vscode/settings.json` in your local Miri clone:
         "./cargo-miri/Cargo.toml"
     ],
     "rust-analyzer.checkOnSave.overrideCommand": [
+        "env",
+        "AUTO_OPS=42",
         "./miri",
         "check",
         "--message-format=json"
     ],
     "rust-analyzer.buildScripts.overrideCommand": [
+        "env",
+        "AUTO_OPS=42",
         "./miri",
         "check",
         "--message-format=json",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,14 +169,14 @@ to `.vscode/settings.json` in your local Miri clone:
     ],
     "rust-analyzer.checkOnSave.overrideCommand": [
         "env",
-        "AUTO_OPS=42",
+        "MIRI_AUTO_OPS=no",
         "./miri",
         "check",
         "--message-format=json"
     ],
     "rust-analyzer.buildScripts.overrideCommand": [
         "env",
-        "AUTO_OPS=42",
+        "MIRI_AUTO_OPS=no",
         "./miri",
         "check",
         "--message-format=json",

--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -60,7 +60,7 @@ struct CrateRunEnv {
 
 impl CrateRunEnv {
     /// Gather all the information we need.
-    fn collect(args: env::Args, capture_stdin: bool) -> Self {
+    fn collect(args: impl Iterator<Item = String>, capture_stdin: bool) -> Self {
         let args = args.collect();
         let env = env::vars_os().collect();
         let current_dir = env::current_dir().unwrap().into_os_string();
@@ -707,7 +707,7 @@ enum RustcPhase {
     Rustdoc,
 }
 
-fn phase_rustc(mut args: env::Args, phase: RustcPhase) {
+fn phase_rustc(mut args: impl Iterator<Item = String>, phase: RustcPhase) {
     /// Determines if we are being invoked (as rustc) to build a crate for
     /// the "target" architecture, in contrast to the "host" architecture.
     /// Host crates are for build scripts and proc macros and still need to

--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -661,6 +661,13 @@ fn phase_cargo_miri(mut args: env::Args) {
         );
     }
     cmd.env("RUSTC_WRAPPER", &cargo_miri_path);
+    // Having both `RUSTC_WRAPPER` and `RUSTC` set does some odd things, so let's avoid that.
+    // See <https://github.com/rust-lang/miri/issues/2238>.
+    if env::var_os("RUSTC").is_some() && env::var_os("MIRI").is_none() {
+        println!(
+            "WARNING: Ignoring `RUSTC` environment variable; set `MIRI` if you want to control the binary used as the driver."
+        );
+    }
 
     let runner_env_name =
         |triple: &str| format!("CARGO_TARGET_{}_RUNNER", triple.to_uppercase().replace('-', "_"));

--- a/miri
+++ b/miri
@@ -53,8 +53,8 @@ EOF
 MIRIDIR=$(python3 -c 'import os, sys; print(os.path.dirname(os.path.realpath(sys.argv[1])))' "$0")
 
 ## Run the auto-things.
-if [ -z "$AUTO_OPS" ]; then
-    export AUTO_OPS=42
+if [ -z "$MIRI_AUTO_OPS" ]; then
+    export MIRI_AUTO_OPS=42
 
     # Run this first, so that the toolchain doesn't change after
     # other code has run.


### PR DESCRIPTION
Ok, this one works now. I had to manually remove `.cargo/bin` from my path to reproduce the rustc failure, and then figure out a few shenanigans around how cargo forwards arguments.