### PR TITLE
normalize stronger

### DIFF
--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -133,7 +133,7 @@ regexes! {
     // erase platform file paths
     "sys/[a-z]+/"                    => "sys/PLATFORM/",
     // erase paths into the crate registry
-    r"[^ ]*/\.cargo/registry/.*/(.*\.rs)"  => "CARGO_REGISTRY/$1",
+    r"[^ ]*/\.?cargo/registry/.*/(.*\.rs)"  => "CARGO_REGISTRY/.../$1",
 }
 
 fn ui(mode: Mode, path: &str) -> Result<()> {

--- a/tests/fail/crates/tokio_mvp.stderr
+++ b/tests/fail/crates/tokio_mvp.stderr
@@ -1,5 +1,5 @@
 error: unsupported operation: can't call foreign function: epoll_create1
-  --> CARGO_REGISTRY/epoll.rs:LL:CC
+  --> CARGO_REGISTRY/.../epoll.rs:LL:CC
    |
 LL |         syscall!(epoll_create1(flag)).map(|ep| Selector {
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't call foreign function: epoll_create1


### PR DESCRIPTION
rustc CI has the cargo stuff in `/cargo/...`, so we also need to handle that path.