### PR TITLE
don't dump xargo output onto users of 'cargo miri test'

### DIFF
--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -497,9 +497,24 @@ path = "lib.rs"
     // Disable debug assertions in the standard library -- Miri is already slow enough.
     // But keep the overflow checks, they are cheap.
     command.env("RUSTFLAGS", "-Cdebug-assertions=off -Coverflow-checks=on");
+    // Manage the output the user sees.
+    if only_setup {
+        eprintln!("Preparing a sysroot for Miri...");
+    } else {
+        eprint!("Preparing a sysroot for Miri... ");
+        command.stdout(process::Stdio::null());
+        command.stderr(process::Stdio::null());
+    }
     // Finally run it!
     if command.status().expect("failed to run xargo").success().not() {
-        show_error(format!("failed to run xargo"));
+        if only_setup {
+            show_error(format!("failed to run xargo, see error details above"))
+        } else {
+            show_error(format!("failed to run xargo; run `cargo miri setup` to see the error details"))
+        }
+    }
+    if !only_setup {
+        eprintln!("done");
     }
 
     // That should be it! But we need to figure out where xargo built stuff.
@@ -510,10 +525,10 @@ path = "lib.rs"
     // Figure out what to print.
     let print_sysroot = only_setup && has_arg_flag("--print-sysroot"); // whether we just print the sysroot path
     if print_sysroot {
-        // Print just the sysroot and nothing else; this way we do not need any escaping.
+        // Print just the sysroot and nothing else to stdout; this way we do not need any escaping.
         println!("{}", sysroot.display());
     } else if only_setup {
-        println!("A libstd for Miri is now available in `{}`.", sysroot.display());
+        eprintln!("A sysroot for Miri is now available in `{}`.", sysroot.display());
     }
 }
 

--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -510,7 +510,9 @@ path = "lib.rs"
         if only_setup {
             show_error(format!("failed to run xargo, see error details above"))
         } else {
-            show_error(format!("failed to run xargo; run `cargo miri setup` to see the error details"))
+            show_error(format!(
+                "failed to run xargo; run `cargo miri setup` to see the error details"
+            ))
         }
     }
     if !only_setup {

--- a/ci.sh
+++ b/ci.sh
@@ -21,6 +21,7 @@ function run_tests {
     echo "Testing host architecture"
   fi
 
+  ## ui test suite
   ./miri test --locked
   if [ -z "${MIRI_TEST_TARGET+exists}" ]; then
     # Only for host architecture: tests with optimizations (`-O` is what cargo passes, but crank MIR
@@ -30,15 +31,13 @@ function run_tests {
     MIRIFLAGS="-O -Zmir-opt-level=4" MIRI_SKIP_UI_CHECKS=1 ./miri test --locked -- tests/{pass,panic}
   fi
 
+  ## test-cargo-miri
   # On Windows, there is always "python", not "python3" or "python2".
   if command -v python3 > /dev/null; then
     PYTHON=python3
   else
     PYTHON=python
   fi
-
-  # "miri test" has built the sysroot for us, now this should pass without
-  # any interactive questions.
   ${PYTHON} test-cargo-miri/run-test.py
   echo
 


### PR DESCRIPTION
The xargo invocation prints a lot of details users probably won't care about, so let's hide them (unless the user did `cargo miri setup`, then we still print everything).