### PR TITLE
cargo-miri: use '--config target.runner' rather than the TARGET_RUNNER env vars

### DIFF
--- a/miri
+++ b/miri
@@ -131,9 +131,6 @@ export RUSTFLAGS="-C link-args=-Wl,-rpath,$LIBDIR $RUSTFLAGS"
 
 # Build a sysroot and set MIRI_SYSROOT to use it. Arguments are passed to `cargo miri setup`.
 build_sysroot() {
-    # Build once, for the user to see.
-    $CARGO run $CARGO_EXTRA_FLAGS --manifest-path "$MIRIDIR"/cargo-miri/Cargo.toml -- miri setup "$@"
-    # Call again, to just set env var.
     export MIRI_SYSROOT="$($CARGO run $CARGO_EXTRA_FLAGS --manifest-path "$MIRIDIR"/cargo-miri/Cargo.toml -q -- miri setup --print-sysroot "$@")"
 }
 


### PR DESCRIPTION
That means we can properly escape spaces in our filename. This should fix https://github.com/rust-lang/miri/issues/2417, hopefully for real this time. We can also specify a "leading command" which makes it much easier to disambiguate runner invocations from rustdoc invocations!

Thanks to @ehuss for suggesting this.