### PR TITLE
fix build.rs invoking RUSTC to do check builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,9 +409,9 @@ Moreover, Miri recognizes some environment variables:
   checkout. Note that changing files in that directory does not automatically
   trigger a re-build of the standard library; you have to clear the Miri build
   cache manually (on Linux, `rm -rf ~/.cache/miri`).
-* `MIRI_SYSROOT` (recognized by `cargo miri` and the Miri driver) indicates the
-  sysroot to use. Only set this if you do not want to use the automatically
-  created sysroot.
+* `MIRI_SYSROOT` (recognized by `cargo miri` and the Miri driver) indicates the sysroot to use. When
+  using `cargo miri`, only set this if you do not want to use the automatically created sysroot. For
+  directly invoking the Miri driver, this variable (or a `--sysroot` flag) is mandatory.
 * `MIRI_TEST_TARGET` (recognized by the test suite and the `./miri` script) indicates which target
   architecture to test against.  `miri` and `cargo miri` accept the `--target` flag for the same
   purpose.

--- a/README.md
+++ b/README.md
@@ -409,10 +409,9 @@ Moreover, Miri recognizes some environment variables:
   checkout. Note that changing files in that directory does not automatically
   trigger a re-build of the standard library; you have to clear the Miri build
   cache manually (on Linux, `rm -rf ~/.cache/miri`).
-* `MIRI_SYSROOT` (recognized by `cargo miri` and the test suite) indicates the
+* `MIRI_SYSROOT` (recognized by `cargo miri` and the Miri driver) indicates the
   sysroot to use. Only set this if you do not want to use the automatically
-  created sysroot. (The `miri` driver sysroot is controlled via the `--sysroot`
-  flag instead.)
+  created sysroot.
 * `MIRI_TEST_TARGET` (recognized by the test suite and the `./miri` script) indicates which target
   architecture to test against.  `miri` and `cargo miri` accept the `--target` flag for the same
   purpose.

--- a/miri
+++ b/miri
@@ -131,7 +131,11 @@ export RUSTFLAGS="-C link-args=-Wl,-rpath,$LIBDIR $RUSTFLAGS"
 
 # Build a sysroot and set MIRI_SYSROOT to use it. Arguments are passed to `cargo miri setup`.
 build_sysroot() {
-    export MIRI_SYSROOT="$($CARGO run $CARGO_EXTRA_FLAGS --manifest-path "$MIRIDIR"/cargo-miri/Cargo.toml -q -- miri setup --print-sysroot "$@")"
+    if ! MIRI_SYSROOT="$($CARGO run $CARGO_EXTRA_FLAGS --manifest-path "$MIRIDIR"/cargo-miri/Cargo.toml -q -- miri setup --print-sysroot "$@")"; then
+        echo "'cargo miri setup' failed"
+        exit 1
+    fi
+    export MIRI_SYSROOT
 }
 
 # Prepare and set MIRI_SYSROOT. Respects `MIRI_TEST_TARGET` and takes into account
@@ -201,7 +205,7 @@ run)
     $CARGO build $CARGO_EXTRA_FLAGS --manifest-path "$MIRIDIR"/Cargo.toml
     find_sysroot
     # Then run the actual command.
-    exec $CARGO run $CARGO_EXTRA_FLAGS --manifest-path "$MIRIDIR"/Cargo.toml -- --sysroot "$MIRI_SYSROOT" $MIRIFLAGS "$@"
+    exec $CARGO run $CARGO_EXTRA_FLAGS --manifest-path "$MIRIDIR"/Cargo.toml -- $MIRIFLAGS "$@"
     ;;
 fmt)
     find "$MIRIDIR" -not \( -name target -prune \) -name '*.rs' \

--- a/test-cargo-miri/Cargo.lock
+++ b/test-cargo-miri/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "byteorder"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,6 +24,7 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 name = "cargo-miri-test"
 version = "0.1.0"
 dependencies = [
+ "autocfg",
  "byteorder 0.5.3",
  "byteorder 1.4.3",
  "cdylib",

--- a/test-cargo-miri/Cargo.toml
+++ b/test-cargo-miri/Cargo.toml
@@ -21,6 +21,9 @@ issue_rust_86261 = { path = "issue-rust-86261" }
 byteorder_2 = { package = "byteorder", version = "0.5" } # to test dev-dependencies behave as expected, with renaming
 serde_derive = "1.0" # not actually used, but exercises some unique code path (`--extern` .so file)
 
+[build-dependencies]
+autocfg = "1"
+
 [lib]
 test = false # test that this is respected (will show in the output)
 

--- a/test-cargo-miri/build.rs
+++ b/test-cargo-miri/build.rs
@@ -25,4 +25,16 @@ fn main() {
     let a = autocfg::new();
     assert!(a.probe_sysroot_crate("std"));
     assert!(!a.probe_sysroot_crate("doesnotexist"));
+    assert!(a.probe_rustc_version(1, 0));
+    assert!(!a.probe_rustc_version(2, 0));
+    assert!(a.probe_type("i128"));
+    assert!(!a.probe_type("doesnotexist"));
+    assert!(a.probe_trait("Send"));
+    assert!(!a.probe_trait("doesnotexist"));
+    assert!(a.probe_path("std::num"));
+    assert!(!a.probe_path("doesnotexist"));
+    assert!(a.probe_constant("i32::MAX"));
+    assert!(!a.probe_constant("doesnotexist"));
+    assert!(a.probe_expression("Box::new(0)"));
+    assert!(!a.probe_expression("doesnotexist"));
 }

--- a/test-cargo-miri/build.rs
+++ b/test-cargo-miri/build.rs
@@ -20,4 +20,9 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=MIRITESTVAR");
     println!("cargo:rustc-env=MIRITESTVAR=testval");
+
+    // Test that autocfg works. This invokes RUSTC.
+    let a = autocfg::new();
+    assert!(a.probe_sysroot_crate("std"));
+    assert!(!a.probe_sysroot_crate("doesnotexist"));
 }

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -24,10 +24,6 @@ fn run_tests(mode: Mode, path: &str, target: Option<String>) -> Result<()> {
         flags.push("-Dwarnings".into());
         flags.push("-Dunused".into());
     }
-    if let Some(sysroot) = env::var_os("MIRI_SYSROOT") {
-        flags.push("--sysroot".into());
-        flags.push(sysroot);
-    }
     if let Ok(extra_flags) = env::var("MIRIFLAGS") {
         for flag in extra_flags.split_whitespace() {
             flags.push(flag.into());


### PR DESCRIPTION
This makes the Miri driver, when invokved via the RUSTC env var from inside a build script, behave almost entirely like rustc. I had to redo how we propagate sysroot information for this (which is actually back to how we used to do sysroot propagation many years ago).

Fixes https://github.com/rust-lang/miri/issues/2431