### PR TITLE
pass clippy::integer_arithmetic in our shims

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@
     clippy::too_many_arguments,
     clippy::type_complexity,
     clippy::single_element_loop,
+    clippy::needless_return,
     // We are not implementing queries here so it's fine
     rustc::potential_query_instability
 )]

--- a/src/shims/backtrace.rs
+++ b/src/shims/backtrace.rs
@@ -175,7 +175,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         // file would have more than 2^32 lines or columns, but whatever, just default to 0.
         let lineno: u32 = u32::try_from(lo.line).unwrap_or(0);
         // `lo.col` is 0-based - add 1 to make it 1-based for the caller.
-        let colno: u32 = u32::try_from(lo.col.0 + 1).unwrap_or(0);
+        let colno: u32 = u32::try_from(lo.col.0.saturating_add(1)).unwrap_or(0);
 
         let dest = this.force_allocation(dest)?;
         if let ty::Adt(adt, _) = dest.layout.ty.kind() {

--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -164,6 +164,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                     .expect("interpreting a non-executable crate");
                 for cnum in iter::once(LOCAL_CRATE).chain(
                     dependency_format.1.iter().enumerate().filter_map(|(num, &linkage)| {
+                        // We add 1 to the number because that's what rustc also does everywhere it
+                        // calls `CrateNum::new`...
+                        #[allow(clippy::integer_arithmetic)]
                         (linkage != Linkage::NotLinked).then_some(CrateNum::new(num + 1))
                     }),
                 ) {
@@ -542,7 +545,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                     .rev()
                     .position(|&c| c == val)
                 {
-                    let new_ptr = ptr.offset(Size::from_bytes(num - idx as u64 - 1), this)?;
+                    let idx = u64::try_from(idx).unwrap();
+                    #[allow(clippy::integer_arithmetic)] // idx < num, so this never wraps
+                    let new_ptr = ptr.offset(Size::from_bytes(num - idx - 1), this)?;
                     this.write_pointer(new_ptr, dest)?;
                 } else {
                     this.write_null(dest)?;
@@ -708,7 +713,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 let a = this.read_scalar(a)?.to_u64()?;
                 let b = this.read_scalar(b)?.to_u64()?;
 
+                #[allow(clippy::integer_arithmetic)] // adding two u64 and a u8 cannot wrap in a u128
                 let wide_sum = u128::from(c_in) + u128::from(a) + u128::from(b);
+                #[allow(clippy::integer_arithmetic)] // it's a u128, we can shift by 64
                 let (c_out, sum) = ((wide_sum >> 64).truncate::<u8>(), wide_sum.truncate::<u64>());
 
                 let c_out_field = this.place_field(dest, 0)?;

--- a/src/shims/mod.rs
+++ b/src/shims/mod.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::integer_arithmetic)]
+
 mod backtrace;
 pub mod foreign_items;
 pub mod intrinsics;

--- a/src/shims/time.rs
+++ b/src/shims/time.rs
@@ -84,7 +84,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         Ok(0)
     }
 
-    #[allow(non_snake_case)]
+    #[allow(non_snake_case, clippy::integer_arithmetic)]
     fn GetSystemTimeAsFileTime(
         &mut self,
         LPFILETIME_op: &OpTy<'tcx, Provenance>,

--- a/src/shims/tls.rs
+++ b/src/shims/tls.rs
@@ -63,6 +63,7 @@ impl<'tcx> Default for TlsData<'tcx> {
 impl<'tcx> TlsData<'tcx> {
     /// Generate a new TLS key with the given destructor.
     /// `max_size` determines the integer size the key has to fit in.
+    #[allow(clippy::integer_arithmetic)]
     pub fn create_tls_key(
         &mut self,
         dtor: Option<ty::Instance<'tcx>>,

--- a/src/shims/unix/fs.rs
+++ b/src/shims/unix/fs.rs
@@ -443,6 +443,7 @@ pub struct DirHandler {
 }
 
 impl DirHandler {
+    #[allow(clippy::integer_arithmetic)]
     fn insert_new(&mut self, read_dir: ReadDir) -> u64 {
         let id = self.next_id;
         self.next_id += 1;

--- a/src/shims/unix/linux/sync.rs
+++ b/src/shims/unix/linux/sync.rs
@@ -242,6 +242,7 @@ pub fn futex<'tcx>(
             // before doing the syscall.
             this.atomic_fence(AtomicFenceOrd::SeqCst)?;
             let mut n = 0;
+            #[allow(clippy::integer_arithmetic)]
             for _ in 0..val {
                 if let Some(thread) = this.futex_wake(addr_usize, bitset) {
                     this.unblock_thread(thread);


### PR DESCRIPTION
@oli-obk [raised some concerns](https://github.com/rust-lang/miri/pull/2422#discussion_r928220546) about this one. I still think it is the right call, since I don't see a good way to enable overflow checks for our official release builds. I'm open to suggestions though!

Fixes https://github.com/rust-lang/miri/issues/1236