### PR TITLE
Add default impls for `FileDescriptor` methods

### DIFF
--- a/tests/fail/fs/close_stdout.rs
+++ b/tests/fail/fs/close_stdout.rs
@@ -7,6 +7,6 @@
 
 fn main() {
     unsafe {
-        libc::close(1); //~ ERROR: stdout cannot be closed
+        libc::close(1); //~ ERROR: cannot close stdout
     }
 }

--- a/tests/fail/fs/close_stdout.stderr
+++ b/tests/fail/fs/close_stdout.stderr
@@ -1,8 +1,8 @@
-error: unsupported operation: stdout cannot be closed
+error: unsupported operation: cannot close stdout
   --> $DIR/close_stdout.rs:LL:CC
    |
 LL |         libc::close(1);
-   |         ^^^^^^^^^^^^^^ stdout cannot be closed
+   |         ^^^^^^^^^^^^^^ cannot close stdout
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
    = note: backtrace:


### PR DESCRIPTION
I felt like it was just noisy to have to write the "can't do this here" defaults