### PR TITLE
Use cargo_metadata in cargo-miri

### DIFF
--- a/cargo-miri/Cargo.lock
+++ b/cargo-miri/Cargo.lock
@@ -21,15 +21,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "camino"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "869119e97797867fd90f5e22af7d0bd274bd4635ebb9eb68c04f3f513ae6c412"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cargo-miri"
 version = "0.1.0"
 dependencies = [
+ "cargo_metadata",
  "directories",
  "rustc-workspace-hack",
  "rustc_version",
  "serde",
  "serde_json",
  "vergen",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3abb7553d5b9b8421c6de7cb02606ff15e0c6eea7d8eadd75ef013fd636bec36"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -274,11 +306,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.33"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb37d2df5df740e582f28f8560cf425f52bb267d872fe58358eadb554909f07a"
+checksum = "c278e965f1d8cf32d6e0e96de3d3e79712178ae67986d9cf9151f51e95aac89b"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -338,24 +370,27 @@ checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "semver"
-version = "1.0.4"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
-version = "1.0.131"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ad69dfbd3e45369132cc64e6748c2d65cdfb001a2b1c232d128b4ad60561c1"
+checksum = "fc855a42c7967b7c369eb5860f7164ef1f6f81c20c7cc1141f2a604e18723b03"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.131"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b710a83c4e0dff6a3d511946b95274ad9ca9e5d3ae497b63fda866ac955358d2"
+checksum = "6f2122636b9fe3b81f1cb25099fcf2d3f542cdb1d45940d56c713158884a05da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -364,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.73"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
+checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
  "itoa",
  "ryu",
@@ -375,13 +410,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.82"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -436,6 +471,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,12 +484,6 @@ checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "url"

--- a/cargo-miri/Cargo.toml
+++ b/cargo-miri/Cargo.toml
@@ -17,6 +17,7 @@ doctest = false # and no doc tests
 directories = "3"
 rustc_version = "0.4"
 serde_json = "1.0.40"
+cargo_metadata = "0.15.0"
 
 # A noop dependency that changes in the Rust repository, it's a bit of a hack.
 # See the `src/tools/rustc-workspace-hack/README.md` file in `rust-lang/rust`

--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -14,9 +14,9 @@ use std::ops::Not;
 use std::path::{Path, PathBuf};
 use std::process::{self, Command};
 
+use cargo_metadata::{Metadata, MetadataCommand};
 use rustc_version::VersionMeta;
 use serde::{Deserialize, Serialize};
-use cargo_metadata::{MetadataCommand, Metadata};
 
 use version::*;
 
@@ -594,16 +594,16 @@ fn get_cargo_metadata() -> Metadata {
     for arg in ArgSplitFlagValue::new(
         env::args().skip(3), // skip the program name, "miri" and "run" / "test"
         config_flag,
-    ).flatten() { // Only look at `Ok`
+    )
+    // Only look at `Ok`
+    .flatten()
+    {
         additional_options.push(config_flag.to_string());
         additional_options.push(arg);
     }
 
-    let metadata = MetadataCommand::new()
-        .no_deps()
-        .other_options(additional_options)
-        .exec()
-        .unwrap();
+    let metadata =
+        MetadataCommand::new().no_deps().other_options(additional_options).exec().unwrap();
 
     metadata
 }

--- a/cargo-miri/bin.rs
+++ b/cargo-miri/bin.rs
@@ -16,6 +16,7 @@ use std::process::{self, Command};
 
 use rustc_version::VersionMeta;
 use serde::{Deserialize, Serialize};
+use cargo_metadata::{MetadataCommand, Metadata};
 
 use version::*;
 
@@ -582,41 +583,29 @@ path = "lib.rs"
     }
 }
 
-#[derive(Deserialize)]
-struct Metadata {
-    target_directory: PathBuf,
-    workspace_members: Vec<String>,
-}
-
 fn get_cargo_metadata() -> Metadata {
-    let mut cmd = cargo();
-    // `-Zunstable-options` is required by `--config`.
-    cmd.args(["metadata", "--no-deps", "--format-version=1", "-Zunstable-options"]);
     // The `build.target-dir` config can be passed by `--config` flags, so forward them to
     // `cargo metadata`.
+    let mut additional_options = Vec::new();
+    // `-Zunstable-options` is required by `--config`.
+    additional_options.push("-Zunstable-options".to_string());
+
     let config_flag = "--config";
     for arg in ArgSplitFlagValue::new(
         env::args().skip(3), // skip the program name, "miri" and "run" / "test"
         config_flag,
-    )
-    // Only look at `Ok`
-    .flatten()
-    {
-        cmd.arg(config_flag).arg(arg);
+    ).flatten() { // Only look at `Ok`
+        additional_options.push(config_flag.to_string());
+        additional_options.push(arg);
     }
-    let mut child = cmd
-        .stdin(process::Stdio::null())
-        .stdout(process::Stdio::piped())
-        .spawn()
-        .expect("failed ro run `cargo metadata`");
-    // Check this `Result` after `status.success()` is checked, so we don't print the error
-    // to stderr if `cargo metadata` is also printing to stderr.
-    let metadata: Result<Metadata, _> = serde_json::from_reader(child.stdout.take().unwrap());
-    let status = child.wait().expect("failed to wait for `cargo metadata` to exit");
-    if !status.success() {
-        std::process::exit(status.code().unwrap_or(-1));
-    }
-    metadata.unwrap_or_else(|e| show_error(format!("invalid `cargo metadata` output: {}", e)))
+
+    let metadata = MetadataCommand::new()
+        .no_deps()
+        .other_options(additional_options)
+        .exec()
+        .unwrap();
+
+    metadata
 }
 
 /// Pulls all the crates in this workspace from the cargo metadata.
@@ -627,7 +616,7 @@ fn local_crates(metadata: &Metadata) -> String {
     assert!(!metadata.workspace_members.is_empty());
     let mut local_crates = String::new();
     for member in &metadata.workspace_members {
-        let name = member.split(' ').next().unwrap();
+        let name = member.repr.split(' ').next().unwrap();
         let name = name.replace('-', "_");
         local_crates.push_str(&name);
         local_crates.push(',');


### PR DESCRIPTION
Closes #2393

Added `cargo_metadata` to `cargo-miri` and changed metadata from manual parsing to `cargo_metadata` invocations. Thus, removed local `Metadata` struct too.

Happy to fix if anything isn't right :)