### PR TITLE
add special exception for std_miri_test crate to call std-only functions

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -803,7 +803,12 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         // Fall back to the instance of the function itself.
         let instance = instance.unwrap_or(frame.instance);
         // Now check if this is in the same crate as start_fn.
-        this.tcx.def_path(instance.def_id()).krate == this.tcx.def_path(start_fn).krate
+        // As a special exception we also allow unit tests from
+        // <https://github.com/rust-lang/miri-test-libstd/tree/master/std_miri_test> to call these
+        // shims.
+        let frame_crate = this.tcx.def_path(instance.def_id()).krate;
+        frame_crate == this.tcx.def_path(start_fn).krate
+            || this.tcx.crate_name(frame_crate).as_str() == "std_miri_test"
     }
 
     /// Handler that should be called when unsupported functionality is encountered.


### PR DESCRIPTION
These being the unit tests of std, they have their own copy of `std::sys` and `std::thread`, so the existing check says this is not std.  The check is correct but we want to allow this so we just hard-code the crate name.

The point of this `frame_in_std` check is to prevent people from directly interacting with shims that aren't really properly implemented, but it doesn't need to be 100% airtight. If someone really wants to call their crate `std_miri_test` in order to access some broken shims... they can keep the pieces.