### PR TITLE
implement some missing float functions

### DIFF
--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -588,7 +588,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 let [f] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 // FIXME: Using host floats.
                 let f = f32::from_bits(this.read_scalar(f)?.to_u32()?);
-                let f = match link_name.as_str() {
+                let res = match link_name.as_str() {
                     "cbrtf" => f.cbrt(),
                     "coshf" => f.cosh(),
                     "sinhf" => f.sinh(),
@@ -598,7 +598,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                     "atanf" => f.atan(),
                     _ => bug!(),
                 };
-                this.write_scalar(Scalar::from_u32(f.to_bits()), dest)?;
+                this.write_scalar(Scalar::from_u32(res.to_bits()), dest)?;
             }
             #[rustfmt::skip]
             | "_hypotf"
@@ -611,12 +611,12 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 // FIXME: Using host floats.
                 let f1 = f32::from_bits(this.read_scalar(f1)?.to_u32()?);
                 let f2 = f32::from_bits(this.read_scalar(f2)?.to_u32()?);
-                let n = match link_name.as_str() {
+                let res = match link_name.as_str() {
                     "_hypotf" | "hypotf" => f1.hypot(f2),
                     "atan2f" => f1.atan2(f2),
                     _ => bug!(),
                 };
-                this.write_scalar(Scalar::from_u32(n.to_bits()), dest)?;
+                this.write_scalar(Scalar::from_u32(res.to_bits()), dest)?;
             }
             #[rustfmt::skip]
             | "cbrt"
@@ -630,7 +630,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 let [f] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 // FIXME: Using host floats.
                 let f = f64::from_bits(this.read_scalar(f)?.to_u64()?);
-                let f = match link_name.as_str() {
+                let res = match link_name.as_str() {
                     "cbrt" => f.cbrt(),
                     "cosh" => f.cosh(),
                     "sinh" => f.sinh(),
@@ -640,7 +640,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                     "atan" => f.atan(),
                     _ => bug!(),
                 };
-                this.write_scalar(Scalar::from_u64(f.to_bits()), dest)?;
+                this.write_scalar(Scalar::from_u64(res.to_bits()), dest)?;
             }
             #[rustfmt::skip]
             | "_hypot"
@@ -651,12 +651,12 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 // FIXME: Using host floats.
                 let f1 = f64::from_bits(this.read_scalar(f1)?.to_u64()?);
                 let f2 = f64::from_bits(this.read_scalar(f2)?.to_u64()?);
-                let n = match link_name.as_str() {
+                let res = match link_name.as_str() {
                     "_hypot" | "hypot" => f1.hypot(f2),
                     "atan2" => f1.atan2(f2),
                     _ => bug!(),
                 };
-                this.write_scalar(Scalar::from_u64(n.to_bits()), dest)?;
+                this.write_scalar(Scalar::from_u64(res.to_bits()), dest)?;
             }
             #[rustfmt::skip]
             | "_ldexp"
@@ -668,7 +668,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 let x = this.read_scalar(x)?.to_f64()?;
                 let exp = this.read_scalar(exp)?.to_i32()?;
 
-                // Saturating cast to i16. Even those are outside the valid exponent range to
+                // Saturating cast to i16. Even those are outside the valid exponent range so
                 // `scalbn` below will do its over/underflow handling.
                 let exp = if exp > i32::from(i16::MAX) {
                     i16::MAX

--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -575,15 +575,18 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 this.write_scalar(Scalar::from_machine_usize(u64::try_from(n).unwrap(), this), dest)?;
             }
 
-            // math functions
+            // math functions (note that there are also intrinsics for some other functions)
             #[rustfmt::skip]
             | "cbrtf"
             | "coshf"
             | "sinhf"
             | "tanf"
+            | "tanhf"
             | "acosf"
             | "asinf"
             | "atanf"
+            | "log1pf"
+            | "expm1f"
             => {
                 let [f] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 // FIXME: Using host floats.
@@ -593,9 +596,12 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                     "coshf" => f.cosh(),
                     "sinhf" => f.sinh(),
                     "tanf" => f.tan(),
+                    "tanhf" => f.tanh(),
                     "acosf" => f.acos(),
                     "asinf" => f.asin(),
                     "atanf" => f.atan(),
+                    "log1pf" => f.ln_1p(),
+                    "expm1f" => f.exp_m1(),
                     _ => bug!(),
                 };
                 this.write_scalar(Scalar::from_u32(res.to_bits()), dest)?;
@@ -604,6 +610,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             | "_hypotf"
             | "hypotf"
             | "atan2f"
+            | "fdimf"
             => {
                 let [f1, f2] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 // underscore case for windows, here and below
@@ -614,6 +621,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 let res = match link_name.as_str() {
                     "_hypotf" | "hypotf" => f1.hypot(f2),
                     "atan2f" => f1.atan2(f2),
+                    #[allow(deprecated)]
+                    "fdimf" => f1.abs_sub(f2),
                     _ => bug!(),
                 };
                 this.write_scalar(Scalar::from_u32(res.to_bits()), dest)?;
@@ -623,9 +632,12 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             | "cosh"
             | "sinh"
             | "tan"
+            | "tanh"
             | "acos"
             | "asin"
             | "atan"
+            | "log1p"
+            | "expm1"
             => {
                 let [f] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 // FIXME: Using host floats.
@@ -635,9 +647,12 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                     "cosh" => f.cosh(),
                     "sinh" => f.sinh(),
                     "tan" => f.tan(),
+                    "tanh" => f.tanh(),
                     "acos" => f.acos(),
                     "asin" => f.asin(),
                     "atan" => f.atan(),
+                    "log1p" => f.ln_1p(),
+                    "expm1" => f.exp_m1(),
                     _ => bug!(),
                 };
                 this.write_scalar(Scalar::from_u64(res.to_bits()), dest)?;
@@ -646,6 +661,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             | "_hypot"
             | "hypot"
             | "atan2"
+            | "fdim"
             => {
                 let [f1, f2] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 // FIXME: Using host floats.
@@ -654,6 +670,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 let res = match link_name.as_str() {
                     "_hypot" | "hypot" => f1.hypot(f2),
                     "atan2" => f1.atan2(f2),
+                    #[allow(deprecated)]
+                    "fdim" => f1.abs_sub(f2),
                     _ => bug!(),
                 };
                 this.write_scalar(Scalar::from_u64(res.to_bits()), dest)?;

--- a/src/shims/intrinsics/mod.rs
+++ b/src/shims/intrinsics/mod.rs
@@ -285,7 +285,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 // FIXME: Using host floats.
                 let f = f32::from_bits(this.read_scalar(f)?.to_u32()?);
                 let f2 = f32::from_bits(this.read_scalar(f2)?.to_u32()?);
-                this.write_scalar(Scalar::from_u32(f.powf(f2).to_bits()), dest)?;
+                let res = f.powf(f2);
+                this.write_scalar(Scalar::from_u32(res.to_bits()), dest)?;
             }
 
             "powf64" => {
@@ -293,25 +294,28 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 // FIXME: Using host floats.
                 let f = f64::from_bits(this.read_scalar(f)?.to_u64()?);
                 let f2 = f64::from_bits(this.read_scalar(f2)?.to_u64()?);
-                this.write_scalar(Scalar::from_u64(f.powf(f2).to_bits()), dest)?;
+                let res = f.powf(f2);
+                this.write_scalar(Scalar::from_u64(res.to_bits()), dest)?;
             }
 
             "fmaf32" => {
                 let [a, b, c] = check_arg_count(args)?;
-                let a = this.read_scalar(a)?.to_f32()?;
-                let b = this.read_scalar(b)?.to_f32()?;
-                let c = this.read_scalar(c)?.to_f32()?;
-                let res = a.mul_add(b, c).value;
-                this.write_scalar(Scalar::from_f32(res), dest)?;
+                // FIXME: Using host floats, to work around https://github.com/rust-lang/miri/issues/2468.
+                let a = f32::from_bits(this.read_scalar(a)?.to_u32()?);
+                let b = f32::from_bits(this.read_scalar(b)?.to_u32()?);
+                let c = f32::from_bits(this.read_scalar(c)?.to_u32()?);
+                let res = a.mul_add(b, c);
+                this.write_scalar(Scalar::from_u32(res.to_bits()), dest)?;
             }
 
             "fmaf64" => {
                 let [a, b, c] = check_arg_count(args)?;
-                let a = this.read_scalar(a)?.to_f64()?;
-                let b = this.read_scalar(b)?.to_f64()?;
-                let c = this.read_scalar(c)?.to_f64()?;
-                let res = a.mul_add(b, c).value;
-                this.write_scalar(Scalar::from_f64(res), dest)?;
+                // FIXME: Using host floats, to work around https://github.com/rust-lang/miri/issues/2468.
+                let a = f64::from_bits(this.read_scalar(a)?.to_u64()?);
+                let b = f64::from_bits(this.read_scalar(b)?.to_u64()?);
+                let c = f64::from_bits(this.read_scalar(c)?.to_u64()?);
+                let res = a.mul_add(b, c);
+                this.write_scalar(Scalar::from_u64(res.to_bits()), dest)?;
             }
 
             "powif32" => {
@@ -319,7 +323,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 // FIXME: Using host floats.
                 let f = f32::from_bits(this.read_scalar(f)?.to_u32()?);
                 let i = this.read_scalar(i)?.to_i32()?;
-                this.write_scalar(Scalar::from_u32(f.powi(i).to_bits()), dest)?;
+                let res = f.powi(i);
+                this.write_scalar(Scalar::from_u32(res.to_bits()), dest)?;
             }
 
             "powif64" => {
@@ -327,7 +332,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
                 // FIXME: Using host floats.
                 let f = f64::from_bits(this.read_scalar(f)?.to_u64()?);
                 let i = this.read_scalar(i)?.to_i32()?;
-                this.write_scalar(Scalar::from_u64(f.powi(i).to_bits()), dest)?;
+                let res = f.powi(i);
+                this.write_scalar(Scalar::from_u64(res.to_bits()), dest)?;
             }
 
             "float_to_int_unchecked" => {

--- a/tests/pass/intrinsics-math.rs
+++ b/tests/pass/intrinsics-math.rs
@@ -60,6 +60,8 @@ pub fn main() {
     assert_eq!(0.0f32.mul_add(-2.0, f32::consts::E), f32::consts::E);
     assert_approx_eq!(3.0f64.mul_add(2.0, 5.0), 11.0);
     assert_eq!(0.0f64.mul_add(-2.0f64, f64::consts::E), f64::consts::E);
+    assert_eq!((-3.2f32).mul_add(2.4, f32::NEG_INFINITY), f32::NEG_INFINITY);
+    assert_eq!((-3.2f64).mul_add(2.4, f64::NEG_INFINITY), f64::NEG_INFINITY);
 
     assert_approx_eq!((-1.0f32).abs(), 1.0f32);
     assert_approx_eq!(34.2f64.abs(), 34.2f64);

--- a/tests/pass/intrinsics-math.rs
+++ b/tests/pass/intrinsics-math.rs
@@ -32,23 +32,23 @@ pub fn main() {
     assert_approx_eq!(25f32.powi(-2), 0.0016f32);
     assert_approx_eq!(23.2f64.powi(2), 538.24f64);
 
-    assert_approx_eq!(0f32.sin(), 0f32);
-    assert_approx_eq!((f64::consts::PI / 2f64).sin(), 1f64);
-
-    assert_approx_eq!(0f32.cos(), 1f32);
-    assert_approx_eq!((f64::consts::PI * 2f64).cos(), 1f64);
-
     assert_approx_eq!(25f32.powf(-2f32), 0.0016f32);
     assert_approx_eq!(400f64.powf(0.5f64), 20f64);
 
-    assert_approx_eq!((1f32.exp() - f32::consts::E).abs(), 0f32);
+    assert_approx_eq!(1f32.exp(), f32::consts::E);
     assert_approx_eq!(1f64.exp(), f64::consts::E);
+
+    assert_approx_eq!(1f32.exp_m1(), f32::consts::E - 1.0);
+    assert_approx_eq!(1f64.exp_m1(), f64::consts::E - 1.0);
 
     assert_approx_eq!(10f32.exp2(), 1024f32);
     assert_approx_eq!(50f64.exp2(), 1125899906842624f64);
 
-    assert_approx_eq!((f32::consts::E.ln() - 1f32).abs(), 0f32);
+    assert_approx_eq!(f32::consts::E.ln(), 1f32);
     assert_approx_eq!(1f64.ln(), 0f64);
+
+    assert_approx_eq!(0f32.ln_1p(), 0f32);
+    assert_approx_eq!(0f64.ln_1p(), 0f64);
 
     assert_approx_eq!(10f32.log10(), 1f32);
     assert_approx_eq!(f64::consts::E.log10(), f64::consts::LOG10_E);
@@ -66,6 +66,12 @@ pub fn main() {
     assert_approx_eq!((-1.0f32).abs(), 1.0f32);
     assert_approx_eq!(34.2f64.abs(), 34.2f64);
 
+    #[allow(deprecated)]
+    {
+        assert_approx_eq!(5.0f32.abs_sub(3.0), 2.0);
+        assert_approx_eq!(3.0f64.abs_sub(5.0), 0.0);
+    }
+
     assert_approx_eq!(3.8f32.floor(), 3.0f32);
     assert_approx_eq!((-1.1f64).floor(), -2.0f64);
 
@@ -81,31 +87,54 @@ pub fn main() {
     assert_approx_eq!(3.0f32.hypot(4.0f32), 5.0f32);
     assert_approx_eq!(3.0f64.hypot(4.0f64), 5.0f64);
 
-    assert_approx_eq!(1.0f32.atan2(2.0f32), 0.46364761f32);
-    assert_approx_eq!(1.0f32.atan2(2.0f32), 0.46364761f32);
-
-    assert_approx_eq!(1.0f32.cosh(), 1.54308f32);
-    assert_approx_eq!(1.0f64.cosh(), 1.54308f64);
-
-    assert_approx_eq!(1.0f32.sinh(), 1.1752012f32);
-    assert_approx_eq!(1.0f64.sinh(), 1.1752012f64);
-
-    assert_approx_eq!(1.0f32.tan(), 1.557408f32);
-    assert_approx_eq!(1.0f64.tan(), 1.557408f64);
-
-    assert_approx_eq!(f32::consts::FRAC_PI_4.cos().acos(), f32::consts::FRAC_PI_4);
-    assert_approx_eq!(f64::consts::FRAC_PI_4.cos().acos(), f64::consts::FRAC_PI_4);
-
-    assert_approx_eq!(f32::consts::FRAC_PI_4.sin().asin(), f32::consts::FRAC_PI_4);
-    assert_approx_eq!(f64::consts::FRAC_PI_4.sin().asin(), f64::consts::FRAC_PI_4);
-
-    assert_approx_eq!(1.0_f32, 1.0_f32.tan().atan());
-    assert_approx_eq!(1.0_f64, 1.0_f64.tan().atan());
-
     assert_eq!(3.3_f32.round(), 3.0);
     assert_eq!(3.3_f64.round(), 3.0);
 
     assert_eq!(ldexp(0.65f64, 3i32), 5.2f64);
     assert_eq!(ldexp(1.42, 0xFFFF), f64::INFINITY);
     assert_eq!(ldexp(1.42, -0xFFFF), 0f64);
+
+    // Trigonometric functions.
+
+    assert_approx_eq!(0f32.sin(), 0f32);
+    assert_approx_eq!((f64::consts::PI / 2f64).sin(), 1f64);
+    assert_approx_eq!(f32::consts::FRAC_PI_6.sin(), 0.5);
+    assert_approx_eq!(f64::consts::FRAC_PI_6.sin(), 0.5);
+    assert_approx_eq!(f32::consts::FRAC_PI_4.sin().asin(), f32::consts::FRAC_PI_4);
+    assert_approx_eq!(f64::consts::FRAC_PI_4.sin().asin(), f64::consts::FRAC_PI_4);
+
+    assert_approx_eq!(1.0f32.sinh(), 1.1752012f32);
+    assert_approx_eq!(1.0f64.sinh(), 1.1752012f64);
+    assert_approx_eq!(2.0f32.asinh(), 1.443635475178810342493276740273105f32);
+    assert_approx_eq!((-2.0f64).asinh(), -1.443635475178810342493276740273105f64);
+
+    assert_approx_eq!(0f32.cos(), 1f32);
+    assert_approx_eq!((f64::consts::PI * 2f64).cos(), 1f64);
+    assert_approx_eq!(f32::consts::FRAC_PI_3.cos(), 0.5);
+    assert_approx_eq!(f64::consts::FRAC_PI_3.cos(), 0.5);
+    assert_approx_eq!(f32::consts::FRAC_PI_4.cos().acos(), f32::consts::FRAC_PI_4);
+    assert_approx_eq!(f64::consts::FRAC_PI_4.cos().acos(), f64::consts::FRAC_PI_4);
+
+    assert_approx_eq!(1.0f32.cosh(), 1.54308f32);
+    assert_approx_eq!(1.0f64.cosh(), 1.54308f64);
+    assert_approx_eq!(2.0f32.acosh(), 1.31695789692481670862504634730796844f32);
+    assert_approx_eq!(3.0f64.acosh(), 1.76274717403908605046521864995958461f64);
+
+    assert_approx_eq!(1.0f32.tan(), 1.557408f32);
+    assert_approx_eq!(1.0f64.tan(), 1.557408f64);
+    assert_approx_eq!(1.0_f32, 1.0_f32.tan().atan());
+    assert_approx_eq!(1.0_f64, 1.0_f64.tan().atan());
+    assert_approx_eq!(1.0f32.atan2(2.0f32), 0.46364761f32);
+    assert_approx_eq!(1.0f32.atan2(2.0f32), 0.46364761f32);
+
+    assert_approx_eq!(
+        1.0f32.tanh(),
+        (1.0 - f32::consts::E.powi(-2)) / (1.0 + f32::consts::E.powi(-2))
+    );
+    assert_approx_eq!(
+        1.0f64.tanh(),
+        (1.0 - f64::consts::E.powi(-2)) / (1.0 + f64::consts::E.powi(-2))
+    );
+    assert_approx_eq!(0.5f32.atanh(), 0.54930614433405484569762261846126285f32);
+    assert_approx_eq!(0.5f64.atanh(), 0.54930614433405484569762261846126285f64);
 }

--- a/tests/pass/portable-simd.rs
+++ b/tests/pass/portable-simd.rs
@@ -18,6 +18,11 @@ fn simd_ops_f32() {
 
     assert_eq!(a.mul_add(b, a), (a * b) + a);
     assert_eq!(b.mul_add(b, a), (b * b) + a);
+    assert_eq!(a.mul_add(b, b), (a * b) + b);
+    assert_eq!(
+        f32x4::splat(-3.2).mul_add(b, f32x4::splat(f32::NEG_INFINITY)),
+        f32x4::splat(f32::NEG_INFINITY)
+    );
     assert_eq!((a * a).sqrt(), a);
     assert_eq!((b * b).sqrt(), b.abs());
 
@@ -67,6 +72,11 @@ fn simd_ops_f64() {
 
     assert_eq!(a.mul_add(b, a), (a * b) + a);
     assert_eq!(b.mul_add(b, a), (b * b) + a);
+    assert_eq!(a.mul_add(b, b), (a * b) + b);
+    assert_eq!(
+        f64x4::splat(-3.2).mul_add(b, f64x4::splat(f64::NEG_INFINITY)),
+        f64x4::splat(f64::NEG_INFINITY)
+    );
     assert_eq!((a * a).sqrt(), a);
     assert_eq!((b * b).sqrt(), b.abs());
 


### PR DESCRIPTION
With this we support the entire float API surface of the standard library. :)

Also fixes https://github.com/rust-lang/miri/issues/2468 by using host floats to implement FMA.