### PR TITLE
enable rustc lints

### DIFF
--- a/cargo-miri/src/main.rs
+++ b/cargo-miri/src/main.rs
@@ -1,5 +1,5 @@
 #![feature(let_else)]
-#![allow(clippy::useless_format, clippy::derive_partial_eq_without_eq)]
+#![allow(clippy::useless_format, clippy::derive_partial_eq_without_eq, rustc::internal)]
 
 mod arg;
 mod phases;

--- a/miri
+++ b/miri
@@ -124,7 +124,7 @@ fi
 if [ -z "$CARGO_PROFILE_DEV_OPT_LEVEL" ]; then
     export CARGO_PROFILE_DEV_OPT_LEVEL=2
 fi
-# Enable rustc-specific lints
+# Enable rustc-specific lints (ignored without `-Zunstable-options`).
 export RUSTFLAGS="-Zunstable-options -Wrustc::internal $RUSTFLAGS"
 # We set the rpath so that Miri finds the private rustc libraries it needs.
 export RUSTFLAGS="-C link-args=-Wl,-rpath,$LIBDIR $RUSTFLAGS"

--- a/miri
+++ b/miri
@@ -124,6 +124,8 @@ fi
 if [ -z "$CARGO_PROFILE_DEV_OPT_LEVEL" ]; then
     export CARGO_PROFILE_DEV_OPT_LEVEL=2
 fi
+# Enable rustc-specific lints
+export RUSTFLAGS="-Zunstable-options -Wrustc::internal $RUSTFLAGS"
 # We set the rpath so that Miri finds the private rustc libraries it needs.
 export RUSTFLAGS="-C link-args=-Wl,-rpath,$LIBDIR $RUSTFLAGS"
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,6 +1,5 @@
 //! Main evaluator loop and setting up the initial stack frame.
 
-use std::collections::HashSet;
 use std::ffi::{OsStr, OsString};
 use std::iter;
 use std::panic::{self, AssertUnwindSafe};
@@ -8,6 +7,7 @@ use std::thread;
 
 use log::info;
 
+use rustc_data_structures::fx::FxHashSet;
 use rustc_hir::def_id::DefId;
 use rustc_middle::ty::{
     self,
@@ -96,11 +96,11 @@ pub struct MiriConfig {
     /// The seed to use when non-determinism or randomness are required (e.g. ptr-to-int cast, `getrandom()`).
     pub seed: Option<u64>,
     /// The stacked borrows pointer ids to report about
-    pub tracked_pointer_tags: HashSet<SbTag>,
+    pub tracked_pointer_tags: FxHashSet<SbTag>,
     /// The stacked borrows call IDs to report about
-    pub tracked_call_ids: HashSet<CallId>,
+    pub tracked_call_ids: FxHashSet<CallId>,
     /// The allocation ids to report about.
-    pub tracked_alloc_ids: HashSet<AllocId>,
+    pub tracked_alloc_ids: FxHashSet<AllocId>,
     /// Determine if data race detection should be enabled
     pub data_race_detector: bool,
     /// Determine if weak memory emulation should be enabled. Requires data race detection to be enabled
@@ -144,9 +144,9 @@ impl Default for MiriConfig {
             forwarded_env_vars: vec![],
             args: vec![],
             seed: None,
-            tracked_pointer_tags: HashSet::default(),
-            tracked_call_ids: HashSet::default(),
-            tracked_alloc_ids: HashSet::default(),
+            tracked_pointer_tags: FxHashSet::default(),
+            tracked_call_ids: FxHashSet::default(),
+            tracked_alloc_ids: FxHashSet::default(),
             data_race_detector: true,
             weak_memory_emulation: true,
             track_outdated_loads: false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,9 @@
     clippy::derive_partial_eq_without_eq,
     clippy::derive_hash_xor_eq,
     clippy::too_many_arguments,
-    clippy::type_complexity
+    clippy::type_complexity,
+    // We are not implementing queries here so it's fine
+    rustc::potential_query_instability
 )]
 #![warn(
     rust_2018_idioms,

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -3,7 +3,6 @@
 
 use std::borrow::Cow;
 use std::cell::RefCell;
-use std::collections::HashSet;
 use std::fmt;
 use std::time::Instant;
 
@@ -11,7 +10,7 @@ use rand::rngs::StdRng;
 use rand::SeedableRng;
 
 use rustc_ast::ast::Mutability;
-use rustc_data_structures::fx::FxHashMap;
+use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 #[allow(unused)]
 use rustc_data_structures::static_assert_size;
 use rustc_middle::{
@@ -19,7 +18,7 @@ use rustc_middle::{
     ty::{
         self,
         layout::{LayoutCx, LayoutError, LayoutOf, TyAndLayout},
-        Instance, TyCtxt, TypeAndMut,
+        Instance, Ty, TyCtxt, TypeAndMut,
     },
 };
 use rustc_span::def_id::{CrateNum, DefId};
@@ -335,7 +334,7 @@ pub struct Evaluator<'mir, 'tcx> {
 
     /// The allocation IDs to report when they are being allocated
     /// (helps for debugging memory leaks and use after free bugs).
-    tracked_alloc_ids: HashSet<AllocId>,
+    tracked_alloc_ids: FxHashSet<AllocId>,
 
     /// Controls whether alignment of memory accesses is being checked.
     pub(crate) check_alignment: AlignmentCheck,
@@ -613,7 +612,7 @@ impl<'mir, 'tcx> Machine<'mir, 'tcx> for Evaluator<'mir, 'tcx> {
         bin_op: mir::BinOp,
         left: &ImmTy<'tcx, Provenance>,
         right: &ImmTy<'tcx, Provenance>,
-    ) -> InterpResult<'tcx, (Scalar<Provenance>, bool, ty::Ty<'tcx>)> {
+    ) -> InterpResult<'tcx, (Scalar<Provenance>, bool, Ty<'tcx>)> {
         ecx.binary_ptr_op(bin_op, left, right)
     }
 

--- a/src/shims/intrinsics/mod.rs
+++ b/src/shims/intrinsics/mod.rs
@@ -7,7 +7,10 @@ use log::trace;
 
 use rustc_apfloat::{Float, Round};
 use rustc_middle::ty::layout::{IntegerExt, LayoutOf};
-use rustc_middle::{mir, ty, ty::FloatTy};
+use rustc_middle::{
+    mir,
+    ty::{self, FloatTy, Ty},
+};
 use rustc_target::abi::Integer;
 
 use crate::*;
@@ -377,7 +380,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
     fn float_to_int_unchecked<F>(
         &self,
         f: F,
-        dest_ty: ty::Ty<'tcx>,
+        dest_ty: Ty<'tcx>,
     ) -> InterpResult<'tcx, Scalar<Provenance>>
     where
         F: Float + Into<Scalar<Provenance>>,

--- a/src/stacked_borrows/mod.rs
+++ b/src/stacked_borrows/mod.rs
@@ -13,11 +13,11 @@ use rustc_middle::mir::RetagKind;
 use rustc_middle::ty::{
     self,
     layout::{HasParamEnv, LayoutOf},
+    Ty,
 };
 use rustc_span::DUMMY_SP;
 use rustc_target::abi::Size;
 use smallvec::SmallVec;
-use std::collections::HashSet;
 
 use crate::*;
 
@@ -100,9 +100,9 @@ pub struct GlobalStateInner {
     /// `GlobalStateInner::end_call`. See `Stack::item_popped` for more details.
     protected_tags: FxHashSet<SbTag>,
     /// The pointer ids to trace
-    tracked_pointer_tags: HashSet<SbTag>,
+    tracked_pointer_tags: FxHashSet<SbTag>,
     /// The call ids to trace
-    tracked_call_ids: HashSet<CallId>,
+    tracked_call_ids: FxHashSet<CallId>,
     /// Whether to recurse into datatypes when searching for pointers to retag.
     retag_fields: bool,
 }
@@ -154,8 +154,8 @@ impl fmt::Display for RefKind {
 /// Utilities for initialization and ID generation
 impl GlobalStateInner {
     pub fn new(
-        tracked_pointer_tags: HashSet<SbTag>,
-        tracked_call_ids: HashSet<CallId>,
+        tracked_pointer_tags: FxHashSet<SbTag>,
+        tracked_call_ids: FxHashSet<CallId>,
         retag_fields: bool,
     ) -> Self {
         GlobalStateInner {
@@ -1013,7 +1013,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         // Determine mutability and whether to add a protector.
         // Cannot use `builtin_deref` because that reports *immutable* for `Box`,
         // making it useless.
-        fn qualify(ty: ty::Ty<'_>, kind: RetagKind) -> Option<(RefKind, bool)> {
+        fn qualify(ty: Ty<'_>, kind: RetagKind) -> Option<(RefKind, bool)> {
             match ty.kind() {
                 // References are simple.
                 ty::Ref(_, _, Mutability::Mut) =>

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,9 +1,10 @@
-use std::collections::{hash_map::Entry, HashMap, VecDeque};
+use std::collections::{hash_map::Entry, VecDeque};
 use std::num::NonZeroU32;
 use std::ops::Not;
 
 use log::trace;
 
+use rustc_data_structures::fx::FxHashMap;
 use rustc_index::vec::{Idx, IndexVec};
 
 use crate::*;
@@ -77,7 +78,7 @@ struct RwLock {
     writer: Option<ThreadId>,
     /// The readers that currently own the lock and how many times they acquired
     /// the lock.
-    readers: HashMap<ThreadId, usize>,
+    readers: FxHashMap<ThreadId, usize>,
     /// The queue of writer threads waiting for this lock.
     writer_queue: VecDeque<ThreadId>,
     /// The queue of reader threads waiting for this lock.
@@ -153,7 +154,7 @@ pub(super) struct SynchronizationState {
     mutexes: IndexVec<MutexId, Mutex>,
     rwlocks: IndexVec<RwLockId, RwLock>,
     condvars: IndexVec<CondvarId, Condvar>,
-    futexes: HashMap<u64, Futex>,
+    futexes: FxHashMap<u64, Futex>,
 }
 
 // Private extension trait for local helper methods

--- a/ui_test/src/lib.rs
+++ b/ui_test/src/lib.rs
@@ -1,4 +1,9 @@
-#![allow(clippy::enum_variant_names, clippy::useless_format, clippy::too_many_arguments)]
+#![allow(
+    clippy::enum_variant_names,
+    clippy::useless_format,
+    clippy::too_many_arguments,
+    rustc::internal
+)]
 
 use std::collections::VecDeque;
 use std::ffi::OsString;


### PR DESCRIPTION
Given how many rustc APIs we are using, this is probably a good idea.
Seems like we are lint-clean right now. :)