### PR TITLE
clarifying comments for target-dir handling

### DIFF
--- a/cargo-miri/src/phases.rs
+++ b/cargo-miri/src/phases.rs
@@ -133,6 +133,7 @@ pub fn phase_cargo_miri(mut args: impl Iterator<Item = String>) {
         }
     }
     // Detect the target directory if it's not specified via `--target-dir`.
+    // (`cargo metadata` does not support `--target-dir`, that's why we have to handle this ourselves.)
     let target_dir = target_dir.get_or_insert_with(|| metadata.target_directory.clone());
     // Set `--target-dir` to `miri` inside the original target directory.
     target_dir.push("miri");

--- a/cargo-miri/src/util.rs
+++ b/cargo-miri/src/util.rs
@@ -237,6 +237,8 @@ fn cargo_extra_flags() -> Vec<String> {
         flags.push(manifest);
     }
 
+    // Forwarding `--target-dir` would make sense, but `cargo metadata` does not support that flag.
+
     flags
 }
 


### PR DESCRIPTION
I thought we could simplify this logic, but alas, `cargo metadata --target-dir` is not a thing (even though the effective target-dir *does* affect the metadata).