### PR TITLE
add test for raw_eq on a pointer

### DIFF
--- a/tests/fail/intrinsics/raw_eq_on_ptr.rs
+++ b/tests/fail/intrinsics/raw_eq_on_ptr.rs
@@ -1,0 +1,11 @@
+#![feature(intrinsics)]
+
+extern "rust-intrinsic" {
+    fn raw_eq<T>(a: &T, b: &T) -> bool;
+}
+
+fn main() {
+    let x = &0;
+    // FIXME: the error message is not great (should be UB rather than 'unsupported')
+    unsafe { raw_eq(&x, &x) }; //~ERROR: unsupported operation
+}

--- a/tests/fail/intrinsics/raw_eq_on_ptr.stderr
+++ b/tests/fail/intrinsics/raw_eq_on_ptr.stderr
@@ -1,0 +1,14 @@
+error: unsupported operation: unable to turn pointer into raw bytes
+  --> $DIR/raw_eq_on_ptr.rs:LL:CC
+   |
+LL |     unsafe { raw_eq(&x, &x) };
+   |              ^^^^^^^^^^^^^^ unable to turn pointer into raw bytes
+   |
+   = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
+   = note: backtrace:
+   = note: inside `main` at $DIR/raw_eq_on_ptr.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Let's make sure this keeps erroring; I have plans to refactor that part of the interpreter which will fix the error message (but could also lead to us accidentally accepting this which this test is there to avoid).