### PR TITLE
add ./miri cargo for RA to invoke

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,7 +171,8 @@ to `.vscode/settings.json` in your local Miri clone:
         "env",
         "MIRI_AUTO_OPS=no",
         "./miri",
-        "check",
+        "cargo",
+        "clippy", // make this `check` when working with a locally built rustc
         "--message-format=json"
     ],
     // Contrary to what the name suggests, this also affects proc macros.
@@ -179,6 +180,7 @@ to `.vscode/settings.json` in your local Miri clone:
         "env",
         "MIRI_AUTO_OPS=no",
         "./miri",
+        "cargo",
         "check",
         "--message-format=json",
     ],

--- a/cargo-miri/miri
+++ b/cargo-miri/miri
@@ -1,3 +1,4 @@
 #!/bin/sh
-# Hack to work around https://github.com/rust-analyzer/rust-analyzer/issues/10793.
+# RA invokes `./miri cargo ...` for each workspace, so we need to forward that to the main `miri`
+# script. See <https://github.com/rust-analyzer/rust-analyzer/issues/10793>.
 exec "$(dirname "$0")"/../miri "$@"

--- a/miri
+++ b/miri
@@ -29,6 +29,10 @@ Format all sources and tests. <flags> are passed to `rustfmt`.
 ./miri clippy <flags>:
 Runs clippy on all sources. <flags> are passed to `cargo clippy`.
 
+./miri cargo <flags>:
+Runs just `cargo <flags>` with the Miri-specific environment variables.
+Mainly meant to be invoked by rust-analyzer.
+
 ./miri many-seeds <command>:
 Runs <command> over and over again with different seeds for Miri. The MIRIFLAGS
 variable is set to its original value appended with ` -Zmiri-seed=$SEED` for
@@ -44,7 +48,7 @@ MIRI_SYSROOT:
 If already set, the "sysroot setup" step is skipped.
 
 CARGO_EXTRA_FLAGS:
-Pass extra flags to all cargo invocations.
+Pass extra flags to all cargo invocations. (Ignored by `./miri cargo`.)
 EOF
 )
 
@@ -217,6 +221,11 @@ clippy)
     $CARGO clippy $CARGO_EXTRA_FLAGS --manifest-path "$MIRIDIR"/Cargo.toml --all-targets "$@"
     $CARGO clippy $CARGO_EXTRA_FLAGS --manifest-path "$MIRIDIR"/ui_test/Cargo.toml --all-targets "$@"
     $CARGO clippy $CARGO_EXTRA_FLAGS --manifest-path "$MIRIDIR"/cargo-miri/Cargo.toml "$@"
+    ;;
+cargo)
+    # We carefully kept the working dir intact, so this will run cargo *on the workspace in the
+    # current working dir*, not on the main Miri workspace. That is exactly what RA needs.
+    $CARGO "$@"
     ;;
 *)
     if [ -n "$COMMAND" ]; then


### PR DESCRIPTION
RA expects a check command to check *individual workspaces*, whereas `./miri` is designed to check/build/test all parts of Miri. So add a new `./miri cargo` that performs just a single cargo invocation, but with the right env vars so that the build cache can be shared with `./miri check`.