### PR TITLE
Make `sleep` work with isolation enabled

### DIFF
--- a/src/clock.rs
+++ b/src/clock.rs
@@ -1,0 +1,131 @@
+use std::sync::atomic::AtomicU64;
+use std::time::{Duration, Instant as StdInstant};
+
+use rustc_data_structures::sync::Ordering;
+
+use crate::*;
+
+/// When using a virtual clock, this defines how many nanoseconds do we pretend
+/// are passing for each basic block.
+const NANOSECOND_PER_BASIC_BLOCK: u64 = 10;
+
+#[derive(Debug)]
+pub struct Instant {
+    kind: InstantKind,
+}
+
+#[derive(Debug)]
+enum InstantKind {
+    Host(StdInstant),
+    Virtual { nanoseconds: u64 },
+}
+
+/// A monotone clock used for `Instant` simulation.
+#[derive(Debug)]
+pub struct Clock {
+    kind: ClockKind,
+}
+
+#[derive(Debug)]
+enum ClockKind {
+    Host {
+        /// The "time anchor" for this machine's monotone clock.
+        time_anchor: StdInstant,
+    },
+    Virtual {
+        /// The "current virtual time".
+        nanoseconds: AtomicU64,
+    },
+}
+
+impl Clock {
+    /// Create a new clock based on the availability of communication with the host.
+    pub fn new(communicate: bool) -> Self {
+        let kind = if communicate {
+            ClockKind::Host { time_anchor: StdInstant::now() }
+        } else {
+            ClockKind::Virtual { nanoseconds: 0.into() }
+        };
+
+        Self { kind }
+    }
+
+    /// Get the current time relative to this clock.
+    pub fn get(&self) -> Duration {
+        match &self.kind {
+            ClockKind::Host { time_anchor } =>
+                StdInstant::now().saturating_duration_since(*time_anchor),
+            ClockKind::Virtual { nanoseconds } =>
+                Duration::from_nanos(nanoseconds.load(Ordering::Relaxed)),
+        }
+    }
+
+    /// Let the time pass for a small interval.
+    pub fn tick(&self) {
+        match &self.kind {
+            ClockKind::Host { .. } => {
+                // Time will pass without us doing anything.
+            }
+            ClockKind::Virtual { nanoseconds } => {
+                nanoseconds.fetch_add(NANOSECOND_PER_BASIC_BLOCK, Ordering::Relaxed);
+            }
+        }
+    }
+
+    /// Sleep for the desired duration.
+    pub fn sleep(&self, duration: Duration) {
+        match &self.kind {
+            ClockKind::Host { .. } => std::thread::sleep(duration),
+            ClockKind::Virtual { nanoseconds } => {
+                // Just pretend that we have slept for some time.
+                nanoseconds.fetch_add(duration.as_nanos().try_into().unwrap(), Ordering::Relaxed);
+            }
+        }
+    }
+
+    /// Compute `now + duration` relative to this clock.
+    pub fn get_time_relative(&self, duration: Duration) -> Option<Instant> {
+        match &self.kind {
+            ClockKind::Host { .. } =>
+                StdInstant::now()
+                    .checked_add(duration)
+                    .map(|instant| Instant { kind: InstantKind::Host(instant) }),
+            ClockKind::Virtual { nanoseconds } =>
+                nanoseconds
+                    .load(Ordering::Relaxed)
+                    .checked_add(duration.as_nanos().try_into().unwrap())
+                    .map(|nanoseconds| Instant { kind: InstantKind::Virtual { nanoseconds } }),
+        }
+    }
+
+    /// Compute `start + duration` relative to this clock where `start` is the instant of time when
+    /// this clock was created.
+    pub fn get_time_absolute(&self, duration: Duration) -> Option<Instant> {
+        match &self.kind {
+            ClockKind::Host { time_anchor } =>
+                time_anchor
+                    .checked_add(duration)
+                    .map(|instant| Instant { kind: InstantKind::Host(instant) }),
+            ClockKind::Virtual { .. } =>
+                Some(Instant {
+                    kind: InstantKind::Virtual {
+                        nanoseconds: duration.as_nanos().try_into().unwrap(),
+                    },
+                }),
+        }
+    }
+
+    /// Returns the duration until the given instant.
+    pub fn duration_until(&self, instant: &Instant) -> Duration {
+        match (&instant.kind, &self.kind) {
+            (InstantKind::Host(instant), ClockKind::Host { .. }) =>
+                instant.saturating_duration_since(StdInstant::now()),
+            (
+                InstantKind::Virtual { nanoseconds },
+                ClockKind::Virtual { nanoseconds: current_ns },
+            ) =>
+                Duration::from_nanos(nanoseconds.saturating_sub(current_ns.load(Ordering::Relaxed))),
+            _ => panic!(),
+        }
+    }
+}

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -1,13 +1,9 @@
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant as StdInstant};
 
-use rustc_data_structures::sync::Ordering;
-
-use crate::*;
-
-/// When using a virtual clock, this defines how many nanoseconds do we pretend
-/// are passing for each basic block.
-const NANOSECOND_PER_BASIC_BLOCK: u64 = 10;
+/// When using a virtual clock, this defines how many nanoseconds we pretend are passing for each
+/// basic block.
+const NANOSECONDS_PER_BASIC_BLOCK: u64 = 10;
 
 #[derive(Debug)]
 pub struct Instant {
@@ -83,7 +79,7 @@ impl Clock {
                 // Time will pass without us doing anything.
             }
             ClockKind::Virtual { nanoseconds } => {
-                nanoseconds.fetch_add(NANOSECOND_PER_BASIC_BLOCK, Ordering::SeqCst);
+                nanoseconds.fetch_add(NANOSECONDS_PER_BASIC_BLOCK, Ordering::SeqCst);
             }
         }
     }

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -20,6 +20,32 @@ enum InstantKind {
     Virtual { nanoseconds: u64 },
 }
 
+impl Instant {
+    pub fn checked_add(&self, duration: Duration) -> Option<Instant> {
+        match self.kind {
+            InstantKind::Host(instant) =>
+                instant.checked_add(duration).map(|i| Instant { kind: InstantKind::Host(i) }),
+            InstantKind::Virtual { nanoseconds } =>
+                u128::from(nanoseconds)
+                    .checked_add(duration.as_nanos())
+                    .and_then(|n| u64::try_from(n).ok())
+                    .map(|nanoseconds| Instant { kind: InstantKind::Virtual { nanoseconds } }),
+        }
+    }
+
+    pub fn duration_since(&self, earlier: Instant) -> Duration {
+        match (&self.kind, earlier.kind) {
+            (InstantKind::Host(instant), InstantKind::Host(earlier)) =>
+                instant.duration_since(earlier),
+            (
+                InstantKind::Virtual { nanoseconds },
+                InstantKind::Virtual { nanoseconds: earlier },
+            ) => Duration::from_nanos(nanoseconds.saturating_sub(earlier)),
+            _ => panic!("all `Instant` must be of the same kind"),
+        }
+    }
+}
+
 /// A monotone clock used for `Instant` simulation.
 #[derive(Debug)]
 pub struct Clock {
@@ -50,16 +76,6 @@ impl Clock {
         Self { kind }
     }
 
-    /// Get the current time relative to this clock.
-    pub fn get(&self) -> Duration {
-        match &self.kind {
-            ClockKind::Host { time_anchor } =>
-                StdInstant::now().saturating_duration_since(*time_anchor),
-            ClockKind::Virtual { nanoseconds } =>
-                Duration::from_nanos(nanoseconds.load(Ordering::Relaxed)),
-        }
-    }
-
     /// Let the time pass for a small interval.
     pub fn tick(&self) {
         match &self.kind {
@@ -67,7 +83,7 @@ impl Clock {
                 // Time will pass without us doing anything.
             }
             ClockKind::Virtual { nanoseconds } => {
-                nanoseconds.fetch_add(NANOSECOND_PER_BASIC_BLOCK, Ordering::Relaxed);
+                nanoseconds.fetch_add(NANOSECOND_PER_BASIC_BLOCK, Ordering::SeqCst);
             }
         }
     }
@@ -78,54 +94,26 @@ impl Clock {
             ClockKind::Host { .. } => std::thread::sleep(duration),
             ClockKind::Virtual { nanoseconds } => {
                 // Just pretend that we have slept for some time.
-                nanoseconds.fetch_add(duration.as_nanos().try_into().unwrap(), Ordering::Relaxed);
+                nanoseconds.fetch_add(duration.as_nanos().try_into().unwrap(), Ordering::SeqCst);
             }
         }
     }
 
-    /// Compute `now + duration` relative to this clock.
-    pub fn get_time_relative(&self, duration: Duration) -> Option<Instant> {
+    /// Return the `anchor` instant, to convert between monotone instants and durations relative to the anchor.
+    pub fn anchor(&self) -> Instant {
         match &self.kind {
-            ClockKind::Host { .. } =>
-                StdInstant::now()
-                    .checked_add(duration)
-                    .map(|instant| Instant { kind: InstantKind::Host(instant) }),
+            ClockKind::Host { time_anchor } => Instant { kind: InstantKind::Host(*time_anchor) },
+            ClockKind::Virtual { .. } => Instant { kind: InstantKind::Virtual { nanoseconds: 0 } },
+        }
+    }
+
+    pub fn now(&self) -> Instant {
+        match &self.kind {
+            ClockKind::Host { .. } => Instant { kind: InstantKind::Host(StdInstant::now()) },
             ClockKind::Virtual { nanoseconds } =>
-                nanoseconds
-                    .load(Ordering::Relaxed)
-                    .checked_add(duration.as_nanos().try_into().unwrap())
-                    .map(|nanoseconds| Instant { kind: InstantKind::Virtual { nanoseconds } }),
-        }
-    }
-
-    /// Compute `start + duration` relative to this clock where `start` is the instant of time when
-    /// this clock was created.
-    pub fn get_time_absolute(&self, duration: Duration) -> Option<Instant> {
-        match &self.kind {
-            ClockKind::Host { time_anchor } =>
-                time_anchor
-                    .checked_add(duration)
-                    .map(|instant| Instant { kind: InstantKind::Host(instant) }),
-            ClockKind::Virtual { .. } =>
-                Some(Instant {
-                    kind: InstantKind::Virtual {
-                        nanoseconds: duration.as_nanos().try_into().unwrap(),
-                    },
-                }),
-        }
-    }
-
-    /// Returns the duration until the given instant.
-    pub fn duration_until(&self, instant: &Instant) -> Duration {
-        match (&instant.kind, &self.kind) {
-            (InstantKind::Host(instant), ClockKind::Host { .. }) =>
-                instant.saturating_duration_since(StdInstant::now()),
-            (
-                InstantKind::Virtual { nanoseconds },
-                ClockKind::Virtual { nanoseconds: current_ns },
-            ) =>
-                Duration::from_nanos(nanoseconds.saturating_sub(current_ns.load(Ordering::Relaxed))),
-            _ => panic!(),
+                Instant {
+                    kind: InstantKind::Virtual { nanoseconds: nanoseconds.load(Ordering::SeqCst) },
+                },
         }
     }
 }

--- a/src/concurrency/thread.rs
+++ b/src/concurrency/thread.rs
@@ -869,6 +869,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         callback: TimeoutCallback<'mir, 'tcx>,
     ) {
         let this = self.eval_context_mut();
+        if !this.machine.communicate() && matches!(call_time, Time::RealTime(..)) {
+            panic!("cannot have `RealTime` callback with isolation enabled!")
+        }
         this.machine.threads.register_timeout_callback(thread, call_time, callback);
     }
 

--- a/src/concurrency/thread.rs
+++ b/src/concurrency/thread.rs
@@ -191,7 +191,7 @@ impl Time {
     /// How long do we have to wait from now until the specified time?
     fn get_wait_time(&self, clock: &Clock) -> Duration {
         match self {
-            Time::Monotonic(instant) => clock.duration_until(instant),
+            Time::Monotonic(instant) => instant.duration_since(clock.now()),
             Time::RealTime(time) =>
                 time.duration_since(SystemTime::now()).unwrap_or(Duration::new(0, 0)),
         }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -359,11 +359,6 @@ pub fn eval_entry<'tcx>(
                     assert!(ecx.step()?, "a terminated thread was scheduled for execution");
                 }
                 SchedulingAction::ExecuteTimeoutCallback => {
-                    assert!(
-                        ecx.machine.communicate(),
-                        "scheduler callbacks require disabled isolation, but the code \
-                        that created the callback did not check it"
-                    );
                     ecx.run_timeout_callback()?;
                 }
                 SchedulingAction::ExecuteDtors => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ extern crate rustc_session;
 extern crate rustc_span;
 extern crate rustc_target;
 
+mod clock;
 mod concurrency;
 mod diagnostics;
 mod eval;
@@ -81,6 +82,7 @@ pub use crate::shims::time::EvalContextExt as _;
 pub use crate::shims::tls::{EvalContextExt as _, TlsData};
 pub use crate::shims::EvalContextExt as _;
 
+pub use crate::clock::{Clock, Instant};
 pub use crate::concurrency::{
     data_race::{
         AtomicFenceOrd, AtomicReadOrd, AtomicRwOrd, AtomicWriteOrd,
@@ -89,7 +91,7 @@ pub use crate::concurrency::{
     sync::{CondvarId, EvalContextExt as SyncEvalContextExt, MutexId, RwLockId},
     thread::{
         EvalContextExt as ThreadsEvalContextExt, SchedulingAction, ThreadId, ThreadManager,
-        ThreadState,
+        ThreadState, Time,
     },
 };
 pub use crate::diagnostics::{

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -27,7 +27,7 @@ use rustc_target::spec::abi::Abi;
 
 use crate::{
     concurrency::{data_race, weak_memory},
-    shims::{time::Clock, unix::FileHandler},
+    shims::unix::FileHandler,
     *,
 };
 

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1036,6 +1036,7 @@ impl<'mir, 'tcx> Machine<'mir, 'tcx> for Evaluator<'mir, 'tcx> {
         // These are our preemption points.
         ecx.maybe_preempt_active_thread();
 
+        // Make sure some time passes.
         ecx.machine.clock.tick();
 
         Ok(())

--- a/src/shims/time.rs
+++ b/src/shims/time.rs
@@ -1,144 +1,6 @@
-use std::sync::atomic::AtomicU64;
-use std::time::{Duration, Instant as StdInstant, SystemTime};
+use std::time::{Duration, SystemTime};
 
-use rustc_data_structures::sync::Ordering;
-
-use crate::concurrency::thread::Time;
 use crate::*;
-
-/// When using a virtual clock, this defines how many nanoseconds do we pretend
-/// are passing for each basic block.
-const NANOSECOND_PER_BASIC_BLOCK: u64 = 10;
-
-#[derive(Debug)]
-pub struct Instant {
-    kind: InstantKind,
-}
-
-#[derive(Debug)]
-enum InstantKind {
-    Host(StdInstant),
-    Virtual { nanoseconds: u64 },
-}
-
-/// A monotone clock used for `Instant` simulation.
-#[derive(Debug)]
-pub struct Clock {
-    kind: ClockKind,
-}
-
-#[derive(Debug)]
-enum ClockKind {
-    Host {
-        /// The "time anchor" for this machine's monotone clock.
-        time_anchor: StdInstant,
-    },
-    Virtual {
-        /// The "current virtual time".
-        nanoseconds: AtomicU64,
-    },
-}
-
-impl Clock {
-    /// Create a new clock based on the availability of communication with the host.
-    pub fn new(communicate: bool) -> Self {
-        let kind = if communicate {
-            ClockKind::Host { time_anchor: StdInstant::now() }
-        } else {
-            ClockKind::Virtual { nanoseconds: 0.into() }
-        };
-
-        Self { kind }
-    }
-
-    /// Get the current time relative to this clock.
-    pub fn get(&self) -> Duration {
-        match &self.kind {
-            ClockKind::Host { time_anchor } =>
-                StdInstant::now().saturating_duration_since(*time_anchor),
-            ClockKind::Virtual { nanoseconds } =>
-                Duration::from_nanos(nanoseconds.load(Ordering::Relaxed)),
-        }
-    }
-
-    /// Let the time pass for a small interval.
-    pub fn tick(&self) {
-        match &self.kind {
-            ClockKind::Host { .. } => {
-                // Time will pass without us doing anything.
-            }
-            ClockKind::Virtual { nanoseconds } => {
-                nanoseconds.fetch_add(NANOSECOND_PER_BASIC_BLOCK, Ordering::Relaxed);
-            }
-        }
-    }
-
-    /// Sleep for the desired duration.
-    pub fn sleep(&self, duration: Duration) {
-        match &self.kind {
-            ClockKind::Host { .. } => std::thread::sleep(duration),
-            ClockKind::Virtual { nanoseconds } => {
-                // Just pretend that we have slept for some time.
-                nanoseconds.fetch_add(duration.as_nanos().try_into().unwrap(), Ordering::Relaxed);
-            }
-        }
-    }
-
-    /// Compute `now + duration` relative to this clock.
-    pub fn get_time_relative(&self, duration: Duration) -> Option<Time> {
-        match &self.kind {
-            ClockKind::Host { .. } =>
-                StdInstant::now()
-                    .checked_add(duration)
-                    .map(|instant| Time::Monotonic(Instant { kind: InstantKind::Host(instant) })),
-            ClockKind::Virtual { nanoseconds } =>
-                nanoseconds
-                    .load(Ordering::Relaxed)
-                    .checked_add(duration.as_nanos().try_into().unwrap())
-                    .map(|nanoseconds| {
-                        Time::Monotonic(Instant { kind: InstantKind::Virtual { nanoseconds } })
-                    }),
-        }
-    }
-
-    /// Compute `start + duration` relative to this clock where `start` is the instant of time when
-    /// this clock was created.
-    pub fn get_time_absolute(&self, duration: Duration) -> Option<Time> {
-        match &self.kind {
-            ClockKind::Host { time_anchor } =>
-                time_anchor
-                    .checked_add(duration)
-                    .map(|instant| Time::Monotonic(Instant { kind: InstantKind::Host(instant) })),
-            ClockKind::Virtual { .. } =>
-                Some(Time::Monotonic(Instant {
-                    kind: InstantKind::Virtual {
-                        nanoseconds: duration.as_nanos().try_into().unwrap(),
-                    },
-                })),
-        }
-    }
-
-    /// How long do we have to wait from now until the specified time?
-    pub fn get_wait_time(&self, time: &Time) -> Duration {
-        match time {
-            Time::Monotonic(instant) =>
-                match (&instant.kind, &self.kind) {
-                    (InstantKind::Host(instant), ClockKind::Host { .. }) =>
-                        instant.saturating_duration_since(StdInstant::now()),
-                    (
-                        InstantKind::Virtual { nanoseconds },
-                        ClockKind::Virtual { nanoseconds: current_ns },
-                    ) =>
-                        Duration::from_nanos(
-                            nanoseconds.saturating_sub(current_ns.load(Ordering::Relaxed)),
-                        ),
-                    _ => panic!(),
-                },
-            Time::RealTime(time) =>
-                time.duration_since(SystemTime::now()).unwrap_or(Duration::new(0, 0)),
-        }
-    }
-}
 
 /// Returns the time elapsed between the provided time and the unix epoch as a `Duration`.
 pub fn system_time_to_duration<'tcx>(time: &SystemTime) -> InterpResult<'tcx, Duration> {
@@ -354,7 +216,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
         this.register_timeout_callback(
             active_thread,
-            timeout_time,
+            Time::Monotonic(timeout_time),
             Box::new(move |ecx| {
                 ecx.unblock_thread(active_thread);
                 Ok(())
@@ -380,7 +242,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
 
         this.register_timeout_callback(
             active_thread,
-            timeout_time,
+            Time::Monotonic(timeout_time),
             Box::new(move |ecx| {
                 ecx.unblock_thread(active_thread);
                 Ok(())

--- a/src/shims/time.rs
+++ b/src/shims/time.rs
@@ -38,7 +38,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
             [this.eval_libc_i32("CLOCK_MONOTONIC")?, this.eval_libc_i32("CLOCK_MONOTONIC_COARSE")?];
 
         let duration = if absolute_clocks.contains(&clk_id) {
-            this.check_no_isolation("`clock_gettime` with real time clocks")?;
+            this.check_no_isolation("`clock_gettime` with `REALTIME` clocks")?;
             system_time_to_duration(&SystemTime::now())?
         } else if relative_clocks.contains(&clk_id) {
             this.machine.clock.now().duration_since(this.machine.clock.anchor())

--- a/src/shims/unix/linux/sync.rs
+++ b/src/shims/unix/linux/sync.rs
@@ -106,14 +106,14 @@ pub fn futex<'tcx>(
                     if op & futex_realtime != 0 {
                         Time::RealTime(SystemTime::UNIX_EPOCH.checked_add(duration).unwrap())
                     } else {
-                        Time::Monotonic(this.machine.clock.get_time_absolute(duration).unwrap())
+                        Time::Monotonic(this.machine.clock.anchor().checked_add(duration).unwrap())
                     }
                 } else {
                     // FUTEX_WAIT uses a relative timestamp.
                     if op & futex_realtime != 0 {
                         Time::RealTime(SystemTime::now().checked_add(duration).unwrap())
                     } else {
-                        Time::Monotonic(this.machine.clock.get_time_relative(duration).unwrap())
+                        Time::Monotonic(this.machine.clock.now().checked_add(duration).unwrap())
                     }
                 })
             };

--- a/src/shims/unix/linux/sync.rs
+++ b/src/shims/unix/linux/sync.rs
@@ -1,7 +1,7 @@
 use crate::concurrency::thread::Time;
 use crate::*;
 use rustc_target::abi::{Align, Size};
-use std::time::{Instant, SystemTime};
+use std::time::SystemTime;
 
 /// Implementation of the SYS_futex syscall.
 /// `args` is the arguments *after* the syscall number.
@@ -106,14 +106,14 @@ pub fn futex<'tcx>(
                     if op & futex_realtime != 0 {
                         Time::RealTime(SystemTime::UNIX_EPOCH.checked_add(duration).unwrap())
                     } else {
-                        Time::Monotonic(this.machine.time_anchor.checked_add(duration).unwrap())
+                        this.machine.clock.get_time_absolute(duration).unwrap()
                     }
                 } else {
                     // FUTEX_WAIT uses a relative timestamp.
                     if op & futex_realtime != 0 {
                         Time::RealTime(SystemTime::now().checked_add(duration).unwrap())
                     } else {
-                        Time::Monotonic(Instant::now().checked_add(duration).unwrap())
+                        this.machine.clock.get_time_relative(duration).unwrap()
                     }
                 })
             };

--- a/src/shims/unix/linux/sync.rs
+++ b/src/shims/unix/linux/sync.rs
@@ -106,14 +106,14 @@ pub fn futex<'tcx>(
                     if op & futex_realtime != 0 {
                         Time::RealTime(SystemTime::UNIX_EPOCH.checked_add(duration).unwrap())
                     } else {
-                        this.machine.clock.get_time_absolute(duration).unwrap()
+                        Time::Monotonic(this.machine.clock.get_time_absolute(duration).unwrap())
                     }
                 } else {
                     // FUTEX_WAIT uses a relative timestamp.
                     if op & futex_realtime != 0 {
                         Time::RealTime(SystemTime::now().checked_add(duration).unwrap())
                     } else {
-                        this.machine.clock.get_time_relative(duration).unwrap()
+                        Time::Monotonic(this.machine.clock.get_time_relative(duration).unwrap())
                     }
                 })
             };

--- a/src/shims/unix/sync.rs
+++ b/src/shims/unix/sync.rs
@@ -840,7 +840,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         let timeout_time = if clock_id == this.eval_libc_i32("CLOCK_REALTIME")? {
             Time::RealTime(SystemTime::UNIX_EPOCH.checked_add(duration).unwrap())
         } else if clock_id == this.eval_libc_i32("CLOCK_MONOTONIC")? {
-            this.machine.clock.get_time_absolute(duration).unwrap()
+            Time::Monotonic(this.machine.clock.get_time_absolute(duration).unwrap())
         } else {
             throw_unsup_format!("unsupported clock id: {}", clock_id);
         };

--- a/src/shims/unix/sync.rs
+++ b/src/shims/unix/sync.rs
@@ -840,7 +840,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         let timeout_time = if clock_id == this.eval_libc_i32("CLOCK_REALTIME")? {
             Time::RealTime(SystemTime::UNIX_EPOCH.checked_add(duration).unwrap())
         } else if clock_id == this.eval_libc_i32("CLOCK_MONOTONIC")? {
-            Time::Monotonic(this.machine.clock.get_time_absolute(duration).unwrap())
+            Time::Monotonic(this.machine.clock.anchor().checked_add(duration).unwrap())
         } else {
             throw_unsup_format!("unsupported clock id: {}", clock_id);
         };

--- a/src/shims/unix/sync.rs
+++ b/src/shims/unix/sync.rs
@@ -840,7 +840,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriEvalContextExt<'mir, 'tcx
         let timeout_time = if clock_id == this.eval_libc_i32("CLOCK_REALTIME")? {
             Time::RealTime(SystemTime::UNIX_EPOCH.checked_add(duration).unwrap())
         } else if clock_id == this.eval_libc_i32("CLOCK_MONOTONIC")? {
-            Time::Monotonic(this.machine.time_anchor.checked_add(duration).unwrap())
+            this.machine.clock.get_time_absolute(duration).unwrap()
         } else {
             throw_unsup_format!("unsupported clock id: {}", clock_id);
         };

--- a/tests/pass/shims/time-with-isolation.rs
+++ b/tests/pass/shims/time-with-isolation.rs
@@ -1,21 +1,15 @@
 use std::time::{Duration, Instant};
 
-fn duration_sanity(diff: Duration) {
-    // The virtual clock is deterministic and I got 29us on a 64-bit Linux machine. However, this
-    // changes according to the platform so we use an interval to be safe. This should be updated
-    // if `NANOSECONDS_PER_BASIC_BLOCK` changes.
-    assert!(diff.as_micros() > 10);
-    assert!(diff.as_micros() < 40);
-}
-
 fn test_sleep() {
+    // We sleep a *long* time here -- but the clock is virtual so the test should still pass quickly.
     let before = Instant::now();
-    std::thread::sleep(Duration::from_millis(100));
+    std::thread::sleep(Duration::from_secs(3600));
     let after = Instant::now();
-    assert!((after - before).as_millis() >= 100);
+    assert!((after - before).as_secs() >= 3600);
 }
 
-fn main() {
+/// Ensure that time passes even if we don't sleep (but just wor).
+fn test_time_passes() {
     // Check `Instant`.
     let now1 = Instant::now();
     // Do some work to make time pass.
@@ -28,7 +22,14 @@ fn main() {
     let diff = now2.duration_since(now1);
     assert_eq!(now1 + diff, now2);
     assert_eq!(now2 - diff, now1);
-    duration_sanity(diff);
+    // The virtual clock is deterministic and I got 29us on a 64-bit Linux machine. However, this
+    // changes according to the platform so we use an interval to be safe. This should be updated
+    // if `NANOSECONDS_PER_BASIC_BLOCK` changes.
+    assert!(diff.as_micros() > 10);
+    assert!(diff.as_micros() < 40);
+}
 
+fn main() {
+    test_time_passes();
     test_sleep();
 }

--- a/tests/pass/shims/time-with-isolation.rs
+++ b/tests/pass/shims/time-with-isolation.rs
@@ -8,7 +8,7 @@ fn test_sleep() {
     assert!((after - before).as_secs() >= 3600);
 }
 
-/// Ensure that time passes even if we don't sleep (but just wor).
+/// Ensure that time passes even if we don't sleep (but just work).
 fn test_time_passes() {
     // Check `Instant`.
     let now1 = Instant::now();

--- a/tests/pass/shims/time-with-isolation.rs
+++ b/tests/pass/shims/time-with-isolation.rs
@@ -1,0 +1,34 @@
+use std::time::{Duration, Instant};
+
+fn duration_sanity(diff: Duration) {
+    // The virtual clock is deterministic and I got 29us on a 64-bit Linux machine. However, this
+    // changes according to the platform so we use an interval to be safe. This should be updated
+    // if `NANOSECONDS_PER_BASIC_BLOCK` changes.
+    assert!(diff.as_micros() > 10);
+    assert!(diff.as_micros() < 40);
+}
+
+fn test_sleep() {
+    let before = Instant::now();
+    std::thread::sleep(Duration::from_millis(100));
+    let after = Instant::now();
+    assert!((after - before).as_millis() >= 100);
+}
+
+fn main() {
+    // Check `Instant`.
+    let now1 = Instant::now();
+    // Do some work to make time pass.
+    for _ in 0..10 {
+        drop(vec![42]);
+    }
+    let now2 = Instant::now();
+    assert!(now2 > now1);
+    // Sanity-check the difference we got.
+    let diff = now2.duration_since(now1);
+    assert_eq!(now1 + diff, now2);
+    assert_eq!(now2 - diff, now1);
+    duration_sanity(diff);
+
+    test_sleep();
+}


### PR DESCRIPTION
Implement a virtual monotone clock that can be used to track time while isolation is enabled. This virtual clock keeps an internal nanoseconds counter that will be increased by a fixed amount at the end of every basic block.

When a process sleeps, this clock will return immediately and increase the counter by the interval the process was supposed to sleep. Making miri execution faster than native code :trollface:.

cc @RalfJung @saethlin @JakobDegen 