### PR TITLE
Strengthen C++20 SC accesses

### DIFF
--- a/src/concurrency/weak_memory.rs
+++ b/src/concurrency/weak_memory.rs
@@ -320,7 +320,6 @@ impl<'mir, 'tcx: 'mir> StoreBuffer {
                     // CoWR: if a store happens-before the current load,
                     // then we can't read-from anything earlier in modification order.
                     // C++20 §6.9.2.2 [intro.races] paragraph 18
-                    log::info!("Stopping due to coherent write-read");
                     false
                 } else if store_elem.loads.borrow().iter().any(|(&load_index, &load_timestamp)| {
                     load_timestamp <= clocks.clock[load_index]
@@ -328,13 +327,11 @@ impl<'mir, 'tcx: 'mir> StoreBuffer {
                     // CoRR: if there was a load from this store which happened-before the current load,
                     // then we cannot read-from anything earlier in modification order.
                     // C++20 §6.9.2.2 [intro.races] paragraph 16
-                    log::info!("Stopping due to coherent read-read");
                     false
                 } else if store_elem.timestamp <= clocks.fence_seqcst[store_elem.store_index] {
                     // The current load, which may be sequenced-after an SC fence, cannot read-before
                     // the last store sequenced-before an SC fence in another thread.
                     // C++17 §32.4 [atomics.order] paragraph 6
-                    log::info!("Stopping due to coherent load sequenced after sc fence");
                     false
                 } else if store_elem.timestamp <= clocks.write_seqcst[store_elem.store_index]
                     && store_elem.is_seqcst
@@ -342,13 +339,11 @@ impl<'mir, 'tcx: 'mir> StoreBuffer {
                     // The current non-SC load, which may be sequenced-after an SC fence,
                     // cannot read-before the last SC store executed before the fence.
                     // C++17 §32.4 [atomics.order] paragraph 4
-                    log::info!("Stopping due to needing to load from the last SC store");
                     false
                 } else if is_seqcst && store_elem.timestamp <= clocks.read_seqcst[store_elem.store_index] {
                     // The current SC load cannot read-before the last store sequenced-before
                     // the last SC fence.
                     // C++17 §32.4 [atomics.order] paragraph 5
-                    log::info!("Stopping due to sc load needing to load from the last SC store before an SC fence");
                     false
                 } else {true};
 

--- a/src/concurrency/weak_memory.rs
+++ b/src/concurrency/weak_memory.rs
@@ -11,6 +11,11 @@
 //! This implementation is not fully correct under the revised C++20 model and may generate behaviours C++20
 //! disallows (<https://github.com/rust-lang/miri/issues/2301>).
 //!
+//! A modification is made to the paper's model to partially address C++20 changes.
+//! Specifically, if an SC load reads from an atomic store of any ordering, then a later SC load cannot read from
+//! an earlier store in the location's modification order. This is to prevent creating a backwards S edge from the second
+//! load to the first, as a result of C++20's coherence-ordered before rules.
+//!
 //! Rust follows the C++20 memory model (except for the Consume ordering and some operations not performable through C++'s
 //! std::atomic<T> API). It is therefore possible for this implementation to generate behaviours never observable when the
 //! same program is compiled and run natively. Unfortunately, no literature exists at the time of writing which proposes

--- a/src/concurrency/weak_memory.rs
+++ b/src/concurrency/weak_memory.rs
@@ -319,6 +319,7 @@ impl<'mir, 'tcx: 'mir> StoreBuffer {
                 keep_searching = if store_elem.timestamp <= clocks.clock[store_elem.store_index] {
                     // CoWR: if a store happens-before the current load,
                     // then we can't read-from anything earlier in modification order.
+                    // C++20 §6.9.2.2 [intro.races] paragraph 18
                     log::info!("Stopping due to coherent write-read");
                     false
                 } else if store_elem.loads.borrow().iter().any(|(&load_index, &load_timestamp)| {
@@ -326,24 +327,27 @@ impl<'mir, 'tcx: 'mir> StoreBuffer {
                 }) {
                     // CoRR: if there was a load from this store which happened-before the current load,
                     // then we cannot read-from anything earlier in modification order.
+                    // C++20 §6.9.2.2 [intro.races] paragraph 16
                     log::info!("Stopping due to coherent read-read");
                     false
                 } else if store_elem.timestamp <= clocks.fence_seqcst[store_elem.store_index] {
-                    // The current load, which may be sequenced-after an SC fence, can only read-from
-                    // the last store sequenced-before an SC fence in another thread (or any stores
-                    // later than that SC fence)
+                    // The current load, which may be sequenced-after an SC fence, cannot read-before
+                    // the last store sequenced-before an SC fence in another thread.
+                    // C++17 §32.4 [atomics.order] paragraph 6
                     log::info!("Stopping due to coherent load sequenced after sc fence");
                     false
                 } else if store_elem.timestamp <= clocks.write_seqcst[store_elem.store_index]
                     && store_elem.is_seqcst
                 {
-                    // The current non-SC load can only read-from the latest SC store (or any stores later than that
-                    // SC store)
+                    // The current non-SC load, which may be sequenced-after an SC fence,
+                    // cannot read-before the last SC store executed before the fence.
+                    // C++17 §32.4 [atomics.order] paragraph 4
                     log::info!("Stopping due to needing to load from the last SC store");
                     false
                 } else if is_seqcst && store_elem.timestamp <= clocks.read_seqcst[store_elem.store_index] {
-                    // The current SC load can only read-from the last store sequenced-before
-                    // the last SC fence (or any stores later than the SC fence)
+                    // The current SC load cannot read-before the last store sequenced-before
+                    // the last SC fence.
+                    // C++17 §32.4 [atomics.order] paragraph 5
                     log::info!("Stopping due to sc load needing to load from the last SC store before an SC fence");
                     false
                 } else {true};

--- a/src/concurrency/weak_memory.rs
+++ b/src/concurrency/weak_memory.rs
@@ -306,6 +306,7 @@ impl<'mir, 'tcx: 'mir> StoreBuffer {
         Ok(())
     }
 
+    #[allow(clippy::if_same_then_else, clippy::needless_bool)]
     /// Selects a valid store element in the buffer.
     fn fetch_store<R: rand::Rng + ?Sized>(
         &self,


### PR DESCRIPTION
@SabrinaJewson noted in #2301 that Miri could produce behaviours forbidden under C++20 even without SC fences. Due to the added coherence-ordered before relationship which is created from read from and read before, plus the fact that coherence-ordered before between SC operations must be consistent with the Global Total Order S, in C++20 if there's an SC load that reads from any store, then a later SC load cannot read before that store. This PR adds this restriction