### PR TITLE
Skip field retagging on ZSTs, it can take forever

### DIFF
--- a/tests/pass/stacked-borrows/zst-field-retagging-terminates.rs
+++ b/tests/pass/stacked-borrows/zst-field-retagging-terminates.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-retag-fields
+// Checks that the test does not run forever (which relies on a fast path).
 fn main() {
     let array = [(); usize::MAX];
     drop(array); // Pass the array to a function, retagging its fields

--- a/tests/pass/stacked-borrows/zst-field-retagging-terminates.rs
+++ b/tests/pass/stacked-borrows/zst-field-retagging-terminates.rs
@@ -1,0 +1,5 @@
+//@compile-flags: -Zmiri-retag-fields
+fn main() {
+    let array = [(); usize::MAX];
+    drop(array); // Pass the array to a function, retagging its fields
+}


### PR DESCRIPTION
I just tried running the `alloc`'s tests with `miri-test-libstd` with field retagging enabled. The test suite eventually hangs on a few tests which pass around ZSTs that have a lot of fields.

I don't really know how to test this effectively. The test passes, but if you remove this fast-path it effectively just hangs the interpreter. And since it hangs _inside_ a step, there's no hope for doing some kind of timeout within the test.