### PR TITLE
Don't back up past the caller when looking for an FnEntry span

### DIFF
--- a/src/stacked_borrows/diagnostics.rs
+++ b/src/stacked_borrows/diagnostics.rs
@@ -82,7 +82,7 @@ impl fmt::Display for InvalidationCause {
             InvalidationCause::Access(kind) => write!(f, "{}", kind),
             InvalidationCause::Retag(perm, kind) =>
                 if *kind == RetagCause::FnEntry {
-                    write!(f, "{:?} FnEntry retag", perm)
+                    write!(f, "{:?} FnEntry retag inside this call", perm)
                 } else {
                     write!(f, "{:?} retag", perm)
                 },
@@ -275,7 +275,7 @@ impl<'span, 'history, 'ecx, 'mir, 'tcx> DiagnosticCx<'span, 'history, 'ecx, 'mir
         let (range, cause) = match &self.operation {
             Operation::Retag(RetagOp { cause, range, permission, .. }) => {
                 if *cause == RetagCause::FnEntry {
-                    span = self.current_span.get_parent();
+                    span = self.current_span.get_caller();
                 }
                 (*range, InvalidationCause::Retag(permission.unwrap(), *cause))
             }

--- a/tests/fail/stacked_borrows/aliasing_mut3.stderr
+++ b/tests/fail/stacked_borrows/aliasing_mut3.stderr
@@ -14,7 +14,7 @@ help: <TAG> was created by a SharedReadOnly retag at offsets [0x0..0x4]
    |
 LL |     safe_raw(xraw, xshr);
    |                    ^^^^
-help: <TAG> was later invalidated at offsets [0x0..0x4] by a Unique FnEntry retag
+help: <TAG> was later invalidated at offsets [0x0..0x4] by a Unique FnEntry retag inside this call
   --> $DIR/aliasing_mut3.rs:LL:CC
    |
 LL |     safe_raw(xraw, xshr);

--- a/tests/fail/stacked_borrows/fnentry_invalidation2.rs
+++ b/tests/fail/stacked_borrows/fnentry_invalidation2.rs
@@ -1,0 +1,21 @@
+// Regression test for https://github.com/rust-lang/miri/issues/2536
+// This tests that we don't try to back too far up the stack when selecting a span to report.
+// We should display the as_mut_ptr() call as the location of the invalidation, not the call to
+// inner
+
+struct Thing<'a> {
+    sli: &'a mut [i32],
+}
+
+fn main() {
+    let mut t = Thing { sli: &mut [0, 1, 2] };
+    let ptr = t.sli.as_ptr();
+    inner(&mut t);
+    unsafe {
+        let _oof = *ptr; //~ ERROR: /read access .* tag does not exist in the borrow stack/
+    }
+}
+
+fn inner(t: &mut Thing) {
+    let _ = t.sli.as_mut_ptr();
+}

--- a/tests/fail/stacked_borrows/fnentry_invalidation2.stderr
+++ b/tests/fail/stacked_borrows/fnentry_invalidation2.stderr
@@ -1,26 +1,26 @@
 error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
-  --> $DIR/fnentry_invalidation.rs:LL:CC
+  --> $DIR/fnentry_invalidation2.rs:LL:CC
    |
-LL |         let _oof = *z;
-   |                    ^^
+LL |         let _oof = *ptr;
+   |                    ^^^^
    |                    |
    |                    attempting a read access using <TAG> at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
    |                    this error occurs as part of an access at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
-help: <TAG> was created by a SharedReadWrite retag at offsets [0x0..0x4]
-  --> $DIR/fnentry_invalidation.rs:LL:CC
+help: <TAG> was created by a SharedReadOnly retag at offsets [0x0..0xc]
+  --> $DIR/fnentry_invalidation2.rs:LL:CC
    |
-LL |     let z = &mut x as *mut i32;
-   |             ^^^^^^
-help: <TAG> was later invalidated at offsets [0x0..0x4] by a Unique FnEntry retag inside this call
-  --> $DIR/fnentry_invalidation.rs:LL:CC
+LL |     let ptr = t.sli.as_ptr();
+   |               ^^^^^^^^^^^^^^
+help: <TAG> was later invalidated at offsets [0x0..0xc] by a Unique FnEntry retag inside this call
+  --> $DIR/fnentry_invalidation2.rs:LL:CC
    |
-LL |     x.do_bad();
-   |     ^^^^^^^^^^
+LL |     let _ = t.sli.as_mut_ptr();
+   |             ^^^^^^^^^^^^^^^^^^
    = note: BACKTRACE:
-   = note: inside `main` at $DIR/fnentry_invalidation.rs:LL:CC
+   = note: inside `main` at $DIR/fnentry_invalidation2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/miri/issues/2536

This adds a fix for the logic as well as a regression test. In the new test `tests/fail/stacked_borrows/fnentry_invalidation2.rs`, before this PR, we display this diagnostic:
```
help: <3278> was later invalidated at offsets [0x0..0xc] by a Unique FnEntry retag
  --> tests/fail/stacked_borrows/fnentry_invalidation2.rs:13:5
   |
13 |     inner(&mut t);
   |     ^^^^^^^^^^^^^
```
Which is very misleading. It is not this call itself, but what happens within the call that invalidates the tag we want. With this PR, we get:
```
help: <2798> was later invalidated at offsets [0x0..0xc] by a Unique FnEntry retag inside this call
  --> tests/fail/stacked_borrows/fnentry_invalidation2.rs:20:13
   |
20 |     let _ = t.sli.as_mut_ptr();
   |             ^^^^^^^^^^^^^^^^^^
```
Which is much better.