### PR TITLE
make a sync test more reliable

### DIFF
--- a/tests/pass/concurrency/sync.rs
+++ b/tests/pass/concurrency/sync.rs
@@ -77,13 +77,12 @@ fn check_conditional_variables_timed_wait_notimeout() {
     let guard = lock.lock().unwrap();
 
     let handle = thread::spawn(move || {
+        thread::sleep(Duration::from_millis(100)); // Make sure the other thread is waiting by the time we call `notify`.
         let (_lock, cvar) = &*pair2;
         cvar.notify_one();
     });
 
-    // macOS runners are very unreliable.
-    let timeout = if cfg!(target_os = "macos") { 2000 } else { 500 };
-    let (_guard, timeout) = cvar.wait_timeout(guard, Duration::from_millis(timeout)).unwrap();
+    let (_guard, timeout) = cvar.wait_timeout(guard, Duration::from_millis(500)).unwrap();
     assert!(!timeout.timed_out());
     handle.join().unwrap();
 }


### PR DESCRIPTION
CI still failed in https://github.com/rust-lang/miri/actions/runs/3088146532/jobs/4994285794, with a 2 second timeout?!??