### PR TITLE
Expand VisitMachineValues to cover more pointers in the interpreter

### DIFF
--- a/src/concurrency/data_race.rs
+++ b/src/concurrency/data_race.rs
@@ -696,6 +696,12 @@ pub struct VClockAlloc {
     alloc_ranges: RefCell<RangeMap<MemoryCellClocks>>,
 }
 
+impl VisitTags for VClockAlloc {
+    fn visit_tags(&self, _visit: &mut dyn FnMut(SbTag)) {
+        // No tags here.
+    }
+}
+
 impl VClockAlloc {
     /// Create a new data-race detector for newly allocated memory.
     pub fn new_allocation(
@@ -1237,6 +1243,12 @@ pub struct GlobalState {
 
     /// Track when an outdated (weak memory) load happens.
     pub track_outdated_loads: bool,
+}
+
+impl VisitTags for GlobalState {
+    fn visit_tags(&self, _visit: &mut dyn FnMut(SbTag)) {
+        // We don't have any tags.
+    }
 }
 
 impl GlobalState {

--- a/src/concurrency/range_object_map.rs
+++ b/src/concurrency/range_object_map.rs
@@ -132,6 +132,10 @@ impl<T> RangeObjectMap<T> {
     pub fn remove_from_pos(&mut self, pos: Position) {
         self.v.remove(pos);
     }
+
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.v.iter().map(|e| &e.data)
+    }
 }
 
 impl<T> Index<Position> for RangeObjectMap<T> {

--- a/src/concurrency/thread.rs
+++ b/src/concurrency/thread.rs
@@ -183,7 +183,8 @@ impl<'mir, 'tcx> Thread<'mir, 'tcx> {
 
 impl VisitMachineValues for Thread<'_, '_> {
     fn visit_machine_values(&self, visit: &mut impl FnMut(&Operand<Provenance>)) {
-        let Thread { panic_payload, last_error, stack, .. } = self;
+        let Thread { panic_payload, last_error, stack, state: _, thread_name: _, join_status: _ } =
+            self;
 
         if let Some(payload) = panic_payload {
             visit(&Operand::Immediate(Immediate::Scalar(*payload)))
@@ -199,7 +200,16 @@ impl VisitMachineValues for Thread<'_, '_> {
 
 impl VisitMachineValues for Frame<'_, '_, Provenance, FrameData<'_>> {
     fn visit_machine_values(&self, visit: &mut impl FnMut(&Operand<Provenance>)) {
-        let Frame { return_place, locals, extra, .. } = self;
+        let Frame {
+            return_place,
+            locals,
+            extra,
+            body: _,
+            instance: _,
+            return_to_block: _,
+            loc: _,
+            ..
+        } = self;
 
         // Return place.
         if let Place::Ptr(mplace) = **return_place {
@@ -290,7 +300,14 @@ impl<'mir, 'tcx> Default for ThreadManager<'mir, 'tcx> {
 
 impl VisitMachineValues for ThreadManager<'_, '_> {
     fn visit_machine_values(&self, visit: &mut impl FnMut(&Operand<Provenance>)) {
-        let ThreadManager { threads, thread_local_alloc_ids, .. } = self;
+        let ThreadManager {
+            threads,
+            thread_local_alloc_ids,
+            active_thread: _,
+            yield_active_thread: _,
+            sync: _,
+            timeout_callbacks: _,
+        } = self;
 
         for thread in threads {
             thread.visit_machine_values(visit);

--- a/src/concurrency/weak_memory.rs
+++ b/src/concurrency/weak_memory.rs
@@ -108,15 +108,15 @@ pub struct StoreBufferAlloc {
     store_buffers: RefCell<RangeObjectMap<StoreBuffer>>,
 }
 
-impl VisitMachineValues for StoreBufferAlloc {
-    fn visit_machine_values(&self, visit: &mut ProvenanceVisitor) {
-        for val in self
-            .store_buffers
+impl VisitTags for StoreBufferAlloc {
+    fn visit_tags(&self, visit: &mut dyn FnMut(SbTag)) {
+        let Self { store_buffers } = self;
+        for val in store_buffers
             .borrow()
             .iter()
             .flat_map(|buf| buf.buffer.iter().map(|element| &element.val))
         {
-            visit.visit(val);
+            val.visit_tags(visit);
         }
     }
 }

--- a/src/concurrency/weak_memory.rs
+++ b/src/concurrency/weak_memory.rs
@@ -108,19 +108,15 @@ pub struct StoreBufferAlloc {
     store_buffers: RefCell<RangeObjectMap<StoreBuffer>>,
 }
 
-impl VisitProvenance for StoreBufferAlloc {
-    fn visit_provenance(&self, visitor: &mut impl FnMut(SbTag)) {
+impl VisitMachineValues for StoreBufferAlloc {
+    fn visit_machine_values(&self, visit: &mut ProvenanceVisitor) {
         for val in self
             .store_buffers
             .borrow()
             .iter()
             .flat_map(|buf| buf.buffer.iter().map(|element| &element.val))
         {
-            if let Scalar::Ptr(ptr, _) = val {
-                if let Provenance::Concrete { sb, .. } = ptr.provenance {
-                    visitor(sb);
-                }
-            }
+            visit.visit(val);
         }
     }
 }

--- a/src/concurrency/weak_memory.rs
+++ b/src/concurrency/weak_memory.rs
@@ -108,6 +108,19 @@ pub struct StoreBufferAlloc {
     store_buffers: RefCell<RangeObjectMap<StoreBuffer>>,
 }
 
+impl StoreBufferAlloc {
+    pub fn iter(&self, mut visitor: impl FnMut(&Scalar<Provenance>)) {
+        for val in self
+            .store_buffers
+            .borrow()
+            .iter()
+            .flat_map(|buf| buf.buffer.iter().map(|element| &element.val))
+        {
+            visitor(val)
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct StoreBuffer {
     // Stores to this location in modification order

--- a/src/concurrency/weak_memory.rs
+++ b/src/concurrency/weak_memory.rs
@@ -108,15 +108,19 @@ pub struct StoreBufferAlloc {
     store_buffers: RefCell<RangeObjectMap<StoreBuffer>>,
 }
 
-impl StoreBufferAlloc {
-    pub fn iter(&self, mut visitor: impl FnMut(&Scalar<Provenance>)) {
+impl VisitProvenance for StoreBufferAlloc {
+    fn visit_provenance(&self, visitor: &mut impl FnMut(SbTag)) {
         for val in self
             .store_buffers
             .borrow()
             .iter()
             .flat_map(|buf| buf.buffer.iter().map(|element| &element.val))
         {
-            visitor(val)
+            if let Scalar::Ptr(ptr, _) = val {
+                if let Provenance::Concrete { sb, .. } = ptr.provenance {
+                    visitor(sb);
+                }
+            }
         }
     }
 }

--- a/src/intptrcast.rs
+++ b/src/intptrcast.rs
@@ -44,6 +44,12 @@ pub struct GlobalStateInner {
     provenance_mode: ProvenanceMode,
 }
 
+impl VisitTags for GlobalStateInner {
+    fn visit_tags(&self, _visit: &mut dyn FnMut(SbTag)) {
+        // Nothing to visit here.
+    }
+}
+
 impl GlobalStateInner {
     pub fn new(config: &MiriConfig) -> Self {
         GlobalStateInner {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ pub use crate::range_map::RangeMap;
 pub use crate::stacked_borrows::{
     CallId, EvalContextExt as StackedBorEvalContextExt, Item, Permission, SbTag, Stack, Stacks,
 };
-pub use crate::tag_gc::{EvalContextExt as _, VisitMachineValues};
+pub use crate::tag_gc::{EvalContextExt as _, VisitMachineValues, VisitProvenance};
 
 /// Insert rustc arguments at the beginning of the argument list that Miri wants to be
 /// set per default, for maximal validation power.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ pub use crate::range_map::RangeMap;
 pub use crate::stacked_borrows::{
     CallId, EvalContextExt as StackedBorEvalContextExt, Item, Permission, SbTag, Stack, Stacks,
 };
-pub use crate::tag_gc::{EvalContextExt as _, ProvenanceVisitor, VisitMachineValues};
+pub use crate::tag_gc::{EvalContextExt as _, VisitTags};
 
 /// Insert rustc arguments at the beginning of the argument list that Miri wants to be
 /// set per default, for maximal validation power.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ pub use crate::range_map::RangeMap;
 pub use crate::stacked_borrows::{
     CallId, EvalContextExt as StackedBorEvalContextExt, Item, Permission, SbTag, Stack, Stacks,
 };
-pub use crate::tag_gc::{EvalContextExt as _, VisitMachineValues, VisitProvenance};
+pub use crate::tag_gc::{EvalContextExt as _, ProvenanceVisitor, VisitMachineValues};
 
 /// Insert rustc arguments at the beginning of the argument list that Miri wants to be
 /// set per default, for maximal validation power.

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -63,13 +63,12 @@ impl<'tcx> std::fmt::Debug for FrameData<'tcx> {
     }
 }
 
-impl VisitMachineValues for FrameData<'_> {
-    fn visit_machine_values(&self, visit: &mut ProvenanceVisitor) {
-        let FrameData { catch_unwind, stacked_borrows: _, timing: _ } = self;
+impl VisitTags for FrameData<'_> {
+    fn visit_tags(&self, visit: &mut dyn FnMut(SbTag)) {
+        let FrameData { catch_unwind, stacked_borrows, timing: _ } = self;
 
-        if let Some(catch_unwind) = catch_unwind {
-            catch_unwind.visit_machine_values(visit);
-        }
+        catch_unwind.visit_tags(visit);
+        stacked_borrows.visit_tags(visit);
     }
 }
 
@@ -261,17 +260,13 @@ pub struct AllocExtra {
     pub weak_memory: Option<weak_memory::AllocExtra>,
 }
 
-impl VisitMachineValues for AllocExtra {
-    fn visit_machine_values(&self, visit: &mut ProvenanceVisitor) {
-        let AllocExtra { stacked_borrows, data_race: _, weak_memory } = self;
+impl VisitTags for AllocExtra {
+    fn visit_tags(&self, visit: &mut dyn FnMut(SbTag)) {
+        let AllocExtra { stacked_borrows, data_race, weak_memory } = self;
 
-        if let Some(stacked_borrows) = stacked_borrows {
-            stacked_borrows.borrow().visit_machine_values(visit);
-        }
-
-        if let Some(weak_memory) = weak_memory {
-            weak_memory.visit_machine_values(visit);
-        }
+        stacked_borrows.visit_tags(visit);
+        data_race.visit_tags(visit);
+        weak_memory.visit_tags(visit);
     }
 }
 
@@ -615,8 +610,9 @@ impl<'mir, 'tcx> MiriMachine<'mir, 'tcx> {
     }
 }
 
-impl VisitMachineValues for MiriMachine<'_, '_> {
-    fn visit_machine_values(&self, visit: &mut ProvenanceVisitor) {
+impl VisitTags for MiriMachine<'_, '_> {
+    fn visit_tags(&self, visit: &mut dyn FnMut(SbTag)) {
+        #[rustfmt::skip]
         let MiriMachine {
             threads,
             tls,
@@ -626,25 +622,52 @@ impl VisitMachineValues for MiriMachine<'_, '_> {
             cmd_line,
             extern_statics,
             dir_handler,
-            ..
+            stacked_borrows,
+            data_race,
+            intptrcast,
+            file_handler,
+            tcx: _,
+            isolated_op: _,
+            validate: _,
+            enforce_abi: _,
+            clock: _,
+            layouts: _,
+            static_roots: _,
+            profiler: _,
+            string_cache: _,
+            exported_symbols_cache: _,
+            panic_on_unsupported: _,
+            backtrace_style: _,
+            local_crates: _,
+            rng: _,
+            tracked_alloc_ids: _,
+            check_alignment: _,
+            cmpxchg_weak_failure_rate: _,
+            mute_stdout_stderr: _,
+            weak_memory: _,
+            preemption_rate: _,
+            report_progress: _,
+            basic_block_count: _,
+            #[cfg(unix)]
+            external_so_lib: _,
+            gc_interval: _,
+            since_gc: _,
+            num_cpus: _,
         } = self;
 
-        threads.visit_machine_values(visit);
-        tls.visit_machine_values(visit);
-        env_vars.visit_machine_values(visit);
-        dir_handler.visit_machine_values(visit);
-
-        if let Some(argc) = argc {
-            visit.visit(argc);
-        }
-        if let Some(argv) = argv {
-            visit.visit(argv);
-        }
-        if let Some(cmd_line) = cmd_line {
-            visit.visit(cmd_line);
-        }
-        for ptr in extern_statics.values().copied() {
-            visit.visit(ptr);
+        threads.visit_tags(visit);
+        tls.visit_tags(visit);
+        env_vars.visit_tags(visit);
+        dir_handler.visit_tags(visit);
+        file_handler.visit_tags(visit);
+        data_race.visit_tags(visit);
+        stacked_borrows.visit_tags(visit);
+        intptrcast.visit_tags(visit);
+        argc.visit_tags(visit);
+        argv.visit_tags(visit);
+        cmd_line.visit_tags(visit);
+        for ptr in extern_statics.values() {
+            ptr.visit_tags(visit);
         }
     }
 }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -65,7 +65,7 @@ impl<'tcx> std::fmt::Debug for FrameData<'tcx> {
 
 impl VisitMachineValues for FrameData<'_> {
     fn visit_machine_values(&self, visit: &mut impl FnMut(&Operand<Provenance>)) {
-        let FrameData { catch_unwind, .. } = self;
+        let FrameData { catch_unwind, stacked_borrows: _, timing: _ } = self;
 
         if let Some(catch_unwind) = catch_unwind {
             catch_unwind.visit_machine_values(visit);

--- a/src/shims/env.rs
+++ b/src/shims/env.rs
@@ -36,15 +36,13 @@ pub struct EnvVars<'tcx> {
     pub(crate) environ: Option<MPlaceTy<'tcx, Provenance>>,
 }
 
-impl VisitMachineValues for EnvVars<'_> {
-    fn visit_machine_values(&self, visit: &mut ProvenanceVisitor) {
+impl VisitTags for EnvVars<'_> {
+    fn visit_tags(&self, visit: &mut dyn FnMut(SbTag)) {
         let EnvVars { map, environ } = self;
 
+        environ.visit_tags(visit);
         for ptr in map.values() {
-            visit.visit(*ptr);
-        }
-        if let Some(env) = environ {
-            visit.visit(**env);
+            ptr.visit_tags(visit);
         }
     }
 }

--- a/src/shims/env.rs
+++ b/src/shims/env.rs
@@ -37,15 +37,14 @@ pub struct EnvVars<'tcx> {
 }
 
 impl VisitMachineValues for EnvVars<'_> {
-    fn visit_machine_values(&self, visit: &mut impl FnMut(&Operand<Provenance>)) {
+    fn visit_machine_values(&self, visit: &mut ProvenanceVisitor) {
         let EnvVars { map, environ } = self;
 
         for ptr in map.values() {
-            visit(&Operand::Indirect(MemPlace::from_ptr(*ptr)));
+            visit.visit(*ptr);
         }
-
         if let Some(env) = environ {
-            visit(&Operand::Indirect(**env));
+            visit.visit(**env);
         }
     }
 }

--- a/src/shims/env.rs
+++ b/src/shims/env.rs
@@ -36,6 +36,20 @@ pub struct EnvVars<'tcx> {
     pub(crate) environ: Option<MPlaceTy<'tcx, Provenance>>,
 }
 
+impl VisitMachineValues for EnvVars<'_> {
+    fn visit_machine_values(&self, visit: &mut impl FnMut(&Operand<Provenance>)) {
+        let EnvVars { map, environ } = self;
+
+        for ptr in map.values() {
+            visit(&Operand::Indirect(MemPlace::from_ptr(*ptr)));
+        }
+
+        if let Some(env) = environ {
+            visit(&Operand::Indirect(**env));
+        }
+    }
+}
+
 impl<'tcx> EnvVars<'tcx> {
     pub(crate) fn init<'mir>(
         ecx: &mut InterpCx<'mir, 'tcx, MiriMachine<'mir, 'tcx>>,

--- a/src/shims/panic.rs
+++ b/src/shims/panic.rs
@@ -35,6 +35,13 @@ pub struct CatchUnwindData<'tcx> {
     ret: mir::BasicBlock,
 }
 
+impl VisitMachineValues for CatchUnwindData<'_> {
+    fn visit_machine_values(&self, visit: &mut impl FnMut(&Operand<Provenance>)) {
+        visit(&Operand::Indirect(MemPlace::from_ptr(self.catch_fn)));
+        visit(&Operand::Immediate(Immediate::Scalar(self.data)));
+    }
+}
+
 impl<'mir, 'tcx: 'mir> EvalContextExt<'mir, 'tcx> for crate::MiriInterpCx<'mir, 'tcx> {}
 pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
     /// Handles the special `miri_start_panic` intrinsic, which is called

--- a/src/shims/panic.rs
+++ b/src/shims/panic.rs
@@ -37,8 +37,9 @@ pub struct CatchUnwindData<'tcx> {
 
 impl VisitMachineValues for CatchUnwindData<'_> {
     fn visit_machine_values(&self, visit: &mut impl FnMut(&Operand<Provenance>)) {
-        visit(&Operand::Indirect(MemPlace::from_ptr(self.catch_fn)));
-        visit(&Operand::Immediate(Immediate::Scalar(self.data)));
+        let CatchUnwindData { catch_fn, data, dest: _, ret: _ } = self;
+        visit(&Operand::Indirect(MemPlace::from_ptr(*catch_fn)));
+        visit(&Operand::Immediate(Immediate::Scalar(*data)));
     }
 }
 

--- a/src/shims/panic.rs
+++ b/src/shims/panic.rs
@@ -35,11 +35,12 @@ pub struct CatchUnwindData<'tcx> {
     ret: mir::BasicBlock,
 }
 
-impl VisitMachineValues for CatchUnwindData<'_> {
-    fn visit_machine_values(&self, visit: &mut ProvenanceVisitor) {
-        let CatchUnwindData { catch_fn, data, dest: _, ret: _ } = self;
-        visit.visit(catch_fn);
-        visit.visit(data);
+impl VisitTags for CatchUnwindData<'_> {
+    fn visit_tags(&self, visit: &mut dyn FnMut(SbTag)) {
+        let CatchUnwindData { catch_fn, data, dest, ret: _ } = self;
+        catch_fn.visit_tags(visit);
+        data.visit_tags(visit);
+        dest.visit_tags(visit);
     }
 }
 

--- a/src/shims/panic.rs
+++ b/src/shims/panic.rs
@@ -36,10 +36,10 @@ pub struct CatchUnwindData<'tcx> {
 }
 
 impl VisitMachineValues for CatchUnwindData<'_> {
-    fn visit_machine_values(&self, visit: &mut impl FnMut(&Operand<Provenance>)) {
+    fn visit_machine_values(&self, visit: &mut ProvenanceVisitor) {
         let CatchUnwindData { catch_fn, data, dest: _, ret: _ } = self;
-        visit(&Operand::Indirect(MemPlace::from_ptr(*catch_fn)));
-        visit(&Operand::Immediate(Immediate::Scalar(*data)));
+        visit.visit(catch_fn);
+        visit.visit(data);
     }
 }
 

--- a/src/shims/time.rs
+++ b/src/shims/time.rs
@@ -1,6 +1,6 @@
 use std::time::{Duration, SystemTime};
 
-use crate::concurrency::thread::TimeoutCallback;
+use crate::concurrency::thread::MachineCallback;
 use crate::*;
 
 /// Returns the time elapsed between the provided time and the unix epoch as a `Duration`.
@@ -257,7 +257,7 @@ impl VisitMachineValues for Callback {
     fn visit_machine_values(&self, _visit: &mut ProvenanceVisitor) {}
 }
 
-impl<'mir, 'tcx: 'mir> TimeoutCallback<'mir, 'tcx> for Callback {
+impl<'mir, 'tcx: 'mir> MachineCallback<'mir, 'tcx> for Callback {
     fn call(&self, ecx: &mut MiriInterpCx<'mir, 'tcx>) -> InterpResult<'tcx> {
         ecx.unblock_thread(self.active_thread);
         Ok(())

--- a/src/shims/tls.rs
+++ b/src/shims/tls.rs
@@ -235,15 +235,15 @@ impl<'tcx> TlsData<'tcx> {
     }
 }
 
-impl VisitMachineValues for TlsData<'_> {
-    fn visit_machine_values(&self, visit: &mut ProvenanceVisitor) {
+impl VisitTags for TlsData<'_> {
+    fn visit_tags(&self, visit: &mut dyn FnMut(SbTag)) {
         let TlsData { keys, macos_thread_dtors, next_key: _, dtors_running: _ } = self;
 
         for scalar in keys.values().flat_map(|v| v.data.values()) {
-            visit.visit(scalar);
+            scalar.visit_tags(visit);
         }
         for (_, scalar) in macos_thread_dtors.values() {
-            visit.visit(scalar);
+            scalar.visit_tags(visit);
         }
     }
 }

--- a/src/shims/tls.rs
+++ b/src/shims/tls.rs
@@ -236,14 +236,14 @@ impl<'tcx> TlsData<'tcx> {
 }
 
 impl VisitMachineValues for TlsData<'_> {
-    fn visit_machine_values(&self, visit: &mut impl FnMut(&Operand<Provenance>)) {
+    fn visit_machine_values(&self, visit: &mut ProvenanceVisitor) {
         let TlsData { keys, macos_thread_dtors, next_key: _, dtors_running: _ } = self;
 
         for scalar in keys.values().flat_map(|v| v.data.values()) {
-            visit(&Operand::Immediate(Immediate::Scalar(*scalar)));
+            visit.visit(scalar);
         }
         for (_, scalar) in macos_thread_dtors.values() {
-            visit(&Operand::Immediate(Immediate::Scalar(*scalar)));
+            visit.visit(scalar);
         }
     }
 }

--- a/src/shims/unix/fs.rs
+++ b/src/shims/unix/fs.rs
@@ -464,7 +464,9 @@ impl Default for DirHandler {
 
 impl VisitMachineValues for DirHandler {
     fn visit_machine_values(&self, visit: &mut impl FnMut(&Operand<Provenance>)) {
-        for dir in self.streams.values() {
+        let DirHandler { streams, next_id: _ } = self;
+
+        for dir in streams.values() {
             visit(&Operand::Indirect(MemPlace::from_ptr(dir.entry)));
         }
     }

--- a/src/shims/unix/fs.rs
+++ b/src/shims/unix/fs.rs
@@ -256,6 +256,12 @@ pub struct FileHandler {
     handles: BTreeMap<i32, Box<dyn FileDescriptor>>,
 }
 
+impl VisitTags for FileHandler {
+    fn visit_tags(&self, _visit: &mut dyn FnMut(SbTag)) {
+        // All our FileDescriptor do not have any tags.
+    }
+}
+
 impl FileHandler {
     pub(crate) fn new(mute_stdout_stderr: bool) -> FileHandler {
         let mut handles: BTreeMap<_, Box<dyn FileDescriptor>> = BTreeMap::new();
@@ -462,12 +468,12 @@ impl Default for DirHandler {
     }
 }
 
-impl VisitMachineValues for DirHandler {
-    fn visit_machine_values(&self, visit: &mut ProvenanceVisitor) {
+impl VisitTags for DirHandler {
+    fn visit_tags(&self, visit: &mut dyn FnMut(SbTag)) {
         let DirHandler { streams, next_id: _ } = self;
 
         for dir in streams.values() {
-            visit.visit(dir.entry);
+            dir.entry.visit_tags(visit);
         }
     }
 }

--- a/src/shims/unix/fs.rs
+++ b/src/shims/unix/fs.rs
@@ -462,6 +462,14 @@ impl Default for DirHandler {
     }
 }
 
+impl VisitMachineValues for DirHandler {
+    fn visit_machine_values(&self, visit: &mut impl FnMut(&Operand<Provenance>)) {
+        for dir in self.streams.values() {
+            visit(&Operand::Indirect(MemPlace::from_ptr(dir.entry)));
+        }
+    }
+}
+
 fn maybe_sync_file(
     file: &File,
     writable: bool,

--- a/src/shims/unix/fs.rs
+++ b/src/shims/unix/fs.rs
@@ -463,11 +463,11 @@ impl Default for DirHandler {
 }
 
 impl VisitMachineValues for DirHandler {
-    fn visit_machine_values(&self, visit: &mut impl FnMut(&Operand<Provenance>)) {
+    fn visit_machine_values(&self, visit: &mut ProvenanceVisitor) {
         let DirHandler { streams, next_id: _ } = self;
 
         for dir in streams.values() {
-            visit(&Operand::Indirect(MemPlace::from_ptr(dir.entry)));
+            visit.visit(dir.entry);
         }
     }
 }

--- a/src/shims/unix/linux/sync.rs
+++ b/src/shims/unix/linux/sync.rs
@@ -1,4 +1,4 @@
-use crate::concurrency::thread::{Time, TimeoutCallback};
+use crate::concurrency::thread::{MachineCallback, Time};
 use crate::*;
 use rustc_target::abi::{Align, Size};
 use std::time::SystemTime;
@@ -268,7 +268,7 @@ impl<'tcx> VisitMachineValues for Callback<'tcx> {
     }
 }
 
-impl<'mir, 'tcx: 'mir> TimeoutCallback<'mir, 'tcx> for Callback<'tcx> {
+impl<'mir, 'tcx: 'mir> MachineCallback<'mir, 'tcx> for Callback<'tcx> {
     fn call(&self, this: &mut MiriInterpCx<'mir, 'tcx>) -> InterpResult<'tcx> {
         this.unblock_thread(self.thread);
         this.futex_remove_waiter(self.addr_usize, self.thread);

--- a/src/shims/unix/sync.rs
+++ b/src/shims/unix/sync.rs
@@ -3,7 +3,7 @@ use std::time::SystemTime;
 use rustc_hir::LangItem;
 use rustc_middle::ty::{layout::TyAndLayout, query::TyCtxtAt, Ty};
 
-use crate::concurrency::thread::{Time, TimeoutCallback};
+use crate::concurrency::thread::{MachineCallback, Time};
 use crate::*;
 
 // pthread_mutexattr_t is either 4 or 8 bytes, depending on the platform.
@@ -901,7 +901,7 @@ impl<'tcx> VisitMachineValues for Callback<'tcx> {
     }
 }
 
-impl<'mir, 'tcx: 'mir> TimeoutCallback<'mir, 'tcx> for Callback<'tcx> {
+impl<'mir, 'tcx: 'mir> MachineCallback<'mir, 'tcx> for Callback<'tcx> {
     fn call(&self, ecx: &mut MiriInterpCx<'mir, 'tcx>) -> InterpResult<'tcx> {
         // We are not waiting for the condvar any more, wait for the
         // mutex instead.

--- a/src/stacked_borrows/mod.rs
+++ b/src/stacked_borrows/mod.rs
@@ -71,6 +71,12 @@ pub struct FrameExtra {
     protected_tags: SmallVec<[SbTag; 2]>,
 }
 
+impl VisitTags for FrameExtra {
+    fn visit_tags(&self, _visit: &mut dyn FnMut(SbTag)) {
+        // `protected_tags` are fine to GC.
+    }
+}
+
 /// Extra per-allocation state.
 #[derive(Clone, Debug)]
 pub struct Stacks {
@@ -107,6 +113,13 @@ pub struct GlobalStateInner {
     tracked_call_ids: FxHashSet<CallId>,
     /// Whether to recurse into datatypes when searching for pointers to retag.
     retag_fields: bool,
+}
+
+impl VisitTags for GlobalStateInner {
+    fn visit_tags(&self, _visit: &mut dyn FnMut(SbTag)) {
+        // The only candidate is base_ptr_tags, and that does not need visiting since we don't ever
+        // GC the bottommost tag.
+    }
 }
 
 /// We need interior mutable access to the global state.
@@ -513,10 +526,10 @@ impl Stacks {
     }
 }
 
-impl VisitMachineValues for Stacks {
-    fn visit_machine_values(&self, visit: &mut ProvenanceVisitor) {
+impl VisitTags for Stacks {
+    fn visit_tags(&self, visit: &mut dyn FnMut(SbTag)) {
         for tag in self.exposed_tags.iter().copied() {
-            visit.visit(tag);
+            visit(tag);
         }
     }
 }

--- a/src/stacked_borrows/mod.rs
+++ b/src/stacked_borrows/mod.rs
@@ -513,10 +513,10 @@ impl Stacks {
     }
 }
 
-impl VisitProvenance for Stacks {
-    fn visit_provenance(&self, visit: &mut impl FnMut(SbTag)) {
+impl VisitMachineValues for Stacks {
+    fn visit_machine_values(&self, visit: &mut ProvenanceVisitor) {
         for tag in self.exposed_tags.iter().copied() {
-            visit(tag);
+            visit.visit(tag);
         }
     }
 }

--- a/src/stacked_borrows/mod.rs
+++ b/src/stacked_borrows/mod.rs
@@ -79,7 +79,7 @@ pub struct Stacks {
     /// Stores past operations on this allocation
     history: AllocHistory,
     /// The set of tags that have been exposed inside this allocation.
-    pub exposed_tags: FxHashSet<SbTag>,
+    exposed_tags: FxHashSet<SbTag>,
     /// Whether this memory has been modified since the last time the tag GC ran
     modified_since_last_gc: bool,
 }
@@ -509,6 +509,14 @@ impl Stacks {
                 }
             }
             self.modified_since_last_gc = false;
+        }
+    }
+}
+
+impl VisitProvenance for Stacks {
+    fn visit_provenance(&self, visit: &mut impl FnMut(SbTag)) {
+        for tag in self.exposed_tags.iter().copied() {
+            visit(tag);
         }
     }
 }

--- a/src/stacked_borrows/mod.rs
+++ b/src/stacked_borrows/mod.rs
@@ -79,7 +79,7 @@ pub struct Stacks {
     /// Stores past operations on this allocation
     history: AllocHistory,
     /// The set of tags that have been exposed inside this allocation.
-    exposed_tags: FxHashSet<SbTag>,
+    pub exposed_tags: FxHashSet<SbTag>,
     /// Whether this memory has been modified since the last time the tag GC ran
     modified_since_last_gc: bool,
 }

--- a/src/stacked_borrows/stack.rs
+++ b/src/stacked_borrows/stack.rs
@@ -43,8 +43,11 @@ impl Stack {
     pub fn retain(&mut self, tags: &FxHashSet<SbTag>) {
         let mut first_removed = None;
 
-        let mut read_idx = 1;
-        let mut write_idx = 1;
+        // For stacks with a known bottom, we never consider removing the bottom-most tag, because
+        // that is the base tag which exists whether or not there are any pointers to the
+        // allocation.
+        let mut read_idx = usize::from(self.unknown_bottom.is_none());
+        let mut write_idx = read_idx;
         while read_idx < self.borrows.len() {
             let left = self.borrows[read_idx - 1];
             let this = self.borrows[read_idx];

--- a/src/stacked_borrows/stack.rs
+++ b/src/stacked_borrows/stack.rs
@@ -46,7 +46,7 @@ impl Stack {
         // For stacks with a known bottom, we never consider removing the bottom-most tag, because
         // that is the base tag which exists whether or not there are any pointers to the
         // allocation.
-        let mut read_idx = usize::from(self.unknown_bottom.is_none());
+        let mut read_idx = if self.unknown_bottom.is_some() { 0 } else { 1 };
         let mut write_idx = read_idx;
         while read_idx < self.borrows.len() {
             let left = self.borrows[read_idx - 1];

--- a/src/tag_gc.rs
+++ b/src/tag_gc.rs
@@ -2,123 +2,155 @@ use rustc_data_structures::fx::FxHashSet;
 
 use crate::*;
 
-pub trait VisitMachineValues {
-    fn visit_machine_values(&self, visit: &mut ProvenanceVisitor);
+pub trait VisitTags {
+    fn visit_tags(&self, visit: &mut dyn FnMut(SbTag));
 }
 
-pub trait MachineValue {
-    fn visit_provenance(&self, tags: &mut FxHashSet<SbTag>);
-}
-
-pub struct ProvenanceVisitor {
-    tags: FxHashSet<SbTag>,
-}
-
-impl ProvenanceVisitor {
-    pub fn visit<V>(&mut self, v: V)
-    where
-        V: MachineValue,
-    {
-        v.visit_provenance(&mut self.tags);
+impl<T: VisitTags> VisitTags for Option<T> {
+    fn visit_tags(&self, visit: &mut dyn FnMut(SbTag)) {
+        if let Some(x) = self {
+            x.visit_tags(visit);
+        }
     }
 }
 
-impl<T: MachineValue> MachineValue for &T {
-    fn visit_provenance(&self, tags: &mut FxHashSet<SbTag>) {
-        (**self).visit_provenance(tags);
+impl<T: VisitTags> VisitTags for std::cell::RefCell<T> {
+    fn visit_tags(&self, visit: &mut dyn FnMut(SbTag)) {
+        self.borrow().visit_tags(visit)
     }
 }
 
-impl MachineValue for Operand<Provenance> {
-    fn visit_provenance(&self, tags: &mut FxHashSet<SbTag>) {
+impl VisitTags for SbTag {
+    fn visit_tags(&self, visit: &mut dyn FnMut(SbTag)) {
+        visit(*self)
+    }
+}
+
+impl VisitTags for Provenance {
+    fn visit_tags(&self, visit: &mut dyn FnMut(SbTag)) {
+        if let Provenance::Concrete { sb, .. } = self {
+            visit(*sb);
+        }
+    }
+}
+
+impl VisitTags for Pointer<Provenance> {
+    fn visit_tags(&self, visit: &mut dyn FnMut(SbTag)) {
+        let (prov, _offset) = self.into_parts();
+        prov.visit_tags(visit);
+    }
+}
+
+impl VisitTags for Pointer<Option<Provenance>> {
+    fn visit_tags(&self, visit: &mut dyn FnMut(SbTag)) {
+        let (prov, _offset) = self.into_parts();
+        prov.visit_tags(visit);
+    }
+}
+
+impl VisitTags for Scalar<Provenance> {
+    fn visit_tags(&self, visit: &mut dyn FnMut(SbTag)) {
         match self {
-            Operand::Immediate(Immediate::Scalar(s)) => {
-                s.visit_provenance(tags);
+            Scalar::Ptr(ptr, _) => ptr.visit_tags(visit),
+            Scalar::Int(_) => (),
+        }
+    }
+}
+
+impl VisitTags for Immediate<Provenance> {
+    fn visit_tags(&self, visit: &mut dyn FnMut(SbTag)) {
+        match self {
+            Immediate::Scalar(s) => {
+                s.visit_tags(visit);
             }
-            Operand::Immediate(Immediate::ScalarPair(s1, s2)) => {
-                s1.visit_provenance(tags);
-                s2.visit_provenance(tags);
+            Immediate::ScalarPair(s1, s2) => {
+                s1.visit_tags(visit);
+                s2.visit_tags(visit);
             }
-            Operand::Immediate(Immediate::Uninit) => {}
+            Immediate::Uninit => {}
+        }
+    }
+}
+
+impl VisitTags for MemPlaceMeta<Provenance> {
+    fn visit_tags(&self, visit: &mut dyn FnMut(SbTag)) {
+        match self {
+            MemPlaceMeta::Meta(m) => m.visit_tags(visit),
+            MemPlaceMeta::None => {}
+        }
+    }
+}
+
+impl VisitTags for MemPlace<Provenance> {
+    fn visit_tags(&self, visit: &mut dyn FnMut(SbTag)) {
+        let MemPlace { ptr, meta } = self;
+        ptr.visit_tags(visit);
+        meta.visit_tags(visit);
+    }
+}
+
+impl VisitTags for MPlaceTy<'_, Provenance> {
+    fn visit_tags(&self, visit: &mut dyn FnMut(SbTag)) {
+        (**self).visit_tags(visit)
+    }
+}
+
+impl VisitTags for Place<Provenance> {
+    fn visit_tags(&self, visit: &mut dyn FnMut(SbTag)) {
+        match self {
+            Place::Ptr(p) => p.visit_tags(visit),
+            Place::Local { .. } => {
+                // Will be visited as part of the stack frame.
+            }
+        }
+    }
+}
+
+impl VisitTags for PlaceTy<'_, Provenance> {
+    fn visit_tags(&self, visit: &mut dyn FnMut(SbTag)) {
+        (**self).visit_tags(visit)
+    }
+}
+
+impl VisitTags for Operand<Provenance> {
+    fn visit_tags(&self, visit: &mut dyn FnMut(SbTag)) {
+        match self {
+            Operand::Immediate(imm) => {
+                imm.visit_tags(visit);
+            }
             Operand::Indirect(p) => {
-                p.visit_provenance(tags);
+                p.visit_tags(visit);
             }
         }
     }
 }
 
-impl MachineValue for Scalar<Provenance> {
-    fn visit_provenance(&self, tags: &mut FxHashSet<SbTag>) {
-        if let Scalar::Ptr(ptr, _) = self {
-            if let Provenance::Concrete { sb, .. } = ptr.provenance {
-                tags.insert(sb);
-            }
-        }
-    }
-}
-
-impl MachineValue for MemPlace<Provenance> {
-    fn visit_provenance(&self, tags: &mut FxHashSet<SbTag>) {
-        if let Some(Provenance::Concrete { sb, .. }) = self.ptr.provenance {
-            tags.insert(sb);
-        }
-    }
-}
-
-impl MachineValue for SbTag {
-    fn visit_provenance(&self, tags: &mut FxHashSet<SbTag>) {
-        tags.insert(*self);
-    }
-}
-
-impl MachineValue for Pointer<Provenance> {
-    fn visit_provenance(&self, tags: &mut FxHashSet<SbTag>) {
-        let (prov, _offset) = self.into_parts();
-        if let Provenance::Concrete { sb, .. } = prov {
-            tags.insert(sb);
-        }
-    }
-}
-
-impl MachineValue for Pointer<Option<Provenance>> {
-    fn visit_provenance(&self, tags: &mut FxHashSet<SbTag>) {
-        let (prov, _offset) = self.into_parts();
-        if let Some(Provenance::Concrete { sb, .. }) = prov {
-            tags.insert(sb);
-        }
-    }
-}
-
-impl VisitMachineValues for Allocation<Provenance, AllocExtra> {
-    fn visit_machine_values(&self, visit: &mut ProvenanceVisitor) {
+impl VisitTags for Allocation<Provenance, AllocExtra> {
+    fn visit_tags(&self, visit: &mut dyn FnMut(SbTag)) {
         for (_size, prov) in self.provenance().iter() {
-            if let Provenance::Concrete { sb, .. } = prov {
-                visit.visit(*sb);
-            }
+            prov.visit_tags(visit);
         }
 
-        self.extra.visit_machine_values(visit);
+        self.extra.visit_tags(visit);
+    }
+}
+
+impl VisitTags for crate::MiriInterpCx<'_, '_> {
+    fn visit_tags(&self, visit: &mut dyn FnMut(SbTag)) {
+        // Memory.
+        self.memory.alloc_map().iter(|it| {
+            for (_id, (_kind, alloc)) in it {
+                alloc.visit_tags(visit);
+            }
+        });
+
+        // And all the other machine values.
+        self.machine.visit_tags(visit);
     }
 }
 
 impl<'mir, 'tcx: 'mir> EvalContextExt<'mir, 'tcx> for crate::MiriInterpCx<'mir, 'tcx> {}
 pub trait EvalContextExt<'mir, 'tcx: 'mir>: MiriInterpCxExt<'mir, 'tcx> {
-    /// GC helper to visit everything that can store provenance. The `ProvenanceVisitor` knows how
-    /// to extract provenance from the interpreter data types.
-    fn visit_all_machine_values(&self, acc: &mut ProvenanceVisitor) {
-        let this = self.eval_context_ref();
-
-        // Memory.
-        this.memory.alloc_map().iter(|it| {
-            for (_id, (_kind, alloc)) in it {
-                alloc.visit_machine_values(acc);
-            }
-        });
-
-        // And all the other machine values.
-        this.machine.visit_machine_values(acc);
-    }
-
     fn garbage_collect_tags(&mut self) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
         // No reason to do anything at all if stacked borrows is off.
@@ -126,9 +158,11 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: MiriInterpCxExt<'mir, 'tcx> {
             return Ok(());
         }
 
-        let mut visitor = ProvenanceVisitor { tags: FxHashSet::default() };
-        this.visit_all_machine_values(&mut visitor);
-        self.remove_unreachable_tags(visitor.tags);
+        let mut tags = FxHashSet::default();
+        this.visit_tags(&mut |tag| {
+            tags.insert(tag);
+        });
+        self.remove_unreachable_tags(tags);
 
         Ok(())
     }


### PR DESCRIPTION
Follow-on to https://github.com/rust-lang/miri/pull/2559

This is making me want to write a proc macro :thinking: 

r? @RalfJung 