### PR TITLE
relax vergen dependency

### DIFF
--- a/cargo-miri/Cargo.toml
+++ b/cargo-miri/Cargo.toml
@@ -30,4 +30,4 @@ rustc-workspace-hack = "1.0.0"
 serde = { version = "*", features = ["derive"] }
 
 [build-dependencies]
-vergen = { version = "7.4", default_features = false, features = ["git"] }
+vergen = { version = "7", default_features = false, features = ["git"] }


### PR DESCRIPTION
vergen 7.4 needs git2 0.14 which we cannot use in the rustc workspace since it conflicts with git2 0.13... so relax the vergen dependency such that the rustc workspace can use an older git2.