### PR TITLE
Add -Zmiri-always-two-phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,9 @@ The remaining flags are for advanced use only, and more likely to change or be r
 Some of these are **unsound**, which means they can lead
 to Miri failing to detect cases of undefined behavior in a program.
 
+* `-Zmiri-always-two-phase` causes all `Unique` retags to be treated as
+  two-phase retags. This generally has the effect of delaying tag invalidation
+  due to `&mut` until a write occurs.
 * `-Zmiri-disable-abi-check` disables checking [function ABI]. Using this flag
   is **unsound**.
 * `-Zmiri-disable-alignment-check` disables checking pointer alignment, so you

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -431,6 +431,8 @@ fn main() {
             eprintln!(
                 "WARNING: `-Zmiri-track-raw-pointers` has no effect; it is enabled by default"
             );
+        } else if arg == "-Zmiri-always-two-phase" {
+            miri_config.always_two_phase = true;
         } else if let Some(param) = arg.strip_prefix("-Zmiri-seed=") {
             if miri_config.seed.is_some() {
                 show_error!("Cannot specify -Zmiri-seed multiple times!");

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -134,6 +134,8 @@ pub struct MiriConfig {
     pub gc_interval: u32,
     /// The number of CPUs to be reported by miri.
     pub num_cpus: u32,
+    /// Whether we should always treat Unique retags as TwoPhase.
+    pub always_two_phase: bool,
 }
 
 impl Default for MiriConfig {
@@ -167,6 +169,7 @@ impl Default for MiriConfig {
             external_so_file: None,
             gc_interval: 10_000,
             num_cpus: 1,
+            always_two_phase: false,
         }
     }
 }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -430,6 +430,9 @@ pub struct MiriMachine<'mir, 'tcx> {
     pub(crate) since_gc: u32,
     /// The number of CPUs to be reported by miri.
     pub(crate) num_cpus: u32,
+
+    /// Whether we should always treat Unique retags as TwoPhase.
+    pub(crate) always_two_phase: bool,
 }
 
 impl<'mir, 'tcx> MiriMachine<'mir, 'tcx> {
@@ -510,6 +513,7 @@ impl<'mir, 'tcx> MiriMachine<'mir, 'tcx> {
             gc_interval: config.gc_interval,
             since_gc: 0,
             num_cpus: config.num_cpus,
+            always_two_phase: config.always_two_phase,
         }
     }
 
@@ -653,6 +657,7 @@ impl VisitTags for MiriMachine<'_, '_> {
             gc_interval: _,
             since_gc: _,
             num_cpus: _,
+            always_two_phase: _,
         } = self;
 
         threads.visit_tags(visit);

--- a/tests/pass/stacked-borrows/always-two-phase.rs
+++ b/tests/pass/stacked-borrows/always-two-phase.rs
@@ -1,0 +1,9 @@
+//@compile-flags: -Zmiri-always-two-phase
+
+fn main() {
+    let data = &mut [0, 1];
+    unsafe {
+        core::ptr::copy_nonoverlapping(data.as_ptr(), data.as_mut_ptr().add(1), 1);
+    }
+    assert_eq!(data, &[0, 0]);
+}


### PR DESCRIPTION
@RalfJung I think a while ago you said we could make all `Unique` retags two-phase, which would have the effect of delaying tag invalidation until the mutable reference is actually used for a write, as opposed to just reborrowed.

It occurs to me that we should at least be able to try out that idea in Miri?