### PR TITLE
remove FFI support for macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,10 @@ smallvec = "1.7"
 rustc-workspace-hack = "1.0.0"
 measureme = "10.0.0"
 
-[target."cfg(unix)".dependencies]
+[target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[target.'cfg(target_os = "linux")'.dependencies]
 libffi = "3.0.0"
 libloading = "0.7"
 

--- a/src/shims/ffi_support.rs
+++ b/src/shims/ffi_support.rs
@@ -183,9 +183,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
         // from: https://docs.rs/libloading/0.7.3/src/libloading/os/unix/mod.rs.html#411
         // using the `libc` crate where this interface is public.
         // No `libc::dladdr` on windows.
-        #[cfg(unix)]
         let mut info = std::mem::MaybeUninit::<libc::Dl_info>::uninit();
-        #[cfg(unix)]
         unsafe {
             if libc::dladdr(*func.deref() as *const _, info.as_mut_ptr()) != 0 {
                 if std::ffi::CStr::from_ptr(info.assume_init().dli_fname).to_str().unwrap()

--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -23,8 +23,6 @@ use rustc_target::{
 
 use super::backtrace::EvalContextExt as _;
 use crate::helpers::{convert::Truncate, target_os_is_unix};
-#[cfg(unix)]
-use crate::shims::ffi_support::EvalContextExt as _;
 use crate::*;
 
 /// Returned by `emulate_foreign_item_by_name`.
@@ -372,8 +370,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
         let this = self.eval_context_mut();
 
         // First deal with any external C functions in linked .so file.
-        #[cfg(unix)]
+        #[cfg(target_os = "linux")]
         if this.machine.external_so_lib.as_ref().is_some() {
+            use crate::shims::ffi_support::EvalContextExt as _;
             // An Ok(false) here means that the function being called was not exported
             // by the specified `.so` file; we should continue and check if it corresponds to
             // a provided shim.

--- a/src/shims/mod.rs
+++ b/src/shims/mod.rs
@@ -1,7 +1,7 @@
 #![warn(clippy::integer_arithmetic)]
 
 mod backtrace;
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 pub mod ffi_support;
 pub mod foreign_items;
 pub mod intrinsics;


### PR DESCRIPTION
We're only testing this on Linux, and @thomcc reports that libffi on macOS is a pain, so let's just disable this for now.