### PR TITLE
use Scalar return types for Windows shims

### DIFF
--- a/src/shims/env.rs
+++ b/src/shims/env.rs
@@ -144,7 +144,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
         name_op: &OpTy<'tcx, Provenance>, // LPCWSTR
         buf_op: &OpTy<'tcx, Provenance>,  // LPWSTR
         size_op: &OpTy<'tcx, Provenance>, // DWORD
-    ) -> InterpResult<'tcx, u32> {
+    ) -> InterpResult<'tcx, Scalar<Provenance>> {
         // ^ Returns DWORD (u32 on Windows)
 
         let this = self.eval_context_mut();
@@ -165,12 +165,14 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                 let buf_ptr = this.read_pointer(buf_op)?;
                 // `buf_size` represents the size in characters.
                 let buf_size = u64::from(this.read_scalar(size_op)?.to_u32()?);
-                windows_check_buffer_size(this.write_os_str_to_wide_str(&var, buf_ptr, buf_size)?)
+                Scalar::from_u32(windows_check_buffer_size(
+                    this.write_os_str_to_wide_str(&var, buf_ptr, buf_size)?,
+                ))
             }
             None => {
                 let envvar_not_found = this.eval_windows("c", "ERROR_ENVVAR_NOT_FOUND")?;
                 this.set_last_error(envvar_not_found)?;
-                0 // return zero upon failure
+                Scalar::from_u32(0) // return zero upon failure
             }
         })
     }
@@ -200,14 +202,14 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
     fn FreeEnvironmentStringsW(
         &mut self,
         env_block_op: &OpTy<'tcx, Provenance>,
-    ) -> InterpResult<'tcx, i32> {
+    ) -> InterpResult<'tcx, Scalar<Provenance>> {
         let this = self.eval_context_mut();
         this.assert_target_os("windows", "FreeEnvironmentStringsW");
 
         let env_block_ptr = this.read_pointer(env_block_op)?;
         let result = this.deallocate_ptr(env_block_ptr, None, MiriMemoryKind::Runtime.into());
         // If the function succeeds, the return value is nonzero.
-        Ok(i32::from(result.is_ok()))
+        Ok(Scalar::from_i32(i32::from(result.is_ok())))
     }
 
     fn setenv(
@@ -249,7 +251,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
         &mut self,
         name_op: &OpTy<'tcx, Provenance>,  // LPCWSTR
         value_op: &OpTy<'tcx, Provenance>, // LPCWSTR
-    ) -> InterpResult<'tcx, i32> {
+    ) -> InterpResult<'tcx, Scalar<Provenance>> {
         let this = self.eval_context_mut();
         this.assert_target_os("windows", "SetEnvironmentVariableW");
 
@@ -272,7 +274,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                 this.deallocate_ptr(var, None, MiriMemoryKind::Runtime.into())?;
                 this.update_environ()?;
             }
-            Ok(1) // return non-zero on success
+            Ok(Scalar::from_i32(1)) // return non-zero on success
         } else {
             let value = this.read_os_str_from_wide_str(value_ptr)?;
             let var_ptr = alloc_env_var_as_wide_str(&name, &value, this)?;
@@ -280,7 +282,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                 this.deallocate_ptr(var, None, MiriMemoryKind::Runtime.into())?;
             }
             this.update_environ()?;
-            Ok(1) // return non-zero on success
+            Ok(Scalar::from_i32(1)) // return non-zero on success
         }
     }
 
@@ -347,7 +349,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
         &mut self,
         size_op: &OpTy<'tcx, Provenance>, // DWORD
         buf_op: &OpTy<'tcx, Provenance>,  // LPTSTR
-    ) -> InterpResult<'tcx, u32> {
+    ) -> InterpResult<'tcx, Scalar<Provenance>> {
         let this = self.eval_context_mut();
         this.assert_target_os("windows", "GetCurrentDirectoryW");
 
@@ -357,16 +359,18 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
         if let IsolatedOp::Reject(reject_with) = this.machine.isolated_op {
             this.reject_in_isolation("`GetCurrentDirectoryW`", reject_with)?;
             this.set_last_error_from_io_error(ErrorKind::PermissionDenied)?;
-            return Ok(0);
+            return Ok(Scalar::from_u32(0));
         }
 
         // If we cannot get the current directory, we return 0
         match env::current_dir() {
             Ok(cwd) =>
-                return Ok(windows_check_buffer_size(this.write_path_to_wide_str(&cwd, buf, size)?)),
+                return Ok(Scalar::from_u32(windows_check_buffer_size(
+                    this.write_path_to_wide_str(&cwd, buf, size)?,
+                ))),
             Err(e) => this.set_last_error_from_io_error(e.kind())?,
         }
-        Ok(0)
+        Ok(Scalar::from_u32(0))
     }
 
     fn chdir(&mut self, path_op: &OpTy<'tcx, Provenance>) -> InterpResult<'tcx, i32> {
@@ -395,7 +399,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
     fn SetCurrentDirectoryW(
         &mut self,
         path_op: &OpTy<'tcx, Provenance>, // LPCTSTR
-    ) -> InterpResult<'tcx, i32> {
+    ) -> InterpResult<'tcx, Scalar<Provenance>> {
         // ^ Returns BOOL (i32 on Windows)
 
         let this = self.eval_context_mut();
@@ -407,14 +411,14 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
             this.reject_in_isolation("`SetCurrentDirectoryW`", reject_with)?;
             this.set_last_error_from_io_error(ErrorKind::PermissionDenied)?;
 
-            return Ok(0);
+            return Ok(Scalar::from_i32(0));
         }
 
         match env::set_current_dir(path) {
-            Ok(()) => Ok(1),
+            Ok(()) => Ok(Scalar::from_i32(1)),
             Err(e) => {
                 this.set_last_error_from_io_error(e.kind())?;
-                Ok(0)
+                Ok(Scalar::from_i32(0))
             }
         }
     }

--- a/src/shims/time.rs
+++ b/src/shims/time.rs
@@ -119,7 +119,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
     fn QueryPerformanceCounter(
         &mut self,
         lpPerformanceCount_op: &OpTy<'tcx, Provenance>,
-    ) -> InterpResult<'tcx, i32> {
+    ) -> InterpResult<'tcx, Scalar<Provenance>> {
         let this = self.eval_context_mut();
 
         this.assert_target_os("windows", "QueryPerformanceCounter");
@@ -134,14 +134,14 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
             Scalar::from_i64(qpc),
             &this.deref_operand(lpPerformanceCount_op)?.into(),
         )?;
-        Ok(-1) // return non-zero on success
+        Ok(Scalar::from_i32(-1)) // return non-zero on success
     }
 
     #[allow(non_snake_case)]
     fn QueryPerformanceFrequency(
         &mut self,
         lpFrequency_op: &OpTy<'tcx, Provenance>,
-    ) -> InterpResult<'tcx, i32> {
+    ) -> InterpResult<'tcx, Scalar<Provenance>> {
         let this = self.eval_context_mut();
 
         this.assert_target_os("windows", "QueryPerformanceFrequency");
@@ -155,7 +155,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
             Scalar::from_i64(1_000_000_000),
             &this.deref_operand(lpFrequency_op)?.into(),
         )?;
-        Ok(-1) // Return non-zero on success
+        Ok(Scalar::from_i32(-1)) // Return non-zero on success
     }
 
     fn mach_absolute_time(&self) -> InterpResult<'tcx, Scalar<Provenance>> {

--- a/src/shims/windows/foreign_items.rs
+++ b/src/shims/windows/foreign_items.rs
@@ -37,13 +37,13 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                 let [name, buf, size] =
                     this.check_shim(abi, Abi::System { unwind: false }, link_name, args)?;
                 let result = this.GetEnvironmentVariableW(name, buf, size)?;
-                this.write_scalar(Scalar::from_u32(result), dest)?;
+                this.write_scalar(result, dest)?;
             }
             "SetEnvironmentVariableW" => {
                 let [name, value] =
                     this.check_shim(abi, Abi::System { unwind: false }, link_name, args)?;
                 let result = this.SetEnvironmentVariableW(name, value)?;
-                this.write_scalar(Scalar::from_i32(result), dest)?;
+                this.write_scalar(result, dest)?;
             }
             "GetEnvironmentStringsW" => {
                 let [] = this.check_shim(abi, Abi::System { unwind: false }, link_name, args)?;
@@ -54,19 +54,19 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                 let [env_block] =
                     this.check_shim(abi, Abi::System { unwind: false }, link_name, args)?;
                 let result = this.FreeEnvironmentStringsW(env_block)?;
-                this.write_scalar(Scalar::from_i32(result), dest)?;
+                this.write_scalar(result, dest)?;
             }
             "GetCurrentDirectoryW" => {
                 let [size, buf] =
                     this.check_shim(abi, Abi::System { unwind: false }, link_name, args)?;
                 let result = this.GetCurrentDirectoryW(size, buf)?;
-                this.write_scalar(Scalar::from_u32(result), dest)?;
+                this.write_scalar(result, dest)?;
             }
             "SetCurrentDirectoryW" => {
                 let [path] =
                     this.check_shim(abi, Abi::System { unwind: false }, link_name, args)?;
                 let result = this.SetCurrentDirectoryW(path)?;
-                this.write_scalar(Scalar::from_i32(result), dest)?;
+                this.write_scalar(result, dest)?;
             }
 
             // Allocation
@@ -218,14 +218,14 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                 let [lpPerformanceCount] =
                     this.check_shim(abi, Abi::System { unwind: false }, link_name, args)?;
                 let result = this.QueryPerformanceCounter(lpPerformanceCount)?;
-                this.write_scalar(Scalar::from_i32(result), dest)?;
+                this.write_scalar(result, dest)?;
             }
             "QueryPerformanceFrequency" => {
                 #[allow(non_snake_case)]
                 let [lpFrequency] =
                     this.check_shim(abi, Abi::System { unwind: false }, link_name, args)?;
                 let result = this.QueryPerformanceFrequency(lpFrequency)?;
-                this.write_scalar(Scalar::from_i32(result), dest)?;
+                this.write_scalar(result, dest)?;
             }
             "Sleep" => {
                 let [timeout] =
@@ -246,7 +246,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
             "TryAcquireSRWLockExclusive" => {
                 let [ptr] = this.check_shim(abi, Abi::System { unwind: false }, link_name, args)?;
                 let ret = this.TryAcquireSRWLockExclusive(ptr)?;
-                this.write_scalar(Scalar::from_u8(ret), dest)?;
+                this.write_scalar(ret, dest)?;
             }
             "AcquireSRWLockShared" => {
                 let [ptr] = this.check_shim(abi, Abi::System { unwind: false }, link_name, args)?;
@@ -259,7 +259,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
             "TryAcquireSRWLockShared" => {
                 let [ptr] = this.check_shim(abi, Abi::System { unwind: false }, link_name, args)?;
                 let ret = this.TryAcquireSRWLockShared(ptr)?;
-                this.write_scalar(Scalar::from_u8(ret), dest)?;
+                this.write_scalar(ret, dest)?;
             }
 
             // Dynamic symbol loading

--- a/src/shims/windows/sync.rs
+++ b/src/shims/windows/sync.rs
@@ -58,17 +58,17 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
     fn TryAcquireSRWLockExclusive(
         &mut self,
         lock_op: &OpTy<'tcx, Provenance>,
-    ) -> InterpResult<'tcx, u8> {
+    ) -> InterpResult<'tcx, Scalar<Provenance>> {
         let this = self.eval_context_mut();
         let id = srwlock_get_or_create_id(this, lock_op)?;
         let active_thread = this.get_active_thread();
 
         if this.rwlock_is_locked(id) {
             // Lock is already held.
-            Ok(0)
+            Ok(Scalar::from_u8(0))
         } else {
             this.rwlock_writer_lock(id, active_thread);
-            Ok(1)
+            Ok(Scalar::from_u8(1))
         }
     }
 
@@ -107,16 +107,16 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
     fn TryAcquireSRWLockShared(
         &mut self,
         lock_op: &OpTy<'tcx, Provenance>,
-    ) -> InterpResult<'tcx, u8> {
+    ) -> InterpResult<'tcx, Scalar<Provenance>> {
         let this = self.eval_context_mut();
         let id = srwlock_get_or_create_id(this, lock_op)?;
         let active_thread = this.get_active_thread();
 
         if this.rwlock_is_write_locked(id) {
-            Ok(0)
+            Ok(Scalar::from_u8(0))
         } else {
             this.rwlock_reader_lock(id, active_thread);
-            Ok(1)
+            Ok(Scalar::from_u8(1))
         }
     }
 


### PR DESCRIPTION
I started doing this while working on https://github.com/rust-lang/miri/issues/2595; now I don't need the rest of this patch but this part still makes sense.