### PR TITLE
Update libffi-sys to 2.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "libffi-sys"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4106b7f09d7b87d021334d5618fac1dfcfb824d4c5fe111ff0074dfd242e15"
+checksum = "84e78d02e5a8eae9c24c38ce6e6026f80e16dff76adcdae4bc5c6c52c2de4a60"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
Prior version of libffi [could not be cross-compiled to illumos](https://github.com/tov/libffi-rs/pull/59) due to host-triple complications.  This should fix rustup builds of miri for the illumos platform.