### PR TITLE
test on windows-gnu target

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -93,6 +93,7 @@ case $HOST_TARGET in
     ;;
   i686-pc-windows-msvc)
     MIRI_TEST_TARGET=x86_64-unknown-linux-gnu run_tests
+    MIRI_TEST_TARGET=x86_64-pc-windows-gnu run_tests
     ;;
   *)
     echo "FATAL: unknown OS"


### PR DESCRIPTION
The windows-gnu target for an open-source windows toolchain is slightly different in some low-level aspects of the standard library, such as TLS handling. So let's separately ensure that this works. (Also tests a 64bit windows target on a windows host, which we didn't have so far.)