### PR TITLE
simplify GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,16 +24,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build: [linux64, macos, win32]
         include:
-          - build: linux64
-            os: ubuntu-latest
+          - os: ubuntu-latest
             host_target: x86_64-unknown-linux-gnu
-          - build: macos
-            os: macos-latest
+          - os: macos-latest
             host_target: x86_64-apple-darwin
-          - build: win32
-            os: windows-latest
+          - os: windows-latest
             host_target: i686-pc-windows-msvc
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
I think we can just list the cases with `include:` and don't also need this `build` array.