### PR TITLE
pthread_setname_np returns an int on macOS

### DIFF
--- a/tests/pass-dep/shims/pthreads.rs
+++ b/tests/pass-dep/shims/pthreads.rs
@@ -1,6 +1,6 @@
 //@ignore-target-windows: No libc on Windows
 #![feature(cstr_from_bytes_until_nul)]
-use std::ffi::CStr;
+use std::ffi::{CStr, CString};
 use std::thread;
 
 fn main() {
@@ -135,6 +135,13 @@ fn test_named_thread_truncation() {
         .chain(std::iter::repeat(" yada").take(100))
         .collect::<String>();
 
+    fn set_thread_name(name: &CStr) -> i32 {
+        #[cfg(target_os = "linux")]
+        return unsafe { libc::pthread_setname_np(libc::pthread_self(), name.as_ptr().cast()) };
+        #[cfg(target_os = "macos")]
+        return unsafe { libc::pthread_setname_np(name.as_ptr().cast()) };
+    }
+
     let result = thread::Builder::new().name(long_name.clone()).spawn(move || {
         // Rust remembers the full thread name itself.
         assert_eq!(thread::current().name(), Some(long_name.as_str()));
@@ -142,11 +149,16 @@ fn test_named_thread_truncation() {
         // But the system is limited -- make sure we successfully set a truncation.
         let mut buf = vec![0u8; long_name.len() + 1];
         unsafe {
-            libc::pthread_getname_np(libc::pthread_self(), buf.as_mut_ptr().cast(), buf.len());
-        }
+            libc::pthread_getname_np(libc::pthread_self(), buf.as_mut_ptr().cast(), buf.len())
+        };
         let cstr = CStr::from_bytes_until_nul(&buf).unwrap();
         assert!(cstr.to_bytes().len() >= 15); // POSIX seems to promise at least 15 chars
         assert!(long_name.as_bytes().starts_with(cstr.to_bytes()));
+
+        // Also test directly calling pthread_setname to check its return value.
+        assert_eq!(set_thread_name(&cstr), 0);
+        // But with a too long name it should fail.
+        assert_ne!(set_thread_name(&CString::new(long_name).unwrap()), 0);
     });
     result.unwrap().join().unwrap();
 }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/miri/issues/2625