### PR TITLE
InitOnce: synchronize with completion when already complete

### DIFF
--- a/src/shims/windows/sync.rs
+++ b/src/shims/windows/sync.rs
@@ -178,7 +178,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                 )
             }
             InitOnceStatus::Complete => {
-                this.init_once_acquire(id);
+                this.init_once_observe_completed(id);
                 this.write_scalar(this.eval_windows("c", "FALSE")?, &pending_place)?;
             }
         }

--- a/src/shims/windows/sync.rs
+++ b/src/shims/windows/sync.rs
@@ -177,8 +177,10 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                     Box::new(Callback { init_once_id: id, pending_place }),
                 )
             }
-            InitOnceStatus::Complete =>
-                this.write_scalar(this.eval_windows("c", "FALSE")?, &pending_place)?,
+            InitOnceStatus::Complete => {
+                this.init_once_acquire(id);
+                this.write_scalar(this.eval_windows("c", "FALSE")?, &pending_place)?;
+            }
         }
 
         // This always succeeds (even if the thread is blocked, we will succeed if we ever unblock).

--- a/tests/pass/concurrency/windows_init_once.rs
+++ b/tests/pass/concurrency/windows_init_once.rs
@@ -131,8 +131,46 @@ fn retry_on_fail() {
     waiter2.join().unwrap();
 }
 
+fn no_data_race_after_complete() {
+    let mut init_once = null_mut();
+    let mut pending = 0;
+
+    unsafe {
+        assert_eq!(InitOnceBeginInitialize(&mut init_once, 0, &mut pending, null_mut()), TRUE);
+        assert_eq!(pending, TRUE);
+    }
+
+    let init_once_ptr = SendPtr(&mut init_once);
+
+    let mut place = 0;
+    let place_ptr = SendPtr(&mut place);
+
+    let reader = thread::spawn(move || unsafe {
+        let mut pending = 0;
+
+        assert_eq!(InitOnceBeginInitialize(init_once_ptr.0, 0, &mut pending, null_mut()), TRUE);
+        assert_eq!(pending, FALSE);
+        // this should not data race
+        place_ptr.0.read()
+    });
+
+    unsafe {
+        // this should not data race
+        place_ptr.0.write(1);
+    }
+
+    unsafe {
+        assert_eq!(InitOnceComplete(init_once_ptr.0, 0, null_mut()), TRUE);
+    }
+    //println!("complete");
+
+    // run reader
+    assert_eq!(reader.join().unwrap(), 1);
+}
+
 fn main() {
     single_thread();
     block_until_complete();
     retry_on_fail();
+    no_data_race_after_complete();
 }

--- a/tests/pass/concurrency/windows_init_once.rs
+++ b/tests/pass/concurrency/windows_init_once.rs
@@ -148,6 +148,7 @@ fn no_data_race_after_complete() {
     let reader = thread::spawn(move || unsafe {
         let mut pending = 0;
 
+        // this doesn't block because reader only executes after `InitOnceComplete` is called
         assert_eq!(InitOnceBeginInitialize(init_once_ptr.0, 0, &mut pending, null_mut()), TRUE);
         assert_eq!(pending, FALSE);
         // this should not data race
@@ -162,9 +163,8 @@ fn no_data_race_after_complete() {
     unsafe {
         assert_eq!(InitOnceComplete(init_once_ptr.0, 0, null_mut()), TRUE);
     }
-    //println!("complete");
 
-    // run reader
+    // run reader (without preemption, it has not taken a step yet)
     assert_eq!(reader.join().unwrap(), 1);
 }
 


### PR DESCRIPTION
The completion of an InitOnce happens-before the threads waiting on it wake up. However, this is not the case for threads that call `InitOnceBeginInitialize` after the completion, leading to data races and outdated weak memory loads as observed in the CI for  #2638. This PR fixes this.