### PR TITLE
Data race spans

### DIFF
--- a/src/concurrency/data_race.rs
+++ b/src/concurrency/data_race.rs
@@ -811,14 +811,14 @@ impl VClockAlloc {
         Err(err_machine_stop!(TerminationInfo::DataRace {
             ptr: ptr_dbg,
             op1: RacingOp {
-                action: action.to_string(),
-                thread_info: current_thread_info,
-                span: current_clocks.clock.as_slice()[current_index.index()].span_data(),
-            },
-            op2: RacingOp {
                 action: other_action.to_string(),
                 thread_info: other_thread_info,
                 span: other_clock.as_slice()[other_thread.index()].span_data(),
+            },
+            op2: RacingOp {
+                action: action.to_string(),
+                thread_info: current_thread_info,
+                span: current_clocks.clock.as_slice()[current_index.index()].span_data(),
             },
         }))?
     }

--- a/src/concurrency/init_once.rs
+++ b/src/concurrency/init_once.rs
@@ -160,6 +160,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
     fn init_once_complete(&mut self, id: InitOnceId) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
         let current_thread = this.get_active_thread();
+        let current_span = this.machine.current_span();
         let init_once = &mut this.machine.threads.sync.init_onces[id];
 
         assert_eq!(
@@ -172,7 +173,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
 
         // Each complete happens-before the end of the wait
         if let Some(data_race) = &this.machine.data_race {
-            data_race.validate_lock_release(&mut init_once.data_race, current_thread);
+            data_race.validate_lock_release(&mut init_once.data_race, current_thread, current_span);
         }
 
         // Wake up everyone.
@@ -188,6 +189,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
     fn init_once_fail(&mut self, id: InitOnceId) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
         let current_thread = this.get_active_thread();
+        let current_span = this.machine.current_span();
         let init_once = &mut this.machine.threads.sync.init_onces[id];
         assert_eq!(
             init_once.status,
@@ -197,7 +199,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
 
         // Each complete happens-before the end of the wait
         if let Some(data_race) = &this.machine.data_race {
-            data_race.validate_lock_release(&mut init_once.data_race, current_thread);
+            data_race.validate_lock_release(&mut init_once.data_race, current_thread, current_span);
         }
 
         // Wake up one waiting thread, so they can go ahead and try to init this.

--- a/src/concurrency/vector_clock.rs
+++ b/src/concurrency/vector_clock.rs
@@ -378,8 +378,9 @@ impl IndexMut<VectorIdx> for VClock {
 #[cfg(test)]
 mod tests {
 
-    use super::{VClock, VectorIdx};
+    use super::{VClock, VTimestamp, VectorIdx};
     use rustc_span::DUMMY_SP;
+    use std::cmp::Ordering;
 
     #[test]
     fn test_equal() {
@@ -396,7 +397,6 @@ mod tests {
         assert_eq!(c1, c2);
     }
 
-    /*
     #[test]
     fn test_partial_order() {
         // Small test
@@ -442,14 +442,14 @@ mod tests {
         );
     }
 
-    fn from_slice(mut slice: &[VTimestamp]) -> VClock {
+    fn from_slice(mut slice: &[u32]) -> VClock {
         while let Some(0) = slice.last() {
             slice = &slice[..slice.len() - 1]
         }
-        VClock(smallvec::SmallVec::from_slice(slice))
+        VClock(slice.iter().copied().map(|time| VTimestamp { time, span: DUMMY_SP }).collect())
     }
 
-    fn assert_order(l: &[VTimestamp], r: &[VTimestamp], o: Option<Ordering>) {
+    fn assert_order(l: &[u32], r: &[u32], o: Option<Ordering>) {
         let l = from_slice(l);
         let r = from_slice(r);
 
@@ -505,5 +505,4 @@ mod tests {
             "Invalid alt (>=):\n l: {l:?}\n r: {r:?}"
         );
     }
-    */
 }

--- a/src/concurrency/vector_clock.rs
+++ b/src/concurrency/vector_clock.rs
@@ -48,14 +48,14 @@ const SMALL_VECTOR: usize = 4;
 /// The time-stamps recorded in the data-race detector consist of both
 /// a 32-bit unsigned integer which is the actual timestamp, and a `Span`
 /// so that diagnostics can report what code was responsible for an operation.
-#[derive(Clone, Copy, Debug, Eq)]
+#[derive(Clone, Copy, Debug)]
 pub struct VTimestamp {
     time: u32,
     pub span: Span,
 }
 
 impl VTimestamp {
-    pub const NONE: VTimestamp = VTimestamp { time: 0, span: DUMMY_SP };
+    pub const ZERO: VTimestamp = VTimestamp { time: 0, span: DUMMY_SP };
 
     pub fn span_data(&self) -> SpanData {
         self.span.data()
@@ -67,6 +67,8 @@ impl PartialEq for VTimestamp {
         self.time == other.time
     }
 }
+
+impl Eq for VTimestamp {}
 
 impl PartialOrd for VTimestamp {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
@@ -98,7 +100,7 @@ impl VClock {
     /// for a value at the given index
     pub fn new_with_index(index: VectorIdx, timestamp: VTimestamp) -> VClock {
         let len = index.index() + 1;
-        let mut vec = smallvec::smallvec![VTimestamp::NONE; len];
+        let mut vec = smallvec::smallvec![VTimestamp::ZERO; len];
         vec[index.index()] = timestamp;
         VClock(vec)
     }
@@ -115,7 +117,7 @@ impl VClock {
     #[inline]
     fn get_mut_with_min_len(&mut self, min_len: usize) -> &mut [VTimestamp] {
         if self.0.len() < min_len {
-            self.0.resize(min_len, VTimestamp::NONE);
+            self.0.resize(min_len, VTimestamp::ZERO);
         }
         assert!(self.0.len() >= min_len);
         self.0.as_mut_slice()
@@ -361,7 +363,7 @@ impl Index<VectorIdx> for VClock {
 
     #[inline]
     fn index(&self, index: VectorIdx) -> &VTimestamp {
-        self.as_slice().get(index.to_u32() as usize).unwrap_or(&VTimestamp::NONE)
+        self.as_slice().get(index.to_u32() as usize).unwrap_or(&VTimestamp::ZERO)
     }
 }
 

--- a/src/concurrency/weak_memory.rs
+++ b/src/concurrency/weak_memory.rs
@@ -258,7 +258,7 @@ impl<'mir, 'tcx: 'mir> StoreBuffer {
             // The thread index and timestamp of the initialisation write
             // are never meaningfully used, so it's fine to leave them as 0
             store_index: VectorIdx::from(0),
-            timestamp: VTimestamp::NONE,
+            timestamp: VTimestamp::ZERO,
             val: init,
             is_seqcst: false,
             load_info: RefCell::new(LoadInfo::default()),

--- a/src/concurrency/weak_memory.rs
+++ b/src/concurrency/weak_memory.rs
@@ -258,7 +258,7 @@ impl<'mir, 'tcx: 'mir> StoreBuffer {
             // The thread index and timestamp of the initialisation write
             // are never meaningfully used, so it's fine to leave them as 0
             store_index: VectorIdx::from(0),
-            timestamp: 0,
+            timestamp: VTimestamp::NONE,
             val: init,
             is_seqcst: false,
             load_info: RefCell::new(LoadInfo::default()),

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -69,8 +69,8 @@ impl fmt::Display for TerminationInfo {
             DataRace { ptr, op1, op2 } =>
                 write!(
                     f,
-                    "Data race detected between {} on {} and {} on {} at {:?}. The {} is here",
-                    op1.action, op1.thread_info, op2.action, op2.thread_info, ptr, op1.action
+                    "Data race detected between (1) {} on {} and (2) {} on {} at {ptr:?}. (1) just happened here",
+                    op1.action, op1.thread_info, op2.action, op2.thread_info
                 ),
         }
     }
@@ -224,7 +224,7 @@ pub fn report_error<'tcx, 'mir>(
                 vec![(None, format!("use Strict Provenance APIs (https://doc.rust-lang.org/nightly/std/ptr/index.html#strict-provenance, https://crates.io/crates/sptr) instead"))],
             DataRace { op2, .. } =>
                 vec![
-                    (Some(op2.span), format!("and the {} on {} is here", op2.action, op2.thread_info)),
+                    (Some(op2.span), format!("and (2) occurred earlier here")),
                     (None, format!("this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior")),
                     (None, format!("see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information")),
                 ],

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -362,9 +362,11 @@ fn report_msg<'tcx>(
     }
 
     // Show note and help messages.
+    let mut extra_span = false;
     for (span_data, note) in &notes {
         if let Some(span_data) = span_data {
             err.span_note(span_data.span(), note);
+            extra_span = true;
         } else {
             err.note(note);
         }
@@ -372,13 +374,14 @@ fn report_msg<'tcx>(
     for (span_data, help) in &helps {
         if let Some(span_data) = span_data {
             err.span_help(span_data.span(), help);
+            extra_span = true;
         } else {
             err.help(help);
         }
     }
     if notes.len() + helps.len() > 0 {
         // Add visual separator before backtrace.
-        err.note("BACKTRACE:");
+        err.note(if extra_span { "BACKTRACE (of the first span):" } else { "BACKTRACE:" });
     }
     // Add backtrace
     for (idx, frame_info) in stacktrace.iter().enumerate() {

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -69,8 +69,8 @@ impl fmt::Display for TerminationInfo {
             DataRace { ptr, op1, op2 } =>
                 write!(
                     f,
-                    "Data race detected between {} on {} and {} on {} at {:?}",
-                    op1.action, op1.thread_info, op2.action, op2.thread_info, ptr,
+                    "Data race detected between {} on {} and {} on {} at {:?}. The {} is here",
+                    op1.action, op1.thread_info, op2.action, op2.thread_info, ptr, op1.action
                 ),
         }
     }
@@ -222,10 +222,9 @@ pub fn report_error<'tcx, 'mir>(
                 vec![(Some(*span), format!("the `{link_name}` symbol is defined here"))],
             Int2PtrWithStrictProvenance =>
                 vec![(None, format!("use Strict Provenance APIs (https://doc.rust-lang.org/nightly/std/ptr/index.html#strict-provenance, https://crates.io/crates/sptr) instead"))],
-            DataRace { ptr: _, op1, op2 } =>
+            DataRace { op2, .. } =>
                 vec![
-                    (Some(op1.span), format!("The {} on {} is here", op1.action, op1.thread_info)),
-                    (Some(op2.span), format!("The {} on {} is here", op2.action, op2.thread_info)),
+                    (Some(op2.span), format!("and {} on {}, which is here", op2.action, op2.thread_info)),
                     (None, format!("this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior")),
                     (None, format!("see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information")),
                 ],

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -69,7 +69,7 @@ impl fmt::Display for TerminationInfo {
             DataRace { ptr, op1, op2 } =>
                 write!(
                     f,
-                    "Data race detected between (1) {} on {} and (2) {} on {} at {ptr:?}. (1) just happened here",
+                    "Data race detected between (1) {} on {} and (2) {} on {} at {ptr:?}. (2) just happened here",
                     op1.action, op1.thread_info, op2.action, op2.thread_info
                 ),
         }
@@ -222,9 +222,9 @@ pub fn report_error<'tcx, 'mir>(
                 vec![(Some(*span), format!("the `{link_name}` symbol is defined here"))],
             Int2PtrWithStrictProvenance =>
                 vec![(None, format!("use Strict Provenance APIs (https://doc.rust-lang.org/nightly/std/ptr/index.html#strict-provenance, https://crates.io/crates/sptr) instead"))],
-            DataRace { op2, .. } =>
+            DataRace { op1, .. } =>
                 vec![
-                    (Some(op2.span), format!("and (2) occurred earlier here")),
+                    (Some(op1.span), format!("and (1) occurred earlier here")),
                     (None, format!("this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior")),
                     (None, format!("see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information")),
                 ],

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -224,7 +224,7 @@ pub fn report_error<'tcx, 'mir>(
                 vec![(None, format!("use Strict Provenance APIs (https://doc.rust-lang.org/nightly/std/ptr/index.html#strict-provenance, https://crates.io/crates/sptr) instead"))],
             DataRace { op2, .. } =>
                 vec![
-                    (Some(op2.span), format!("and {} on {}, which is here", op2.action, op2.thread_info)),
+                    (Some(op2.span), format!("and the {} on {} is here", op2.action, op2.thread_info)),
                     (None, format!("this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior")),
                     (None, format!("see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information")),
                 ],

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -956,6 +956,7 @@ impl<'mir, 'tcx> Machine<'mir, 'tcx> for MiriMachine<'mir, 'tcx> {
                 &ecx.machine.threads,
                 alloc.size(),
                 kind,
+                ecx.machine.current_span(),
             )
         });
         let buffer_alloc = ecx.machine.weak_memory.then(weak_memory::AllocState::new_allocation);

--- a/tests/fail/box-cell-alias.stderr
+++ b/tests/fail/box-cell-alias.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x1] by a Unique retag
    |
 LL |     let res = helper(val, ptr);
    |                      ^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `helper` at $DIR/box-cell-alias.rs:LL:CC
 note: inside `main`
   --> $DIR/box-cell-alias.rs:LL:CC

--- a/tests/fail/data_race/alloc_read_race.rs
+++ b/tests/fail/data_race/alloc_read_race.rs
@@ -37,7 +37,7 @@ pub fn main() {
             let pointer = &*ptr.0;
 
             // Note: could also error due to reading uninitialized memory, but the data-race detector triggers first.
-            *pointer.load(Ordering::Relaxed) //~ ERROR: Data race detected between Read on thread `<unnamed>` and Allocate on thread `<unnamed>`
+            *pointer.load(Ordering::Relaxed) //~ ERROR: Data race detected between (1) Read on thread `<unnamed>` and (2) Allocate on thread `<unnamed>`
         });
 
         j1.join().unwrap();

--- a/tests/fail/data_race/alloc_read_race.rs
+++ b/tests/fail/data_race/alloc_read_race.rs
@@ -37,7 +37,7 @@ pub fn main() {
             let pointer = &*ptr.0;
 
             // Note: could also error due to reading uninitialized memory, but the data-race detector triggers first.
-            *pointer.load(Ordering::Relaxed) //~ ERROR: Data race detected between (1) Read on thread `<unnamed>` and (2) Allocate on thread `<unnamed>`
+            *pointer.load(Ordering::Relaxed) //~ ERROR: Data race detected between (1) Allocate on thread `<unnamed>` and (2) Read on thread `<unnamed>`
         });
 
         j1.join().unwrap();

--- a/tests/fail/data_race/alloc_read_race.stderr
+++ b/tests/fail/data_race/alloc_read_race.stderr
@@ -4,7 +4,7 @@ error: Undefined Behavior: Data race detected between Read on thread `<unnamed>`
 LL |             *pointer.load(Ordering::Relaxed)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Read on thread `<unnamed>` and Allocate on thread `<unnamed>` at ALLOC. The Read is here
    |
-help: and Allocate on thread `<unnamed>`, which is here
+help: and the Allocate on thread `<unnamed>` is here
   --> $DIR/alloc_read_race.rs:LL:CC
    |
 LL |             pointer.store(Box::into_raw(Box::new_uninit()), Ordering::Relaxed);

--- a/tests/fail/data_race/alloc_read_race.stderr
+++ b/tests/fail/data_race/alloc_read_race.stderr
@@ -1,15 +1,10 @@
-error: Undefined Behavior: Data race detected between Read on thread `<unnamed>` and Allocate on thread `<unnamed>` at ALLOC
+error: Undefined Behavior: Data race detected between Read on thread `<unnamed>` and Allocate on thread `<unnamed>` at ALLOC. The Read is here
   --> $DIR/alloc_read_race.rs:LL:CC
    |
 LL |             *pointer.load(Ordering::Relaxed)
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Read on thread `<unnamed>` and Allocate on thread `<unnamed>` at ALLOC
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Read on thread `<unnamed>` and Allocate on thread `<unnamed>` at ALLOC. The Read is here
    |
-help: The Read on thread `<unnamed>` is here
-  --> $DIR/alloc_read_race.rs:LL:CC
-   |
-LL | ...   *pointer.load(Ordering::Relaxed)
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: The Allocate on thread `<unnamed>` is here
+help: and Allocate on thread `<unnamed>`, which is here
   --> $DIR/alloc_read_race.rs:LL:CC
    |
 LL |             pointer.store(Box::into_raw(Box::new_uninit()), Ordering::Relaxed);

--- a/tests/fail/data_race/alloc_read_race.stderr
+++ b/tests/fail/data_race/alloc_read_race.stderr
@@ -4,6 +4,16 @@ error: Undefined Behavior: Data race detected between Read on thread `<unnamed>`
 LL |             *pointer.load(Ordering::Relaxed)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Read on thread `<unnamed>` and Allocate on thread `<unnamed>` at ALLOC
    |
+help: The Read on thread `<unnamed>` is here
+  --> $DIR/alloc_read_race.rs:LL:CC
+   |
+LL | ...   *pointer.load(Ordering::Relaxed)
+   |                                      ^
+help: The Allocate on thread `<unnamed>` is here
+  --> $DIR/alloc_read_race.rs:LL:CC
+   |
+LL |             pointer.store(Box::into_raw(Box::new_uninit()), Ordering::Relaxed);
+   |                                         ^^^^^^^^^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/alloc_read_race.stderr
+++ b/tests/fail/data_race/alloc_read_race.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between (1) Read on thread `<unnamed>` and (2) Allocate on thread `<unnamed>` at ALLOC. (1) just happened here
+error: Undefined Behavior: Data race detected between (1) Allocate on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (2) just happened here
   --> $DIR/alloc_read_race.rs:LL:CC
    |
 LL |             *pointer.load(Ordering::Relaxed)
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between (1) Read on thread `<unnamed>` and (2) Allocate on thread `<unnamed>` at ALLOC. (1) just happened here
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between (1) Allocate on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (2) just happened here
    |
-help: and (2) occurred earlier here
+help: and (1) occurred earlier here
   --> $DIR/alloc_read_race.rs:LL:CC
    |
 LL |             pointer.store(Box::into_raw(Box::new_uninit()), Ordering::Relaxed);

--- a/tests/fail/data_race/alloc_read_race.stderr
+++ b/tests/fail/data_race/alloc_read_race.stderr
@@ -11,7 +11,7 @@ LL |             pointer.store(Box::into_raw(Box::new_uninit()), Ordering::Relax
    |                                         ^^^^^^^^^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside closure at $DIR/alloc_read_race.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/alloc_read_race.stderr
+++ b/tests/fail/data_race/alloc_read_race.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between Read on thread `<unnamed>` and Allocate on thread `<unnamed>` at ALLOC. The Read is here
+error: Undefined Behavior: Data race detected between (1) Read on thread `<unnamed>` and (2) Allocate on thread `<unnamed>` at ALLOC. (1) just happened here
   --> $DIR/alloc_read_race.rs:LL:CC
    |
 LL |             *pointer.load(Ordering::Relaxed)
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Read on thread `<unnamed>` and Allocate on thread `<unnamed>` at ALLOC. The Read is here
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between (1) Read on thread `<unnamed>` and (2) Allocate on thread `<unnamed>` at ALLOC. (1) just happened here
    |
-help: and the Allocate on thread `<unnamed>` is here
+help: and (2) occurred earlier here
   --> $DIR/alloc_read_race.rs:LL:CC
    |
 LL |             pointer.store(Box::into_raw(Box::new_uninit()), Ordering::Relaxed);

--- a/tests/fail/data_race/alloc_read_race.stderr
+++ b/tests/fail/data_race/alloc_read_race.stderr
@@ -8,7 +8,7 @@ help: The Read on thread `<unnamed>` is here
   --> $DIR/alloc_read_race.rs:LL:CC
    |
 LL | ...   *pointer.load(Ordering::Relaxed)
-   |                                      ^
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: The Allocate on thread `<unnamed>` is here
   --> $DIR/alloc_read_race.rs:LL:CC
    |

--- a/tests/fail/data_race/alloc_write_race.rs
+++ b/tests/fail/data_race/alloc_write_race.rs
@@ -35,7 +35,7 @@ pub fn main() {
 
         let j2 = spawn(move || {
             let pointer = &*ptr.0;
-            *pointer.load(Ordering::Relaxed) = 2; //~ ERROR: Data race detected between (1) Write on thread `<unnamed>` and (2) Allocate on thread `<unnamed>`
+            *pointer.load(Ordering::Relaxed) = 2; //~ ERROR: Data race detected between (1) Allocate on thread `<unnamed>` and (2) Write on thread `<unnamed>`
         });
 
         j1.join().unwrap();

--- a/tests/fail/data_race/alloc_write_race.rs
+++ b/tests/fail/data_race/alloc_write_race.rs
@@ -35,7 +35,7 @@ pub fn main() {
 
         let j2 = spawn(move || {
             let pointer = &*ptr.0;
-            *pointer.load(Ordering::Relaxed) = 2; //~ ERROR: Data race detected between Write on thread `<unnamed>` and Allocate on thread `<unnamed>`
+            *pointer.load(Ordering::Relaxed) = 2; //~ ERROR: Data race detected between (1) Write on thread `<unnamed>` and (2) Allocate on thread `<unnamed>`
         });
 
         j1.join().unwrap();

--- a/tests/fail/data_race/alloc_write_race.stderr
+++ b/tests/fail/data_race/alloc_write_race.stderr
@@ -4,7 +4,7 @@ error: Undefined Behavior: Data race detected between Write on thread `<unnamed>
 LL |             *pointer.load(Ordering::Relaxed) = 2;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Allocate on thread `<unnamed>` at ALLOC. The Write is here
    |
-help: and Allocate on thread `<unnamed>`, which is here
+help: and the Allocate on thread `<unnamed>` is here
   --> $DIR/alloc_write_race.rs:LL:CC
    |
 LL |                 .store(Box::into_raw(Box::<usize>::new_uninit()) as *mut usize, Ordering::Relaxed);

--- a/tests/fail/data_race/alloc_write_race.stderr
+++ b/tests/fail/data_race/alloc_write_race.stderr
@@ -4,6 +4,16 @@ error: Undefined Behavior: Data race detected between Write on thread `<unnamed>
 LL |             *pointer.load(Ordering::Relaxed) = 2;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Allocate on thread `<unnamed>` at ALLOC
    |
+help: The Write on thread `<unnamed>` is here
+  --> $DIR/alloc_write_race.rs:LL:CC
+   |
+LL | ...   *pointer.load(Ordering::Relaxed) = 2;
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: The Allocate on thread `<unnamed>` is here
+  --> $DIR/alloc_write_race.rs:LL:CC
+   |
+LL |                 .store(Box::into_raw(Box::<usize>::new_uninit()) as *mut usize, Ordering::Relaxed);
+   |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/alloc_write_race.stderr
+++ b/tests/fail/data_race/alloc_write_race.stderr
@@ -11,7 +11,7 @@ LL |                 .store(Box::into_raw(Box::<usize>::new_uninit()) as *mut us
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside closure at $DIR/alloc_write_race.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/alloc_write_race.stderr
+++ b/tests/fail/data_race/alloc_write_race.stderr
@@ -1,15 +1,10 @@
-error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Allocate on thread `<unnamed>` at ALLOC
+error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Allocate on thread `<unnamed>` at ALLOC. The Write is here
   --> $DIR/alloc_write_race.rs:LL:CC
    |
 LL |             *pointer.load(Ordering::Relaxed) = 2;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Allocate on thread `<unnamed>` at ALLOC
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Allocate on thread `<unnamed>` at ALLOC. The Write is here
    |
-help: The Write on thread `<unnamed>` is here
-  --> $DIR/alloc_write_race.rs:LL:CC
-   |
-LL | ...   *pointer.load(Ordering::Relaxed) = 2;
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: The Allocate on thread `<unnamed>` is here
+help: and Allocate on thread `<unnamed>`, which is here
   --> $DIR/alloc_write_race.rs:LL:CC
    |
 LL |                 .store(Box::into_raw(Box::<usize>::new_uninit()) as *mut usize, Ordering::Relaxed);

--- a/tests/fail/data_race/alloc_write_race.stderr
+++ b/tests/fail/data_race/alloc_write_race.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Allocate on thread `<unnamed>` at ALLOC. (1) just happened here
+error: Undefined Behavior: Data race detected between (1) Allocate on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (2) just happened here
   --> $DIR/alloc_write_race.rs:LL:CC
    |
 LL |             *pointer.load(Ordering::Relaxed) = 2;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Allocate on thread `<unnamed>` at ALLOC. (1) just happened here
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between (1) Allocate on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (2) just happened here
    |
-help: and (2) occurred earlier here
+help: and (1) occurred earlier here
   --> $DIR/alloc_write_race.rs:LL:CC
    |
 LL |                 .store(Box::into_raw(Box::<usize>::new_uninit()) as *mut usize, Ordering::Relaxed);

--- a/tests/fail/data_race/alloc_write_race.stderr
+++ b/tests/fail/data_race/alloc_write_race.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Allocate on thread `<unnamed>` at ALLOC. The Write is here
+error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Allocate on thread `<unnamed>` at ALLOC. (1) just happened here
   --> $DIR/alloc_write_race.rs:LL:CC
    |
 LL |             *pointer.load(Ordering::Relaxed) = 2;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Allocate on thread `<unnamed>` at ALLOC. The Write is here
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Allocate on thread `<unnamed>` at ALLOC. (1) just happened here
    |
-help: and the Allocate on thread `<unnamed>` is here
+help: and (2) occurred earlier here
   --> $DIR/alloc_write_race.rs:LL:CC
    |
 LL |                 .store(Box::into_raw(Box::<usize>::new_uninit()) as *mut usize, Ordering::Relaxed);

--- a/tests/fail/data_race/atomic_read_na_write_race1.rs
+++ b/tests/fail/data_race/atomic_read_na_write_race1.rs
@@ -20,7 +20,7 @@ pub fn main() {
         });
 
         let j2 = spawn(move || {
-            (&*c.0).load(Ordering::SeqCst) //~ ERROR: Data race detected between Atomic Load on thread `<unnamed>` and Write on thread `<unnamed>`
+            (&*c.0).load(Ordering::SeqCst) //~ ERROR: Data race detected between (1) Atomic Load on thread `<unnamed>` and (2) Write on thread `<unnamed>`
         });
 
         j1.join().unwrap();

--- a/tests/fail/data_race/atomic_read_na_write_race1.rs
+++ b/tests/fail/data_race/atomic_read_na_write_race1.rs
@@ -20,7 +20,7 @@ pub fn main() {
         });
 
         let j2 = spawn(move || {
-            (&*c.0).load(Ordering::SeqCst) //~ ERROR: Data race detected between (1) Atomic Load on thread `<unnamed>` and (2) Write on thread `<unnamed>`
+            (&*c.0).load(Ordering::SeqCst) //~ ERROR: Data race detected between (1) Write on thread `<unnamed>` and (2) Atomic Load on thread `<unnamed>`
         });
 
         j1.join().unwrap();

--- a/tests/fail/data_race/atomic_read_na_write_race1.stderr
+++ b/tests/fail/data_race/atomic_read_na_write_race1.stderr
@@ -4,6 +4,16 @@ error: Undefined Behavior: Data race detected between Atomic Load on thread `<un
 LL |             (&*c.0).load(Ordering::SeqCst)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Atomic Load on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
    |
+help: The Atomic Load on thread `<unnamed>` is here
+  --> $DIR/atomic_read_na_write_race1.rs:LL:CC
+   |
+LL | ...   (&*c.0).load(Ordering::SeqCst)
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: The Write on thread `<unnamed>` is here
+  --> $DIR/atomic_read_na_write_race1.rs:LL:CC
+   |
+LL |             *(c.0 as *mut usize) = 32;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/atomic_read_na_write_race1.stderr
+++ b/tests/fail/data_race/atomic_read_na_write_race1.stderr
@@ -4,7 +4,7 @@ error: Undefined Behavior: Data race detected between Atomic Load on thread `<un
 LL |             (&*c.0).load(Ordering::SeqCst)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Atomic Load on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Atomic Load is here
    |
-help: and Write on thread `<unnamed>`, which is here
+help: and the Write on thread `<unnamed>` is here
   --> $DIR/atomic_read_na_write_race1.rs:LL:CC
    |
 LL |             *(c.0 as *mut usize) = 32;

--- a/tests/fail/data_race/atomic_read_na_write_race1.stderr
+++ b/tests/fail/data_race/atomic_read_na_write_race1.stderr
@@ -11,7 +11,7 @@ LL |             *(c.0 as *mut usize) = 32;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside closure at $DIR/atomic_read_na_write_race1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/atomic_read_na_write_race1.stderr
+++ b/tests/fail/data_race/atomic_read_na_write_race1.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between (1) Atomic Load on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Atomic Load on thread `<unnamed>` at ALLOC. (2) just happened here
   --> $DIR/atomic_read_na_write_race1.rs:LL:CC
    |
 LL |             (&*c.0).load(Ordering::SeqCst)
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between (1) Atomic Load on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Atomic Load on thread `<unnamed>` at ALLOC. (2) just happened here
    |
-help: and (2) occurred earlier here
+help: and (1) occurred earlier here
   --> $DIR/atomic_read_na_write_race1.rs:LL:CC
    |
 LL |             *(c.0 as *mut usize) = 32;

--- a/tests/fail/data_race/atomic_read_na_write_race1.stderr
+++ b/tests/fail/data_race/atomic_read_na_write_race1.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between Atomic Load on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Atomic Load is here
+error: Undefined Behavior: Data race detected between (1) Atomic Load on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
   --> $DIR/atomic_read_na_write_race1.rs:LL:CC
    |
 LL |             (&*c.0).load(Ordering::SeqCst)
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Atomic Load on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Atomic Load is here
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between (1) Atomic Load on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
    |
-help: and the Write on thread `<unnamed>` is here
+help: and (2) occurred earlier here
   --> $DIR/atomic_read_na_write_race1.rs:LL:CC
    |
 LL |             *(c.0 as *mut usize) = 32;

--- a/tests/fail/data_race/atomic_read_na_write_race1.stderr
+++ b/tests/fail/data_race/atomic_read_na_write_race1.stderr
@@ -1,15 +1,10 @@
-error: Undefined Behavior: Data race detected between Atomic Load on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
+error: Undefined Behavior: Data race detected between Atomic Load on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Atomic Load is here
   --> $DIR/atomic_read_na_write_race1.rs:LL:CC
    |
 LL |             (&*c.0).load(Ordering::SeqCst)
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Atomic Load on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Atomic Load on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Atomic Load is here
    |
-help: The Atomic Load on thread `<unnamed>` is here
-  --> $DIR/atomic_read_na_write_race1.rs:LL:CC
-   |
-LL | ...   (&*c.0).load(Ordering::SeqCst)
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: The Write on thread `<unnamed>` is here
+help: and Write on thread `<unnamed>`, which is here
   --> $DIR/atomic_read_na_write_race1.rs:LL:CC
    |
 LL |             *(c.0 as *mut usize) = 32;

--- a/tests/fail/data_race/atomic_read_na_write_race2.rs
+++ b/tests/fail/data_race/atomic_read_na_write_race2.rs
@@ -23,7 +23,7 @@ pub fn main() {
 
         let j2 = spawn(move || {
             let atomic_ref = &mut *c.0;
-            *atomic_ref.get_mut() = 32; //~ ERROR: Data race detected between (1) Write on thread `<unnamed>` and (2) Atomic Load on thread `<unnamed>`
+            *atomic_ref.get_mut() = 32; //~ ERROR: Data race detected between (1) Atomic Load on thread `<unnamed>` and (2) Write on thread `<unnamed>`
         });
 
         j1.join().unwrap();

--- a/tests/fail/data_race/atomic_read_na_write_race2.rs
+++ b/tests/fail/data_race/atomic_read_na_write_race2.rs
@@ -23,7 +23,7 @@ pub fn main() {
 
         let j2 = spawn(move || {
             let atomic_ref = &mut *c.0;
-            *atomic_ref.get_mut() = 32; //~ ERROR: Data race detected between Write on thread `<unnamed>` and Atomic Load on thread `<unnamed>`
+            *atomic_ref.get_mut() = 32; //~ ERROR: Data race detected between (1) Write on thread `<unnamed>` and (2) Atomic Load on thread `<unnamed>`
         });
 
         j1.join().unwrap();

--- a/tests/fail/data_race/atomic_read_na_write_race2.stderr
+++ b/tests/fail/data_race/atomic_read_na_write_race2.stderr
@@ -4,7 +4,7 @@ error: Undefined Behavior: Data race detected between Write on thread `<unnamed>
 LL |             *atomic_ref.get_mut() = 32;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Atomic Load on thread `<unnamed>` at ALLOC. The Write is here
    |
-help: and Atomic Load on thread `<unnamed>`, which is here
+help: and the Atomic Load on thread `<unnamed>` is here
   --> $DIR/atomic_read_na_write_race2.rs:LL:CC
    |
 LL |             atomic_ref.load(Ordering::SeqCst)

--- a/tests/fail/data_race/atomic_read_na_write_race2.stderr
+++ b/tests/fail/data_race/atomic_read_na_write_race2.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Atomic Load on thread `<unnamed>` at ALLOC. (1) just happened here
+error: Undefined Behavior: Data race detected between (1) Atomic Load on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (2) just happened here
   --> $DIR/atomic_read_na_write_race2.rs:LL:CC
    |
 LL |             *atomic_ref.get_mut() = 32;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Atomic Load on thread `<unnamed>` at ALLOC. (1) just happened here
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between (1) Atomic Load on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (2) just happened here
    |
-help: and (2) occurred earlier here
+help: and (1) occurred earlier here
   --> $DIR/atomic_read_na_write_race2.rs:LL:CC
    |
 LL |             atomic_ref.load(Ordering::SeqCst)

--- a/tests/fail/data_race/atomic_read_na_write_race2.stderr
+++ b/tests/fail/data_race/atomic_read_na_write_race2.stderr
@@ -4,6 +4,16 @@ error: Undefined Behavior: Data race detected between Write on thread `<unnamed>
 LL |             *atomic_ref.get_mut() = 32;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Atomic Load on thread `<unnamed>` at ALLOC
    |
+help: The Write on thread `<unnamed>` is here
+  --> $DIR/atomic_read_na_write_race2.rs:LL:CC
+   |
+LL | ...   *atomic_ref.get_mut() = 32;
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: The Atomic Load on thread `<unnamed>` is here
+  --> $DIR/atomic_read_na_write_race2.rs:LL:CC
+   |
+LL |             atomic_ref.load(Ordering::SeqCst)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/atomic_read_na_write_race2.stderr
+++ b/tests/fail/data_race/atomic_read_na_write_race2.stderr
@@ -11,7 +11,7 @@ LL |             atomic_ref.load(Ordering::SeqCst)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside closure at $DIR/atomic_read_na_write_race2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/atomic_read_na_write_race2.stderr
+++ b/tests/fail/data_race/atomic_read_na_write_race2.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Atomic Load on thread `<unnamed>` at ALLOC. The Write is here
+error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Atomic Load on thread `<unnamed>` at ALLOC. (1) just happened here
   --> $DIR/atomic_read_na_write_race2.rs:LL:CC
    |
 LL |             *atomic_ref.get_mut() = 32;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Atomic Load on thread `<unnamed>` at ALLOC. The Write is here
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Atomic Load on thread `<unnamed>` at ALLOC. (1) just happened here
    |
-help: and the Atomic Load on thread `<unnamed>` is here
+help: and (2) occurred earlier here
   --> $DIR/atomic_read_na_write_race2.rs:LL:CC
    |
 LL |             atomic_ref.load(Ordering::SeqCst)

--- a/tests/fail/data_race/atomic_read_na_write_race2.stderr
+++ b/tests/fail/data_race/atomic_read_na_write_race2.stderr
@@ -1,15 +1,10 @@
-error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Atomic Load on thread `<unnamed>` at ALLOC
+error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Atomic Load on thread `<unnamed>` at ALLOC. The Write is here
   --> $DIR/atomic_read_na_write_race2.rs:LL:CC
    |
 LL |             *atomic_ref.get_mut() = 32;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Atomic Load on thread `<unnamed>` at ALLOC
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Atomic Load on thread `<unnamed>` at ALLOC. The Write is here
    |
-help: The Write on thread `<unnamed>` is here
-  --> $DIR/atomic_read_na_write_race2.rs:LL:CC
-   |
-LL | ...   *atomic_ref.get_mut() = 32;
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: The Atomic Load on thread `<unnamed>` is here
+help: and Atomic Load on thread `<unnamed>`, which is here
   --> $DIR/atomic_read_na_write_race2.rs:LL:CC
    |
 LL |             atomic_ref.load(Ordering::SeqCst)

--- a/tests/fail/data_race/atomic_write_na_read_race1.rs
+++ b/tests/fail/data_race/atomic_write_na_read_race1.rs
@@ -23,7 +23,7 @@ pub fn main() {
 
         let j2 = spawn(move || {
             let atomic_ref = &mut *c.0;
-            *atomic_ref.get_mut() //~ ERROR: Data race detected between Read on thread `<unnamed>` and Atomic Store on thread `<unnamed>`
+            *atomic_ref.get_mut() //~ ERROR: Data race detected between (1) Read on thread `<unnamed>` and (2) Atomic Store on thread `<unnamed>`
         });
 
         j1.join().unwrap();

--- a/tests/fail/data_race/atomic_write_na_read_race1.rs
+++ b/tests/fail/data_race/atomic_write_na_read_race1.rs
@@ -23,7 +23,7 @@ pub fn main() {
 
         let j2 = spawn(move || {
             let atomic_ref = &mut *c.0;
-            *atomic_ref.get_mut() //~ ERROR: Data race detected between (1) Read on thread `<unnamed>` and (2) Atomic Store on thread `<unnamed>`
+            *atomic_ref.get_mut() //~ ERROR: Data race detected between (1) Atomic Store on thread `<unnamed>` and (2) Read on thread `<unnamed>`
         });
 
         j1.join().unwrap();

--- a/tests/fail/data_race/atomic_write_na_read_race1.stderr
+++ b/tests/fail/data_race/atomic_write_na_read_race1.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between Read on thread `<unnamed>` and Atomic Store on thread `<unnamed>` at ALLOC. The Read is here
+error: Undefined Behavior: Data race detected between (1) Read on thread `<unnamed>` and (2) Atomic Store on thread `<unnamed>` at ALLOC. (1) just happened here
   --> $DIR/atomic_write_na_read_race1.rs:LL:CC
    |
 LL |             *atomic_ref.get_mut()
-   |             ^^^^^^^^^^^^^^^^^^^^^ Data race detected between Read on thread `<unnamed>` and Atomic Store on thread `<unnamed>` at ALLOC. The Read is here
+   |             ^^^^^^^^^^^^^^^^^^^^^ Data race detected between (1) Read on thread `<unnamed>` and (2) Atomic Store on thread `<unnamed>` at ALLOC. (1) just happened here
    |
-help: and the Atomic Store on thread `<unnamed>` is here
+help: and (2) occurred earlier here
   --> $DIR/atomic_write_na_read_race1.rs:LL:CC
    |
 LL |             atomic_ref.store(32, Ordering::SeqCst)

--- a/tests/fail/data_race/atomic_write_na_read_race1.stderr
+++ b/tests/fail/data_race/atomic_write_na_read_race1.stderr
@@ -11,7 +11,7 @@ LL |             atomic_ref.store(32, Ordering::SeqCst)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside closure at $DIR/atomic_write_na_read_race1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/atomic_write_na_read_race1.stderr
+++ b/tests/fail/data_race/atomic_write_na_read_race1.stderr
@@ -5,10 +5,10 @@ LL |             *atomic_ref.get_mut()
    |             ^^^^^^^^^^^^^^^^^^^^^ Data race detected between Read on thread `<unnamed>` and Atomic Store on thread `<unnamed>` at ALLOC
    |
 help: The Read on thread `<unnamed>` is here
-  --> RUSTLIB/core/src/ptr/mod.rs:LL:CC
+  --> $DIR/atomic_write_na_read_race1.rs:LL:CC
    |
-LL | }
-   | ^
+LL |             *atomic_ref.get_mut()
+   |             ^^^^^^^^^^^^^^^^^^^^^
 help: The Atomic Store on thread `<unnamed>` is here
   --> $DIR/atomic_write_na_read_race1.rs:LL:CC
    |

--- a/tests/fail/data_race/atomic_write_na_read_race1.stderr
+++ b/tests/fail/data_race/atomic_write_na_read_race1.stderr
@@ -4,6 +4,16 @@ error: Undefined Behavior: Data race detected between Read on thread `<unnamed>`
 LL |             *atomic_ref.get_mut()
    |             ^^^^^^^^^^^^^^^^^^^^^ Data race detected between Read on thread `<unnamed>` and Atomic Store on thread `<unnamed>` at ALLOC
    |
+help: The Read on thread `<unnamed>` is here
+  --> RUSTLIB/core/src/ptr/mod.rs:LL:CC
+   |
+LL | }
+   | ^
+help: The Atomic Store on thread `<unnamed>` is here
+  --> $DIR/atomic_write_na_read_race1.rs:LL:CC
+   |
+LL |             atomic_ref.store(32, Ordering::SeqCst)
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/atomic_write_na_read_race1.stderr
+++ b/tests/fail/data_race/atomic_write_na_read_race1.stderr
@@ -4,7 +4,7 @@ error: Undefined Behavior: Data race detected between Read on thread `<unnamed>`
 LL |             *atomic_ref.get_mut()
    |             ^^^^^^^^^^^^^^^^^^^^^ Data race detected between Read on thread `<unnamed>` and Atomic Store on thread `<unnamed>` at ALLOC. The Read is here
    |
-help: and Atomic Store on thread `<unnamed>`, which is here
+help: and the Atomic Store on thread `<unnamed>` is here
   --> $DIR/atomic_write_na_read_race1.rs:LL:CC
    |
 LL |             atomic_ref.store(32, Ordering::SeqCst)

--- a/tests/fail/data_race/atomic_write_na_read_race1.stderr
+++ b/tests/fail/data_race/atomic_write_na_read_race1.stderr
@@ -1,15 +1,10 @@
-error: Undefined Behavior: Data race detected between Read on thread `<unnamed>` and Atomic Store on thread `<unnamed>` at ALLOC
+error: Undefined Behavior: Data race detected between Read on thread `<unnamed>` and Atomic Store on thread `<unnamed>` at ALLOC. The Read is here
   --> $DIR/atomic_write_na_read_race1.rs:LL:CC
    |
 LL |             *atomic_ref.get_mut()
-   |             ^^^^^^^^^^^^^^^^^^^^^ Data race detected between Read on thread `<unnamed>` and Atomic Store on thread `<unnamed>` at ALLOC
+   |             ^^^^^^^^^^^^^^^^^^^^^ Data race detected between Read on thread `<unnamed>` and Atomic Store on thread `<unnamed>` at ALLOC. The Read is here
    |
-help: The Read on thread `<unnamed>` is here
-  --> $DIR/atomic_write_na_read_race1.rs:LL:CC
-   |
-LL |             *atomic_ref.get_mut()
-   |             ^^^^^^^^^^^^^^^^^^^^^
-help: The Atomic Store on thread `<unnamed>` is here
+help: and Atomic Store on thread `<unnamed>`, which is here
   --> $DIR/atomic_write_na_read_race1.rs:LL:CC
    |
 LL |             atomic_ref.store(32, Ordering::SeqCst)

--- a/tests/fail/data_race/atomic_write_na_read_race1.stderr
+++ b/tests/fail/data_race/atomic_write_na_read_race1.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between (1) Read on thread `<unnamed>` and (2) Atomic Store on thread `<unnamed>` at ALLOC. (1) just happened here
+error: Undefined Behavior: Data race detected between (1) Atomic Store on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (2) just happened here
   --> $DIR/atomic_write_na_read_race1.rs:LL:CC
    |
 LL |             *atomic_ref.get_mut()
-   |             ^^^^^^^^^^^^^^^^^^^^^ Data race detected between (1) Read on thread `<unnamed>` and (2) Atomic Store on thread `<unnamed>` at ALLOC. (1) just happened here
+   |             ^^^^^^^^^^^^^^^^^^^^^ Data race detected between (1) Atomic Store on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (2) just happened here
    |
-help: and (2) occurred earlier here
+help: and (1) occurred earlier here
   --> $DIR/atomic_write_na_read_race1.rs:LL:CC
    |
 LL |             atomic_ref.store(32, Ordering::SeqCst)

--- a/tests/fail/data_race/atomic_write_na_read_race2.rs
+++ b/tests/fail/data_race/atomic_write_na_read_race2.rs
@@ -20,7 +20,7 @@ pub fn main() {
         });
 
         let j2 = spawn(move || {
-            (&*c.0).store(32, Ordering::SeqCst); //~ ERROR: Data race detected between (1) Atomic Store on thread `<unnamed>` and (2) Read on thread `<unnamed>`
+            (&*c.0).store(32, Ordering::SeqCst); //~ ERROR: Data race detected between (1) Read on thread `<unnamed>` and (2) Atomic Store on thread `<unnamed>`
         });
 
         j1.join().unwrap();

--- a/tests/fail/data_race/atomic_write_na_read_race2.rs
+++ b/tests/fail/data_race/atomic_write_na_read_race2.rs
@@ -20,7 +20,7 @@ pub fn main() {
         });
 
         let j2 = spawn(move || {
-            (&*c.0).store(32, Ordering::SeqCst); //~ ERROR: Data race detected between Atomic Store on thread `<unnamed>` and Read on thread `<unnamed>`
+            (&*c.0).store(32, Ordering::SeqCst); //~ ERROR: Data race detected between (1) Atomic Store on thread `<unnamed>` and (2) Read on thread `<unnamed>`
         });
 
         j1.join().unwrap();

--- a/tests/fail/data_race/atomic_write_na_read_race2.stderr
+++ b/tests/fail/data_race/atomic_write_na_read_race2.stderr
@@ -4,7 +4,7 @@ error: Undefined Behavior: Data race detected between Atomic Store on thread `<u
 LL |             (&*c.0).store(32, Ordering::SeqCst);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Atomic Store on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC. The Atomic Store is here
    |
-help: and Read on thread `<unnamed>`, which is here
+help: and the Read on thread `<unnamed>` is here
   --> $DIR/atomic_write_na_read_race2.rs:LL:CC
    |
 LL |             let _val = *(c.0 as *mut usize);

--- a/tests/fail/data_race/atomic_write_na_read_race2.stderr
+++ b/tests/fail/data_race/atomic_write_na_read_race2.stderr
@@ -11,7 +11,7 @@ LL |             let _val = *(c.0 as *mut usize);
    |                        ^^^^^^^^^^^^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside closure at $DIR/atomic_write_na_read_race2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/atomic_write_na_read_race2.stderr
+++ b/tests/fail/data_race/atomic_write_na_read_race2.stderr
@@ -4,6 +4,16 @@ error: Undefined Behavior: Data race detected between Atomic Store on thread `<u
 LL |             (&*c.0).store(32, Ordering::SeqCst);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Atomic Store on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC
    |
+help: The Atomic Store on thread `<unnamed>` is here
+  --> $DIR/atomic_write_na_read_race2.rs:LL:CC
+   |
+LL | ...   (&*c.0).store(32, Ordering::SeqCst);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: The Read on thread `<unnamed>` is here
+  --> RUSTLIB/core/src/ptr/mod.rs:LL:CC
+   |
+LL | }
+   | ^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/atomic_write_na_read_race2.stderr
+++ b/tests/fail/data_race/atomic_write_na_read_race2.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between Atomic Store on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC. The Atomic Store is here
+error: Undefined Behavior: Data race detected between (1) Atomic Store on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (1) just happened here
   --> $DIR/atomic_write_na_read_race2.rs:LL:CC
    |
 LL |             (&*c.0).store(32, Ordering::SeqCst);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Atomic Store on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC. The Atomic Store is here
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between (1) Atomic Store on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (1) just happened here
    |
-help: and the Read on thread `<unnamed>` is here
+help: and (2) occurred earlier here
   --> $DIR/atomic_write_na_read_race2.rs:LL:CC
    |
 LL |             let _val = *(c.0 as *mut usize);

--- a/tests/fail/data_race/atomic_write_na_read_race2.stderr
+++ b/tests/fail/data_race/atomic_write_na_read_race2.stderr
@@ -10,10 +10,10 @@ help: The Atomic Store on thread `<unnamed>` is here
 LL | ...   (&*c.0).store(32, Ordering::SeqCst);
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: The Read on thread `<unnamed>` is here
-  --> RUSTLIB/core/src/ptr/mod.rs:LL:CC
+  --> $DIR/atomic_write_na_read_race2.rs:LL:CC
    |
-LL | }
-   | ^
+LL |             let _val = *(c.0 as *mut usize);
+   |                        ^^^^^^^^^^^^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/atomic_write_na_read_race2.stderr
+++ b/tests/fail/data_race/atomic_write_na_read_race2.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between (1) Atomic Store on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (1) just happened here
+error: Undefined Behavior: Data race detected between (1) Read on thread `<unnamed>` and (2) Atomic Store on thread `<unnamed>` at ALLOC. (2) just happened here
   --> $DIR/atomic_write_na_read_race2.rs:LL:CC
    |
 LL |             (&*c.0).store(32, Ordering::SeqCst);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between (1) Atomic Store on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (1) just happened here
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between (1) Read on thread `<unnamed>` and (2) Atomic Store on thread `<unnamed>` at ALLOC. (2) just happened here
    |
-help: and (2) occurred earlier here
+help: and (1) occurred earlier here
   --> $DIR/atomic_write_na_read_race2.rs:LL:CC
    |
 LL |             let _val = *(c.0 as *mut usize);

--- a/tests/fail/data_race/atomic_write_na_read_race2.stderr
+++ b/tests/fail/data_race/atomic_write_na_read_race2.stderr
@@ -1,15 +1,10 @@
-error: Undefined Behavior: Data race detected between Atomic Store on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC
+error: Undefined Behavior: Data race detected between Atomic Store on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC. The Atomic Store is here
   --> $DIR/atomic_write_na_read_race2.rs:LL:CC
    |
 LL |             (&*c.0).store(32, Ordering::SeqCst);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Atomic Store on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Atomic Store on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC. The Atomic Store is here
    |
-help: The Atomic Store on thread `<unnamed>` is here
-  --> $DIR/atomic_write_na_read_race2.rs:LL:CC
-   |
-LL | ...   (&*c.0).store(32, Ordering::SeqCst);
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: The Read on thread `<unnamed>` is here
+help: and Read on thread `<unnamed>`, which is here
   --> $DIR/atomic_write_na_read_race2.rs:LL:CC
    |
 LL |             let _val = *(c.0 as *mut usize);

--- a/tests/fail/data_race/atomic_write_na_write_race1.rs
+++ b/tests/fail/data_race/atomic_write_na_write_race1.rs
@@ -20,7 +20,7 @@ pub fn main() {
         });
 
         let j2 = spawn(move || {
-            (&*c.0).store(64, Ordering::SeqCst); //~ ERROR: Data race detected between Atomic Store on thread `<unnamed>` and Write on thread `<unnamed>`
+            (&*c.0).store(64, Ordering::SeqCst); //~ ERROR: Data race detected between (1) Atomic Store on thread `<unnamed>` and (2) Write on thread `<unnamed>`
         });
 
         j1.join().unwrap();

--- a/tests/fail/data_race/atomic_write_na_write_race1.rs
+++ b/tests/fail/data_race/atomic_write_na_write_race1.rs
@@ -20,7 +20,7 @@ pub fn main() {
         });
 
         let j2 = spawn(move || {
-            (&*c.0).store(64, Ordering::SeqCst); //~ ERROR: Data race detected between (1) Atomic Store on thread `<unnamed>` and (2) Write on thread `<unnamed>`
+            (&*c.0).store(64, Ordering::SeqCst); //~ ERROR: Data race detected between (1) Write on thread `<unnamed>` and (2) Atomic Store on thread `<unnamed>`
         });
 
         j1.join().unwrap();

--- a/tests/fail/data_race/atomic_write_na_write_race1.stderr
+++ b/tests/fail/data_race/atomic_write_na_write_race1.stderr
@@ -4,6 +4,16 @@ error: Undefined Behavior: Data race detected between Atomic Store on thread `<u
 LL |             (&*c.0).store(64, Ordering::SeqCst);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Atomic Store on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
    |
+help: The Atomic Store on thread `<unnamed>` is here
+  --> $DIR/atomic_write_na_write_race1.rs:LL:CC
+   |
+LL | ...   (&*c.0).store(64, Ordering::SeqCst);
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: The Write on thread `<unnamed>` is here
+  --> $DIR/atomic_write_na_write_race1.rs:LL:CC
+   |
+LL |             *(c.0 as *mut usize) = 32;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/atomic_write_na_write_race1.stderr
+++ b/tests/fail/data_race/atomic_write_na_write_race1.stderr
@@ -4,7 +4,7 @@ error: Undefined Behavior: Data race detected between Atomic Store on thread `<u
 LL |             (&*c.0).store(64, Ordering::SeqCst);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Atomic Store on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Atomic Store is here
    |
-help: and Write on thread `<unnamed>`, which is here
+help: and the Write on thread `<unnamed>` is here
   --> $DIR/atomic_write_na_write_race1.rs:LL:CC
    |
 LL |             *(c.0 as *mut usize) = 32;

--- a/tests/fail/data_race/atomic_write_na_write_race1.stderr
+++ b/tests/fail/data_race/atomic_write_na_write_race1.stderr
@@ -11,7 +11,7 @@ LL |             *(c.0 as *mut usize) = 32;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside closure at $DIR/atomic_write_na_write_race1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/atomic_write_na_write_race1.stderr
+++ b/tests/fail/data_race/atomic_write_na_write_race1.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between (1) Atomic Store on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Atomic Store on thread `<unnamed>` at ALLOC. (2) just happened here
   --> $DIR/atomic_write_na_write_race1.rs:LL:CC
    |
 LL |             (&*c.0).store(64, Ordering::SeqCst);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between (1) Atomic Store on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Atomic Store on thread `<unnamed>` at ALLOC. (2) just happened here
    |
-help: and (2) occurred earlier here
+help: and (1) occurred earlier here
   --> $DIR/atomic_write_na_write_race1.rs:LL:CC
    |
 LL |             *(c.0 as *mut usize) = 32;

--- a/tests/fail/data_race/atomic_write_na_write_race1.stderr
+++ b/tests/fail/data_race/atomic_write_na_write_race1.stderr
@@ -1,15 +1,10 @@
-error: Undefined Behavior: Data race detected between Atomic Store on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
+error: Undefined Behavior: Data race detected between Atomic Store on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Atomic Store is here
   --> $DIR/atomic_write_na_write_race1.rs:LL:CC
    |
 LL |             (&*c.0).store(64, Ordering::SeqCst);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Atomic Store on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Atomic Store on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Atomic Store is here
    |
-help: The Atomic Store on thread `<unnamed>` is here
-  --> $DIR/atomic_write_na_write_race1.rs:LL:CC
-   |
-LL | ...   (&*c.0).store(64, Ordering::SeqCst);
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: The Write on thread `<unnamed>` is here
+help: and Write on thread `<unnamed>`, which is here
   --> $DIR/atomic_write_na_write_race1.rs:LL:CC
    |
 LL |             *(c.0 as *mut usize) = 32;

--- a/tests/fail/data_race/atomic_write_na_write_race1.stderr
+++ b/tests/fail/data_race/atomic_write_na_write_race1.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between Atomic Store on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Atomic Store is here
+error: Undefined Behavior: Data race detected between (1) Atomic Store on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
   --> $DIR/atomic_write_na_write_race1.rs:LL:CC
    |
 LL |             (&*c.0).store(64, Ordering::SeqCst);
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Atomic Store on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Atomic Store is here
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between (1) Atomic Store on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
    |
-help: and the Write on thread `<unnamed>` is here
+help: and (2) occurred earlier here
   --> $DIR/atomic_write_na_write_race1.rs:LL:CC
    |
 LL |             *(c.0 as *mut usize) = 32;

--- a/tests/fail/data_race/atomic_write_na_write_race2.rs
+++ b/tests/fail/data_race/atomic_write_na_write_race2.rs
@@ -23,7 +23,7 @@ pub fn main() {
 
         let j2 = spawn(move || {
             let atomic_ref = &mut *c.0;
-            *atomic_ref.get_mut() = 32; //~ ERROR: Data race detected between (1) Write on thread `<unnamed>` and (2) Atomic Store on thread `<unnamed>`
+            *atomic_ref.get_mut() = 32; //~ ERROR: Data race detected between (1) Atomic Store on thread `<unnamed>` and (2) Write on thread `<unnamed>`
         });
 
         j1.join().unwrap();

--- a/tests/fail/data_race/atomic_write_na_write_race2.rs
+++ b/tests/fail/data_race/atomic_write_na_write_race2.rs
@@ -23,7 +23,7 @@ pub fn main() {
 
         let j2 = spawn(move || {
             let atomic_ref = &mut *c.0;
-            *atomic_ref.get_mut() = 32; //~ ERROR: Data race detected between Write on thread `<unnamed>` and Atomic Store on thread `<unnamed>`
+            *atomic_ref.get_mut() = 32; //~ ERROR: Data race detected between (1) Write on thread `<unnamed>` and (2) Atomic Store on thread `<unnamed>`
         });
 
         j1.join().unwrap();

--- a/tests/fail/data_race/atomic_write_na_write_race2.stderr
+++ b/tests/fail/data_race/atomic_write_na_write_race2.stderr
@@ -11,7 +11,7 @@ LL |             atomic_ref.store(64, Ordering::SeqCst);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside closure at $DIR/atomic_write_na_write_race2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/atomic_write_na_write_race2.stderr
+++ b/tests/fail/data_race/atomic_write_na_write_race2.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Atomic Store on thread `<unnamed>` at ALLOC. The Write is here
+error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Atomic Store on thread `<unnamed>` at ALLOC. (1) just happened here
   --> $DIR/atomic_write_na_write_race2.rs:LL:CC
    |
 LL |             *atomic_ref.get_mut() = 32;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Atomic Store on thread `<unnamed>` at ALLOC. The Write is here
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Atomic Store on thread `<unnamed>` at ALLOC. (1) just happened here
    |
-help: and the Atomic Store on thread `<unnamed>` is here
+help: and (2) occurred earlier here
   --> $DIR/atomic_write_na_write_race2.rs:LL:CC
    |
 LL |             atomic_ref.store(64, Ordering::SeqCst);

--- a/tests/fail/data_race/atomic_write_na_write_race2.stderr
+++ b/tests/fail/data_race/atomic_write_na_write_race2.stderr
@@ -4,7 +4,7 @@ error: Undefined Behavior: Data race detected between Write on thread `<unnamed>
 LL |             *atomic_ref.get_mut() = 32;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Atomic Store on thread `<unnamed>` at ALLOC. The Write is here
    |
-help: and Atomic Store on thread `<unnamed>`, which is here
+help: and the Atomic Store on thread `<unnamed>` is here
   --> $DIR/atomic_write_na_write_race2.rs:LL:CC
    |
 LL |             atomic_ref.store(64, Ordering::SeqCst);

--- a/tests/fail/data_race/atomic_write_na_write_race2.stderr
+++ b/tests/fail/data_race/atomic_write_na_write_race2.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Atomic Store on thread `<unnamed>` at ALLOC. (1) just happened here
+error: Undefined Behavior: Data race detected between (1) Atomic Store on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (2) just happened here
   --> $DIR/atomic_write_na_write_race2.rs:LL:CC
    |
 LL |             *atomic_ref.get_mut() = 32;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Atomic Store on thread `<unnamed>` at ALLOC. (1) just happened here
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between (1) Atomic Store on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (2) just happened here
    |
-help: and (2) occurred earlier here
+help: and (1) occurred earlier here
   --> $DIR/atomic_write_na_write_race2.rs:LL:CC
    |
 LL |             atomic_ref.store(64, Ordering::SeqCst);

--- a/tests/fail/data_race/atomic_write_na_write_race2.stderr
+++ b/tests/fail/data_race/atomic_write_na_write_race2.stderr
@@ -4,6 +4,16 @@ error: Undefined Behavior: Data race detected between Write on thread `<unnamed>
 LL |             *atomic_ref.get_mut() = 32;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Atomic Store on thread `<unnamed>` at ALLOC
    |
+help: The Write on thread `<unnamed>` is here
+  --> $DIR/atomic_write_na_write_race2.rs:LL:CC
+   |
+LL | ...   *atomic_ref.get_mut() = 32;
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: The Atomic Store on thread `<unnamed>` is here
+  --> $DIR/atomic_write_na_write_race2.rs:LL:CC
+   |
+LL |             atomic_ref.store(64, Ordering::SeqCst);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/atomic_write_na_write_race2.stderr
+++ b/tests/fail/data_race/atomic_write_na_write_race2.stderr
@@ -1,15 +1,10 @@
-error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Atomic Store on thread `<unnamed>` at ALLOC
+error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Atomic Store on thread `<unnamed>` at ALLOC. The Write is here
   --> $DIR/atomic_write_na_write_race2.rs:LL:CC
    |
 LL |             *atomic_ref.get_mut() = 32;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Atomic Store on thread `<unnamed>` at ALLOC
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Atomic Store on thread `<unnamed>` at ALLOC. The Write is here
    |
-help: The Write on thread `<unnamed>` is here
-  --> $DIR/atomic_write_na_write_race2.rs:LL:CC
-   |
-LL | ...   *atomic_ref.get_mut() = 32;
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: The Atomic Store on thread `<unnamed>` is here
+help: and Atomic Store on thread `<unnamed>`, which is here
   --> $DIR/atomic_write_na_write_race2.rs:LL:CC
    |
 LL |             atomic_ref.store(64, Ordering::SeqCst);

--- a/tests/fail/data_race/dangling_thread_async_race.rs
+++ b/tests/fail/data_race/dangling_thread_async_race.rs
@@ -34,7 +34,7 @@ fn main() {
 
     let join2 = unsafe {
         spawn(move || {
-            *c.0 = 64; //~ ERROR: Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>`
+            *c.0 = 64; //~ ERROR: Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>`
         })
     };
 

--- a/tests/fail/data_race/dangling_thread_async_race.stderr
+++ b/tests/fail/data_race/dangling_thread_async_race.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (2) just happened here
   --> $DIR/dangling_thread_async_race.rs:LL:CC
    |
 LL |             *c.0 = 64;
-   |             ^^^^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+   |             ^^^^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (2) just happened here
    |
-help: and (2) occurred earlier here
+help: and (1) occurred earlier here
   --> $DIR/dangling_thread_async_race.rs:LL:CC
    |
 LL |             *c.0 = 32;

--- a/tests/fail/data_race/dangling_thread_async_race.stderr
+++ b/tests/fail/data_race/dangling_thread_async_race.stderr
@@ -11,7 +11,7 @@ LL |             *c.0 = 32;
    |             ^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside closure at $DIR/dangling_thread_async_race.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/dangling_thread_async_race.stderr
+++ b/tests/fail/data_race/dangling_thread_async_race.stderr
@@ -4,6 +4,16 @@ error: Undefined Behavior: Data race detected between Write on thread `<unnamed>
 LL |             *c.0 = 64;
    |             ^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
    |
+help: The Write on thread `<unnamed>` is here
+  --> $DIR/dangling_thread_async_race.rs:LL:CC
+   |
+LL |             *c.0 = 64;
+   |             ^^^^^^^^^
+help: The Write on thread `<unnamed>` is here
+  --> $DIR/dangling_thread_async_race.rs:LL:CC
+   |
+LL |             *c.0 = 32;
+   |             ^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/dangling_thread_async_race.stderr
+++ b/tests/fail/data_race/dangling_thread_async_race.stderr
@@ -4,7 +4,7 @@ error: Undefined Behavior: Data race detected between Write on thread `<unnamed>
 LL |             *c.0 = 64;
    |             ^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Write is here
    |
-help: and Write on thread `<unnamed>`, which is here
+help: and the Write on thread `<unnamed>` is here
   --> $DIR/dangling_thread_async_race.rs:LL:CC
    |
 LL |             *c.0 = 32;

--- a/tests/fail/data_race/dangling_thread_async_race.stderr
+++ b/tests/fail/data_race/dangling_thread_async_race.stderr
@@ -1,15 +1,10 @@
-error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
+error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Write is here
   --> $DIR/dangling_thread_async_race.rs:LL:CC
    |
 LL |             *c.0 = 64;
-   |             ^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
+   |             ^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Write is here
    |
-help: The Write on thread `<unnamed>` is here
-  --> $DIR/dangling_thread_async_race.rs:LL:CC
-   |
-LL |             *c.0 = 64;
-   |             ^^^^^^^^^
-help: The Write on thread `<unnamed>` is here
+help: and Write on thread `<unnamed>`, which is here
   --> $DIR/dangling_thread_async_race.rs:LL:CC
    |
 LL |             *c.0 = 32;

--- a/tests/fail/data_race/dangling_thread_async_race.stderr
+++ b/tests/fail/data_race/dangling_thread_async_race.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Write is here
+error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
   --> $DIR/dangling_thread_async_race.rs:LL:CC
    |
 LL |             *c.0 = 64;
-   |             ^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Write is here
+   |             ^^^^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
    |
-help: and the Write on thread `<unnamed>` is here
+help: and (2) occurred earlier here
   --> $DIR/dangling_thread_async_race.rs:LL:CC
    |
 LL |             *c.0 = 32;

--- a/tests/fail/data_race/dangling_thread_race.rs
+++ b/tests/fail/data_race/dangling_thread_race.rs
@@ -33,6 +33,6 @@ fn main() {
     spawn(|| ()).join().unwrap();
 
     unsafe {
-        *c.0 = 64; //~ ERROR: Data race detected between (1) Write on thread `main` and (2) Write on thread `<unnamed>`
+        *c.0 = 64; //~ ERROR: Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `main`
     }
 }

--- a/tests/fail/data_race/dangling_thread_race.rs
+++ b/tests/fail/data_race/dangling_thread_race.rs
@@ -33,6 +33,6 @@ fn main() {
     spawn(|| ()).join().unwrap();
 
     unsafe {
-        *c.0 = 64; //~ ERROR: Data race detected between Write on thread `main` and Write on thread `<unnamed>`
+        *c.0 = 64; //~ ERROR: Data race detected between (1) Write on thread `main` and (2) Write on thread `<unnamed>`
     }
 }

--- a/tests/fail/data_race/dangling_thread_race.stderr
+++ b/tests/fail/data_race/dangling_thread_race.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between (1) Write on thread `main` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `main` at ALLOC. (2) just happened here
   --> $DIR/dangling_thread_race.rs:LL:CC
    |
 LL |         *c.0 = 64;
-   |         ^^^^^^^^^ Data race detected between (1) Write on thread `main` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+   |         ^^^^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `main` at ALLOC. (2) just happened here
    |
-help: and (2) occurred earlier here
+help: and (1) occurred earlier here
   --> $DIR/dangling_thread_race.rs:LL:CC
    |
 LL |             *c.0 = 32;

--- a/tests/fail/data_race/dangling_thread_race.stderr
+++ b/tests/fail/data_race/dangling_thread_race.stderr
@@ -1,15 +1,10 @@
-error: Undefined Behavior: Data race detected between Write on thread `main` and Write on thread `<unnamed>` at ALLOC
+error: Undefined Behavior: Data race detected between Write on thread `main` and Write on thread `<unnamed>` at ALLOC. The Write is here
   --> $DIR/dangling_thread_race.rs:LL:CC
    |
 LL |         *c.0 = 64;
-   |         ^^^^^^^^^ Data race detected between Write on thread `main` and Write on thread `<unnamed>` at ALLOC
+   |         ^^^^^^^^^ Data race detected between Write on thread `main` and Write on thread `<unnamed>` at ALLOC. The Write is here
    |
-help: The Write on thread `main` is here
-  --> $DIR/dangling_thread_race.rs:LL:CC
-   |
-LL |         *c.0 = 64;
-   |         ^^^^^^^^^
-help: The Write on thread `<unnamed>` is here
+help: and Write on thread `<unnamed>`, which is here
   --> $DIR/dangling_thread_race.rs:LL:CC
    |
 LL |             *c.0 = 32;

--- a/tests/fail/data_race/dangling_thread_race.stderr
+++ b/tests/fail/data_race/dangling_thread_race.stderr
@@ -4,6 +4,16 @@ error: Undefined Behavior: Data race detected between Write on thread `main` and
 LL |         *c.0 = 64;
    |         ^^^^^^^^^ Data race detected between Write on thread `main` and Write on thread `<unnamed>` at ALLOC
    |
+help: The Write on thread `main` is here
+  --> $DIR/dangling_thread_race.rs:LL:CC
+   |
+LL |         *c.0 = 64;
+   |         ^^^^^^^^^
+help: The Write on thread `<unnamed>` is here
+  --> $DIR/dangling_thread_race.rs:LL:CC
+   |
+LL |             *c.0 = 32;
+   |             ^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/dangling_thread_race.stderr
+++ b/tests/fail/data_race/dangling_thread_race.stderr
@@ -11,7 +11,7 @@ LL |             *c.0 = 32;
    |             ^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/dangling_thread_race.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/dangling_thread_race.stderr
+++ b/tests/fail/data_race/dangling_thread_race.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between Write on thread `main` and Write on thread `<unnamed>` at ALLOC. The Write is here
+error: Undefined Behavior: Data race detected between (1) Write on thread `main` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
   --> $DIR/dangling_thread_race.rs:LL:CC
    |
 LL |         *c.0 = 64;
-   |         ^^^^^^^^^ Data race detected between Write on thread `main` and Write on thread `<unnamed>` at ALLOC. The Write is here
+   |         ^^^^^^^^^ Data race detected between (1) Write on thread `main` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
    |
-help: and the Write on thread `<unnamed>` is here
+help: and (2) occurred earlier here
   --> $DIR/dangling_thread_race.rs:LL:CC
    |
 LL |             *c.0 = 32;

--- a/tests/fail/data_race/dangling_thread_race.stderr
+++ b/tests/fail/data_race/dangling_thread_race.stderr
@@ -4,7 +4,7 @@ error: Undefined Behavior: Data race detected between Write on thread `main` and
 LL |         *c.0 = 64;
    |         ^^^^^^^^^ Data race detected between Write on thread `main` and Write on thread `<unnamed>` at ALLOC. The Write is here
    |
-help: and Write on thread `<unnamed>`, which is here
+help: and the Write on thread `<unnamed>` is here
   --> $DIR/dangling_thread_race.rs:LL:CC
    |
 LL |             *c.0 = 32;

--- a/tests/fail/data_race/dealloc_read_race1.rs
+++ b/tests/fail/data_race/dealloc_read_race1.rs
@@ -25,7 +25,7 @@ pub fn main() {
 
         let j2 = spawn(move || {
             __rust_dealloc(
-                //~^ ERROR: Data race detected between Deallocate on thread `<unnamed>` and Read on thread `<unnamed>`
+                //~^ ERROR: Data race detected between (1) Deallocate on thread `<unnamed>` and (2) Read on thread `<unnamed>`
                 ptr.0 as *mut _,
                 std::mem::size_of::<usize>(),
                 std::mem::align_of::<usize>(),

--- a/tests/fail/data_race/dealloc_read_race1.rs
+++ b/tests/fail/data_race/dealloc_read_race1.rs
@@ -25,7 +25,7 @@ pub fn main() {
 
         let j2 = spawn(move || {
             __rust_dealloc(
-                //~^ ERROR: Data race detected between (1) Deallocate on thread `<unnamed>` and (2) Read on thread `<unnamed>`
+                //~^ ERROR: Data race detected between (1) Read on thread `<unnamed>` and (2) Deallocate on thread `<unnamed>`
                 ptr.0 as *mut _,
                 std::mem::size_of::<usize>(),
                 std::mem::align_of::<usize>(),

--- a/tests/fail/data_race/dealloc_read_race1.stderr
+++ b/tests/fail/data_race/dealloc_read_race1.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: Data race detected between Deallocate on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC
+error: Undefined Behavior: Data race detected between Deallocate on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC. The Deallocate is here
   --> $DIR/dealloc_read_race1.rs:LL:CC
    |
 LL | /             __rust_dealloc(
@@ -7,19 +7,9 @@ LL | |                 ptr.0 as *mut _,
 LL | |                 std::mem::size_of::<usize>(),
 LL | |                 std::mem::align_of::<usize>(),
 LL | |             );
-   | |_____________^ Data race detected between Deallocate on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC
+   | |_____________^ Data race detected between Deallocate on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC. The Deallocate is here
    |
-help: The Deallocate on thread `<unnamed>` is here
-  --> $DIR/dealloc_read_race1.rs:LL:CC
-   |
-LL | /             __rust_dealloc(
-LL | |
-LL | |                 ptr.0 as *mut _,
-LL | |                 std::mem::size_of::<usize>(),
-LL | |                 std::mem::align_of::<usize>(),
-LL | |             );
-   | |_____________^
-help: The Read on thread `<unnamed>` is here
+help: and Read on thread `<unnamed>`, which is here
   --> $DIR/dealloc_read_race1.rs:LL:CC
    |
 LL |             let _val = *ptr.0;

--- a/tests/fail/data_race/dealloc_read_race1.stderr
+++ b/tests/fail/data_race/dealloc_read_race1.stderr
@@ -20,10 +20,10 @@ LL | |                 std::mem::align_of::<usize>(),
 LL | |             );
    | |_____________^
 help: The Read on thread `<unnamed>` is here
-  --> RUSTLIB/core/src/ptr/mod.rs:LL:CC
+  --> $DIR/dealloc_read_race1.rs:LL:CC
    |
-LL | }
-   | ^
+LL |             let _val = *ptr.0;
+   |                        ^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/dealloc_read_race1.stderr
+++ b/tests/fail/data_race/dealloc_read_race1.stderr
@@ -16,7 +16,7 @@ LL |             let _val = *ptr.0;
    |                        ^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside closure at $DIR/dealloc_read_race1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/dealloc_read_race1.stderr
+++ b/tests/fail/data_race/dealloc_read_race1.stderr
@@ -9,7 +9,7 @@ LL | |                 std::mem::align_of::<usize>(),
 LL | |             );
    | |_____________^ Data race detected between Deallocate on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC. The Deallocate is here
    |
-help: and Read on thread `<unnamed>`, which is here
+help: and the Read on thread `<unnamed>` is here
   --> $DIR/dealloc_read_race1.rs:LL:CC
    |
 LL |             let _val = *ptr.0;

--- a/tests/fail/data_race/dealloc_read_race1.stderr
+++ b/tests/fail/data_race/dealloc_read_race1.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: Data race detected between (1) Deallocate on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (1) just happened here
+error: Undefined Behavior: Data race detected between (1) Read on thread `<unnamed>` and (2) Deallocate on thread `<unnamed>` at ALLOC. (2) just happened here
   --> $DIR/dealloc_read_race1.rs:LL:CC
    |
 LL | /             __rust_dealloc(
@@ -7,9 +7,9 @@ LL | |                 ptr.0 as *mut _,
 LL | |                 std::mem::size_of::<usize>(),
 LL | |                 std::mem::align_of::<usize>(),
 LL | |             );
-   | |_____________^ Data race detected between (1) Deallocate on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (1) just happened here
+   | |_____________^ Data race detected between (1) Read on thread `<unnamed>` and (2) Deallocate on thread `<unnamed>` at ALLOC. (2) just happened here
    |
-help: and (2) occurred earlier here
+help: and (1) occurred earlier here
   --> $DIR/dealloc_read_race1.rs:LL:CC
    |
 LL |             let _val = *ptr.0;

--- a/tests/fail/data_race/dealloc_read_race1.stderr
+++ b/tests/fail/data_race/dealloc_read_race1.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: Data race detected between Deallocate on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC. The Deallocate is here
+error: Undefined Behavior: Data race detected between (1) Deallocate on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (1) just happened here
   --> $DIR/dealloc_read_race1.rs:LL:CC
    |
 LL | /             __rust_dealloc(
@@ -7,9 +7,9 @@ LL | |                 ptr.0 as *mut _,
 LL | |                 std::mem::size_of::<usize>(),
 LL | |                 std::mem::align_of::<usize>(),
 LL | |             );
-   | |_____________^ Data race detected between Deallocate on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC. The Deallocate is here
+   | |_____________^ Data race detected between (1) Deallocate on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (1) just happened here
    |
-help: and the Read on thread `<unnamed>` is here
+help: and (2) occurred earlier here
   --> $DIR/dealloc_read_race1.rs:LL:CC
    |
 LL |             let _val = *ptr.0;

--- a/tests/fail/data_race/dealloc_read_race1.stderr
+++ b/tests/fail/data_race/dealloc_read_race1.stderr
@@ -9,6 +9,21 @@ LL | |                 std::mem::align_of::<usize>(),
 LL | |             );
    | |_____________^ Data race detected between Deallocate on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC
    |
+help: The Deallocate on thread `<unnamed>` is here
+  --> $DIR/dealloc_read_race1.rs:LL:CC
+   |
+LL | /             __rust_dealloc(
+LL | |
+LL | |                 ptr.0 as *mut _,
+LL | |                 std::mem::size_of::<usize>(),
+LL | |                 std::mem::align_of::<usize>(),
+LL | |             );
+   | |_____________^
+help: The Read on thread `<unnamed>` is here
+  --> RUSTLIB/core/src/ptr/mod.rs:LL:CC
+   |
+LL | }
+   | ^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/dealloc_read_race2.rs
+++ b/tests/fail/data_race/dealloc_read_race2.rs
@@ -28,7 +28,7 @@ pub fn main() {
         });
 
         let j2 = spawn(move || {
-            // Also an error of the form: Data race detected between Read on thread `<unnamed>` and Deallocate on thread `<unnamed>`
+            // Also an error of the form: Data race detected between (1) Read on thread `<unnamed>` and (2) Deallocate on thread `<unnamed>`
             // but the invalid allocation is detected first.
             *ptr.0 //~ ERROR: dereferenced after this allocation got freed
         });

--- a/tests/fail/data_race/dealloc_read_race2.rs
+++ b/tests/fail/data_race/dealloc_read_race2.rs
@@ -28,7 +28,7 @@ pub fn main() {
         });
 
         let j2 = spawn(move || {
-            // Also an error of the form: Data race detected between (1) Read on thread `<unnamed>` and (2) Deallocate on thread `<unnamed>`
+            // Also an error of the form: Data race detected between (1) Deallocate on thread `<unnamed>` and (2) Read on thread `<unnamed>`
             // but the invalid allocation is detected first.
             *ptr.0 //~ ERROR: dereferenced after this allocation got freed
         });

--- a/tests/fail/data_race/dealloc_read_race_stack.rs
+++ b/tests/fail/data_race/dealloc_read_race_stack.rs
@@ -35,7 +35,7 @@ pub fn main() {
                 sleep(Duration::from_millis(200));
 
                 // Now `stack_var` gets deallocated.
-            } //~ ERROR: Data race detected between (1) Deallocate on thread `<unnamed>` and (2) Read on thread `<unnamed>`
+            } //~ ERROR: Data race detected between (1) Read on thread `<unnamed>` and (2) Deallocate on thread `<unnamed>`
         });
 
         let j2 = spawn(move || {

--- a/tests/fail/data_race/dealloc_read_race_stack.rs
+++ b/tests/fail/data_race/dealloc_read_race_stack.rs
@@ -35,7 +35,7 @@ pub fn main() {
                 sleep(Duration::from_millis(200));
 
                 // Now `stack_var` gets deallocated.
-            } //~ ERROR: Data race detected between Deallocate on thread `<unnamed>` and Read on thread `<unnamed>`
+            } //~ ERROR: Data race detected between (1) Deallocate on thread `<unnamed>` and (2) Read on thread `<unnamed>`
         });
 
         let j2 = spawn(move || {

--- a/tests/fail/data_race/dealloc_read_race_stack.stderr
+++ b/tests/fail/data_race/dealloc_read_race_stack.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between (1) Deallocate on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (1) just happened here
+error: Undefined Behavior: Data race detected between (1) Read on thread `<unnamed>` and (2) Deallocate on thread `<unnamed>` at ALLOC. (2) just happened here
   --> $DIR/dealloc_read_race_stack.rs:LL:CC
    |
 LL |             }
-   |             ^ Data race detected between (1) Deallocate on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (1) just happened here
+   |             ^ Data race detected between (1) Read on thread `<unnamed>` and (2) Deallocate on thread `<unnamed>` at ALLOC. (2) just happened here
    |
-help: and (2) occurred earlier here
+help: and (1) occurred earlier here
   --> $DIR/dealloc_read_race_stack.rs:LL:CC
    |
 LL |             *pointer.load(Ordering::Acquire)

--- a/tests/fail/data_race/dealloc_read_race_stack.stderr
+++ b/tests/fail/data_race/dealloc_read_race_stack.stderr
@@ -4,6 +4,16 @@ error: Undefined Behavior: Data race detected between Deallocate on thread `<unn
 LL |             }
    |             ^ Data race detected between Deallocate on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC
    |
+help: The Deallocate on thread `<unnamed>` is here
+  --> $DIR/dealloc_read_race_stack.rs:LL:CC
+   |
+LL |             }
+   |             ^
+help: The Read on thread `<unnamed>` is here
+  --> $DIR/dealloc_read_race_stack.rs:LL:CC
+   |
+LL |             *pointer.load(Ordering::Acquire)
+   |                                            ^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/dealloc_read_race_stack.stderr
+++ b/tests/fail/data_race/dealloc_read_race_stack.stderr
@@ -11,7 +11,7 @@ LL |             *pointer.load(Ordering::Acquire)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside closure at $DIR/dealloc_read_race_stack.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/dealloc_read_race_stack.stderr
+++ b/tests/fail/data_race/dealloc_read_race_stack.stderr
@@ -4,7 +4,7 @@ error: Undefined Behavior: Data race detected between Deallocate on thread `<unn
 LL |             }
    |             ^ Data race detected between Deallocate on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC. The Deallocate is here
    |
-help: and Read on thread `<unnamed>`, which is here
+help: and the Read on thread `<unnamed>` is here
   --> $DIR/dealloc_read_race_stack.rs:LL:CC
    |
 LL |             *pointer.load(Ordering::Acquire)

--- a/tests/fail/data_race/dealloc_read_race_stack.stderr
+++ b/tests/fail/data_race/dealloc_read_race_stack.stderr
@@ -13,7 +13,7 @@ help: The Read on thread `<unnamed>` is here
   --> $DIR/dealloc_read_race_stack.rs:LL:CC
    |
 LL |             *pointer.load(Ordering::Acquire)
-   |                                            ^
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/dealloc_read_race_stack.stderr
+++ b/tests/fail/data_race/dealloc_read_race_stack.stderr
@@ -1,15 +1,10 @@
-error: Undefined Behavior: Data race detected between Deallocate on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC
+error: Undefined Behavior: Data race detected between Deallocate on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC. The Deallocate is here
   --> $DIR/dealloc_read_race_stack.rs:LL:CC
    |
 LL |             }
-   |             ^ Data race detected between Deallocate on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC
+   |             ^ Data race detected between Deallocate on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC. The Deallocate is here
    |
-help: The Deallocate on thread `<unnamed>` is here
-  --> $DIR/dealloc_read_race_stack.rs:LL:CC
-   |
-LL |             }
-   |             ^
-help: The Read on thread `<unnamed>` is here
+help: and Read on thread `<unnamed>`, which is here
   --> $DIR/dealloc_read_race_stack.rs:LL:CC
    |
 LL |             *pointer.load(Ordering::Acquire)

--- a/tests/fail/data_race/dealloc_read_race_stack.stderr
+++ b/tests/fail/data_race/dealloc_read_race_stack.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between Deallocate on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC. The Deallocate is here
+error: Undefined Behavior: Data race detected between (1) Deallocate on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (1) just happened here
   --> $DIR/dealloc_read_race_stack.rs:LL:CC
    |
 LL |             }
-   |             ^ Data race detected between Deallocate on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC. The Deallocate is here
+   |             ^ Data race detected between (1) Deallocate on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (1) just happened here
    |
-help: and the Read on thread `<unnamed>` is here
+help: and (2) occurred earlier here
   --> $DIR/dealloc_read_race_stack.rs:LL:CC
    |
 LL |             *pointer.load(Ordering::Acquire)

--- a/tests/fail/data_race/dealloc_write_race1.rs
+++ b/tests/fail/data_race/dealloc_write_race1.rs
@@ -24,7 +24,7 @@ pub fn main() {
 
         let j2 = spawn(move || {
             __rust_dealloc(
-                //~^ ERROR: Data race detected between Deallocate on thread `<unnamed>` and Write on thread `<unnamed>`
+                //~^ ERROR: Data race detected between (1) Deallocate on thread `<unnamed>` and (2) Write on thread `<unnamed>`
                 ptr.0 as *mut _,
                 std::mem::size_of::<usize>(),
                 std::mem::align_of::<usize>(),

--- a/tests/fail/data_race/dealloc_write_race1.rs
+++ b/tests/fail/data_race/dealloc_write_race1.rs
@@ -24,7 +24,7 @@ pub fn main() {
 
         let j2 = spawn(move || {
             __rust_dealloc(
-                //~^ ERROR: Data race detected between (1) Deallocate on thread `<unnamed>` and (2) Write on thread `<unnamed>`
+                //~^ ERROR: Data race detected between (1) Write on thread `<unnamed>` and (2) Deallocate on thread `<unnamed>`
                 ptr.0 as *mut _,
                 std::mem::size_of::<usize>(),
                 std::mem::align_of::<usize>(),

--- a/tests/fail/data_race/dealloc_write_race1.stderr
+++ b/tests/fail/data_race/dealloc_write_race1.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: Data race detected between Deallocate on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Deallocate is here
+error: Undefined Behavior: Data race detected between (1) Deallocate on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
   --> $DIR/dealloc_write_race1.rs:LL:CC
    |
 LL | /             __rust_dealloc(
@@ -7,9 +7,9 @@ LL | |                 ptr.0 as *mut _,
 LL | |                 std::mem::size_of::<usize>(),
 LL | |                 std::mem::align_of::<usize>(),
 LL | |             );
-   | |_____________^ Data race detected between Deallocate on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Deallocate is here
+   | |_____________^ Data race detected between (1) Deallocate on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
    |
-help: and the Write on thread `<unnamed>` is here
+help: and (2) occurred earlier here
   --> $DIR/dealloc_write_race1.rs:LL:CC
    |
 LL |             *ptr.0 = 2;

--- a/tests/fail/data_race/dealloc_write_race1.stderr
+++ b/tests/fail/data_race/dealloc_write_race1.stderr
@@ -9,7 +9,7 @@ LL | |                 std::mem::align_of::<usize>(),
 LL | |             );
    | |_____________^ Data race detected between Deallocate on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Deallocate is here
    |
-help: and Write on thread `<unnamed>`, which is here
+help: and the Write on thread `<unnamed>` is here
   --> $DIR/dealloc_write_race1.rs:LL:CC
    |
 LL |             *ptr.0 = 2;

--- a/tests/fail/data_race/dealloc_write_race1.stderr
+++ b/tests/fail/data_race/dealloc_write_race1.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: Data race detected between (1) Deallocate on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Deallocate on thread `<unnamed>` at ALLOC. (2) just happened here
   --> $DIR/dealloc_write_race1.rs:LL:CC
    |
 LL | /             __rust_dealloc(
@@ -7,9 +7,9 @@ LL | |                 ptr.0 as *mut _,
 LL | |                 std::mem::size_of::<usize>(),
 LL | |                 std::mem::align_of::<usize>(),
 LL | |             );
-   | |_____________^ Data race detected between (1) Deallocate on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+   | |_____________^ Data race detected between (1) Write on thread `<unnamed>` and (2) Deallocate on thread `<unnamed>` at ALLOC. (2) just happened here
    |
-help: and (2) occurred earlier here
+help: and (1) occurred earlier here
   --> $DIR/dealloc_write_race1.rs:LL:CC
    |
 LL |             *ptr.0 = 2;

--- a/tests/fail/data_race/dealloc_write_race1.stderr
+++ b/tests/fail/data_race/dealloc_write_race1.stderr
@@ -16,7 +16,7 @@ LL |             *ptr.0 = 2;
    |             ^^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside closure at $DIR/dealloc_write_race1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/dealloc_write_race1.stderr
+++ b/tests/fail/data_race/dealloc_write_race1.stderr
@@ -9,6 +9,21 @@ LL | |                 std::mem::align_of::<usize>(),
 LL | |             );
    | |_____________^ Data race detected between Deallocate on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
    |
+help: The Deallocate on thread `<unnamed>` is here
+  --> $DIR/dealloc_write_race1.rs:LL:CC
+   |
+LL | /             __rust_dealloc(
+LL | |
+LL | |                 ptr.0 as *mut _,
+LL | |                 std::mem::size_of::<usize>(),
+LL | |                 std::mem::align_of::<usize>(),
+LL | |             );
+   | |_____________^
+help: The Write on thread `<unnamed>` is here
+  --> $DIR/dealloc_write_race1.rs:LL:CC
+   |
+LL |             *ptr.0 = 2;
+   |             ^^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/dealloc_write_race1.stderr
+++ b/tests/fail/data_race/dealloc_write_race1.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: Data race detected between Deallocate on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
+error: Undefined Behavior: Data race detected between Deallocate on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Deallocate is here
   --> $DIR/dealloc_write_race1.rs:LL:CC
    |
 LL | /             __rust_dealloc(
@@ -7,19 +7,9 @@ LL | |                 ptr.0 as *mut _,
 LL | |                 std::mem::size_of::<usize>(),
 LL | |                 std::mem::align_of::<usize>(),
 LL | |             );
-   | |_____________^ Data race detected between Deallocate on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
+   | |_____________^ Data race detected between Deallocate on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Deallocate is here
    |
-help: The Deallocate on thread `<unnamed>` is here
-  --> $DIR/dealloc_write_race1.rs:LL:CC
-   |
-LL | /             __rust_dealloc(
-LL | |
-LL | |                 ptr.0 as *mut _,
-LL | |                 std::mem::size_of::<usize>(),
-LL | |                 std::mem::align_of::<usize>(),
-LL | |             );
-   | |_____________^
-help: The Write on thread `<unnamed>` is here
+help: and Write on thread `<unnamed>`, which is here
   --> $DIR/dealloc_write_race1.rs:LL:CC
    |
 LL |             *ptr.0 = 2;

--- a/tests/fail/data_race/dealloc_write_race2.rs
+++ b/tests/fail/data_race/dealloc_write_race2.rs
@@ -27,7 +27,7 @@ pub fn main() {
         });
 
         let j2 = spawn(move || {
-            // Also an error of the form: Data race detected between (1) Write on thread `<unnamed>` and (2) Deallocate on thread `<unnamed>`
+            // Also an error of the form: Data race detected between (1) Deallocate on thread `<unnamed>` and (2) Write on thread `<unnamed>`
             // but the invalid allocation is detected first.
             *ptr.0 = 2; //~ ERROR: dereferenced after this allocation got freed
         });

--- a/tests/fail/data_race/dealloc_write_race2.rs
+++ b/tests/fail/data_race/dealloc_write_race2.rs
@@ -27,7 +27,7 @@ pub fn main() {
         });
 
         let j2 = spawn(move || {
-            // Also an error of the form: Data race detected between Write on thread `<unnamed>` and Deallocate on thread `<unnamed>`
+            // Also an error of the form: Data race detected between (1) Write on thread `<unnamed>` and (2) Deallocate on thread `<unnamed>`
             // but the invalid allocation is detected first.
             *ptr.0 = 2; //~ ERROR: dereferenced after this allocation got freed
         });

--- a/tests/fail/data_race/dealloc_write_race_stack.rs
+++ b/tests/fail/data_race/dealloc_write_race_stack.rs
@@ -35,7 +35,7 @@ pub fn main() {
                 sleep(Duration::from_millis(200));
 
                 // Now `stack_var` gets deallocated.
-            } //~ ERROR: Data race detected between (1) Deallocate on thread `<unnamed>` and (2) Write on thread `<unnamed>`
+            } //~ ERROR: Data race detected between (1) Write on thread `<unnamed>` and (2) Deallocate on thread `<unnamed>`
         });
 
         let j2 = spawn(move || {

--- a/tests/fail/data_race/dealloc_write_race_stack.rs
+++ b/tests/fail/data_race/dealloc_write_race_stack.rs
@@ -35,7 +35,7 @@ pub fn main() {
                 sleep(Duration::from_millis(200));
 
                 // Now `stack_var` gets deallocated.
-            } //~ ERROR: Data race detected between Deallocate on thread `<unnamed>` and Write on thread `<unnamed>`
+            } //~ ERROR: Data race detected between (1) Deallocate on thread `<unnamed>` and (2) Write on thread `<unnamed>`
         });
 
         let j2 = spawn(move || {

--- a/tests/fail/data_race/dealloc_write_race_stack.stderr
+++ b/tests/fail/data_race/dealloc_write_race_stack.stderr
@@ -1,15 +1,10 @@
-error: Undefined Behavior: Data race detected between Deallocate on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
+error: Undefined Behavior: Data race detected between Deallocate on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Deallocate is here
   --> $DIR/dealloc_write_race_stack.rs:LL:CC
    |
 LL |             }
-   |             ^ Data race detected between Deallocate on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
+   |             ^ Data race detected between Deallocate on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Deallocate is here
    |
-help: The Deallocate on thread `<unnamed>` is here
-  --> $DIR/dealloc_write_race_stack.rs:LL:CC
-   |
-LL |             }
-   |             ^
-help: The Write on thread `<unnamed>` is here
+help: and Write on thread `<unnamed>`, which is here
   --> $DIR/dealloc_write_race_stack.rs:LL:CC
    |
 LL |             *pointer.load(Ordering::Acquire) = 3;

--- a/tests/fail/data_race/dealloc_write_race_stack.stderr
+++ b/tests/fail/data_race/dealloc_write_race_stack.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between Deallocate on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Deallocate is here
+error: Undefined Behavior: Data race detected between (1) Deallocate on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
   --> $DIR/dealloc_write_race_stack.rs:LL:CC
    |
 LL |             }
-   |             ^ Data race detected between Deallocate on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Deallocate is here
+   |             ^ Data race detected between (1) Deallocate on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
    |
-help: and the Write on thread `<unnamed>` is here
+help: and (2) occurred earlier here
   --> $DIR/dealloc_write_race_stack.rs:LL:CC
    |
 LL |             *pointer.load(Ordering::Acquire) = 3;

--- a/tests/fail/data_race/dealloc_write_race_stack.stderr
+++ b/tests/fail/data_race/dealloc_write_race_stack.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between (1) Deallocate on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Deallocate on thread `<unnamed>` at ALLOC. (2) just happened here
   --> $DIR/dealloc_write_race_stack.rs:LL:CC
    |
 LL |             }
-   |             ^ Data race detected between (1) Deallocate on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+   |             ^ Data race detected between (1) Write on thread `<unnamed>` and (2) Deallocate on thread `<unnamed>` at ALLOC. (2) just happened here
    |
-help: and (2) occurred earlier here
+help: and (1) occurred earlier here
   --> $DIR/dealloc_write_race_stack.rs:LL:CC
    |
 LL |             *pointer.load(Ordering::Acquire) = 3;

--- a/tests/fail/data_race/dealloc_write_race_stack.stderr
+++ b/tests/fail/data_race/dealloc_write_race_stack.stderr
@@ -4,6 +4,16 @@ error: Undefined Behavior: Data race detected between Deallocate on thread `<unn
 LL |             }
    |             ^ Data race detected between Deallocate on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
    |
+help: The Deallocate on thread `<unnamed>` is here
+  --> $DIR/dealloc_write_race_stack.rs:LL:CC
+   |
+LL |             }
+   |             ^
+help: The Write on thread `<unnamed>` is here
+  --> $DIR/dealloc_write_race_stack.rs:LL:CC
+   |
+LL |             *pointer.load(Ordering::Acquire) = 3;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/dealloc_write_race_stack.stderr
+++ b/tests/fail/data_race/dealloc_write_race_stack.stderr
@@ -4,7 +4,7 @@ error: Undefined Behavior: Data race detected between Deallocate on thread `<unn
 LL |             }
    |             ^ Data race detected between Deallocate on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Deallocate is here
    |
-help: and Write on thread `<unnamed>`, which is here
+help: and the Write on thread `<unnamed>` is here
   --> $DIR/dealloc_write_race_stack.rs:LL:CC
    |
 LL |             *pointer.load(Ordering::Acquire) = 3;

--- a/tests/fail/data_race/dealloc_write_race_stack.stderr
+++ b/tests/fail/data_race/dealloc_write_race_stack.stderr
@@ -11,7 +11,7 @@ LL |             *pointer.load(Ordering::Acquire) = 3;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside closure at $DIR/dealloc_write_race_stack.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/enable_after_join_to_main.rs
+++ b/tests/fail/data_race/enable_after_join_to_main.rs
@@ -30,7 +30,7 @@ pub fn main() {
         });
 
         let j2 = spawn(move || {
-            *c.0 = 64; //~ ERROR: Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>`
+            *c.0 = 64; //~ ERROR: Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>`
         });
 
         j1.join().unwrap();

--- a/tests/fail/data_race/enable_after_join_to_main.stderr
+++ b/tests/fail/data_race/enable_after_join_to_main.stderr
@@ -4,7 +4,7 @@ error: Undefined Behavior: Data race detected between Write on thread `<unnamed>
 LL |             *c.0 = 64;
    |             ^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Write is here
    |
-help: and Write on thread `<unnamed>`, which is here
+help: and the Write on thread `<unnamed>` is here
   --> $DIR/enable_after_join_to_main.rs:LL:CC
    |
 LL |             *c.0 = 32;

--- a/tests/fail/data_race/enable_after_join_to_main.stderr
+++ b/tests/fail/data_race/enable_after_join_to_main.stderr
@@ -4,6 +4,16 @@ error: Undefined Behavior: Data race detected between Write on thread `<unnamed>
 LL |             *c.0 = 64;
    |             ^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
    |
+help: The Write on thread `<unnamed>` is here
+  --> $DIR/enable_after_join_to_main.rs:LL:CC
+   |
+LL |             *c.0 = 64;
+   |             ^^^^^^^^^
+help: The Write on thread `<unnamed>` is here
+  --> $DIR/enable_after_join_to_main.rs:LL:CC
+   |
+LL |             *c.0 = 32;
+   |             ^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/enable_after_join_to_main.stderr
+++ b/tests/fail/data_race/enable_after_join_to_main.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (2) just happened here
   --> $DIR/enable_after_join_to_main.rs:LL:CC
    |
 LL |             *c.0 = 64;
-   |             ^^^^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+   |             ^^^^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (2) just happened here
    |
-help: and (2) occurred earlier here
+help: and (1) occurred earlier here
   --> $DIR/enable_after_join_to_main.rs:LL:CC
    |
 LL |             *c.0 = 32;

--- a/tests/fail/data_race/enable_after_join_to_main.stderr
+++ b/tests/fail/data_race/enable_after_join_to_main.stderr
@@ -11,7 +11,7 @@ LL |             *c.0 = 32;
    |             ^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside closure at $DIR/enable_after_join_to_main.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/enable_after_join_to_main.stderr
+++ b/tests/fail/data_race/enable_after_join_to_main.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Write is here
+error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
   --> $DIR/enable_after_join_to_main.rs:LL:CC
    |
 LL |             *c.0 = 64;
-   |             ^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Write is here
+   |             ^^^^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
    |
-help: and the Write on thread `<unnamed>` is here
+help: and (2) occurred earlier here
   --> $DIR/enable_after_join_to_main.rs:LL:CC
    |
 LL |             *c.0 = 32;

--- a/tests/fail/data_race/enable_after_join_to_main.stderr
+++ b/tests/fail/data_race/enable_after_join_to_main.stderr
@@ -1,15 +1,10 @@
-error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
+error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Write is here
   --> $DIR/enable_after_join_to_main.rs:LL:CC
    |
 LL |             *c.0 = 64;
-   |             ^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
+   |             ^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Write is here
    |
-help: The Write on thread `<unnamed>` is here
-  --> $DIR/enable_after_join_to_main.rs:LL:CC
-   |
-LL |             *c.0 = 64;
-   |             ^^^^^^^^^
-help: The Write on thread `<unnamed>` is here
+help: and Write on thread `<unnamed>`, which is here
   --> $DIR/enable_after_join_to_main.rs:LL:CC
    |
 LL |             *c.0 = 32;

--- a/tests/fail/data_race/fence_after_load.rs
+++ b/tests/fail/data_race/fence_after_load.rs
@@ -20,5 +20,5 @@ fn main() {
     // The fence is useless, since it did not happen-after the `store` in the other thread.
     // Hence this is a data race.
     // Also see https://github.com/rust-lang/miri/issues/2192.
-    unsafe { V = 2 } //~ERROR: Data race detected between (1) Write on thread `main` and (2) Write on thread `<unnamed>`
+    unsafe { V = 2 } //~ERROR: Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `main`
 }

--- a/tests/fail/data_race/fence_after_load.rs
+++ b/tests/fail/data_race/fence_after_load.rs
@@ -20,5 +20,5 @@ fn main() {
     // The fence is useless, since it did not happen-after the `store` in the other thread.
     // Hence this is a data race.
     // Also see https://github.com/rust-lang/miri/issues/2192.
-    unsafe { V = 2 } //~ERROR: Data race detected between Write on thread `main` and Write on thread `<unnamed>`
+    unsafe { V = 2 } //~ERROR: Data race detected between (1) Write on thread `main` and (2) Write on thread `<unnamed>`
 }

--- a/tests/fail/data_race/fence_after_load.stderr
+++ b/tests/fail/data_race/fence_after_load.stderr
@@ -4,7 +4,7 @@ error: Undefined Behavior: Data race detected between Write on thread `main` and
 LL |     unsafe { V = 2 }
    |              ^^^^^ Data race detected between Write on thread `main` and Write on thread `<unnamed>` at ALLOC. The Write is here
    |
-help: and Write on thread `<unnamed>`, which is here
+help: and the Write on thread `<unnamed>` is here
   --> $DIR/fence_after_load.rs:LL:CC
    |
 LL |         unsafe { V = 1 }

--- a/tests/fail/data_race/fence_after_load.stderr
+++ b/tests/fail/data_race/fence_after_load.stderr
@@ -1,15 +1,10 @@
-error: Undefined Behavior: Data race detected between Write on thread `main` and Write on thread `<unnamed>` at ALLOC
+error: Undefined Behavior: Data race detected between Write on thread `main` and Write on thread `<unnamed>` at ALLOC. The Write is here
   --> $DIR/fence_after_load.rs:LL:CC
    |
 LL |     unsafe { V = 2 }
-   |              ^^^^^ Data race detected between Write on thread `main` and Write on thread `<unnamed>` at ALLOC
+   |              ^^^^^ Data race detected between Write on thread `main` and Write on thread `<unnamed>` at ALLOC. The Write is here
    |
-help: The Write on thread `main` is here
-  --> $DIR/fence_after_load.rs:LL:CC
-   |
-LL |     unsafe { V = 2 }
-   |              ^^^^^
-help: The Write on thread `<unnamed>` is here
+help: and Write on thread `<unnamed>`, which is here
   --> $DIR/fence_after_load.rs:LL:CC
    |
 LL |         unsafe { V = 1 }

--- a/tests/fail/data_race/fence_after_load.stderr
+++ b/tests/fail/data_race/fence_after_load.stderr
@@ -4,6 +4,16 @@ error: Undefined Behavior: Data race detected between Write on thread `main` and
 LL |     unsafe { V = 2 }
    |              ^^^^^ Data race detected between Write on thread `main` and Write on thread `<unnamed>` at ALLOC
    |
+help: The Write on thread `main` is here
+  --> $DIR/fence_after_load.rs:LL:CC
+   |
+LL |     unsafe { V = 2 }
+   |              ^^^^^
+help: The Write on thread `<unnamed>` is here
+  --> $DIR/fence_after_load.rs:LL:CC
+   |
+LL |         unsafe { V = 1 }
+   |                  ^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/fence_after_load.stderr
+++ b/tests/fail/data_race/fence_after_load.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between Write on thread `main` and Write on thread `<unnamed>` at ALLOC. The Write is here
+error: Undefined Behavior: Data race detected between (1) Write on thread `main` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
   --> $DIR/fence_after_load.rs:LL:CC
    |
 LL |     unsafe { V = 2 }
-   |              ^^^^^ Data race detected between Write on thread `main` and Write on thread `<unnamed>` at ALLOC. The Write is here
+   |              ^^^^^ Data race detected between (1) Write on thread `main` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
    |
-help: and the Write on thread `<unnamed>` is here
+help: and (2) occurred earlier here
   --> $DIR/fence_after_load.rs:LL:CC
    |
 LL |         unsafe { V = 1 }

--- a/tests/fail/data_race/fence_after_load.stderr
+++ b/tests/fail/data_race/fence_after_load.stderr
@@ -11,7 +11,7 @@ LL |         unsafe { V = 1 }
    |                  ^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/fence_after_load.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/fence_after_load.stderr
+++ b/tests/fail/data_race/fence_after_load.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between (1) Write on thread `main` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `main` at ALLOC. (2) just happened here
   --> $DIR/fence_after_load.rs:LL:CC
    |
 LL |     unsafe { V = 2 }
-   |              ^^^^^ Data race detected between (1) Write on thread `main` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+   |              ^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `main` at ALLOC. (2) just happened here
    |
-help: and (2) occurred earlier here
+help: and (1) occurred earlier here
   --> $DIR/fence_after_load.rs:LL:CC
    |
 LL |         unsafe { V = 1 }

--- a/tests/fail/data_race/read_write_race.rs
+++ b/tests/fail/data_race/read_write_race.rs
@@ -19,7 +19,7 @@ pub fn main() {
         });
 
         let j2 = spawn(move || {
-            *c.0 = 64; //~ ERROR: Data race detected between (1) Write on thread `<unnamed>` and (2) Read on thread `<unnamed>`
+            *c.0 = 64; //~ ERROR: Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>`
         });
 
         j1.join().unwrap();

--- a/tests/fail/data_race/read_write_race.rs
+++ b/tests/fail/data_race/read_write_race.rs
@@ -19,7 +19,7 @@ pub fn main() {
         });
 
         let j2 = spawn(move || {
-            *c.0 = 64; //~ ERROR: Data race detected between Write on thread `<unnamed>` and Read on thread `<unnamed>`
+            *c.0 = 64; //~ ERROR: Data race detected between (1) Write on thread `<unnamed>` and (2) Read on thread `<unnamed>`
         });
 
         j1.join().unwrap();

--- a/tests/fail/data_race/read_write_race.stderr
+++ b/tests/fail/data_race/read_write_race.stderr
@@ -11,7 +11,7 @@ LL |             let _val = *c.0;
    |                        ^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside closure at $DIR/read_write_race.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/read_write_race.stderr
+++ b/tests/fail/data_race/read_write_race.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (1) just happened here
+error: Undefined Behavior: Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (2) just happened here
   --> $DIR/read_write_race.rs:LL:CC
    |
 LL |             *c.0 = 64;
-   |             ^^^^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (1) just happened here
+   |             ^^^^^^^^^ Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (2) just happened here
    |
-help: and (2) occurred earlier here
+help: and (1) occurred earlier here
   --> $DIR/read_write_race.rs:LL:CC
    |
 LL |             let _val = *c.0;

--- a/tests/fail/data_race/read_write_race.stderr
+++ b/tests/fail/data_race/read_write_race.stderr
@@ -1,15 +1,10 @@
-error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC
+error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC. The Write is here
   --> $DIR/read_write_race.rs:LL:CC
    |
 LL |             *c.0 = 64;
-   |             ^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC
+   |             ^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC. The Write is here
    |
-help: The Write on thread `<unnamed>` is here
-  --> $DIR/read_write_race.rs:LL:CC
-   |
-LL |             *c.0 = 64;
-   |             ^^^^^^^^^
-help: The Read on thread `<unnamed>` is here
+help: and Read on thread `<unnamed>`, which is here
   --> $DIR/read_write_race.rs:LL:CC
    |
 LL |             let _val = *c.0;

--- a/tests/fail/data_race/read_write_race.stderr
+++ b/tests/fail/data_race/read_write_race.stderr
@@ -4,7 +4,7 @@ error: Undefined Behavior: Data race detected between Write on thread `<unnamed>
 LL |             *c.0 = 64;
    |             ^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC. The Write is here
    |
-help: and Read on thread `<unnamed>`, which is here
+help: and the Read on thread `<unnamed>` is here
   --> $DIR/read_write_race.rs:LL:CC
    |
 LL |             let _val = *c.0;

--- a/tests/fail/data_race/read_write_race.stderr
+++ b/tests/fail/data_race/read_write_race.stderr
@@ -10,10 +10,10 @@ help: The Write on thread `<unnamed>` is here
 LL |             *c.0 = 64;
    |             ^^^^^^^^^
 help: The Read on thread `<unnamed>` is here
-  --> RUSTLIB/core/src/ptr/mod.rs:LL:CC
+  --> $DIR/read_write_race.rs:LL:CC
    |
-LL | }
-   | ^
+LL |             let _val = *c.0;
+   |                        ^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/read_write_race.stderr
+++ b/tests/fail/data_race/read_write_race.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC. The Write is here
+error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (1) just happened here
   --> $DIR/read_write_race.rs:LL:CC
    |
 LL |             *c.0 = 64;
-   |             ^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC. The Write is here
+   |             ^^^^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (1) just happened here
    |
-help: and the Read on thread `<unnamed>` is here
+help: and (2) occurred earlier here
   --> $DIR/read_write_race.rs:LL:CC
    |
 LL |             let _val = *c.0;

--- a/tests/fail/data_race/read_write_race.stderr
+++ b/tests/fail/data_race/read_write_race.stderr
@@ -4,6 +4,16 @@ error: Undefined Behavior: Data race detected between Write on thread `<unnamed>
 LL |             *c.0 = 64;
    |             ^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC
    |
+help: The Write on thread `<unnamed>` is here
+  --> $DIR/read_write_race.rs:LL:CC
+   |
+LL |             *c.0 = 64;
+   |             ^^^^^^^^^
+help: The Read on thread `<unnamed>` is here
+  --> RUSTLIB/core/src/ptr/mod.rs:LL:CC
+   |
+LL | }
+   | ^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/read_write_race_stack.rs
+++ b/tests/fail/data_race/read_write_race_stack.rs
@@ -42,7 +42,7 @@ pub fn main() {
 
             sleep(Duration::from_millis(200));
 
-            stack_var //~ ERROR: Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>`
+            stack_var //~ ERROR: Data race detected between (1) Write on thread `<unnamed>` and (2) Read on thread `<unnamed>`
         });
 
         let j2 = spawn(move || {

--- a/tests/fail/data_race/read_write_race_stack.rs
+++ b/tests/fail/data_race/read_write_race_stack.rs
@@ -42,7 +42,7 @@ pub fn main() {
 
             sleep(Duration::from_millis(200));
 
-            stack_var //~ ERROR: Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>`
+            stack_var //~ ERROR: Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>`
         });
 
         let j2 = spawn(move || {

--- a/tests/fail/data_race/read_write_race_stack.stderr
+++ b/tests/fail/data_race/read_write_race_stack.stderr
@@ -7,8 +7,8 @@ LL |             stack_var
 help: The Read on thread `<unnamed>` is here
   --> $DIR/read_write_race_stack.rs:LL:CC
    |
-LL |             sleep(Duration::from_millis(200));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |             stack_var
+   |             ^^^^^^^^^
 help: The Write on thread `<unnamed>` is here
   --> $DIR/read_write_race_stack.rs:LL:CC
    |

--- a/tests/fail/data_race/read_write_race_stack.stderr
+++ b/tests/fail/data_race/read_write_race_stack.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (2) just happened here
   --> $DIR/read_write_race_stack.rs:LL:CC
    |
 LL |             stack_var
-   |             ^^^^^^^^^ Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+   |             ^^^^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (2) just happened here
    |
-help: and (2) occurred earlier here
+help: and (1) occurred earlier here
   --> $DIR/read_write_race_stack.rs:LL:CC
    |
 LL |             *pointer.load(Ordering::Acquire) = 3;

--- a/tests/fail/data_race/read_write_race_stack.stderr
+++ b/tests/fail/data_race/read_write_race_stack.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Read is here
+error: Undefined Behavior: Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
   --> $DIR/read_write_race_stack.rs:LL:CC
    |
 LL |             stack_var
-   |             ^^^^^^^^^ Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Read is here
+   |             ^^^^^^^^^ Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
    |
-help: and the Write on thread `<unnamed>` is here
+help: and (2) occurred earlier here
   --> $DIR/read_write_race_stack.rs:LL:CC
    |
 LL |             *pointer.load(Ordering::Acquire) = 3;

--- a/tests/fail/data_race/read_write_race_stack.stderr
+++ b/tests/fail/data_race/read_write_race_stack.stderr
@@ -4,7 +4,7 @@ error: Undefined Behavior: Data race detected between Read on thread `<unnamed>`
 LL |             stack_var
    |             ^^^^^^^^^ Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Read is here
    |
-help: and Write on thread `<unnamed>`, which is here
+help: and the Write on thread `<unnamed>` is here
   --> $DIR/read_write_race_stack.rs:LL:CC
    |
 LL |             *pointer.load(Ordering::Acquire) = 3;

--- a/tests/fail/data_race/read_write_race_stack.stderr
+++ b/tests/fail/data_race/read_write_race_stack.stderr
@@ -1,15 +1,10 @@
-error: Undefined Behavior: Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
+error: Undefined Behavior: Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Read is here
   --> $DIR/read_write_race_stack.rs:LL:CC
    |
 LL |             stack_var
-   |             ^^^^^^^^^ Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
+   |             ^^^^^^^^^ Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Read is here
    |
-help: The Read on thread `<unnamed>` is here
-  --> $DIR/read_write_race_stack.rs:LL:CC
-   |
-LL |             stack_var
-   |             ^^^^^^^^^
-help: The Write on thread `<unnamed>` is here
+help: and Write on thread `<unnamed>`, which is here
   --> $DIR/read_write_race_stack.rs:LL:CC
    |
 LL |             *pointer.load(Ordering::Acquire) = 3;

--- a/tests/fail/data_race/read_write_race_stack.stderr
+++ b/tests/fail/data_race/read_write_race_stack.stderr
@@ -4,6 +4,16 @@ error: Undefined Behavior: Data race detected between Read on thread `<unnamed>`
 LL |             stack_var
    |             ^^^^^^^^^ Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
    |
+help: The Read on thread `<unnamed>` is here
+  --> $DIR/read_write_race_stack.rs:LL:CC
+   |
+LL |             sleep(Duration::from_millis(200));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: The Write on thread `<unnamed>` is here
+  --> $DIR/read_write_race_stack.rs:LL:CC
+   |
+LL |             *pointer.load(Ordering::Acquire) = 3;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/read_write_race_stack.stderr
+++ b/tests/fail/data_race/read_write_race_stack.stderr
@@ -11,7 +11,7 @@ LL |             *pointer.load(Ordering::Acquire) = 3;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside closure at $DIR/read_write_race_stack.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/relax_acquire_race.rs
+++ b/tests/fail/data_race/relax_acquire_race.rs
@@ -37,7 +37,7 @@ pub fn main() {
 
         let j3 = spawn(move || {
             if SYNC.load(Ordering::Acquire) == 2 {
-                *c.0 //~ ERROR: Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>`
+                *c.0 //~ ERROR: Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>`
             } else {
                 0
             }

--- a/tests/fail/data_race/relax_acquire_race.rs
+++ b/tests/fail/data_race/relax_acquire_race.rs
@@ -37,7 +37,7 @@ pub fn main() {
 
         let j3 = spawn(move || {
             if SYNC.load(Ordering::Acquire) == 2 {
-                *c.0 //~ ERROR: Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>`
+                *c.0 //~ ERROR: Data race detected between (1) Write on thread `<unnamed>` and (2) Read on thread `<unnamed>`
             } else {
                 0
             }

--- a/tests/fail/data_race/relax_acquire_race.stderr
+++ b/tests/fail/data_race/relax_acquire_race.stderr
@@ -11,7 +11,7 @@ LL |             *c.0 = 1;
    |             ^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside closure at $DIR/relax_acquire_race.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/relax_acquire_race.stderr
+++ b/tests/fail/data_race/relax_acquire_race.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (2) just happened here
   --> $DIR/relax_acquire_race.rs:LL:CC
    |
 LL |                 *c.0
-   |                 ^^^^ Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+   |                 ^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (2) just happened here
    |
-help: and (2) occurred earlier here
+help: and (1) occurred earlier here
   --> $DIR/relax_acquire_race.rs:LL:CC
    |
 LL |             *c.0 = 1;

--- a/tests/fail/data_race/relax_acquire_race.stderr
+++ b/tests/fail/data_race/relax_acquire_race.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Read is here
+error: Undefined Behavior: Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
   --> $DIR/relax_acquire_race.rs:LL:CC
    |
 LL |                 *c.0
-   |                 ^^^^ Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Read is here
+   |                 ^^^^ Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
    |
-help: and the Write on thread `<unnamed>` is here
+help: and (2) occurred earlier here
   --> $DIR/relax_acquire_race.rs:LL:CC
    |
 LL |             *c.0 = 1;

--- a/tests/fail/data_race/relax_acquire_race.stderr
+++ b/tests/fail/data_race/relax_acquire_race.stderr
@@ -4,6 +4,16 @@ error: Undefined Behavior: Data race detected between Read on thread `<unnamed>`
 LL |                 *c.0
    |                 ^^^^ Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
    |
+help: The Read on thread `<unnamed>` is here
+  --> $DIR/relax_acquire_race.rs:LL:CC
+   |
+LL |             if SYNC.load(Ordering::Acquire) == 2 {
+   |                                           ^
+help: The Write on thread `<unnamed>` is here
+  --> $DIR/relax_acquire_race.rs:LL:CC
+   |
+LL |             *c.0 = 1;
+   |             ^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/relax_acquire_race.stderr
+++ b/tests/fail/data_race/relax_acquire_race.stderr
@@ -7,8 +7,8 @@ LL |                 *c.0
 help: The Read on thread `<unnamed>` is here
   --> $DIR/relax_acquire_race.rs:LL:CC
    |
-LL |             if SYNC.load(Ordering::Acquire) == 2 {
-   |                                           ^
+LL |                 *c.0
+   |                 ^^^^
 help: The Write on thread `<unnamed>` is here
   --> $DIR/relax_acquire_race.rs:LL:CC
    |

--- a/tests/fail/data_race/relax_acquire_race.stderr
+++ b/tests/fail/data_race/relax_acquire_race.stderr
@@ -1,15 +1,10 @@
-error: Undefined Behavior: Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
+error: Undefined Behavior: Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Read is here
   --> $DIR/relax_acquire_race.rs:LL:CC
    |
 LL |                 *c.0
-   |                 ^^^^ Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
+   |                 ^^^^ Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Read is here
    |
-help: The Read on thread `<unnamed>` is here
-  --> $DIR/relax_acquire_race.rs:LL:CC
-   |
-LL |                 *c.0
-   |                 ^^^^
-help: The Write on thread `<unnamed>` is here
+help: and Write on thread `<unnamed>`, which is here
   --> $DIR/relax_acquire_race.rs:LL:CC
    |
 LL |             *c.0 = 1;

--- a/tests/fail/data_race/relax_acquire_race.stderr
+++ b/tests/fail/data_race/relax_acquire_race.stderr
@@ -4,7 +4,7 @@ error: Undefined Behavior: Data race detected between Read on thread `<unnamed>`
 LL |                 *c.0
    |                 ^^^^ Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Read is here
    |
-help: and Write on thread `<unnamed>`, which is here
+help: and the Write on thread `<unnamed>` is here
   --> $DIR/relax_acquire_race.rs:LL:CC
    |
 LL |             *c.0 = 1;

--- a/tests/fail/data_race/release_seq_race.rs
+++ b/tests/fail/data_race/release_seq_race.rs
@@ -41,7 +41,7 @@ pub fn main() {
         let j3 = spawn(move || {
             sleep(Duration::from_millis(500));
             if SYNC.load(Ordering::Acquire) == 3 {
-                *c.0 //~ ERROR: Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>`
+                *c.0 //~ ERROR: Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>`
             } else {
                 0
             }

--- a/tests/fail/data_race/release_seq_race.rs
+++ b/tests/fail/data_race/release_seq_race.rs
@@ -41,7 +41,7 @@ pub fn main() {
         let j3 = spawn(move || {
             sleep(Duration::from_millis(500));
             if SYNC.load(Ordering::Acquire) == 3 {
-                *c.0 //~ ERROR: Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>`
+                *c.0 //~ ERROR: Data race detected between (1) Write on thread `<unnamed>` and (2) Read on thread `<unnamed>`
             } else {
                 0
             }

--- a/tests/fail/data_race/release_seq_race.stderr
+++ b/tests/fail/data_race/release_seq_race.stderr
@@ -4,7 +4,7 @@ error: Undefined Behavior: Data race detected between Read on thread `<unnamed>`
 LL |                 *c.0
    |                 ^^^^ Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Read is here
    |
-help: and Write on thread `<unnamed>`, which is here
+help: and the Write on thread `<unnamed>` is here
   --> $DIR/release_seq_race.rs:LL:CC
    |
 LL |             *c.0 = 1;

--- a/tests/fail/data_race/release_seq_race.stderr
+++ b/tests/fail/data_race/release_seq_race.stderr
@@ -1,15 +1,10 @@
-error: Undefined Behavior: Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
+error: Undefined Behavior: Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Read is here
   --> $DIR/release_seq_race.rs:LL:CC
    |
 LL |                 *c.0
-   |                 ^^^^ Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
+   |                 ^^^^ Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Read is here
    |
-help: The Read on thread `<unnamed>` is here
-  --> $DIR/release_seq_race.rs:LL:CC
-   |
-LL |                 *c.0
-   |                 ^^^^
-help: The Write on thread `<unnamed>` is here
+help: and Write on thread `<unnamed>`, which is here
   --> $DIR/release_seq_race.rs:LL:CC
    |
 LL |             *c.0 = 1;

--- a/tests/fail/data_race/release_seq_race.stderr
+++ b/tests/fail/data_race/release_seq_race.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (2) just happened here
   --> $DIR/release_seq_race.rs:LL:CC
    |
 LL |                 *c.0
-   |                 ^^^^ Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+   |                 ^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (2) just happened here
    |
-help: and (2) occurred earlier here
+help: and (1) occurred earlier here
   --> $DIR/release_seq_race.rs:LL:CC
    |
 LL |             *c.0 = 1;

--- a/tests/fail/data_race/release_seq_race.stderr
+++ b/tests/fail/data_race/release_seq_race.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Read is here
+error: Undefined Behavior: Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
   --> $DIR/release_seq_race.rs:LL:CC
    |
 LL |                 *c.0
-   |                 ^^^^ Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Read is here
+   |                 ^^^^ Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
    |
-help: and the Write on thread `<unnamed>` is here
+help: and (2) occurred earlier here
   --> $DIR/release_seq_race.rs:LL:CC
    |
 LL |             *c.0 = 1;

--- a/tests/fail/data_race/release_seq_race.stderr
+++ b/tests/fail/data_race/release_seq_race.stderr
@@ -7,8 +7,8 @@ LL |                 *c.0
 help: The Read on thread `<unnamed>` is here
   --> $DIR/release_seq_race.rs:LL:CC
    |
-LL |             if SYNC.load(Ordering::Acquire) == 3 {
-   |                                           ^
+LL |                 *c.0
+   |                 ^^^^
 help: The Write on thread `<unnamed>` is here
   --> $DIR/release_seq_race.rs:LL:CC
    |

--- a/tests/fail/data_race/release_seq_race.stderr
+++ b/tests/fail/data_race/release_seq_race.stderr
@@ -4,6 +4,16 @@ error: Undefined Behavior: Data race detected between Read on thread `<unnamed>`
 LL |                 *c.0
    |                 ^^^^ Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
    |
+help: The Read on thread `<unnamed>` is here
+  --> $DIR/release_seq_race.rs:LL:CC
+   |
+LL |             if SYNC.load(Ordering::Acquire) == 3 {
+   |                                           ^
+help: The Write on thread `<unnamed>` is here
+  --> $DIR/release_seq_race.rs:LL:CC
+   |
+LL |             *c.0 = 1;
+   |             ^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/release_seq_race.stderr
+++ b/tests/fail/data_race/release_seq_race.stderr
@@ -11,7 +11,7 @@ LL |             *c.0 = 1;
    |             ^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside closure at $DIR/release_seq_race.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/release_seq_race_same_thread.rs
+++ b/tests/fail/data_race/release_seq_race_same_thread.rs
@@ -37,7 +37,7 @@ pub fn main() {
 
         let j2 = spawn(move || {
             if SYNC.load(Ordering::Acquire) == 2 {
-                *c.0 //~ ERROR: Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>`
+                *c.0 //~ ERROR: Data race detected between (1) Write on thread `<unnamed>` and (2) Read on thread `<unnamed>`
             } else {
                 0
             }

--- a/tests/fail/data_race/release_seq_race_same_thread.rs
+++ b/tests/fail/data_race/release_seq_race_same_thread.rs
@@ -37,7 +37,7 @@ pub fn main() {
 
         let j2 = spawn(move || {
             if SYNC.load(Ordering::Acquire) == 2 {
-                *c.0 //~ ERROR: Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>`
+                *c.0 //~ ERROR: Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>`
             } else {
                 0
             }

--- a/tests/fail/data_race/release_seq_race_same_thread.stderr
+++ b/tests/fail/data_race/release_seq_race_same_thread.stderr
@@ -7,8 +7,8 @@ LL |                 *c.0
 help: The Read on thread `<unnamed>` is here
   --> $DIR/release_seq_race_same_thread.rs:LL:CC
    |
-LL |             if SYNC.load(Ordering::Acquire) == 2 {
-   |                                           ^
+LL |                 *c.0
+   |                 ^^^^
 help: The Write on thread `<unnamed>` is here
   --> $DIR/release_seq_race_same_thread.rs:LL:CC
    |

--- a/tests/fail/data_race/release_seq_race_same_thread.stderr
+++ b/tests/fail/data_race/release_seq_race_same_thread.stderr
@@ -4,6 +4,16 @@ error: Undefined Behavior: Data race detected between Read on thread `<unnamed>`
 LL |                 *c.0
    |                 ^^^^ Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
    |
+help: The Read on thread `<unnamed>` is here
+  --> $DIR/release_seq_race_same_thread.rs:LL:CC
+   |
+LL |             if SYNC.load(Ordering::Acquire) == 2 {
+   |                                           ^
+help: The Write on thread `<unnamed>` is here
+  --> $DIR/release_seq_race_same_thread.rs:LL:CC
+   |
+LL |             *c.0 = 1;
+   |             ^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/release_seq_race_same_thread.stderr
+++ b/tests/fail/data_race/release_seq_race_same_thread.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (2) just happened here
   --> $DIR/release_seq_race_same_thread.rs:LL:CC
    |
 LL |                 *c.0
-   |                 ^^^^ Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+   |                 ^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (2) just happened here
    |
-help: and (2) occurred earlier here
+help: and (1) occurred earlier here
   --> $DIR/release_seq_race_same_thread.rs:LL:CC
    |
 LL |             *c.0 = 1;

--- a/tests/fail/data_race/release_seq_race_same_thread.stderr
+++ b/tests/fail/data_race/release_seq_race_same_thread.stderr
@@ -4,7 +4,7 @@ error: Undefined Behavior: Data race detected between Read on thread `<unnamed>`
 LL |                 *c.0
    |                 ^^^^ Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Read is here
    |
-help: and Write on thread `<unnamed>`, which is here
+help: and the Write on thread `<unnamed>` is here
   --> $DIR/release_seq_race_same_thread.rs:LL:CC
    |
 LL |             *c.0 = 1;

--- a/tests/fail/data_race/release_seq_race_same_thread.stderr
+++ b/tests/fail/data_race/release_seq_race_same_thread.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Read is here
+error: Undefined Behavior: Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
   --> $DIR/release_seq_race_same_thread.rs:LL:CC
    |
 LL |                 *c.0
-   |                 ^^^^ Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Read is here
+   |                 ^^^^ Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
    |
-help: and the Write on thread `<unnamed>` is here
+help: and (2) occurred earlier here
   --> $DIR/release_seq_race_same_thread.rs:LL:CC
    |
 LL |             *c.0 = 1;

--- a/tests/fail/data_race/release_seq_race_same_thread.stderr
+++ b/tests/fail/data_race/release_seq_race_same_thread.stderr
@@ -1,15 +1,10 @@
-error: Undefined Behavior: Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
+error: Undefined Behavior: Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Read is here
   --> $DIR/release_seq_race_same_thread.rs:LL:CC
    |
 LL |                 *c.0
-   |                 ^^^^ Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
+   |                 ^^^^ Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Read is here
    |
-help: The Read on thread `<unnamed>` is here
-  --> $DIR/release_seq_race_same_thread.rs:LL:CC
-   |
-LL |                 *c.0
-   |                 ^^^^
-help: The Write on thread `<unnamed>` is here
+help: and Write on thread `<unnamed>`, which is here
   --> $DIR/release_seq_race_same_thread.rs:LL:CC
    |
 LL |             *c.0 = 1;

--- a/tests/fail/data_race/release_seq_race_same_thread.stderr
+++ b/tests/fail/data_race/release_seq_race_same_thread.stderr
@@ -11,7 +11,7 @@ LL |             *c.0 = 1;
    |             ^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside closure at $DIR/release_seq_race_same_thread.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/rmw_race.rs
+++ b/tests/fail/data_race/rmw_race.rs
@@ -38,7 +38,7 @@ pub fn main() {
 
         let j3 = spawn(move || {
             if SYNC.load(Ordering::Acquire) == 3 {
-                *c.0 //~ ERROR: Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>`
+                *c.0 //~ ERROR: Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>`
             } else {
                 0
             }

--- a/tests/fail/data_race/rmw_race.rs
+++ b/tests/fail/data_race/rmw_race.rs
@@ -38,7 +38,7 @@ pub fn main() {
 
         let j3 = spawn(move || {
             if SYNC.load(Ordering::Acquire) == 3 {
-                *c.0 //~ ERROR: Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>`
+                *c.0 //~ ERROR: Data race detected between (1) Write on thread `<unnamed>` and (2) Read on thread `<unnamed>`
             } else {
                 0
             }

--- a/tests/fail/data_race/rmw_race.stderr
+++ b/tests/fail/data_race/rmw_race.stderr
@@ -7,8 +7,8 @@ LL |                 *c.0
 help: The Read on thread `<unnamed>` is here
   --> $DIR/rmw_race.rs:LL:CC
    |
-LL |             if SYNC.load(Ordering::Acquire) == 3 {
-   |                                           ^
+LL |                 *c.0
+   |                 ^^^^
 help: The Write on thread `<unnamed>` is here
   --> $DIR/rmw_race.rs:LL:CC
    |

--- a/tests/fail/data_race/rmw_race.stderr
+++ b/tests/fail/data_race/rmw_race.stderr
@@ -1,15 +1,10 @@
-error: Undefined Behavior: Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
+error: Undefined Behavior: Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Read is here
   --> $DIR/rmw_race.rs:LL:CC
    |
 LL |                 *c.0
-   |                 ^^^^ Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
+   |                 ^^^^ Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Read is here
    |
-help: The Read on thread `<unnamed>` is here
-  --> $DIR/rmw_race.rs:LL:CC
-   |
-LL |                 *c.0
-   |                 ^^^^
-help: The Write on thread `<unnamed>` is here
+help: and Write on thread `<unnamed>`, which is here
   --> $DIR/rmw_race.rs:LL:CC
    |
 LL |             *c.0 = 1;

--- a/tests/fail/data_race/rmw_race.stderr
+++ b/tests/fail/data_race/rmw_race.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (2) just happened here
   --> $DIR/rmw_race.rs:LL:CC
    |
 LL |                 *c.0
-   |                 ^^^^ Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+   |                 ^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (2) just happened here
    |
-help: and (2) occurred earlier here
+help: and (1) occurred earlier here
   --> $DIR/rmw_race.rs:LL:CC
    |
 LL |             *c.0 = 1;

--- a/tests/fail/data_race/rmw_race.stderr
+++ b/tests/fail/data_race/rmw_race.stderr
@@ -4,6 +4,16 @@ error: Undefined Behavior: Data race detected between Read on thread `<unnamed>`
 LL |                 *c.0
    |                 ^^^^ Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
    |
+help: The Read on thread `<unnamed>` is here
+  --> $DIR/rmw_race.rs:LL:CC
+   |
+LL |             if SYNC.load(Ordering::Acquire) == 3 {
+   |                                           ^
+help: The Write on thread `<unnamed>` is here
+  --> $DIR/rmw_race.rs:LL:CC
+   |
+LL |             *c.0 = 1;
+   |             ^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/rmw_race.stderr
+++ b/tests/fail/data_race/rmw_race.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Read is here
+error: Undefined Behavior: Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
   --> $DIR/rmw_race.rs:LL:CC
    |
 LL |                 *c.0
-   |                 ^^^^ Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Read is here
+   |                 ^^^^ Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
    |
-help: and the Write on thread `<unnamed>` is here
+help: and (2) occurred earlier here
   --> $DIR/rmw_race.rs:LL:CC
    |
 LL |             *c.0 = 1;

--- a/tests/fail/data_race/rmw_race.stderr
+++ b/tests/fail/data_race/rmw_race.stderr
@@ -11,7 +11,7 @@ LL |             *c.0 = 1;
    |             ^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside closure at $DIR/rmw_race.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/rmw_race.stderr
+++ b/tests/fail/data_race/rmw_race.stderr
@@ -4,7 +4,7 @@ error: Undefined Behavior: Data race detected between Read on thread `<unnamed>`
 LL |                 *c.0
    |                 ^^^^ Data race detected between Read on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Read is here
    |
-help: and Write on thread `<unnamed>`, which is here
+help: and the Write on thread `<unnamed>` is here
   --> $DIR/rmw_race.rs:LL:CC
    |
 LL |             *c.0 = 1;

--- a/tests/fail/data_race/stack_pop_race.rs
+++ b/tests/fail/data_race/stack_pop_race.rs
@@ -21,4 +21,4 @@ fn race(local: i32) {
     // Deallocating the local (when `main` returns)
     // races with the read in the other thread.
     // Make sure the error points at this function's end, not just the call site.
-} //~ERROR: Data race detected between (1) Deallocate on thread `main` and (2) Read on thread `<unnamed>`
+} //~ERROR: Data race detected between (1) Read on thread `<unnamed>` and (2) Deallocate on thread `main`

--- a/tests/fail/data_race/stack_pop_race.rs
+++ b/tests/fail/data_race/stack_pop_race.rs
@@ -21,4 +21,4 @@ fn race(local: i32) {
     // Deallocating the local (when `main` returns)
     // races with the read in the other thread.
     // Make sure the error points at this function's end, not just the call site.
-} //~ERROR: Data race detected between Deallocate on thread `main` and Read on thread `<unnamed>`
+} //~ERROR: Data race detected between (1) Deallocate on thread `main` and (2) Read on thread `<unnamed>`

--- a/tests/fail/data_race/stack_pop_race.stderr
+++ b/tests/fail/data_race/stack_pop_race.stderr
@@ -4,6 +4,16 @@ error: Undefined Behavior: Data race detected between Deallocate on thread `main
 LL | }
    |  ^ Data race detected between Deallocate on thread `main` and Read on thread `<unnamed>` at ALLOC
    |
+help: The Deallocate on thread `main` is here
+  --> $DIR/stack_pop_race.rs:LL:CC
+   |
+LL | }
+   |  ^
+help: The Read on thread `<unnamed>` is here
+  --> RUSTLIB/core/src/ptr/mod.rs:LL:CC
+   |
+LL | }
+   | ^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/stack_pop_race.stderr
+++ b/tests/fail/data_race/stack_pop_race.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between (1) Deallocate on thread `main` and (2) Read on thread `<unnamed>` at ALLOC. (1) just happened here
+error: Undefined Behavior: Data race detected between (1) Read on thread `<unnamed>` and (2) Deallocate on thread `main` at ALLOC. (2) just happened here
   --> $DIR/stack_pop_race.rs:LL:CC
    |
 LL | }
-   |  ^ Data race detected between (1) Deallocate on thread `main` and (2) Read on thread `<unnamed>` at ALLOC. (1) just happened here
+   |  ^ Data race detected between (1) Read on thread `<unnamed>` and (2) Deallocate on thread `main` at ALLOC. (2) just happened here
    |
-help: and (2) occurred earlier here
+help: and (1) occurred earlier here
   --> $DIR/stack_pop_race.rs:LL:CC
    |
 LL |         let _val = unsafe { *ptr.0 };

--- a/tests/fail/data_race/stack_pop_race.stderr
+++ b/tests/fail/data_race/stack_pop_race.stderr
@@ -1,15 +1,10 @@
-error: Undefined Behavior: Data race detected between Deallocate on thread `main` and Read on thread `<unnamed>` at ALLOC
+error: Undefined Behavior: Data race detected between Deallocate on thread `main` and Read on thread `<unnamed>` at ALLOC. The Deallocate is here
   --> $DIR/stack_pop_race.rs:LL:CC
    |
 LL | }
-   |  ^ Data race detected between Deallocate on thread `main` and Read on thread `<unnamed>` at ALLOC
+   |  ^ Data race detected between Deallocate on thread `main` and Read on thread `<unnamed>` at ALLOC. The Deallocate is here
    |
-help: The Deallocate on thread `main` is here
-  --> $DIR/stack_pop_race.rs:LL:CC
-   |
-LL | }
-   |  ^
-help: The Read on thread `<unnamed>` is here
+help: and Read on thread `<unnamed>`, which is here
   --> $DIR/stack_pop_race.rs:LL:CC
    |
 LL |         let _val = unsafe { *ptr.0 };

--- a/tests/fail/data_race/stack_pop_race.stderr
+++ b/tests/fail/data_race/stack_pop_race.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between Deallocate on thread `main` and Read on thread `<unnamed>` at ALLOC. The Deallocate is here
+error: Undefined Behavior: Data race detected between (1) Deallocate on thread `main` and (2) Read on thread `<unnamed>` at ALLOC. (1) just happened here
   --> $DIR/stack_pop_race.rs:LL:CC
    |
 LL | }
-   |  ^ Data race detected between Deallocate on thread `main` and Read on thread `<unnamed>` at ALLOC. The Deallocate is here
+   |  ^ Data race detected between (1) Deallocate on thread `main` and (2) Read on thread `<unnamed>` at ALLOC. (1) just happened here
    |
-help: and the Read on thread `<unnamed>` is here
+help: and (2) occurred earlier here
   --> $DIR/stack_pop_race.rs:LL:CC
    |
 LL |         let _val = unsafe { *ptr.0 };

--- a/tests/fail/data_race/stack_pop_race.stderr
+++ b/tests/fail/data_race/stack_pop_race.stderr
@@ -4,7 +4,7 @@ error: Undefined Behavior: Data race detected between Deallocate on thread `main
 LL | }
    |  ^ Data race detected between Deallocate on thread `main` and Read on thread `<unnamed>` at ALLOC. The Deallocate is here
    |
-help: and Read on thread `<unnamed>`, which is here
+help: and the Read on thread `<unnamed>` is here
   --> $DIR/stack_pop_race.rs:LL:CC
    |
 LL |         let _val = unsafe { *ptr.0 };

--- a/tests/fail/data_race/stack_pop_race.stderr
+++ b/tests/fail/data_race/stack_pop_race.stderr
@@ -11,7 +11,7 @@ LL |         let _val = unsafe { *ptr.0 };
    |                             ^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `race` at $DIR/stack_pop_race.rs:LL:CC
 note: inside `main`
   --> $DIR/stack_pop_race.rs:LL:CC

--- a/tests/fail/data_race/stack_pop_race.stderr
+++ b/tests/fail/data_race/stack_pop_race.stderr
@@ -10,10 +10,10 @@ help: The Deallocate on thread `main` is here
 LL | }
    |  ^
 help: The Read on thread `<unnamed>` is here
-  --> RUSTLIB/core/src/ptr/mod.rs:LL:CC
+  --> $DIR/stack_pop_race.rs:LL:CC
    |
-LL | }
-   | ^
+LL |         let _val = unsafe { *ptr.0 };
+   |                             ^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/write_write_race.rs
+++ b/tests/fail/data_race/write_write_race.rs
@@ -19,7 +19,7 @@ pub fn main() {
         });
 
         let j2 = spawn(move || {
-            *c.0 = 64; //~ ERROR: Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>`
+            *c.0 = 64; //~ ERROR: Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>`
         });
 
         j1.join().unwrap();

--- a/tests/fail/data_race/write_write_race.stderr
+++ b/tests/fail/data_race/write_write_race.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (2) just happened here
   --> $DIR/write_write_race.rs:LL:CC
    |
 LL |             *c.0 = 64;
-   |             ^^^^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+   |             ^^^^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (2) just happened here
    |
-help: and (2) occurred earlier here
+help: and (1) occurred earlier here
   --> $DIR/write_write_race.rs:LL:CC
    |
 LL |             *c.0 = 32;

--- a/tests/fail/data_race/write_write_race.stderr
+++ b/tests/fail/data_race/write_write_race.stderr
@@ -1,15 +1,10 @@
-error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
+error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Write is here
   --> $DIR/write_write_race.rs:LL:CC
    |
 LL |             *c.0 = 64;
-   |             ^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
+   |             ^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Write is here
    |
-help: The Write on thread `<unnamed>` is here
-  --> $DIR/write_write_race.rs:LL:CC
-   |
-LL |             *c.0 = 64;
-   |             ^^^^^^^^^
-help: The Write on thread `<unnamed>` is here
+help: and Write on thread `<unnamed>`, which is here
   --> $DIR/write_write_race.rs:LL:CC
    |
 LL |             *c.0 = 32;

--- a/tests/fail/data_race/write_write_race.stderr
+++ b/tests/fail/data_race/write_write_race.stderr
@@ -4,7 +4,7 @@ error: Undefined Behavior: Data race detected between Write on thread `<unnamed>
 LL |             *c.0 = 64;
    |             ^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Write is here
    |
-help: and Write on thread `<unnamed>`, which is here
+help: and the Write on thread `<unnamed>` is here
   --> $DIR/write_write_race.rs:LL:CC
    |
 LL |             *c.0 = 32;

--- a/tests/fail/data_race/write_write_race.stderr
+++ b/tests/fail/data_race/write_write_race.stderr
@@ -4,6 +4,16 @@ error: Undefined Behavior: Data race detected between Write on thread `<unnamed>
 LL |             *c.0 = 64;
    |             ^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
    |
+help: The Write on thread `<unnamed>` is here
+  --> $DIR/write_write_race.rs:LL:CC
+   |
+LL |             *c.0 = 64;
+   |             ^^^^^^^^^
+help: The Write on thread `<unnamed>` is here
+  --> $DIR/write_write_race.rs:LL:CC
+   |
+LL |             *c.0 = 32;
+   |             ^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/data_race/write_write_race.stderr
+++ b/tests/fail/data_race/write_write_race.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Write is here
+error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
   --> $DIR/write_write_race.rs:LL:CC
    |
 LL |             *c.0 = 64;
-   |             ^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Write is here
+   |             ^^^^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
    |
-help: and the Write on thread `<unnamed>` is here
+help: and (2) occurred earlier here
   --> $DIR/write_write_race.rs:LL:CC
    |
 LL |             *c.0 = 32;

--- a/tests/fail/data_race/write_write_race.stderr
+++ b/tests/fail/data_race/write_write_race.stderr
@@ -11,7 +11,7 @@ LL |             *c.0 = 32;
    |             ^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside closure at $DIR/write_write_race.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/write_write_race_stack.rs
+++ b/tests/fail/data_race/write_write_race_stack.rs
@@ -39,7 +39,7 @@ pub fn main() {
 
             sleep(Duration::from_millis(200));
 
-            stack_var = 1usize; //~ ERROR: Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>`
+            stack_var = 1usize; //~ ERROR: Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>`
 
             // read to silence errors
             stack_var

--- a/tests/fail/data_race/write_write_race_stack.stderr
+++ b/tests/fail/data_race/write_write_race_stack.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (2) just happened here
   --> $DIR/write_write_race_stack.rs:LL:CC
    |
 LL |             stack_var = 1usize;
-   |             ^^^^^^^^^^^^^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+   |             ^^^^^^^^^^^^^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (2) just happened here
    |
-help: and (2) occurred earlier here
+help: and (1) occurred earlier here
   --> $DIR/write_write_race_stack.rs:LL:CC
    |
 LL |             *pointer.load(Ordering::Acquire) = 3;

--- a/tests/fail/data_race/write_write_race_stack.stderr
+++ b/tests/fail/data_race/write_write_race_stack.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Write is here
+error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
   --> $DIR/write_write_race_stack.rs:LL:CC
    |
 LL |             stack_var = 1usize;
-   |             ^^^^^^^^^^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Write is here
+   |             ^^^^^^^^^^^^^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
    |
-help: and the Write on thread `<unnamed>` is here
+help: and (2) occurred earlier here
   --> $DIR/write_write_race_stack.rs:LL:CC
    |
 LL |             *pointer.load(Ordering::Acquire) = 3;

--- a/tests/fail/data_race/write_write_race_stack.stderr
+++ b/tests/fail/data_race/write_write_race_stack.stderr
@@ -4,7 +4,7 @@ error: Undefined Behavior: Data race detected between Write on thread `<unnamed>
 LL |             stack_var = 1usize;
    |             ^^^^^^^^^^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Write is here
    |
-help: and Write on thread `<unnamed>`, which is here
+help: and the Write on thread `<unnamed>` is here
   --> $DIR/write_write_race_stack.rs:LL:CC
    |
 LL |             *pointer.load(Ordering::Acquire) = 3;

--- a/tests/fail/data_race/write_write_race_stack.stderr
+++ b/tests/fail/data_race/write_write_race_stack.stderr
@@ -11,7 +11,7 @@ LL |             *pointer.load(Ordering::Acquire) = 3;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside closure at $DIR/write_write_race_stack.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/data_race/write_write_race_stack.stderr
+++ b/tests/fail/data_race/write_write_race_stack.stderr
@@ -1,15 +1,10 @@
-error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
+error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Write is here
   --> $DIR/write_write_race_stack.rs:LL:CC
    |
 LL |             stack_var = 1usize;
-   |             ^^^^^^^^^^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
+   |             ^^^^^^^^^^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Write is here
    |
-help: The Write on thread `<unnamed>` is here
-  --> $DIR/write_write_race_stack.rs:LL:CC
-   |
-LL |             stack_var = 1usize;
-   |             ^^^^^^^^^^^^^^^^^^
-help: The Write on thread `<unnamed>` is here
+help: and Write on thread `<unnamed>`, which is here
   --> $DIR/write_write_race_stack.rs:LL:CC
    |
 LL |             *pointer.load(Ordering::Acquire) = 3;

--- a/tests/fail/data_race/write_write_race_stack.stderr
+++ b/tests/fail/data_race/write_write_race_stack.stderr
@@ -4,6 +4,16 @@ error: Undefined Behavior: Data race detected between Write on thread `<unnamed>
 LL |             stack_var = 1usize;
    |             ^^^^^^^^^^^^^^^^^^ Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
    |
+help: The Write on thread `<unnamed>` is here
+  --> $DIR/write_write_race_stack.rs:LL:CC
+   |
+LL |             stack_var = 1usize;
+   |             ^^^^^^^^^^^^^^^^^^
+help: The Write on thread `<unnamed>` is here
+  --> $DIR/write_write_race_stack.rs:LL:CC
+   |
+LL |             *pointer.load(Ordering::Acquire) = 3;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/function_calls/exported_symbol_clashing.stderr
+++ b/tests/fail/function_calls/exported_symbol_clashing.stderr
@@ -14,7 +14,7 @@ help: then it's defined here again, in crate `exported_symbol_clashing`
    |
 LL | fn bar() {}
    | ^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/exported_symbol_clashing.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_calls/exported_symbol_shim_clashing.stderr
+++ b/tests/fail/function_calls/exported_symbol_shim_clashing.stderr
@@ -12,7 +12,7 @@ LL | |
 LL | |     unreachable!()
 LL | | }
    | |_^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/exported_symbol_shim_clashing.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/alias_through_mutation.stderr
+++ b/tests/fail/stacked_borrows/alias_through_mutation.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a write access
    |
 LL |     *target = 13;
    |     ^^^^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/alias_through_mutation.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/aliasing_mut1.stderr
+++ b/tests/fail/stacked_borrows/aliasing_mut1.stderr
@@ -16,7 +16,7 @@ help: <TAG> is this argument
    |
 LL | pub fn safe(_x: &mut i32, _y: &mut i32) {}
    |             ^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `safe` at $DIR/aliasing_mut1.rs:LL:CC
 note: inside `main`
   --> $DIR/aliasing_mut1.rs:LL:CC

--- a/tests/fail/stacked_borrows/aliasing_mut2.stderr
+++ b/tests/fail/stacked_borrows/aliasing_mut2.stderr
@@ -16,7 +16,7 @@ help: <TAG> is this argument
    |
 LL | pub fn safe(_x: &i32, _y: &mut i32) {}
    |             ^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `safe` at $DIR/aliasing_mut2.rs:LL:CC
 note: inside `main`
   --> $DIR/aliasing_mut2.rs:LL:CC

--- a/tests/fail/stacked_borrows/aliasing_mut3.stderr
+++ b/tests/fail/stacked_borrows/aliasing_mut3.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a Unique FnEntry reta
    |
 LL |     safe_raw(xraw, xshr);
    |     ^^^^^^^^^^^^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `safe` at $DIR/aliasing_mut3.rs:LL:CC
 note: inside `main`
   --> $DIR/aliasing_mut3.rs:LL:CC

--- a/tests/fail/stacked_borrows/aliasing_mut4.stderr
+++ b/tests/fail/stacked_borrows/aliasing_mut4.stderr
@@ -16,7 +16,7 @@ help: <TAG> is this argument
    |
 LL | pub fn safe(_x: &i32, _y: &mut Cell<i32>) {}
    |             ^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `safe` at $DIR/aliasing_mut4.rs:LL:CC
 note: inside `main`
   --> $DIR/aliasing_mut4.rs:LL:CC

--- a/tests/fail/stacked_borrows/box_exclusive_violation1.stderr
+++ b/tests/fail/stacked_borrows/box_exclusive_violation1.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a write access
    |
 LL |     *our = 5;
    |     ^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `unknown_code_2` at $DIR/box_exclusive_violation1.rs:LL:CC
 note: inside `demo_box_advanced_unique`
   --> $DIR/box_exclusive_violation1.rs:LL:CC

--- a/tests/fail/stacked_borrows/box_noalias_violation.stderr
+++ b/tests/fail/stacked_borrows/box_noalias_violation.stderr
@@ -16,7 +16,7 @@ help: <TAG> is this argument
    |
 LL | unsafe fn test(mut x: Box<i32>, y: *const i32) -> i32 {
    |                ^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `test` at $DIR/box_noalias_violation.rs:LL:CC
 note: inside `main`
   --> $DIR/box_noalias_violation.rs:LL:CC

--- a/tests/fail/stacked_borrows/buggy_as_mut_slice.stderr
+++ b/tests/fail/stacked_borrows/buggy_as_mut_slice.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0xc] by a Unique retag
    |
 LL |         unsafe { from_raw_parts_mut(self_.as_ptr() as *mut T, self_.len()) }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/buggy_as_mut_slice.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/buggy_split_at_mut.stderr
+++ b/tests/fail/stacked_borrows/buggy_split_at_mut.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x10] by a Unique retag
    |
 LL |                 from_raw_parts_mut(ptr.offset(mid as isize), len - mid),
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/buggy_split_at_mut.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/disable_mut_does_not_merge_srw.stderr
+++ b/tests/fail/stacked_borrows/disable_mut_does_not_merge_srw.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a write access
    |
 LL |         *base = 1;
    |         ^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/disable_mut_does_not_merge_srw.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/fnentry_invalidation.stderr
+++ b/tests/fail/stacked_borrows/fnentry_invalidation.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a Unique FnEntry reta
    |
 LL |     x.do_bad();
    |     ^^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/fnentry_invalidation.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/fnentry_invalidation2.stderr
+++ b/tests/fail/stacked_borrows/fnentry_invalidation2.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0xc] by a Unique FnEntry reta
    |
 LL |     let _ = t.sli.as_mut_ptr();
    |             ^^^^^^^^^^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/fnentry_invalidation2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_dealloc1.stderr
+++ b/tests/fail/stacked_borrows/illegal_dealloc1.stderr
@@ -16,7 +16,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x1] by a write access
    |
 LL |         ptr1.write(0);
    |         ^^^^^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `std::alloc::dealloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
 note: inside `main`
   --> $DIR/illegal_deALLOC.rs:LL:CC

--- a/tests/fail/stacked_borrows/illegal_read1.stderr
+++ b/tests/fail/stacked_borrows/illegal_read1.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a read access
    |
 LL |     let _val = unsafe { *xraw };
    |                         ^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_read1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_read2.stderr
+++ b/tests/fail/stacked_borrows/illegal_read2.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a SharedReadOnly reta
    |
 LL |     let shr = unsafe { &*xraw };
    |                        ^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_read2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_read3.stderr
+++ b/tests/fail/stacked_borrows/illegal_read3.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a read access
    |
 LL |     let _val = unsafe { *xref1.r };
    |                         ^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_read3.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_read4.stderr
+++ b/tests/fail/stacked_borrows/illegal_read4.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a read access
    |
 LL |     let _val = unsafe { *xraw }; // use the raw again, this invalidates xref2 *even* with the special read except for uniq refs
    |                         ^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_read4.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_read5.stderr
+++ b/tests/fail/stacked_borrows/illegal_read5.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [$HEX..$HEX] by a read access
    |
 LL |     mem::forget(unsafe { ptr::read(xshr) }); // but after reading through the shared ref
    |                          ^^^^^^^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_read5.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_read6.stderr
+++ b/tests/fail/stacked_borrows/illegal_read6.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a Unique retag
    |
 LL |         let x = &mut *x; // kill `raw`
    |                 ^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_read6.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_read7.stderr
+++ b/tests/fail/stacked_borrows/illegal_read7.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a read access
    |
 LL |         let _val = ptr::read(raw);
    |                    ^^^^^^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_read7.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_read8.stderr
+++ b/tests/fail/stacked_borrows/illegal_read8.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a write access
    |
 LL |         *y2 += 1;
    |         ^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_read8.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_read_despite_exposed1.stderr
+++ b/tests/fail/stacked_borrows/illegal_read_despite_exposed1.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a write access
    |
 LL |         *exposed_ptr = 0;
    |         ^^^^^^^^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_read_despite_exposed1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_read_despite_exposed2.stderr
+++ b/tests/fail/stacked_borrows/illegal_read_despite_exposed2.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a read access
    |
 LL |         let _val = *exposed_ptr;
    |                    ^^^^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_read_despite_exposed2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_write1.stderr
+++ b/tests/fail/stacked_borrows/illegal_write1.stderr
@@ -14,7 +14,7 @@ help: <TAG> was created by a SharedReadOnly retag at offsets [0x0..0x4]
    |
 LL |         let x: *mut u32 = xref as *const _ as *mut _;
    |                           ^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_write1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_write2.stderr
+++ b/tests/fail/stacked_borrows/illegal_write2.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a Unique retag
    |
 LL |     drop(&mut *target); // reborrow
    |          ^^^^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_write2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_write3.stderr
+++ b/tests/fail/stacked_borrows/illegal_write3.stderr
@@ -14,7 +14,7 @@ help: <TAG> was created by a SharedReadOnly retag at offsets [0x0..0x4]
    |
 LL |     let ptr = r#ref as *const _ as *mut _; // raw ptr, with raw tag
    |               ^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_write3.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_write4.stderr
+++ b/tests/fail/stacked_borrows/illegal_write4.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a Unique retag
    |
 LL |     let _mut_ref: &mut i32 = unsafe { mem::transmute(raw) }; // &mut, with raw tag
    |                                       ^^^^^^^^^^^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_write4.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_write5.stderr
+++ b/tests/fail/stacked_borrows/illegal_write5.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a write access
    |
 LL |     unsafe { *xraw = 15 };
    |              ^^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_write5.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/illegal_write6.stderr
+++ b/tests/fail/stacked_borrows/illegal_write6.stderr
@@ -16,7 +16,7 @@ help: <TAG> is this argument
    |
 LL | fn foo(a: &mut u32, y: *mut u32) -> u32 {
    |        ^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `foo` at $DIR/illegal_write6.rs:LL:CC
 note: inside `main`
   --> $DIR/illegal_write6.rs:LL:CC

--- a/tests/fail/stacked_borrows/illegal_write_despite_exposed1.stderr
+++ b/tests/fail/stacked_borrows/illegal_write_despite_exposed1.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a write access
    |
 LL |         *exposed_ptr = 0;
    |         ^^^^^^^^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_write_despite_exposed1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/interior_mut1.stderr
+++ b/tests/fail/stacked_borrows/interior_mut1.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a write access
    |
 LL |         *c.get() = UnsafeCell::new(1); // invalidates inner_shr
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/interior_mut1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/interior_mut2.stderr
+++ b/tests/fail/stacked_borrows/interior_mut2.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a write access
    |
 LL |         *c.get() = UnsafeCell::new(0); // now inner_shr gets invalidated
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/interior_mut2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/invalidate_against_protector1.stderr
+++ b/tests/fail/stacked_borrows/invalidate_against_protector1.stderr
@@ -16,7 +16,7 @@ help: <TAG> is this argument
    |
 LL | fn inner(x: *mut i32, _y: &mut i32) {
    |                       ^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `inner` at $DIR/invalidate_against_protector1.rs:LL:CC
 note: inside `main`
   --> $DIR/invalidate_against_protector1.rs:LL:CC

--- a/tests/fail/stacked_borrows/invalidate_against_protector2.stderr
+++ b/tests/fail/stacked_borrows/invalidate_against_protector2.stderr
@@ -16,7 +16,7 @@ help: <TAG> is this argument
    |
 LL | fn inner(x: *mut i32, _y: &i32) {
    |                       ^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `inner` at $DIR/invalidate_against_protector2.rs:LL:CC
 note: inside `main`
   --> $DIR/invalidate_against_protector2.rs:LL:CC

--- a/tests/fail/stacked_borrows/invalidate_against_protector3.stderr
+++ b/tests/fail/stacked_borrows/invalidate_against_protector3.stderr
@@ -16,7 +16,7 @@ help: <TAG> is this argument
    |
 LL | fn inner(x: *mut i32, _y: &i32) {
    |                       ^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `inner` at $DIR/invalidate_against_protector3.rs:LL:CC
 note: inside `main`
   --> $DIR/invalidate_against_protector3.rs:LL:CC

--- a/tests/fail/stacked_borrows/load_invalid_mut.stderr
+++ b/tests/fail/stacked_borrows/load_invalid_mut.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a read access
    |
 LL |     let _val = unsafe { *xraw }; // invalidate xref
    |                         ^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/load_invalid_mut.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/load_invalid_shr.stderr
+++ b/tests/fail/stacked_borrows/load_invalid_shr.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a write access
    |
 LL |     unsafe { *xraw = 42 }; // unfreeze
    |              ^^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/load_invalid_shr.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/mut_exclusive_violation1.stderr
+++ b/tests/fail/stacked_borrows/mut_exclusive_violation1.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a write access
    |
 LL |     *our = 5;
    |     ^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `unknown_code_2` at $DIR/mut_exclusive_violation1.rs:LL:CC
 note: inside `demo_mut_advanced_unique`
   --> $DIR/mut_exclusive_violation1.rs:LL:CC

--- a/tests/fail/stacked_borrows/mut_exclusive_violation2.stderr
+++ b/tests/fail/stacked_borrows/mut_exclusive_violation2.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a Unique retag
    |
 LL |         let _raw2 = ptr2.as_mut();
    |                     ^^^^^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/mut_exclusive_violation2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/newtype_pair_retagging.stderr
+++ b/tests/fail/stacked_borrows/newtype_pair_retagging.stderr
@@ -16,7 +16,7 @@ help: <TAG> is this argument
    |
 LL | fn dealloc_while_running(_n: Newtype<'_>, dealloc: impl FnOnce()) {
    |                          ^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `std::boxed::Box::<i32>::from_raw_in` at RUSTLIB/alloc/src/boxed.rs:LL:CC
    = note: inside `std::boxed::Box::<i32>::from_raw` at RUSTLIB/alloc/src/boxed.rs:LL:CC
 note: inside closure

--- a/tests/fail/stacked_borrows/newtype_retagging.stderr
+++ b/tests/fail/stacked_borrows/newtype_retagging.stderr
@@ -16,7 +16,7 @@ help: <TAG> is this argument
    |
 LL | fn dealloc_while_running(_n: Newtype<'_>, dealloc: impl FnOnce()) {
    |                          ^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `std::boxed::Box::<i32>::from_raw_in` at RUSTLIB/alloc/src/boxed.rs:LL:CC
    = note: inside `std::boxed::Box::<i32>::from_raw` at RUSTLIB/alloc/src/boxed.rs:LL:CC
 note: inside closure

--- a/tests/fail/stacked_borrows/outdated_local.stderr
+++ b/tests/fail/stacked_borrows/outdated_local.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a write access
    |
 LL |     x = 1; // this invalidates y by reactivating the lowermost uniq borrow for this local
    |     ^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/outdated_local.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/pass_invalid_mut.stderr
+++ b/tests/fail/stacked_borrows/pass_invalid_mut.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a read access
    |
 LL |     let _val = unsafe { *xraw }; // invalidate xref
    |                         ^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/pass_invalid_mut.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/pass_invalid_shr.stderr
+++ b/tests/fail/stacked_borrows/pass_invalid_shr.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a write access
    |
 LL |     unsafe { *xraw = 42 }; // unfreeze
    |              ^^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/pass_invalid_shr.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/pointer_smuggling.stderr
+++ b/tests/fail/stacked_borrows/pointer_smuggling.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x1] by a write access
    |
 LL |     *val = 2; // this invalidates any raw ptrs `fun1` might have created.
    |     ^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `fun2` at $DIR/pointer_smuggling.rs:LL:CC
 note: inside `main`
   --> $DIR/pointer_smuggling.rs:LL:CC

--- a/tests/fail/stacked_borrows/raw_tracking.stderr
+++ b/tests/fail/stacked_borrows/raw_tracking.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a Unique retag
    |
 LL |     let raw2 = &mut l as *mut _; // invalidates raw1
    |                ^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/raw_tracking.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/retag_data_race_read.rs
+++ b/tests/fail/stacked_borrows/retag_data_race_read.rs
@@ -15,7 +15,7 @@ fn thread_1(p: SendPtr) {
 fn thread_2(p: SendPtr) {
     let p = p.0;
     unsafe {
-        *p = 5; //~ ERROR: Data race detected between Write on thread `<unnamed>` and Read on thread `<unnamed>`
+        *p = 5; //~ ERROR: Data race detected between (1) Write on thread `<unnamed>` and (2) Read on thread `<unnamed>`
     }
 }
 

--- a/tests/fail/stacked_borrows/retag_data_race_read.rs
+++ b/tests/fail/stacked_borrows/retag_data_race_read.rs
@@ -15,7 +15,7 @@ fn thread_1(p: SendPtr) {
 fn thread_2(p: SendPtr) {
     let p = p.0;
     unsafe {
-        *p = 5; //~ ERROR: Data race detected between (1) Write on thread `<unnamed>` and (2) Read on thread `<unnamed>`
+        *p = 5; //~ ERROR: Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>`
     }
 }
 

--- a/tests/fail/stacked_borrows/retag_data_race_read.stderr
+++ b/tests/fail/stacked_borrows/retag_data_race_read.stderr
@@ -12,8 +12,8 @@ LL |         *p = 5;
 help: The Read on thread `<unnamed>` is here
   --> $DIR/retag_data_race_read.rs:LL:CC
    |
-LL |     let t1 = std::thread::spawn(move || thread_1(p));
-   |                                                  ^
+LL |         let _r = &*p;
+   |                  ^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/stacked_borrows/retag_data_race_read.stderr
+++ b/tests/fail/stacked_borrows/retag_data_race_read.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC. The Write is here
+error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (1) just happened here
   --> $DIR/retag_data_race_read.rs:LL:CC
    |
 LL |         *p = 5;
-   |         ^^^^^^ Data race detected between Write on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC. The Write is here
+   |         ^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (1) just happened here
    |
-help: and the Read on thread `<unnamed>` is here
+help: and (2) occurred earlier here
   --> $DIR/retag_data_race_read.rs:LL:CC
    |
 LL |         let _r = &*p;

--- a/tests/fail/stacked_borrows/retag_data_race_read.stderr
+++ b/tests/fail/stacked_borrows/retag_data_race_read.stderr
@@ -4,7 +4,7 @@ error: Undefined Behavior: Data race detected between Write on thread `<unnamed>
 LL |         *p = 5;
    |         ^^^^^^ Data race detected between Write on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC. The Write is here
    |
-help: and Read on thread `<unnamed>`, which is here
+help: and the Read on thread `<unnamed>` is here
   --> $DIR/retag_data_race_read.rs:LL:CC
    |
 LL |         let _r = &*p;

--- a/tests/fail/stacked_borrows/retag_data_race_read.stderr
+++ b/tests/fail/stacked_borrows/retag_data_race_read.stderr
@@ -1,15 +1,10 @@
-error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC
+error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC. The Write is here
   --> $DIR/retag_data_race_read.rs:LL:CC
    |
 LL |         *p = 5;
-   |         ^^^^^^ Data race detected between Write on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC
+   |         ^^^^^^ Data race detected between Write on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC. The Write is here
    |
-help: The Write on thread `<unnamed>` is here
-  --> $DIR/retag_data_race_read.rs:LL:CC
-   |
-LL |         *p = 5;
-   |         ^^^^^^
-help: The Read on thread `<unnamed>` is here
+help: and Read on thread `<unnamed>`, which is here
   --> $DIR/retag_data_race_read.rs:LL:CC
    |
 LL |         let _r = &*p;

--- a/tests/fail/stacked_borrows/retag_data_race_read.stderr
+++ b/tests/fail/stacked_borrows/retag_data_race_read.stderr
@@ -4,6 +4,16 @@ error: Undefined Behavior: Data race detected between Write on thread `<unnamed>
 LL |         *p = 5;
    |         ^^^^^^ Data race detected between Write on thread `<unnamed>` and Read on thread `<unnamed>` at ALLOC
    |
+help: The Write on thread `<unnamed>` is here
+  --> $DIR/retag_data_race_read.rs:LL:CC
+   |
+LL |         *p = 5;
+   |         ^^^^^^
+help: The Read on thread `<unnamed>` is here
+  --> $DIR/retag_data_race_read.rs:LL:CC
+   |
+LL |     let t1 = std::thread::spawn(move || thread_1(p));
+   |                                                  ^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/stacked_borrows/retag_data_race_read.stderr
+++ b/tests/fail/stacked_borrows/retag_data_race_read.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (1) just happened here
+error: Undefined Behavior: Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (2) just happened here
   --> $DIR/retag_data_race_read.rs:LL:CC
    |
 LL |         *p = 5;
-   |         ^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Read on thread `<unnamed>` at ALLOC. (1) just happened here
+   |         ^^^^^^ Data race detected between (1) Read on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (2) just happened here
    |
-help: and (2) occurred earlier here
+help: and (1) occurred earlier here
   --> $DIR/retag_data_race_read.rs:LL:CC
    |
 LL |         let _r = &*p;

--- a/tests/fail/stacked_borrows/retag_data_race_read.stderr
+++ b/tests/fail/stacked_borrows/retag_data_race_read.stderr
@@ -11,7 +11,7 @@ LL |         let _r = &*p;
    |                  ^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `thread_2` at $DIR/retag_data_race_read.rs:LL:CC
 note: inside closure
   --> $DIR/retag_data_race_read.rs:LL:CC

--- a/tests/fail/stacked_borrows/retag_data_race_write.rs
+++ b/tests/fail/stacked_borrows/retag_data_race_write.rs
@@ -15,7 +15,7 @@ fn thread_1(p: SendPtr) {
 fn thread_2(p: SendPtr) {
     let p = p.0;
     unsafe {
-        *p = 5; //~ ERROR: Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>`
+        *p = 5; //~ ERROR: Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>`
     }
 }
 

--- a/tests/fail/stacked_borrows/retag_data_race_write.stderr
+++ b/tests/fail/stacked_borrows/retag_data_race_write.stderr
@@ -11,7 +11,7 @@ LL |         let _r = &mut *p;
    |                  ^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `thread_2` at $DIR/retag_data_race_write.rs:LL:CC
 note: inside closure
   --> $DIR/retag_data_race_write.rs:LL:CC

--- a/tests/fail/stacked_borrows/retag_data_race_write.stderr
+++ b/tests/fail/stacked_borrows/retag_data_race_write.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (2) just happened here
   --> $DIR/retag_data_race_write.rs:LL:CC
    |
 LL |         *p = 5;
-   |         ^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
+   |         ^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (2) just happened here
    |
-help: and (2) occurred earlier here
+help: and (1) occurred earlier here
   --> $DIR/retag_data_race_write.rs:LL:CC
    |
 LL |         let _r = &mut *p;

--- a/tests/fail/stacked_borrows/retag_data_race_write.stderr
+++ b/tests/fail/stacked_borrows/retag_data_race_write.stderr
@@ -4,7 +4,7 @@ error: Undefined Behavior: Data race detected between Write on thread `<unnamed>
 LL |         *p = 5;
    |         ^^^^^^ Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Write is here
    |
-help: and Write on thread `<unnamed>`, which is here
+help: and the Write on thread `<unnamed>` is here
   --> $DIR/retag_data_race_write.rs:LL:CC
    |
 LL |         let _r = &mut *p;

--- a/tests/fail/stacked_borrows/retag_data_race_write.stderr
+++ b/tests/fail/stacked_borrows/retag_data_race_write.stderr
@@ -1,15 +1,10 @@
-error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
+error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Write is here
   --> $DIR/retag_data_race_write.rs:LL:CC
    |
 LL |         *p = 5;
-   |         ^^^^^^ Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
+   |         ^^^^^^ Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Write is here
    |
-help: The Write on thread `<unnamed>` is here
-  --> $DIR/retag_data_race_write.rs:LL:CC
-   |
-LL |         *p = 5;
-   |         ^^^^^^
-help: The Write on thread `<unnamed>` is here
+help: and Write on thread `<unnamed>`, which is here
   --> $DIR/retag_data_race_write.rs:LL:CC
    |
 LL |         let _r = &mut *p;

--- a/tests/fail/stacked_borrows/retag_data_race_write.stderr
+++ b/tests/fail/stacked_borrows/retag_data_race_write.stderr
@@ -4,6 +4,16 @@ error: Undefined Behavior: Data race detected between Write on thread `<unnamed>
 LL |         *p = 5;
    |         ^^^^^^ Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC
    |
+help: The Write on thread `<unnamed>` is here
+  --> $DIR/retag_data_race_write.rs:LL:CC
+   |
+LL |         *p = 5;
+   |         ^^^^^^
+help: The Write on thread `<unnamed>` is here
+  --> $DIR/retag_data_race_write.rs:LL:CC
+   |
+LL |         let _r = &mut *p;
+   |                  ^^^^^^^
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:

--- a/tests/fail/stacked_borrows/retag_data_race_write.stderr
+++ b/tests/fail/stacked_borrows/retag_data_race_write.stderr
@@ -1,10 +1,10 @@
-error: Undefined Behavior: Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Write is here
+error: Undefined Behavior: Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
   --> $DIR/retag_data_race_write.rs:LL:CC
    |
 LL |         *p = 5;
-   |         ^^^^^^ Data race detected between Write on thread `<unnamed>` and Write on thread `<unnamed>` at ALLOC. The Write is here
+   |         ^^^^^^ Data race detected between (1) Write on thread `<unnamed>` and (2) Write on thread `<unnamed>` at ALLOC. (1) just happened here
    |
-help: and the Write on thread `<unnamed>` is here
+help: and (2) occurred earlier here
   --> $DIR/retag_data_race_write.rs:LL:CC
    |
 LL |         let _r = &mut *p;

--- a/tests/fail/stacked_borrows/return_invalid_mut.stderr
+++ b/tests/fail/stacked_borrows/return_invalid_mut.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x8] by a read access
    |
 LL |     let _val = unsafe { *xraw }; // invalidate xref
    |                         ^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `foo` at $DIR/return_invalid_mut.rs:LL:CC
 note: inside `main`
   --> $DIR/return_invalid_mut.rs:LL:CC

--- a/tests/fail/stacked_borrows/return_invalid_mut_option.stderr
+++ b/tests/fail/stacked_borrows/return_invalid_mut_option.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x8] by a read access
    |
 LL |     let _val = unsafe { *xraw }; // invalidate xref
    |                         ^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `foo` at $DIR/return_invalid_mut_option.rs:LL:CC
 note: inside `main`
   --> $DIR/return_invalid_mut_option.rs:LL:CC

--- a/tests/fail/stacked_borrows/return_invalid_mut_tuple.stderr
+++ b/tests/fail/stacked_borrows/return_invalid_mut_tuple.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x8] by a read access
    |
 LL |     let _val = unsafe { *xraw }; // invalidate xref
    |                         ^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `foo` at $DIR/return_invalid_mut_tuple.rs:LL:CC
 note: inside `main`
   --> $DIR/return_invalid_mut_tuple.rs:LL:CC

--- a/tests/fail/stacked_borrows/return_invalid_shr.stderr
+++ b/tests/fail/stacked_borrows/return_invalid_shr.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x8] by a write access
    |
 LL |     unsafe { *xraw = (42, 23) }; // unfreeze
    |              ^^^^^^^^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `foo` at $DIR/return_invalid_shr.rs:LL:CC
 note: inside `main`
   --> $DIR/return_invalid_shr.rs:LL:CC

--- a/tests/fail/stacked_borrows/return_invalid_shr_option.stderr
+++ b/tests/fail/stacked_borrows/return_invalid_shr_option.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x8] by a write access
    |
 LL |     unsafe { *xraw = (42, 23) }; // unfreeze
    |              ^^^^^^^^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `foo` at $DIR/return_invalid_shr_option.rs:LL:CC
 note: inside `main`
   --> $DIR/return_invalid_shr_option.rs:LL:CC

--- a/tests/fail/stacked_borrows/return_invalid_shr_tuple.stderr
+++ b/tests/fail/stacked_borrows/return_invalid_shr_tuple.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x8] by a write access
    |
 LL |     unsafe { *xraw = (42, 23) }; // unfreeze
    |              ^^^^^^^^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `foo` at $DIR/return_invalid_shr_tuple.rs:LL:CC
 note: inside `main`
   --> $DIR/return_invalid_shr_tuple.rs:LL:CC

--- a/tests/fail/stacked_borrows/shared_rw_borrows_are_weak1.stderr
+++ b/tests/fail/stacked_borrows/shared_rw_borrows_are_weak1.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a Unique retag
    |
 LL |         shr_rw.set(1);
    |         ^^^^^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/shared_rw_borrows_are_weak1.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/shared_rw_borrows_are_weak2.stderr
+++ b/tests/fail/stacked_borrows/shared_rw_borrows_are_weak2.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [$HEX..$HEX] by a Unique retag
    |
 LL |         shr_rw.replace(1);
    |         ^^^^^^^^^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/shared_rw_borrows_are_weak2.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/shr_frozen_violation1.stderr
+++ b/tests/fail/stacked_borrows/shr_frozen_violation1.stderr
@@ -14,7 +14,7 @@ help: <TAG> was created by a SharedReadOnly retag at offsets [0x0..0x4]
    |
 LL |         *(x as *const i32 as *mut i32) = 7;
    |           ^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `unknown_code` at $DIR/shr_frozen_violation1.rs:LL:CC
 note: inside `foo`
   --> $DIR/shr_frozen_violation1.rs:LL:CC

--- a/tests/fail/stacked_borrows/track_caller.stderr
+++ b/tests/fail/stacked_borrows/track_caller.stderr
@@ -19,7 +19,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x4] by a read access
    |
 LL |     callee(xraw);
    |     ^^^^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/track_caller.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/transmute-is-no-escape.stderr
+++ b/tests/fail/stacked_borrows/transmute-is-no-escape.stderr
@@ -14,7 +14,7 @@ help: <TAG> was created by a SharedReadWrite retag at offsets [0x4..0x8]
    |
 LL |     let raw = (&mut x[1] as *mut i32).wrapping_offset(-1);
    |                ^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/transmute-is-no-escape.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/unescaped_static.stderr
+++ b/tests/fail/stacked_borrows/unescaped_static.stderr
@@ -14,7 +14,7 @@ help: <TAG> was created by a SharedReadOnly retag at offsets [0x0..0x1]
    |
 LL |     let ptr_to_first = &ARRAY[0] as *const u8;
    |                        ^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/unescaped_static.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/zst_slice.stderr
+++ b/tests/fail/stacked_borrows/zst_slice.stderr
@@ -14,7 +14,7 @@ help: <TAG> would have been created here, but this is a zero-size retag ([0x0..0
    |
 LL |         assert_eq!(*s.get_unchecked(1), 2);
    |                     ^^^^^^^^^^^^^^^^^^
-   = note: BACKTRACE:
+   = note: BACKTRACE (of the first span):
    = note: inside `core::slice::<impl [i32]>::get_unchecked::<usize>` at RUSTLIB/core/src/slice/mod.rs:LL:CC
 note: inside `main`
   --> $DIR/zst_slice.rs:LL:CC


### PR DESCRIPTION
Fixes https://github.com/rust-lang/miri/issues/2205

This adds output to data race errors very similar to the spans we emit for Stacked Borrows errors. For example, from our test suite:
```
help: The Atomic Load on thread `<unnamed>` is here
  --> tests/fail/data_race/atomic_read_na_write_race1.rs:23:13
   |
23 | ...   (&*c.0).load(Ordering::SeqCst) //~ ERROR: Data race detected between Atomic Load on thread `<unnamed>` and Write o...
   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
help: The Write on thread `<unnamed>` is here
  --> tests/fail/data_race/atomic_read_na_write_race1.rs:19:13
   |
19 |             *(c.0 as *mut usize) = 32;
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^```
```

Because of https://github.com/rust-lang/miri/pull/2647 this comes without a perf regression, according to our benchmarks.