### PR TITLE
Add miri_alloc, miri_dealloc

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,15 @@ extern "Rust" {
     /// program) the contents of a section of program memory, as bytes. Bytes
     /// written using this function will emerge from the interpreter's stderr.
     fn miri_write_to_stderr(bytes: &[u8]);
+
+    /// Miri-provided extern function to allocate memory from the interpreter.
+    /// 
+    /// This is useful when no fundamental way of allocating memory is
+    /// available, e.g. when using `no_std` + `alloc`.
+    fn miri_alloc(size: usize, align: usize) -> *mut u8;
+
+    /// Miri-provided extern function to deallocate memory.
+    fn miri_dealloc(ptr: *mut u8, size: usize, align: usize);
 }
 ```
 

--- a/src/concurrency/data_race.rs
+++ b/src/concurrency/data_race.rs
@@ -713,7 +713,10 @@ impl VClockAlloc {
         let (alloc_timestamp, alloc_index) = match kind {
             // User allocated and stack memory should track allocation.
             MemoryKind::Machine(
-                MiriMemoryKind::Rust | MiriMemoryKind::C | MiriMemoryKind::WinHeap,
+                MiriMemoryKind::Rust
+                | MiriMemoryKind::Miri
+                | MiriMemoryKind::C
+                | MiriMemoryKind::WinHeap,
             )
             | MemoryKind::Stack => {
                 let (alloc_index, clocks) = global.current_thread_state(thread_mgr);

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -123,7 +123,7 @@ impl fmt::Display for MiriMemoryKind {
         use self::MiriMemoryKind::*;
         match self {
             Rust => write!(f, "Rust heap"),
-            Miri => write!(f, "Miri heap"),
+            Miri => write!(f, "Miri bare-metal heap"),
             C => write!(f, "C heap"),
             WinHeap => write!(f, "Windows heap"),
             Machine => write!(f, "machine-managed memory"),

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -77,6 +77,8 @@ impl VisitTags for FrameData<'_> {
 pub enum MiriMemoryKind {
     /// `__rust_alloc` memory.
     Rust,
+    /// `miri_alloc` memory.
+    Miri,
     /// `malloc` memory.
     C,
     /// Windows `HeapAlloc` memory.
@@ -110,7 +112,7 @@ impl MayLeak for MiriMemoryKind {
     fn may_leak(self) -> bool {
         use self::MiriMemoryKind::*;
         match self {
-            Rust | C | WinHeap | Runtime => false,
+            Rust | Miri | C | WinHeap | Runtime => false,
             Machine | Global | ExternStatic | Tls => true,
         }
     }
@@ -121,6 +123,7 @@ impl fmt::Display for MiriMemoryKind {
         use self::MiriMemoryKind::*;
         match self {
             Rust => write!(f, "Rust heap"),
+            Miri => write!(f, "Miri heap"),
             C => write!(f, "C heap"),
             WinHeap => write!(f, "Windows heap"),
             Machine => write!(f, "machine-managed memory"),

--- a/tests/pass/miri-alloc.rs
+++ b/tests/pass/miri-alloc.rs
@@ -14,7 +14,7 @@ extern "Rust" {
 fn start(_: isize, _: *const *const u8) -> isize {
     unsafe {
         let ptr = miri_alloc(123, 1);
-        core::ptr::write_bytes(ptr, 0, 123);
+        core::ptr::write_bytes(ptr, 0u8, 123);
         miri_dealloc(ptr, 123, 1);
     }
     0

--- a/tests/pass/miri-alloc.rs
+++ b/tests/pass/miri-alloc.rs
@@ -1,0 +1,29 @@
+#![feature(lang_items, start)]
+#![no_std]
+// windows tls dtors go through libstd right now, thus this test
+// cannot pass. When windows tls dtors go through the special magic
+// windows linker section, we can run this test on windows again.
+//@ignore-target-windows: no-std not supported on Windows
+
+extern "Rust" {
+    fn miri_alloc(size: usize, align: usize) -> *mut u8;
+    fn miri_dealloc(ptr: *mut u8, size: usize, align: usize);
+}
+
+#[start]
+fn start(_: isize, _: *const *const u8) -> isize {
+    unsafe {
+        let ptr = miri_alloc(123, 1);
+        core::ptr::write_bytes(ptr, 0, 123);
+        miri_dealloc(ptr, 123, 1);
+    }
+    0
+}
+
+#[panic_handler]
+fn panic_handler(_: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+#[lang = "eh_personality"]
+fn eh_personality() {}


### PR DESCRIPTION
`miri_alloc` and `miri_dealloc` are basically the same as `__rust_alloc` and `__rust_dealloc` respectively, but without the check for a global allocator.

This should allow bootstrapping an allocator in environments, where no fundamental way of allocating memory is available (`no_std` + `alloc` in Miri).