### PR TITLE
Yield from the main thread a few times at shutdown

### DIFF
--- a/src/concurrency/thread.rs
+++ b/src/concurrency/thread.rs
@@ -633,7 +633,7 @@ impl<'mir, 'tcx: 'mir> ThreadManager<'mir, 'tcx> {
         // If we are the main thread, and our call stack is empty but our state is Enabled, we are
         // about to terminate.
         // But, if there are any other threads which can execute, yield to them instead of falling
-        // through to the termination state.
+        // through to the termination state. This is to give them a chance to clean up and quit.
         let active_thread = &self.threads[self.active_thread];
         if self.active_thread == MAIN_THREAD
             && active_thread.stack.is_empty()


### PR DESCRIPTION
Closes https://github.com/rust-lang/miri/issues/2629

... how should we test this? The naive approach is to run `./miri many-seeds ./miri run example.rs`: https://github.com/rust-lang/miri/issues/2629#issuecomment-1295113360
```rust
use std::thread;

fn main() {
  thread::scope(|s| {
    s.spawn(|| {});
  });
}
```
But running _many_ seeds takes an annoyingly long time. How many seeds is enough? And how does such a test fit into our existing testing system?

(I'm also not enthused about the way I'm continuing to pile on complexity into the scheduler here, should this PR include a refactor?)