### PR TITLE
remove CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # Miri
 
-[![Actions build status][actions-badge]][actions-url]
-
-[actions-badge]: https://github.com/rust-lang/miri/workflows/CI/badge.svg?branch=master
-[actions-url]: https://github.com/rust-lang/miri/actions
-
 An experimental interpreter for [Rust][rust]'s
 [mid-level intermediate representation][mir] (MIR). It can run binaries and
 test suites of cargo projects and detect certain classes of


### PR DESCRIPTION
We don't actually run CI on the `master` branch (because bors checks things before they can even be on master), so this doesn't really show anything. rustc doesn't have a badge either. I think we can live without it. :D