### PR TITLE
make align_offset always work on no-provenance pointers

### DIFF
--- a/src/shims/mod.rs
+++ b/src/shims/mod.rs
@@ -89,6 +89,12 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
         }
 
         let ptr = this.read_pointer(ptr_op)?;
+        // If this carries no provenance, treat it like an integer.
+        if ptr.provenance.is_none() {
+            // Use actual implementation.
+            return Ok(false);
+        }
+
         if let Ok((alloc_id, _offset, _)) = this.ptr_try_get_alloc_id(ptr) {
             // Only do anything if we can identify the allocation this goes to.
             let (_size, cur_align, _kind) = this.get_alloc_info(alloc_id);

--- a/tests/pass/align_offset_symbolic.rs
+++ b/tests/pass/align_offset_symbolic.rs
@@ -1,4 +1,7 @@
 //@compile-flags: -Zmiri-symbolic-alignment-check
+#![feature(strict_provenance)]
+
+use std::ptr;
 
 fn test_align_offset() {
     let d = Box::new([0u32; 4]);
@@ -16,6 +19,9 @@ fn test_align_offset() {
     assert_eq!(raw.wrapping_offset(2).align_offset(2), 0);
     assert_eq!(raw.wrapping_offset(2).align_offset(4), 2);
     assert_eq!(raw.wrapping_offset(2).align_offset(8), usize::MAX); // requested alignment higher than allocation alignment
+
+    let p = ptr::invalid::<()>(1);
+    assert_eq!(p.align_offset(1), 0);
 }
 
 fn test_align_to() {


### PR DESCRIPTION
Fixes https://github.com/rust-lang/miri/issues/2682