### PR TITLE
Stack borrows: weak protectors

### DIFF
--- a/src/stacked_borrows/diagnostics.rs
+++ b/src/stacked_borrows/diagnostics.rs
@@ -288,7 +288,7 @@ impl<'span, 'history, 'ecx, 'mir, 'tcx> DiagnosticCx<'span, 'history, 'ecx, 'mir
             }
             Operation::Access(AccessOp { kind, range, .. }) =>
                 (*range, InvalidationCause::Access(*kind)),
-            _ => {
+            Operation::Dealloc(_) => {
                 // This can be reached, but never be relevant later since the entire allocation is
                 // gone now.
                 return;

--- a/src/stacked_borrows/diagnostics.rs
+++ b/src/stacked_borrows/diagnostics.rs
@@ -6,7 +6,7 @@ use rustc_span::{Span, SpanData};
 use rustc_target::abi::Size;
 
 use crate::helpers::CurrentSpan;
-use crate::stacked_borrows::{err_sb_ub, AccessKind, GlobalStateInner, Permission};
+use crate::stacked_borrows::{err_sb_ub, AccessKind, GlobalStateInner, Permission, ProtectorKind};
 use crate::*;
 
 use rustc_middle::mir::interpret::InterpError;
@@ -288,7 +288,11 @@ impl<'span, 'history, 'ecx, 'mir, 'tcx> DiagnosticCx<'span, 'history, 'ecx, 'mir
             }
             Operation::Access(AccessOp { kind, range, .. }) =>
                 (*range, InvalidationCause::Access(*kind)),
-            _ => unreachable!("Tags can only be invalidated during a retag or access"),
+            _ => {
+                // This can be reached, but never be relevant later since the entire allocation is
+                // gone now.
+                return;
+            }
         };
         self.history.invalidations.push(Invalidation { tag, range, span, cause });
     }
@@ -369,7 +373,7 @@ impl<'span, 'history, 'ecx, 'mir, 'tcx> DiagnosticCx<'span, 'history, 'ecx, 'mir
 
     /// Report a descriptive error when `new` could not be granted from `derived_from`.
     #[inline(never)] // This is only called on fatal code paths
-    pub fn grant_error(&self, perm: Permission, stack: &Stack) -> InterpError<'tcx> {
+    pub(super) fn grant_error(&self, perm: Permission, stack: &Stack) -> InterpError<'tcx> {
         let Operation::Retag(op) = &self.operation else {
             unreachable!("grant_error should only be called during a retag")
         };
@@ -389,7 +393,7 @@ impl<'span, 'history, 'ecx, 'mir, 'tcx> DiagnosticCx<'span, 'history, 'ecx, 'mir
 
     /// Report a descriptive error when `access` is not permitted based on `tag`.
     #[inline(never)] // This is only called on fatal code paths
-    pub fn access_error(&self, stack: &Stack) -> InterpError<'tcx> {
+    pub(super) fn access_error(&self, stack: &Stack) -> InterpError<'tcx> {
         let Operation::Access(op) = &self.operation  else {
             unreachable!("access_error should only be called during an access")
         };
@@ -408,7 +412,11 @@ impl<'span, 'history, 'ecx, 'mir, 'tcx> DiagnosticCx<'span, 'history, 'ecx, 'mir
     }
 
     #[inline(never)] // This is only called on fatal code paths
-    pub fn protector_error(&self, item: &Item) -> InterpError<'tcx> {
+    pub(super) fn protector_error(&self, item: &Item, kind: ProtectorKind) -> InterpError<'tcx> {
+        let protected = match kind {
+            ProtectorKind::WeakProtector => "weakly protected",
+            ProtectorKind::StrongProtector => "strongly protected",
+        };
         let call_id = self
             .threads
             .all_stacks()
@@ -422,10 +430,7 @@ impl<'span, 'history, 'ecx, 'mir, 'tcx> DiagnosticCx<'span, 'history, 'ecx, 'mir
         match self.operation {
             Operation::Dealloc(_) =>
                 err_sb_ub(
-                    format!(
-                        "deallocating while item {:?} is protected by call {:?}",
-                        item, call_id
-                    ),
+                    format!("deallocating while item {item:?} is {protected} by call {call_id:?}",),
                     None,
                     None,
                 ),
@@ -433,8 +438,7 @@ impl<'span, 'history, 'ecx, 'mir, 'tcx> DiagnosticCx<'span, 'history, 'ecx, 'mir
             | Operation::Access(AccessOp { tag, .. }) =>
                 err_sb_ub(
                     format!(
-                        "not granting access to tag {:?} because that would remove {:?} which is protected because it is an argument of call {:?}",
-                        tag, item, call_id
+                        "not granting access to tag {tag:?} because that would remove {item:?} which is {protected} because it is an argument of call {call_id:?}",
                     ),
                     None,
                     tag.and_then(|tag| self.get_logs_relevant_to(tag, Some(item.tag()))),

--- a/tests/fail/stacked_borrows/aliasing_mut1.stderr
+++ b/tests/fail/stacked_borrows/aliasing_mut1.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
   --> $DIR/aliasing_mut1.rs:LL:CC
    |
 LL | pub fn safe(_x: &mut i32, _y: &mut i32) {}
-   |                           ^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is protected because it is an argument of call ID
+   |                           ^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/aliasing_mut2.stderr
+++ b/tests/fail/stacked_borrows/aliasing_mut2.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
   --> $DIR/aliasing_mut2.rs:LL:CC
    |
 LL | pub fn safe(_x: &i32, _y: &mut i32) {}
-   |                       ^^ not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is protected because it is an argument of call ID
+   |                       ^^ not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/aliasing_mut4.stderr
+++ b/tests/fail/stacked_borrows/aliasing_mut4.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
   --> $DIR/aliasing_mut4.rs:LL:CC
    |
 LL | pub fn safe(_x: &i32, _y: &mut Cell<i32>) {}
-   |                       ^^ not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is protected because it is an argument of call ID
+   |                       ^^ not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/box_noalias_violation.rs
+++ b/tests/fail/stacked_borrows/box_noalias_violation.rs
@@ -1,0 +1,14 @@
+unsafe fn test(mut x: Box<i32>, y: *const i32) -> i32 {
+    // We will call this in a way that x and y alias.
+    *x = 5;
+    std::mem::forget(x);
+    *y //~ERROR: weakly protected
+}
+
+fn main() {
+    unsafe {
+        let mut v = 42;
+        let ptr = &mut v as *mut i32;
+        test(Box::from_raw(ptr), ptr);
+    }
+}

--- a/tests/fail/stacked_borrows/box_noalias_violation.stderr
+++ b/tests/fail/stacked_borrows/box_noalias_violation.stderr
@@ -1,0 +1,30 @@
+error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is weakly protected because it is an argument of call ID
+  --> $DIR/box_noalias_violation.rs:LL:CC
+   |
+LL |     *y
+   |     ^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is weakly protected because it is an argument of call ID
+   |
+   = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
+   = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
+help: <TAG> was created by a SharedReadWrite retag at offsets [0x0..0x4]
+  --> $DIR/box_noalias_violation.rs:LL:CC
+   |
+LL |         let ptr = &mut v as *mut i32;
+   |                   ^^^^^^
+help: <TAG> is this argument
+  --> $DIR/box_noalias_violation.rs:LL:CC
+   |
+LL | unsafe fn test(mut x: Box<i32>, y: *const i32) -> i32 {
+   |                ^^^^^
+   = note: BACKTRACE:
+   = note: inside `test` at $DIR/box_noalias_violation.rs:LL:CC
+note: inside `main` at $DIR/box_noalias_violation.rs:LL:CC
+  --> $DIR/box_noalias_violation.rs:LL:CC
+   |
+LL |         test(Box::from_raw(ptr), ptr);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to previous error
+

--- a/tests/fail/stacked_borrows/deallocate_against_protector1.rs
+++ b/tests/fail/stacked_borrows/deallocate_against_protector1.rs
@@ -1,4 +1,4 @@
-//@error-pattern: /deallocating while item \[Unique for .*\] is protected/
+//@error-pattern: /deallocating while item \[Unique for .*\] is strongly protected/
 
 fn inner(x: &mut i32, f: fn(&mut i32)) {
     // `f` may mutate, but it may not deallocate!

--- a/tests/fail/stacked_borrows/deallocate_against_protector1.stderr
+++ b/tests/fail/stacked_borrows/deallocate_against_protector1.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: deallocating while item [Unique for <TAG>] is protected by call ID
+error: Undefined Behavior: deallocating while item [Unique for <TAG>] is strongly protected by call ID
   --> RUSTLIB/alloc/src/alloc.rs:LL:CC
    |
 LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocating while item [Unique for <TAG>] is protected by call ID
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocating while item [Unique for <TAG>] is strongly protected by call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/deallocate_against_protector2.rs
+++ b/tests/fail/stacked_borrows/deallocate_against_protector2.rs
@@ -1,4 +1,4 @@
-//@error-pattern: /deallocating while item \[SharedReadWrite for .*\] is protected/
+//@error-pattern: /deallocating while item \[SharedReadWrite for .*\] is strongly protected/
 use std::marker::PhantomPinned;
 
 pub struct NotUnpin(i32, PhantomPinned);

--- a/tests/fail/stacked_borrows/deallocate_against_protector2.stderr
+++ b/tests/fail/stacked_borrows/deallocate_against_protector2.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: deallocating while item [SharedReadWrite for <TAG>] is protected by call ID
+error: Undefined Behavior: deallocating while item [SharedReadWrite for <TAG>] is strongly protected by call ID
   --> RUSTLIB/alloc/src/alloc.rs:LL:CC
    |
 LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocating while item [SharedReadWrite for <TAG>] is protected by call ID
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocating while item [SharedReadWrite for <TAG>] is strongly protected by call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/illegal_write6.rs
+++ b/tests/fail/stacked_borrows/illegal_write6.rs
@@ -7,6 +7,6 @@ fn main() {
 fn foo(a: &mut u32, y: *mut u32) -> u32 {
     *a = 1;
     let _b = &*a;
-    unsafe { *y = 2 }; //~ ERROR: /not granting access .* because that would remove .* which is protected/
+    unsafe { *y = 2 }; //~ ERROR: /not granting access .* because that would remove .* which is strongly protected/
     return *a;
 }

--- a/tests/fail/stacked_borrows/illegal_write6.stderr
+++ b/tests/fail/stacked_borrows/illegal_write6.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
   --> $DIR/illegal_write6.rs:LL:CC
    |
 LL |     unsafe { *y = 2 };
-   |              ^^^^^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is protected because it is an argument of call ID
+   |              ^^^^^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/invalidate_against_protector1.stderr
+++ b/tests/fail/stacked_borrows/invalidate_against_protector1.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
   --> $DIR/invalidate_against_protector1.rs:LL:CC
    |
 LL |     let _val = unsafe { *x };
-   |                         ^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is protected because it is an argument of call ID
+   |                         ^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/invalidate_against_protector2.stderr
+++ b/tests/fail/stacked_borrows/invalidate_against_protector2.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
   --> $DIR/invalidate_against_protector2.rs:LL:CC
    |
 LL |     unsafe { *x = 0 };
-   |              ^^^^^^ not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is protected because it is an argument of call ID
+   |              ^^^^^^ not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/invalidate_against_protector3.stderr
+++ b/tests/fail/stacked_borrows/invalidate_against_protector3.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
   --> $DIR/invalidate_against_protector3.rs:LL:CC
    |
 LL |     unsafe { *x = 0 };
-   |              ^^^^^^ not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is protected because it is an argument of call ID
+   |              ^^^^^^ not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is strongly protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/newtype_pair_retagging.rs
+++ b/tests/fail/stacked_borrows/newtype_pair_retagging.rs
@@ -1,4 +1,4 @@
-//@error-pattern: which is protected
+//@error-pattern: which is strongly protected
 struct Newtype<'a>(&'a mut i32, i32);
 
 fn dealloc_while_running(_n: Newtype<'_>, dealloc: impl FnOnce()) {

--- a/tests/fail/stacked_borrows/newtype_pair_retagging.stderr
+++ b/tests/fail/stacked_borrows/newtype_pair_retagging.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
   --> RUSTLIB/alloc/src/boxed.rs:LL:CC
    |
 LL |         Box(unsafe { Unique::new_unchecked(raw) }, alloc)
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is protected because it is an argument of call ID
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/stacked_borrows/newtype_retagging.rs
+++ b/tests/fail/stacked_borrows/newtype_retagging.rs
@@ -1,4 +1,4 @@
-//@error-pattern: which is protected
+//@error-pattern: which is strongly protected
 struct Newtype<'a>(&'a mut i32);
 
 fn dealloc_while_running(_n: Newtype<'_>, dealloc: impl FnOnce()) {

--- a/tests/fail/stacked_borrows/newtype_retagging.stderr
+++ b/tests/fail/stacked_borrows/newtype_retagging.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is protected because it is an argument of call ID
+error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
   --> RUSTLIB/alloc/src/boxed.rs:LL:CC
    |
 LL |         Box(unsafe { Unique::new_unchecked(raw) }, alloc)
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is protected because it is an argument of call ID
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected because it is an argument of call ID
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information


### PR DESCRIPTION
This addresses the issue described in https://github.com/rust-lang/unsafe-code-guidelines/issues/376.