### PR TITLE
Use `.wasm` extension when building for wasm in cargo-miri

### DIFF
--- a/cargo-miri/src/phases.rs
+++ b/cargo-miri/src/phases.rs
@@ -281,9 +281,10 @@ pub fn phase_rustc(mut args: impl Iterator<Item = String>, phase: RustcPhase) {
             eprintln!("[cargo-miri rustc] writing run info to `{}`", filename.display());
         }
         info.store(&filename);
-        // For Windows, do the same thing again with `.exe` appended to the filename.
+        // For Windows and WASM, do the same thing again with `.exe`/`.wasm` appended to the filename.
         // (Need to do this here as cargo moves that "binary" to a different place before running it.)
         info.store(&out_filename("", ".exe"));
+        info.store(&out_filename("", ".wasm"));
     };
 
     let runnable_crate = !info_query && is_runnable_crate();

--- a/ci.sh
+++ b/ci.sh
@@ -103,6 +103,7 @@ case $HOST_TARGET in
     MIRI_TEST_TARGET=i686-pc-windows-msvc run_tests
     MIRI_TEST_TARGET=x86_64-unknown-freebsd run_tests_minimal hello integer vec panic/panic concurrency/simple atomic data_race env/var
     MIRI_TEST_TARGET=aarch64-linux-android run_tests_minimal hello integer vec panic/panic
+    MIRI_TEST_TARGET=wasm32-wasi MIRI_NO_STD=1 run_tests_minimal no_std # supports std but miri doesn't support it
     MIRI_TEST_TARGET=thumbv7em-none-eabihf MIRI_NO_STD=1 run_tests_minimal no_std # no_std embedded architecture
     ;;
   x86_64-apple-darwin)


### PR DESCRIPTION
WASM uses the `.wasm` file extension for its binaries (just like how windows uses `.exe`), so we need to set that as well.

I'm not sure whether gating this behind the wasm target is a good idea, maybe it makes more sense to always do it just like on windows.