### PR TITLE
Implement runtime checking for platform page size

### DIFF
--- a/src/intptrcast.rs
+++ b/src/intptrcast.rs
@@ -56,7 +56,7 @@ impl GlobalStateInner {
             int_to_ptr_map: Vec::default(),
             base_addr: FxHashMap::default(),
             exposed: FxHashSet::default(),
-            next_base_addr: STACK_ADDR,
+            next_base_addr: stack_addr(),
             provenance_mode: config.provenance_mode,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ pub use crate::helpers::EvalContextExt as _;
 pub use crate::intptrcast::ProvenanceMode;
 pub use crate::machine::{
     AllocExtra, FrameExtra, MiriInterpCx, MiriInterpCxExt, MiriMachine, MiriMemoryKind,
-    PrimitiveLayouts, Provenance, ProvenanceExtra, PAGE_SIZE, STACK_ADDR, STACK_SIZE,
+    PrimitiveLayouts, Provenance, ProvenanceExtra, page_size, stack_addr, stack_size,
 };
 pub use crate::mono_hash_map::MonoHashMap;
 pub use crate::operator::EvalContextExt as _;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,8 +106,8 @@ pub use crate::eval::{
 pub use crate::helpers::EvalContextExt as _;
 pub use crate::intptrcast::ProvenanceMode;
 pub use crate::machine::{
-    AllocExtra, FrameExtra, MiriInterpCx, MiriInterpCxExt, MiriMachine, MiriMemoryKind,
-    PrimitiveLayouts, Provenance, ProvenanceExtra, page_size, stack_addr, stack_size,
+    page_size, stack_addr, stack_size, AllocExtra, FrameExtra, MiriInterpCx, MiriInterpCxExt,
+    MiriMachine, MiriMemoryKind, PrimitiveLayouts, Provenance, ProvenanceExtra,
 };
 pub use crate::mono_hash_map::MonoHashMap;
 pub use crate::operator::EvalContextExt as _;

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -38,15 +38,23 @@ use crate::{
 pub fn page_size() -> u64 {
     match unsafe { sysconf(_SC_PAGESIZE) }.try_into() {
         Ok(sz) => sz,
-        Err(_) => 4 * 1024 // assume 4k pages if it errored
+        Err(_) => 4 * 1024, // assume 4k pages if it errored
     }
 }
 #[cfg(target_family = "wasm")]
-pub fn page_size() -> u64 { 64 * 1024 }
-#[cfg(any(target_family = "windows", target_family = ""))]
-pub fn page_size() -> u64 { 4 * 1024 } // again assume 4k as backup
-pub fn stack_addr() -> u64 { 32 * page_size() } // not really about the "stack", but where we start assigning integer addresses to allocations
-pub fn stack_size() -> u64 { 16 * page_size() } // whatever
+pub fn page_size() -> u64 {
+    64 * 1024
+}
+#[cfg(not(any(target_family = "unix", target_family = "wasm")))]
+pub fn page_size() -> u64 {
+    4 * 1024
+} // again assume 4k as backup
+pub fn stack_addr() -> u64 {
+    32 * page_size()
+} // not really about the "stack", but where we start assigning integer addresses to allocations
+pub fn stack_size() -> u64 {
+    16 * page_size()
+} // whatever
 
 /// Extra data stored with each stack frame
 pub struct FrameExtra<'tcx> {

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -5,6 +5,7 @@ use std::borrow::Cow;
 use std::cell::RefCell;
 use std::fmt;
 
+#[cfg(target_family = "unix")]
 use libc::{sysconf, _SC_PAGESIZE};
 
 use rand::rngs::StdRng;

--- a/src/shims/unix/foreign_items.rs
+++ b/src/shims/unix/foreign_items.rs
@@ -234,7 +234,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                 // FIXME: Which of these are POSIX, and which are GNU/Linux?
                 // At least the names seem to all also exist on macOS.
                 let sysconfs: &[(&str, fn(&MiriInterpCx<'_, '_>) -> Scalar<Provenance>)] = &[
-                    ("_SC_PAGESIZE", |this| Scalar::from_int(PAGE_SIZE, this.pointer_size())),
+                    ("_SC_PAGESIZE", |this| Scalar::from_int(page_size(), this.pointer_size())),
                     ("_SC_NPROCESSORS_CONF", |this| Scalar::from_int(this.machine.num_cpus, this.pointer_size())),
                     ("_SC_NPROCESSORS_ONLN", |this| Scalar::from_int(this.machine.num_cpus, this.pointer_size())),
                     // 512 seems to be a reasonable default. The value is not critical, in
@@ -496,7 +496,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                 let [_attr, guard_size] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 let guard_size = this.deref_operand(guard_size)?;
                 let guard_size_layout = this.libc_ty_layout("size_t")?;
-                this.write_scalar(Scalar::from_uint(crate::PAGE_SIZE, guard_size_layout.size), &guard_size.into())?;
+                this.write_scalar(Scalar::from_uint(crate::page_size(), guard_size_layout.size), &guard_size.into())?;
 
                 // Return success (`0`).
                 this.write_null(dest)?;
@@ -525,11 +525,11 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                 let size_place = this.deref_operand(size_place)?;
 
                 this.write_scalar(
-                    Scalar::from_uint(STACK_ADDR, this.pointer_size()),
+                    Scalar::from_uint(stack_addr(), this.pointer_size()),
                     &addr_place.into(),
                 )?;
                 this.write_scalar(
-                    Scalar::from_uint(STACK_SIZE, this.pointer_size()),
+                    Scalar::from_uint(stack_size(), this.pointer_size()),
                     &size_place.into(),
                 )?;
 

--- a/src/shims/unix/macos/foreign_items.rs
+++ b/src/shims/unix/macos/foreign_items.rs
@@ -162,13 +162,13 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
             "pthread_get_stackaddr_np" => {
                 let [thread] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 this.read_scalar(thread)?.to_machine_usize(this)?;
-                let stack_addr = Scalar::from_uint(STACK_ADDR, this.pointer_size());
+                let stack_addr = Scalar::from_uint(stack_addr(), this.pointer_size());
                 this.write_scalar(stack_addr, dest)?;
             }
             "pthread_get_stacksize_np" => {
                 let [thread] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 this.read_scalar(thread)?.to_machine_usize(this)?;
-                let stack_size = Scalar::from_uint(STACK_SIZE, this.pointer_size());
+                let stack_size = Scalar::from_uint(stack_size(), this.pointer_size());
                 this.write_scalar(stack_size, dest)?;
             }
 

--- a/src/shims/windows/foreign_items.rs
+++ b/src/shims/windows/foreign_items.rs
@@ -158,7 +158,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                 // Set page size.
                 let page_size = system_info.offset(field_offsets[2], dword_layout, &this.tcx)?;
                 this.write_scalar(
-                    Scalar::from_int(PAGE_SIZE, dword_layout.size),
+                    Scalar::from_int(crate::page_size(), dword_layout.size),
                     &page_size.into(),
                 )?;
                 // Set number of processors.


### PR DESCRIPTION
Miri currently assumes all platforms have 4k pages as a hard-coded constant (see #2644). This change replaces it with a `page_size()` function (which just wraps around `sysconf(_SC_PAGESIZE)` on *nix, all other platforms have known values on targets Rust supports) and minimal changes to make this work.