### PR TITLE
enable some warnings that rustc bootstrap enables

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,14 +233,14 @@ You can also directly run Miri on a Rust source file:
 ## Advanced topic: Syncing with the rustc repo
 
 We use the [`josh` proxy](https://github.com/josh-project/josh) to transmit changes between the
-rustc and Miri repositories. The eaisest way to run josh is via docker:
+rustc and Miri repositories.
 
 ```sh
-docker pull joshproject/josh-proxy:latest
-docker run -it -p 8000:8000 -e JOSH_REMOTE=https://github.com -e JOSH_EXTRA_OPTS=--no-background -v josh-vol:/data/git joshproject/josh-proxy:latest
+cargo +stable install josh-proxy --git https://github.com/josh-project/josh --tag r22.12.06
+josh-proxy --local=$HOME/.cache/josh --remote=https://github.com --no-background
 ```
 
-This sets up a local volume `josh-vol` for josh's cache.
+This uses a directory `$HOME/.cache/josh` as a cache, to speed up repeated pulling/pushing.
 
 ### Importing changes from the rustc repo
 

--- a/miri
+++ b/miri
@@ -243,7 +243,7 @@ if [ -z "$CARGO_PROFILE_DEV_OPT_LEVEL" ]; then
     export CARGO_PROFILE_DEV_OPT_LEVEL=2
 fi
 # Enable rustc-specific lints (ignored without `-Zunstable-options`).
-export RUSTFLAGS="-Zunstable-options -Wrustc::internal $RUSTFLAGS"
+export RUSTFLAGS="-Zunstable-options -Wrustc::internal -Wrust_2018_idioms -Wunused_lifetimes -Wsemicolon_in_expressions_from_macros $RUSTFLAGS"
 # We set the rpath so that Miri finds the private rustc libraries it needs.
 export RUSTFLAGS="-C link-args=-Wl,-rpath,$LIBDIR $RUSTFLAGS"
 

--- a/src/shims/unix/linux/fd/epoll.rs
+++ b/src/shims/unix/linux/fd/epoll.rs
@@ -36,7 +36,7 @@ impl FileDescriptor for Epoll {
         Ok(self)
     }
 
-    fn dup<'tcx>(&mut self) -> io::Result<Box<dyn FileDescriptor>> {
+    fn dup(&mut self) -> io::Result<Box<dyn FileDescriptor>> {
         Ok(Box::new(self.clone()))
     }
 

--- a/src/shims/unix/linux/fd/event.rs
+++ b/src/shims/unix/linux/fd/event.rs
@@ -21,7 +21,7 @@ impl FileDescriptor for Event {
         "event"
     }
 
-    fn dup<'tcx>(&mut self) -> io::Result<Box<dyn FileDescriptor>> {
+    fn dup(&mut self) -> io::Result<Box<dyn FileDescriptor>> {
         Ok(Box::new(Event { val: self.val }))
     }
 

--- a/src/shims/unix/linux/fd/socketpair.rs
+++ b/src/shims/unix/linux/fd/socketpair.rs
@@ -15,7 +15,7 @@ impl FileDescriptor for SocketPair {
         "socketpair"
     }
 
-    fn dup<'tcx>(&mut self) -> io::Result<Box<dyn FileDescriptor>> {
+    fn dup(&mut self) -> io::Result<Box<dyn FileDescriptor>> {
         Ok(Box::new(SocketPair))
     }
 


### PR DESCRIPTION
also use cargo-install to install josh-proxy, since the docker version cannot access SSH keys (needed for pushing)