### PR TITLE
handle unknown targets more gracefully

### DIFF
--- a/src/shims/tls.rs
+++ b/src/shims/tls.rs
@@ -257,15 +257,10 @@ impl TlsDtorsState {
                         // And move to the final state.
                         self.0 = Done;
                     }
-                    "wasi" | "none" => {
-                        // No OS, no TLS dtors.
+                    _ => {
+                        // No TLS dtor support.
                         // FIXME: should we do something on wasi?
                         self.0 = Done;
-                    }
-                    os => {
-                        throw_unsup_format!(
-                            "the TLS machinery does not know how to handle OS `{os}`"
-                        );
                     }
                 }
             }

--- a/src/shims/unix/foreign_items.rs
+++ b/src/shims/unix/foreign_items.rs
@@ -596,13 +596,13 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
             // Platform-specific shims
             _ => {
                 let target_os = &*this.tcx.sess.target.os;
-                match target_os {
-                    "android" => return shims::unix::android::foreign_items::EvalContextExt::emulate_foreign_item_by_name(this, link_name, abi, args, dest),
-                    "freebsd" => return shims::unix::freebsd::foreign_items::EvalContextExt::emulate_foreign_item_by_name(this, link_name, abi, args, dest),
-                    "linux" => return shims::unix::linux::foreign_items::EvalContextExt::emulate_foreign_item_by_name(this, link_name, abi, args, dest),
-                    "macos" => return shims::unix::macos::foreign_items::EvalContextExt::emulate_foreign_item_by_name(this, link_name, abi, args, dest),
-                    _ => panic!("unsupported Unix OS {target_os}"),
-                }
+                return match target_os {
+                    "android" => shims::unix::android::foreign_items::EvalContextExt::emulate_foreign_item_by_name(this, link_name, abi, args, dest),
+                    "freebsd" => shims::unix::freebsd::foreign_items::EvalContextExt::emulate_foreign_item_by_name(this, link_name, abi, args, dest),
+                    "linux" => shims::unix::linux::foreign_items::EvalContextExt::emulate_foreign_item_by_name(this, link_name, abi, args, dest),
+                    "macos" => shims::unix::macos::foreign_items::EvalContextExt::emulate_foreign_item_by_name(this, link_name, abi, args, dest),
+                    _ => Ok(EmulateByNameResult::NotSupported),
+                };
             }
         };
 

--- a/tests/extern-so/fail/function_not_in_so.rs
+++ b/tests/extern-so/fail/function_not_in_so.rs
@@ -1,5 +1,6 @@
 //@only-target-linux
 //@only-on-host
+//@normalize-stderr-test: "OS `.*`" -> "$$OS"
 
 extern "C" {
     fn foo();
@@ -7,6 +8,6 @@ extern "C" {
 
 fn main() {
     unsafe {
-        foo(); //~ ERROR: unsupported operation: can't call foreign function: foo
+        foo(); //~ ERROR: unsupported operation: can't call foreign function `foo`
     }
 }

--- a/tests/extern-so/fail/function_not_in_so.stderr
+++ b/tests/extern-so/fail/function_not_in_so.stderr
@@ -1,8 +1,8 @@
-error: unsupported operation: can't call foreign function: foo
+error: unsupported operation: can't call foreign function `foo` on $OS
   --> $DIR/function_not_in_so.rs:LL:CC
    |
 LL |         foo();
-   |         ^^^^^ can't call foreign function: foo
+   |         ^^^^^ can't call foreign function `foo` on $OS
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
    = note: BACKTRACE:

--- a/tests/fail/alloc/no_global_allocator.rs
+++ b/tests/fail/alloc/no_global_allocator.rs
@@ -1,3 +1,4 @@
+//@normalize-stderr-test: "OS `.*`" -> "$$OS"
 // Make sure we pretend the allocation symbols don't exist when there is no allocator
 
 #![feature(lang_items, start)]
@@ -10,7 +11,7 @@ extern "Rust" {
 #[start]
 fn start(_: isize, _: *const *const u8) -> isize {
     unsafe {
-        __rust_alloc(1, 1); //~ERROR: unsupported operation: can't call foreign function: __rust_alloc
+        __rust_alloc(1, 1); //~ERROR: unsupported operation: can't call foreign function `__rust_alloc`
     }
 
     0

--- a/tests/fail/alloc/no_global_allocator.stderr
+++ b/tests/fail/alloc/no_global_allocator.stderr
@@ -1,8 +1,8 @@
-error: unsupported operation: can't call foreign function: __rust_alloc
+error: unsupported operation: can't call foreign function `__rust_alloc` on $OS
   --> $DIR/no_global_allocator.rs:LL:CC
    |
 LL |         __rust_alloc(1, 1);
-   |         ^^^^^^^^^^^^^^^^^^ can't call foreign function: __rust_alloc
+   |         ^^^^^^^^^^^^^^^^^^ can't call foreign function `__rust_alloc` on $OS
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
    = note: BACKTRACE:

--- a/tests/fail/unsupported_foreign_function.rs
+++ b/tests/fail/unsupported_foreign_function.rs
@@ -1,9 +1,11 @@
+//@normalize-stderr-test: "OS `.*`" -> "$$OS"
+
 fn main() {
     extern "Rust" {
         fn foo();
     }
 
     unsafe {
-        foo(); //~ ERROR: unsupported operation: can't call foreign function: foo
+        foo(); //~ ERROR: unsupported operation: can't call foreign function `foo`
     }
 }

--- a/tests/fail/unsupported_foreign_function.stderr
+++ b/tests/fail/unsupported_foreign_function.stderr
@@ -1,8 +1,8 @@
-error: unsupported operation: can't call foreign function: foo
+error: unsupported operation: can't call foreign function `foo` on $OS
   --> $DIR/unsupported_foreign_function.rs:LL:CC
    |
 LL |         foo();
-   |         ^^^^^ can't call foreign function: foo
+   |         ^^^^^ can't call foreign function `foo` on $OS
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
    = note: BACKTRACE:

--- a/tests/fail/unsupported_incomplete_function.rs
+++ b/tests/fail/unsupported_incomplete_function.rs
@@ -1,10 +1,11 @@
 //! `signal()` is special on Linux and macOS that it's only supported within libstd.
 //! The implementation is not complete enough to permit user code to call it.
 //@ignore-target-windows: No libc on Windows
+//@normalize-stderr-test: "OS `.*`" -> "$$OS"
 
 fn main() {
     unsafe {
         libc::signal(libc::SIGPIPE, libc::SIG_IGN);
-        //~^ ERROR: unsupported operation: can't call foreign function: signal
+        //~^ ERROR: unsupported operation: can't call foreign function `signal`
     }
 }

--- a/tests/fail/unsupported_incomplete_function.stderr
+++ b/tests/fail/unsupported_incomplete_function.stderr
@@ -1,12 +1,12 @@
-error: unsupported operation: can't call foreign function: signal
-  --> $DIR/unsupported_signal.rs:LL:CC
+error: unsupported operation: can't call foreign function `signal` on $OS
+  --> $DIR/unsupported_incomplete_function.rs:LL:CC
    |
 LL |         libc::signal(libc::SIGPIPE, libc::SIG_IGN);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't call foreign function: signal
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't call foreign function `signal` on $OS
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
    = note: BACKTRACE:
-   = note: inside `main` at $DIR/unsupported_signal.rs:LL:CC
+   = note: inside `main` at $DIR/unsupported_incomplete_function.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/panic/unsupported_foreign_function.rs
+++ b/tests/panic/unsupported_foreign_function.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-panic-on-unsupported
+//@normalize-stderr-test: "OS `.*`" -> "$$OS"
 
 fn main() {
     extern "Rust" {

--- a/tests/panic/unsupported_foreign_function.stderr
+++ b/tests/panic/unsupported_foreign_function.stderr
@@ -1,2 +1,2 @@
-thread 'main' panicked at 'unsupported Miri functionality: can't call foreign function: foo', $DIR/unsupported_foreign_function.rs:LL:CC
+thread 'main' panicked at 'unsupported Miri functionality: can't call foreign function `foo` on $OS', $DIR/unsupported_foreign_function.rs:LL:CC
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


### PR DESCRIPTION
In particular don't require a list of all OSes in the TLS machinery. Instead just fall back to doing nothing.