### PR TITLE
Implement support for some basic wasm32-wasi syscalls

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -108,7 +108,9 @@ case $HOST_TARGET in
     MIRI_TEST_TARGET=i686-pc-windows-msvc run_tests
     MIRI_TEST_TARGET=x86_64-unknown-freebsd run_tests_minimal hello integer vec panic/panic concurrency/simple atomic data_race env/var
     MIRI_TEST_TARGET=aarch64-linux-android run_tests_minimal hello integer vec panic/panic
-    MIRI_TEST_TARGET=wasm32-wasi run_tests_minimal no_std integer strings
+    # Most wasi foreign items require integer-to-pointer casts to call,
+    # so we enable permissive provenance to suppress the warnings.
+    MIRI_TEST_TARGET=wasm32-wasi MIRIFLAGS="-Zmiri-permissive-provenance" run_tests
     MIRI_TEST_TARGET=wasm32-unknown-unknown run_tests_minimal no_std integer strings
     MIRI_TEST_TARGET=thumbv7em-none-eabihf MIRI_NO_STD=1 run_tests_minimal no_std # no_std embedded architecture
     MIRI_TEST_TARGET=tests/avr.json MIRI_NO_STD=1 run_tests_minimal no_std # JSON target file

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -628,7 +628,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
     ) -> InterpResult<'tcx, Scalar<Provenance>> {
         let this = self.eval_context_ref();
         let target = &this.tcx.sess.target;
-        if target.families.iter().any(|f| f == "unix") {
+        if target.families.iter().any(|f| f == "unix") || target.os == "wasi" {
             for &(name, kind) in UNIX_IO_ERROR_TABLE {
                 if err_kind == kind {
                     return Ok(this.eval_libc(name));
@@ -666,7 +666,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
     ) -> InterpResult<'tcx, Option<std::io::ErrorKind>> {
         let this = self.eval_context_ref();
         let target = &this.tcx.sess.target;
-        if target.families.iter().any(|f| f == "unix") {
+        if target.families.iter().any(|f| f == "unix") || target.os == "wasi" {
             let errnum = errnum.to_i32()?;
             for &(name, kind) in UNIX_IO_ERROR_TABLE {
                 if errnum == this.eval_libc_i32(name) {
@@ -1073,5 +1073,6 @@ pub fn get_local_crates(tcx: TyCtxt<'_>) -> Vec<CrateNum> {
 /// Helper function used inside the shims of foreign functions to check that
 /// `target_os` is a supported UNIX OS.
 pub fn target_os_is_unix(target_os: &str) -> bool {
-    matches!(target_os, "linux" | "macos" | "freebsd" | "android")
+    // See unix::foreign_items for an explanation of why "wasi" is included here.
+    matches!(target_os, "linux" | "macos" | "freebsd" | "android" | "wasi")
 }

--- a/src/shims/unix/foreign_items.rs
+++ b/src/shims/unix/foreign_items.rs
@@ -601,6 +601,10 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                     "freebsd" => shims::unix::freebsd::foreign_items::EvalContextExt::emulate_foreign_item_by_name(this, link_name, abi, args, dest),
                     "linux" => shims::unix::linux::foreign_items::EvalContextExt::emulate_foreign_item_by_name(this, link_name, abi, args, dest),
                     "macos" => shims::unix::macos::foreign_items::EvalContextExt::emulate_foreign_item_by_name(this, link_name, abi, args, dest),
+                    // Note - wasi is not technically a unix-based OS (the rustc target has its os family set to "wasi").
+                    // However, it has a partial implementation of libc built on top of the wasi syscalls (https://github.com/WebAssembly/wasi-libc),
+                    // which libstd relies on for some functions. Thus, we treat it as a unix-based OS to allow unmodified Rust programs to run.
+                    "wasi" => shims::unix::wasi::foreign_items::EvalContextExt::emulate_foreign_item_by_name(this, link_name, abi, args, dest),
                     _ => Ok(EmulateByNameResult::NotSupported),
                 };
             }

--- a/src/shims/unix/mod.rs
+++ b/src/shims/unix/mod.rs
@@ -9,6 +9,7 @@ mod android;
 mod freebsd;
 mod linux;
 mod macos;
+mod wasi;
 
 pub use fs::{DirHandler, FileHandler};
 

--- a/src/shims/unix/wasi/foreign_items.rs
+++ b/src/shims/unix/wasi/foreign_items.rs
@@ -1,0 +1,187 @@
+use std::ffi::OsString;
+
+use rustc_span::Symbol;
+use rustc_target::abi::Size;
+use rustc_target::spec::abi::Abi;
+
+use crate::*;
+use shims::foreign_items::EmulateByNameResult;
+
+use rustc_middle::ty::layout::LayoutOf as _;
+use rustc_middle::ty::Ty;
+
+impl<'mir, 'tcx: 'mir> EvalContextExt<'mir, 'tcx> for crate::MiriInterpCx<'mir, 'tcx> {}
+pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
+    fn emulate_foreign_item_by_name(
+        &mut self,
+        link_name: Symbol,
+        abi: Abi,
+        args: &[OpTy<'tcx, Provenance>],
+        dest: &PlaceTy<'tcx, Provenance>,
+    ) -> InterpResult<'tcx, EmulateByNameResult<'mir, 'tcx>> {
+        let this = self.eval_context_mut();
+
+        // See `fn emulate_foreign_item_by_name` in `shims/foreign_items.rs` for the general pattern.
+        match link_name.as_str() {
+            "args_sizes_get" => {
+                let [num_args_ptr, cumulative_size_ptr] =
+                    this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+
+                let ptr_usize = this.tcx.mk_mut_ptr(this.tcx.types.usize);
+
+                let num_args_ptr = this.addr_to_mplace_ty(num_args_ptr, ptr_usize)?;
+                let cumulative_size_ptr = this.addr_to_mplace_ty(cumulative_size_ptr, ptr_usize)?;
+
+                let argc: u32 = this.machine.args.len().try_into().unwrap();
+                let cumulative_size: u32 = this
+                    .machine
+                    .args
+                    .iter()
+                    .map(|e| {
+                        // Include null terminator
+                        e.as_bytes().len().checked_add(1).unwrap()
+                    })
+                    .sum::<usize>()
+                    .try_into()
+                    .unwrap();
+
+                // Store argc and cumulative size into the pointers passed in as arguments.
+                this.write_scalar(Scalar::from_u32(argc), &num_args_ptr.into())?;
+                this.write_scalar(Scalar::from_u32(cumulative_size), &cumulative_size_ptr.into())?;
+
+                this.write_scalar(Scalar::from_u32(0), dest)?;
+            }
+
+            "args_get" => {
+                let [argv, argv_buf] =
+                    this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+
+                this.args_get(argv, argv_buf)?;
+
+                this.write_scalar(Scalar::from_u32(0), dest)?;
+            }
+
+            "fd_write" => {
+                let [fd, iovs, iovs_len, rp0] =
+                    this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+
+                let iov_layout = this.libc_ty_layout("iovec");
+                let iov_ptr_ty = this.tcx.mk_mut_ptr(iov_layout.ty);
+                let iov_ptr_layout = this.layout_of(iov_ptr_ty).unwrap();
+
+                let fd = this.read_scalar(fd)?.to_i32()?;
+                let iovs = this.addr_to_mplace_ty(iovs, iov_ptr_ty)?;
+                let iovs_len: u64 = this.read_scalar(iovs_len)?.to_u32()?.into();
+
+                let mut total: i64 = 0;
+
+                // Use the unix implementation of 'write' to process our iovv buffers
+                // one at a time.
+                for i in 0..iovs_len {
+                    let iov_elem = iovs.offset(i * iov_ptr_layout.size, iov_layout, this)?;
+
+                    let buf = this.mplace_field(&iov_elem, 0)?;
+                    let buf = this.read_pointer(&buf.into())?;
+
+                    let count = this.mplace_field(&iov_elem, 1)?;
+                    let count = this.read_scalar(&count.into())?.to_u32()?;
+
+                    use crate::shims::unix::fs::EvalContextExt;
+
+                    let res = this.write(fd, buf, count.try_into().unwrap()).unwrap();
+                    if res == -1 {
+                        this.write_scalar(Scalar::from_i32(-1), dest)?;
+                        return Ok(EmulateByNameResult::NeedsJumping);
+                    }
+                    total = total.checked_add(res).unwrap();
+                }
+
+                let rp0 = this.addr_to_mplace_ty(rp0, this.tcx.mk_mut_ptr(this.tcx.types.usize))?;
+                this.write_scalar(Scalar::from_i32(total.try_into().unwrap()), &rp0.into())?;
+                this.write_scalar(Scalar::from_u32(0), dest)?;
+            }
+
+            "random_get" => {
+                let [ptr, len] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+
+                let buf = this.addr_to_mplace_ty(ptr, this.tcx.types.u32)?;
+                let len = this.read_machine_usize(len)?;
+
+                this.gen_random(buf.ptr, len)?;
+
+                // Newer versions of the `wasi` crate return a u32, while
+                // older versions return a i16. We support both.
+                let res = match dest.layout.ty {
+                    ty if ty == this.tcx.types.i32 => Scalar::from_i32(0),
+                    ty if ty == this.tcx.types.u16 => Scalar::from_u16(0),
+                    ty => panic!("Unsupported random_get return type: {ty:?}"),
+                };
+                this.write_scalar(res, dest)?;
+            }
+
+            _ => return Ok(EmulateByNameResult::NotSupported),
+        }
+
+        Ok(EmulateByNameResult::NeedsJumping)
+    }
+
+    fn args_get(
+        &mut self,
+        element_heads: &OpTy<'tcx, Provenance>,
+        buffer: &OpTy<'tcx, Provenance>,
+    ) -> InterpResult<'tcx, ()> {
+        let this = self.eval_context_mut();
+
+        let ptr_u8 = this.tcx.mk_mut_ptr(this.tcx.types.u8);
+        let ptr_ptr_u8 = this.tcx.mk_mut_ptr(ptr_u8);
+
+        let ptr_u8_layout = this.layout_of(ptr_u8).unwrap();
+
+        let element_heads = this.addr_to_mplace_ty(element_heads, ptr_ptr_u8)?;
+        let buffer = this.addr_to_mplace_ty(buffer, ptr_u8)?;
+
+        // Based on
+        // https://github.com/bytecodealliance/wasmtime/blob/f85e3f85170bd2c8378977879f4fdf2c6b64de55/crates/wasi-common/src/string_array.rs#L48
+        let mut cursor: u32 = 0;
+        // Can't iterative directly over it to due borrowcheck conflict with 'this'
+        for i in 0..this.machine.args.len() {
+            let arg = &this.machine.args[i];
+            let bytes = arg.as_bytes();
+            let len: u32 = bytes.len().try_into().unwrap();
+            // Make space for `0` terminator.
+            let size = u64::try_from(arg.len()).unwrap().checked_add(1).unwrap();
+
+            let buffer_loc = buffer.ptr.offset(Size::from_bytes(cursor), this)?;
+
+            let arg = OsString::from(arg.to_owned());
+
+            this.write_os_str_to_c_str(&arg, buffer_loc, size)?;
+
+            let head_ptr = element_heads.ptr.offset((i as u64) * ptr_u8_layout.size, this)?;
+            let head_ptr_mplace = MPlaceTy::from_aligned_ptr(head_ptr, ptr_u8_layout);
+
+            this.write_pointer(buffer_loc, &head_ptr_mplace.into())?;
+            cursor = cursor.checked_add(len).unwrap().checked_add(1).unwrap();
+        }
+        Ok(())
+    }
+
+    fn addr_to_mplace_ty(
+        &mut self,
+        arg: &OpTy<'tcx, Provenance>,
+        ptr_ty: Ty<'tcx>,
+    ) -> InterpResult<'tcx, MPlaceTy<'tcx, Provenance>> {
+        let this = self.eval_context_mut();
+        let arg = this.read_scalar(arg)?;
+        //  Hack: New versions of the `wasi` crate perform an int-to-ptr cast before making a syscall,
+        //  while older versions pass a pointer directly. We need to handle both cases.
+        let ptr = match arg {
+            Scalar::Int(_) => {
+                #[allow(clippy::cast_sign_loss)] // We want to lose the sign.
+                crate::intptrcast::GlobalStateInner::ptr_from_addr_cast(this, arg.to_i32()? as u64)?
+            }
+            Scalar::Ptr(ptr, _) => ptr.into(),
+        };
+        Ok(MPlaceTy::from_aligned_ptr(ptr, this.layout_of(ptr_ty).unwrap()))
+    }
+}

--- a/src/shims/unix/wasi/mod.rs
+++ b/src/shims/unix/wasi/mod.rs
@@ -1,0 +1,1 @@
+pub mod foreign_items;

--- a/test-cargo-miri/run-test.py
+++ b/test-cargo-miri/run-test.py
@@ -51,6 +51,8 @@ def test(name, cmd, stdout_ref, stderr_ref, stdin=b'', env={}):
     ## Call `cargo miri`, capture all output
     p_env = os.environ.copy()
     p_env.update(env)
+    if 'MIRIFLAGS' in os.environ:
+        p_env['MIRIFLAGS'] = os.environ['MIRIFLAGS'] + " " + p_env.get('MIRIFLAGS', '')
     p = subprocess.Popen(
         cmd,
         stdin=subprocess.PIPE,

--- a/test-cargo-miri/test.cross-target-wasm.stdout.ref
+++ b/test-cargo-miri/test.cross-target-wasm.stdout.ref
@@ -1,0 +1,11 @@
+
+running 2 tests
+..
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+
+imported main
+
+running 6 tests
+..iii.
+test result: ok. 3 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out
+

--- a/test-cargo-miri/test.filter.cross-target-wasm.stdout.ref
+++ b/test-cargo-miri/test.filter.cross-target-wasm.stdout.ref
@@ -1,0 +1,12 @@
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out
+
+imported main
+
+running 1 test
+test simple ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out
+

--- a/test-cargo-miri/test.test-target-wasm.stdout.ref
+++ b/test-cargo-miri/test.test-target-wasm.stdout.ref
@@ -1,0 +1,11 @@
+
+running 6 tests
+test cargo_env ... ok
+test deps ... ok
+test do_panic - should panic ... ignored
+test does_not_work_on_miri ... ignored
+test fail_index_check - should panic ... ignored
+test simple ... ok
+
+test result: ok. 3 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out
+

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -169,6 +169,8 @@ regexes! {
     r"\\"                           => "/",
     // erase Rust stdlib path
     "[^ `]*/(rust[^/]*|checkout)/library/" => "RUSTLIB/",
+    // erase platform file pathss - wasm-specific relative path
+    "sys/[a-z]+/../unix/"                    => "sys/PLATFORM/",
     // erase platform file paths
     "sys/[a-z]+/"                    => "sys/PLATFORM/",
     // erase paths into the crate registry

--- a/tests/fail/abort-terminator.rs
+++ b/tests/fail/abort-terminator.rs
@@ -1,3 +1,4 @@
+//@ignore-target-wasm: wasm does not support unwinding
 #![feature(c_unwind)]
 
 extern "C" fn panic_abort() {

--- a/tests/fail/concurrency/libc_pthread_create_main_terminate.rs
+++ b/tests/fail/concurrency/libc_pthread_create_main_terminate.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 //@error-pattern: the main thread terminated without waiting for all remaining threads
 
 // Check that we terminate the program when the main thread terminates.

--- a/tests/fail/concurrency/libc_pthread_create_too_few_args.rs
+++ b/tests/fail/concurrency/libc_pthread_create_too_few_args.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 
 //! The thread function must have exactly one argument.
 

--- a/tests/fail/concurrency/libc_pthread_create_too_many_args.rs
+++ b/tests/fail/concurrency/libc_pthread_create_too_many_args.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 
 //! The thread function must have exactly one argument.
 

--- a/tests/fail/concurrency/libc_pthread_join_detached.rs
+++ b/tests/fail/concurrency/libc_pthread_join_detached.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 
 // Joining a detached thread is undefined behavior.
 

--- a/tests/fail/concurrency/libc_pthread_join_joined.rs
+++ b/tests/fail/concurrency/libc_pthread_join_joined.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 
 // Joining an already joined thread is undefined behavior.
 

--- a/tests/fail/concurrency/libc_pthread_join_main.rs
+++ b/tests/fail/concurrency/libc_pthread_join_main.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 
 // Joining the main thread is undefined behavior.
 

--- a/tests/fail/concurrency/libc_pthread_join_multiple.rs
+++ b/tests/fail/concurrency/libc_pthread_join_multiple.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 
 // Joining the same thread from multiple threads is undefined behavior.
 

--- a/tests/fail/concurrency/libc_pthread_join_self.rs
+++ b/tests/fail/concurrency/libc_pthread_join_self.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 // We are making scheduler assumptions here.
 //@compile-flags: -Zmiri-preemption-rate=0
 

--- a/tests/fail/concurrency/thread_local_static_dealloc.rs
+++ b/tests/fail/concurrency/thread_local_static_dealloc.rs
@@ -1,4 +1,5 @@
 //! Ensure that thread-local statics get deallocated when the thread dies.
+//@ignore-target-wasm: wasm does not support threads
 
 #![feature(thread_local)]
 

--- a/tests/fail/concurrency/unwind_top_of_stack.rs
+++ b/tests/fail/concurrency/unwind_top_of_stack.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 
 //@compile-flags: -Zmiri-disable-abi-check
 

--- a/tests/fail/data_race/alloc_read_race.rs
+++ b/tests/fail/data_race/alloc_read_race.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
+//@ignore-target-wasm: wasm does not support threads
 #![feature(new_uninit)]
 
 use std::mem::MaybeUninit;

--- a/tests/fail/data_race/alloc_write_race.rs
+++ b/tests/fail/data_race/alloc_write_race.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
+//@ignore-target-wasm: wasm does not support threads
 #![feature(new_uninit)]
 
 use std::ptr::null_mut;

--- a/tests/fail/data_race/atomic_read_na_write_race1.rs
+++ b/tests/fail/data_race/atomic_read_na_write_race1.rs
@@ -1,5 +1,6 @@
 // We want to control preemption here. Stacked borrows interferes by having its own accesses.
 //@compile-flags: -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread::spawn;

--- a/tests/fail/data_race/atomic_read_na_write_race2.rs
+++ b/tests/fail/data_race/atomic_read_na_write_race2.rs
@@ -1,5 +1,6 @@
 // We want to control preemption here. Stacked borrows interferes by having its own accesses.
 //@compile-flags: -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;

--- a/tests/fail/data_race/atomic_write_na_read_race1.rs
+++ b/tests/fail/data_race/atomic_write_na_read_race1.rs
@@ -1,5 +1,6 @@
 // We want to control preemption here. Stacked borrows interferes by having its own accesses.
 //@compile-flags: -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;

--- a/tests/fail/data_race/atomic_write_na_read_race2.rs
+++ b/tests/fail/data_race/atomic_write_na_read_race2.rs
@@ -1,5 +1,6 @@
 // We want to control preemption here. Stacked borrows interferes by having its own accesses.
 //@compile-flags: -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread::spawn;

--- a/tests/fail/data_race/atomic_write_na_write_race1.rs
+++ b/tests/fail/data_race/atomic_write_na_write_race1.rs
@@ -1,5 +1,6 @@
 // We want to control preemption here. Stacked borrows interferes by having its own accesses.
 //@compile-flags: -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread::spawn;

--- a/tests/fail/data_race/atomic_write_na_write_race2.rs
+++ b/tests/fail/data_race/atomic_write_na_write_race2.rs
@@ -1,5 +1,6 @@
 // We want to control preemption here. Stacked borrows interferes by having its own accesses.
 //@compile-flags: -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;

--- a/tests/fail/data_race/dangling_thread_async_race.rs
+++ b/tests/fail/data_race/dangling_thread_async_race.rs
@@ -1,5 +1,6 @@
 // We want to control preemption here. Stacked borrows interferes by having its own accesses.
 //@compile-flags: -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::mem;
 use std::thread::{sleep, spawn};

--- a/tests/fail/data_race/dangling_thread_race.rs
+++ b/tests/fail/data_race/dangling_thread_race.rs
@@ -1,5 +1,6 @@
 // We want to control preemption here. Stacked borrows interferes by having its own accesses.
 //@compile-flags: -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::mem;
 use std::thread::{sleep, spawn};

--- a/tests/fail/data_race/dealloc_read_race1.rs
+++ b/tests/fail/data_race/dealloc_read_race1.rs
@@ -1,5 +1,6 @@
 // We want to control preemption here. Stacked borrows interferes by having its own accesses.
 //@compile-flags: -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::thread::spawn;
 

--- a/tests/fail/data_race/dealloc_read_race2.rs
+++ b/tests/fail/data_race/dealloc_read_race2.rs
@@ -1,5 +1,6 @@
 // We want to control preemption here. Stacked borrows interferes by having its own accesses.
 //@compile-flags: -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::thread::spawn;
 

--- a/tests/fail/data_race/dealloc_read_race_stack.rs
+++ b/tests/fail/data_race/dealloc_read_race_stack.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::ptr::null_mut;
 use std::sync::atomic::{AtomicPtr, Ordering};

--- a/tests/fail/data_race/dealloc_write_race1.rs
+++ b/tests/fail/data_race/dealloc_write_race1.rs
@@ -1,5 +1,6 @@
 // We want to control preemption here. Stacked borrows interferes by having its own accesses.
 //@compile-flags: -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::thread::spawn;
 

--- a/tests/fail/data_race/dealloc_write_race2.rs
+++ b/tests/fail/data_race/dealloc_write_race2.rs
@@ -1,5 +1,6 @@
 // We want to control preemption here. Stacked borrows interferes by having its own accesses.
 //@compile-flags: -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::thread::spawn;
 

--- a/tests/fail/data_race/dealloc_write_race_stack.rs
+++ b/tests/fail/data_race/dealloc_write_race_stack.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::ptr::null_mut;
 use std::sync::atomic::{AtomicPtr, Ordering};

--- a/tests/fail/data_race/enable_after_join_to_main.rs
+++ b/tests/fail/data_race/enable_after_join_to_main.rs
@@ -1,5 +1,6 @@
 // We want to control preemption here. Stacked borrows interferes by having its own accesses.
 //@compile-flags: -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::thread::spawn;
 

--- a/tests/fail/data_race/fence_after_load.rs
+++ b/tests/fail/data_race/fence_after_load.rs
@@ -1,5 +1,6 @@
 // We want to control preemption here. Stacked borrows interferes by having its own accesses.
 //@compile-flags: -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
+//@ignore-target-wasm: wasm does not support threads
 use std::sync::atomic::{fence, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread;

--- a/tests/fail/data_race/read_write_race.rs
+++ b/tests/fail/data_race/read_write_race.rs
@@ -1,5 +1,6 @@
 // We want to control preemption here. Stacked borrows interferes by having its own accesses.
 //@compile-flags: -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::thread::spawn;
 

--- a/tests/fail/data_race/read_write_race_stack.rs
+++ b/tests/fail/data_race/read_write_race_stack.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmir-opt-level=0 -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
+//@ignore-target-wasm: wasm does not support threads
 
 // Note: mir-opt-level set to 0 to prevent the read of stack_var in thread 1
 // from being optimized away and preventing the detection of the data-race.

--- a/tests/fail/data_race/relax_acquire_race.rs
+++ b/tests/fail/data_race/relax_acquire_race.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread::spawn;

--- a/tests/fail/data_race/release_seq_race.rs
+++ b/tests/fail/data_race/release_seq_race.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread::{sleep, spawn};

--- a/tests/fail/data_race/release_seq_race_same_thread.rs
+++ b/tests/fail/data_race/release_seq_race_same_thread.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread::spawn;

--- a/tests/fail/data_race/rmw_race.rs
+++ b/tests/fail/data_race/rmw_race.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread::spawn;

--- a/tests/fail/data_race/stack_pop_race.rs
+++ b/tests/fail/data_race/stack_pop_race.rs
@@ -1,4 +1,6 @@
 //@compile-flags: -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
+//@ignore-target-wasm: wasm does not support threads
+
 use std::thread;
 
 #[derive(Copy, Clone)]

--- a/tests/fail/data_race/write_write_race.rs
+++ b/tests/fail/data_race/write_write_race.rs
@@ -1,5 +1,6 @@
 // We want to control preemption here.
 //@compile-flags: -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::thread::spawn;
 

--- a/tests/fail/data_race/write_write_race_stack.rs
+++ b/tests/fail/data_race/write_write_race_stack.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::ptr::null_mut;
 use std::sync::atomic::{AtomicPtr, Ordering};

--- a/tests/fail/environ-gets-deallocated.rs
+++ b/tests/fail/environ-gets-deallocated.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: Windows does not have a global environ list that the program can access directly
+//@ignore-target-wasm: Not yet implemented
 
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 fn get_environ() -> *const *const u8 {

--- a/tests/fail/function_calls/exported_symbol_bad_unwind1.rs
+++ b/tests/fail/function_calls/exported_symbol_bad_unwind1.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-disable-abi-check
+//@ignore-target-wasm: wasm does not support unwinding
 #![feature(c_unwind)]
 
 #[no_mangle]

--- a/tests/fail/function_calls/exported_symbol_bad_unwind2.rs
+++ b/tests/fail/function_calls/exported_symbol_bad_unwind2.rs
@@ -1,4 +1,5 @@
 //@revisions: extern_block definition both
+//@ignore-target-wasm: wasm does not support unwinding
 #![feature(rustc_attrs, c_unwind)]
 
 #[cfg_attr(any(definition, both), rustc_nounwind)]

--- a/tests/fail/panic/bad_unwind.rs
+++ b/tests/fail/panic/bad_unwind.rs
@@ -1,4 +1,5 @@
 #![feature(c_unwind)]
+//@ignore-target-wasm: wasm does not support unwinding
 
 //! Unwinding when the caller ABI is "C" (without "-unwind") is UB.
 

--- a/tests/fail/panic/double_panic.rs
+++ b/tests/fail/panic/double_panic.rs
@@ -1,4 +1,5 @@
 //@error-pattern: the program aborted
+//@ignore-target-wasm: wasm does not support unwinding
 //@normalize-stderr-test: "\| +\^+" -> "| ^"
 //@normalize-stderr-test: "unsafe \{ libc::abort\(\) \}|crate::intrinsics::abort\(\);" -> "ABORT();"
 

--- a/tests/fail/shims/fs/isolated_file.rs
+++ b/tests/fail/shims/fs/isolated_file.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: File handling is not implemented yet
+//@ignore-target-wasm: File handling is not implemented yet
 //@error-pattern: `open` not available when isolation is enabled
 
 fn main() {

--- a/tests/fail/shims/fs/mkstemp_immutable_arg.rs
+++ b/tests/fail/shims/fs/mkstemp_immutable_arg.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: File handling is not implemented yet
 //@compile-flags: -Zmiri-disable-isolation
 
 fn main() {

--- a/tests/fail/shims/fs/unix_open_missing_required_mode.rs
+++ b/tests/fail/shims/fs/unix_open_missing_required_mode.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: File handling is not implemented yet
 //@compile-flags: -Zmiri-disable-isolation
 
 fn main() {

--- a/tests/fail/shims/sync/libc_pthread_cond_double_destroy.rs
+++ b/tests/fail/shims/sync/libc_pthread_cond_double_destroy.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 
 /// Test that destroying a pthread_cond twice fails, even without a check for number validity
 

--- a/tests/fail/shims/sync/libc_pthread_condattr_double_destroy.rs
+++ b/tests/fail/shims/sync/libc_pthread_condattr_double_destroy.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 
 /// Test that destroying a pthread_condattr twice fails, even without a check for number validity
 

--- a/tests/fail/shims/sync/libc_pthread_mutex_NULL_deadlock.rs
+++ b/tests/fail/shims/sync/libc_pthread_mutex_NULL_deadlock.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 //
 // Check that if we pass NULL attribute, then we get the default mutex type.
 

--- a/tests/fail/shims/sync/libc_pthread_mutex_deadlock.rs
+++ b/tests/fail/shims/sync/libc_pthread_mutex_deadlock.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::cell::UnsafeCell;
 use std::sync::Arc;

--- a/tests/fail/shims/sync/libc_pthread_mutex_default_deadlock.rs
+++ b/tests/fail/shims/sync/libc_pthread_mutex_default_deadlock.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 //
 // Check that if we do not set the mutex type, it is the default.
 

--- a/tests/fail/shims/sync/libc_pthread_mutex_destroy_locked.rs
+++ b/tests/fail/shims/sync/libc_pthread_mutex_destroy_locked.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 
 fn main() {
     unsafe {

--- a/tests/fail/shims/sync/libc_pthread_mutex_double_destroy.rs
+++ b/tests/fail/shims/sync/libc_pthread_mutex_double_destroy.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 
 /// Test that destroying a pthread_mutex twice fails, even without a check for number validity
 

--- a/tests/fail/shims/sync/libc_pthread_mutex_normal_deadlock.rs
+++ b/tests/fail/shims/sync/libc_pthread_mutex_normal_deadlock.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 
 fn main() {
     unsafe {

--- a/tests/fail/shims/sync/libc_pthread_mutex_normal_unlock_unlocked.rs
+++ b/tests/fail/shims/sync/libc_pthread_mutex_normal_unlock_unlocked.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 
 fn main() {
     unsafe {

--- a/tests/fail/shims/sync/libc_pthread_mutex_wrong_owner.rs
+++ b/tests/fail/shims/sync/libc_pthread_mutex_wrong_owner.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::cell::UnsafeCell;
 use std::sync::Arc;

--- a/tests/fail/shims/sync/libc_pthread_mutexattr_double_destroy.rs
+++ b/tests/fail/shims/sync/libc_pthread_mutexattr_double_destroy.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 
 /// Test that destroying a pthread_mutexattr twice fails, even without a check for number validity
 

--- a/tests/fail/shims/sync/libc_pthread_rwlock_destroy_read_locked.rs
+++ b/tests/fail/shims/sync/libc_pthread_rwlock_destroy_read_locked.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 
 fn main() {
     let rw = std::cell::UnsafeCell::new(libc::PTHREAD_RWLOCK_INITIALIZER);

--- a/tests/fail/shims/sync/libc_pthread_rwlock_destroy_write_locked.rs
+++ b/tests/fail/shims/sync/libc_pthread_rwlock_destroy_write_locked.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 
 fn main() {
     let rw = std::cell::UnsafeCell::new(libc::PTHREAD_RWLOCK_INITIALIZER);

--- a/tests/fail/shims/sync/libc_pthread_rwlock_double_destroy.rs
+++ b/tests/fail/shims/sync/libc_pthread_rwlock_double_destroy.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 
 /// Test that destroying a pthread_rwlock twice fails, even without a check for number validity
 

--- a/tests/fail/shims/sync/libc_pthread_rwlock_read_write_deadlock_single_thread.rs
+++ b/tests/fail/shims/sync/libc_pthread_rwlock_read_write_deadlock_single_thread.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 
 fn main() {
     let rw = std::cell::UnsafeCell::new(libc::PTHREAD_RWLOCK_INITIALIZER);

--- a/tests/fail/shims/sync/libc_pthread_rwlock_read_wrong_owner.rs
+++ b/tests/fail/shims/sync/libc_pthread_rwlock_read_wrong_owner.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::cell::UnsafeCell;
 use std::sync::Arc;

--- a/tests/fail/shims/sync/libc_pthread_rwlock_unlock_unlocked.rs
+++ b/tests/fail/shims/sync/libc_pthread_rwlock_unlock_unlocked.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 
 fn main() {
     let rw = std::cell::UnsafeCell::new(libc::PTHREAD_RWLOCK_INITIALIZER);

--- a/tests/fail/shims/sync/libc_pthread_rwlock_write_read_deadlock.rs
+++ b/tests/fail/shims/sync/libc_pthread_rwlock_write_read_deadlock.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::cell::UnsafeCell;
 use std::sync::Arc;

--- a/tests/fail/shims/sync/libc_pthread_rwlock_write_read_deadlock_single_thread.rs
+++ b/tests/fail/shims/sync/libc_pthread_rwlock_write_read_deadlock_single_thread.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 
 fn main() {
     let rw = std::cell::UnsafeCell::new(libc::PTHREAD_RWLOCK_INITIALIZER);

--- a/tests/fail/shims/sync/libc_pthread_rwlock_write_write_deadlock.rs
+++ b/tests/fail/shims/sync/libc_pthread_rwlock_write_write_deadlock.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::cell::UnsafeCell;
 use std::sync::Arc;

--- a/tests/fail/shims/sync/libc_pthread_rwlock_write_write_deadlock_single_thread.rs
+++ b/tests/fail/shims/sync/libc_pthread_rwlock_write_write_deadlock_single_thread.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 
 fn main() {
     let rw = std::cell::UnsafeCell::new(libc::PTHREAD_RWLOCK_INITIALIZER);

--- a/tests/fail/shims/sync/libc_pthread_rwlock_write_wrong_owner.rs
+++ b/tests/fail/shims/sync/libc_pthread_rwlock_write_wrong_owner.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::cell::UnsafeCell;
 use std::sync::Arc;

--- a/tests/fail/should-pass/cpp20_rwc_syncs.rs
+++ b/tests/fail/should-pass/cpp20_rwc_syncs.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-ignore-leaks
+//@ignore-target-wasm: wasm does not support threads
 
 // https://plv.mpi-sws.org/scfix/paper.pdf
 // 2.2 Second Problem: SC Fences are Too Weak

--- a/tests/fail/stacked_borrows/retag_data_race_read.rs
+++ b/tests/fail/stacked_borrows/retag_data_race_read.rs
@@ -1,5 +1,6 @@
 //! Make sure that a retag acts like a write for the data race model.
 //@compile-flags: -Zmiri-preemption-rate=0
+//@ignore-target-wasm: wasm does not support threads
 #[derive(Copy, Clone)]
 struct SendPtr(*mut u8);
 

--- a/tests/fail/stacked_borrows/retag_data_race_write.rs
+++ b/tests/fail/stacked_borrows/retag_data_race_write.rs
@@ -1,5 +1,6 @@
 //! Make sure that a retag acts like a write for the data race model.
 //@compile-flags: -Zmiri-preemption-rate=0
+//@ignore-target-wasm: wasm does not support threads
 #[derive(Copy, Clone)]
 struct SendPtr(*mut u8);
 

--- a/tests/fail/unsupported_incomplete_function.rs
+++ b/tests/fail/unsupported_incomplete_function.rs
@@ -1,6 +1,7 @@
 //! `signal()` is special on Linux and macOS that it's only supported within libstd.
 //! The implementation is not complete enough to permit user code to call it.
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support signals
 //@normalize-stderr-test: "OS `.*`" -> "$$OS"
 
 fn main() {

--- a/tests/fail/weak_memory/racing_mixed_size.rs
+++ b/tests/fail/weak_memory/racing_mixed_size.rs
@@ -1,5 +1,6 @@
 // We want to control preemption here.
 //@compile-flags: -Zmiri-preemption-rate=0
+//@ignore-target-wasm: wasm does not support threads
 
 #![feature(core_intrinsics)]
 

--- a/tests/fail/weak_memory/racing_mixed_size_read.rs
+++ b/tests/fail/weak_memory/racing_mixed_size_read.rs
@@ -1,5 +1,6 @@
 // We want to control preemption here.
 //@compile-flags: -Zmiri-preemption-rate=0
+//@ignore-target-wasm: wasm does not support threads
 
 use std::sync::atomic::Ordering::*;
 use std::sync::atomic::{AtomicU16, AtomicU32};

--- a/tests/panic/div-by-zero-2.rs
+++ b/tests/panic/div-by-zero-2.rs
@@ -1,4 +1,5 @@
 #![allow(unconditional_panic)]
+//@ignore-target-wasm: wasm does not support panic=unwind
 
 fn main() {
     let _n = 1 / 0;

--- a/tests/panic/function_calls/exported_symbol_good_unwind.rs
+++ b/tests/panic/function_calls/exported_symbol_good_unwind.rs
@@ -3,6 +3,7 @@
 // `__rust_start_panic`).
 // no-prefer-dynamic
 #![feature(c_unwind, unboxed_closures)]
+//@ignore-target-wasm: wasm does not support panic=unwind
 
 use std::panic;
 

--- a/tests/panic/overflowing-lsh-neg.rs
+++ b/tests/panic/overflowing-lsh-neg.rs
@@ -1,4 +1,5 @@
 #![allow(arithmetic_overflow)]
+//@ignore-target-wasm: wasm does not support panic=unwind
 
 fn main() {
     let _n = 2i64 << -1;

--- a/tests/panic/overflowing-rsh-1.rs
+++ b/tests/panic/overflowing-rsh-1.rs
@@ -1,4 +1,5 @@
 #![allow(arithmetic_overflow)]
+//@ignore-target-wasm: wasm does not support panic=unwind
 
 fn main() {
     let _n = 1i64 >> 64;

--- a/tests/panic/overflowing-rsh-2.rs
+++ b/tests/panic/overflowing-rsh-2.rs
@@ -1,4 +1,5 @@
 #![allow(arithmetic_overflow)]
+//@ignore-target-wasm: wasm does not support panic=unwind
 
 fn main() {
     // Make sure we catch overflows that would be hidden by first casting the RHS to u32

--- a/tests/panic/panic1.rs
+++ b/tests/panic/panic1.rs
@@ -1,4 +1,5 @@
 //@rustc-env: RUST_BACKTRACE=1
+//@ignore-target-wasm: wasm does not support panic=unwind
 //@compile-flags: -Zmiri-disable-isolation
 
 fn main() {

--- a/tests/panic/panic2.rs
+++ b/tests/panic/panic2.rs
@@ -1,3 +1,5 @@
+//@ignore-target-wasm: wasm does not support panic=unwind
+
 fn main() {
     std::panic!("{}-panicking from libstd", 42);
 }

--- a/tests/panic/panic3.rs
+++ b/tests/panic/panic3.rs
@@ -1,3 +1,5 @@
+//@ignore-target-wasm: wasm does not support panic=unwind
+
 fn main() {
     core::panic!("panicking from libcore");
 }

--- a/tests/panic/panic4.rs
+++ b/tests/panic/panic4.rs
@@ -1,3 +1,5 @@
+//@ignore-target-wasm: wasm does not support panic=unwind
+
 fn main() {
     core::panic!("{}-panicking from libcore", 42);
 }

--- a/tests/panic/transmute_fat2.rs
+++ b/tests/panic/transmute_fat2.rs
@@ -1,3 +1,5 @@
+//@ignore-target-wasm: wasm does not support panic=unwind
+
 fn main() {
     #[cfg(all(target_endian = "little", target_pointer_width = "64"))]
     let bad = unsafe { std::mem::transmute::<u128, &[u8]>(42) };

--- a/tests/panic/unsupported_foreign_function.rs
+++ b/tests/panic/unsupported_foreign_function.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-panic-on-unsupported
+//@ignore-target-wasm: wasm does not support panic=unwind
 //@normalize-stderr-test: "OS `.*`" -> "$$OS"
 
 fn main() {

--- a/tests/panic/unsupported_syscall.rs
+++ b/tests/panic/unsupported_syscall.rs
@@ -1,5 +1,6 @@
 //@ignore-target-windows: No libc on Windows
 //@ignore-target-apple: `syscall` is not supported on macOS
+//@ignore-target-wasm: wasm does not support panic=unwind
 //@compile-flags: -Zmiri-panic-on-unsupported
 
 fn main() {

--- a/tests/pass-dep/concurrency/libc_pthread_cond.rs
+++ b/tests/pass-dep/concurrency/libc_pthread_cond.rs
@@ -1,5 +1,6 @@
 //@ignore-target-windows: No libc on Windows
 //@ignore-target-apple: pthread_condattr_setclock is not supported on MacOS.
+//@ignore-target-wasm: wasm does not support threads
 //@compile-flags: -Zmiri-disable-isolation
 
 /// Test that conditional variable timeouts are working properly with both

--- a/tests/pass-dep/concurrency/libc_pthread_cond_isolated.rs
+++ b/tests/pass-dep/concurrency/libc_pthread_cond_isolated.rs
@@ -1,5 +1,6 @@
 //@ignore-target-windows: No libc on Windows
 //@ignore-target-apple: pthread_condattr_setclock is not supported on MacOS.
+//@ignore-target-wasm: wasm does not support threads
 
 /// Test that conditional variable timeouts are working properly
 /// with monotonic clocks even under isolation.

--- a/tests/pass-dep/concurrency/tls_pthread_drop_order.rs
+++ b/tests/pass-dep/concurrency/tls_pthread_drop_order.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 //! Test that pthread_key destructors are run in the right order.
 //! Note that these are *not* used by actual `thread_local!` on Linux! Those use
 //! `thread_local_dtor::register_dtor` from the stdlib instead. In Miri this hits the fallback path

--- a/tests/pass-dep/page_size.rs
+++ b/tests/pass-dep/page_size.rs
@@ -1,3 +1,4 @@
+//@ignore-target-wasm: Not yet implemented
 fn main() {
     let page_size = page_size::get();
 

--- a/tests/pass-dep/page_size_override.rs
+++ b/tests/pass-dep/page_size_override.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-force-page-size=8
+//@ignore-target-wasm: wasm does not have page_size
 
 fn main() {
     let page_size = page_size::get();

--- a/tests/pass-dep/random.rs
+++ b/tests/pass-dep/random.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-strict-provenance
+//@ignore-target-wasm: wasi requires permissive provenance for syscalls to work
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 
 fn main() {

--- a/tests/pass-dep/shims/env-cleanup-data-race.rs
+++ b/tests/pass-dep/shims/env-cleanup-data-race.rs
@@ -1,5 +1,6 @@
 //@compile-flags: -Zmiri-disable-isolation -Zmiri-preemption-rate=0
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 
 use std::ffi::CStr;
 use std::ffi::CString;

--- a/tests/pass-dep/shims/libc-fs-with-isolation.rs
+++ b/tests/pass-dep/shims/libc-fs-with-isolation.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: no libc on Windows
+//@ignore-target-wasm: Does not have libc::F_DUPFD
 //@compile-flags: -Zmiri-isolation-error=warn-nobacktrace
 //@normalize-stderr-test: "(stat(x)?)" -> "$$STAT"
 

--- a/tests/pass-dep/shims/libc-fs.rs
+++ b/tests/pass-dep/shims/libc-fs.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: no libc on Windows
+//@ignore-target-wasm: wasm does not have std::os::unix
 //@compile-flags: -Zmiri-disable-isolation
 
 #![feature(io_error_more)]

--- a/tests/pass-dep/shims/libc-misc.rs
+++ b/tests/pass-dep/shims/libc-misc.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not hae std::os::unix
 //@compile-flags: -Zmiri-disable-isolation
 #![feature(io_error_more)]
 

--- a/tests/pass-dep/shims/pthreads.rs
+++ b/tests/pass-dep/shims/pthreads.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-wasm: wasm does not support threads
 #![feature(cstr_from_bytes_until_nul)]
 use std::ffi::{CStr, CString};
 use std::thread;

--- a/tests/pass/0weak_memory_consistency.rs
+++ b/tests/pass/0weak_memory_consistency.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-ignore-leaks -Zmiri-disable-stacked-borrows
+//@ignore-target-wasm: wasm does not support threads
 
 // The following tests check whether our weak memory emulation produces
 // any inconsistent execution outcomes

--- a/tests/pass/available-parallelism-miri-num-cpus.rs
+++ b/tests/pass/available-parallelism-miri-num-cpus.rs
@@ -1,3 +1,4 @@
+//@ignore-target-wasm: wasm does not support threads
 //@compile-flags: -Zmiri-num-cpus=1024
 
 use std::num::NonZeroUsize;

--- a/tests/pass/available-parallelism.rs
+++ b/tests/pass/available-parallelism.rs
@@ -1,3 +1,5 @@
+//@ignore-target-wasm: wasm does not support threads
+
 fn main() {
     assert_eq!(std::thread::available_parallelism().unwrap().get(), 1);
 }

--- a/tests/pass/box.rs
+++ b/tests/pass/box.rs
@@ -1,4 +1,5 @@
 #![feature(ptr_internals)]
+//@ignore-target-wasm: Enable this when we have a better way of turning on permissive provenance per-test.
 
 fn main() {
     into_raw();

--- a/tests/pass/concurrency/channels.rs
+++ b/tests/pass/concurrency/channels.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-strict-provenance
+//@ignore-target-wasm: wasm does not support threads
 
 use std::sync::mpsc::{channel, sync_channel};
 use std::thread;

--- a/tests/pass/concurrency/concurrent_caller_location.rs
+++ b/tests/pass/concurrency/concurrent_caller_location.rs
@@ -1,3 +1,4 @@
+//@ignore-target-wasm: wasm does not support threads
 use std::panic::Location;
 use std::thread::spawn;
 

--- a/tests/pass/concurrency/data_race.rs
+++ b/tests/pass/concurrency/data_race.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0
+//@ignore-target-wasm: wasm does not support threads
 
 use std::sync::atomic::{fence, AtomicUsize, Ordering};
 use std::thread::spawn;

--- a/tests/pass/concurrency/disable_data_race_detector.rs
+++ b/tests/pass/concurrency/disable_data_race_detector.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-disable-data-race-detector
+//@ignore-target-wasm: wasm does not support threads
 
 use std::thread::spawn;
 

--- a/tests/pass/concurrency/issue1643.rs
+++ b/tests/pass/concurrency/issue1643.rs
@@ -1,3 +1,4 @@
+//@ignore-target-wasm: wasm does not support threads
 use std::thread::spawn;
 
 fn initialize() {

--- a/tests/pass/concurrency/scope.rs
+++ b/tests/pass/concurrency/scope.rs
@@ -1,3 +1,4 @@
+//@ignore-target-wasm: wasm does not support threads
 use std::thread;
 
 fn main() {

--- a/tests/pass/concurrency/simple.rs
+++ b/tests/pass/concurrency/simple.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-strict-provenance
+//@ignore-target-wasm: wasm does not support threads
 
 use std::thread;
 

--- a/tests/pass/concurrency/spin_loop.rs
+++ b/tests/pass/concurrency/spin_loop.rs
@@ -1,3 +1,4 @@
+//@ignore-target-wasm: wasm does not support threads
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
 

--- a/tests/pass/concurrency/spin_loops_nopreempt.rs
+++ b/tests/pass/concurrency/spin_loops_nopreempt.rs
@@ -1,5 +1,6 @@
 // This specifically tests behavior *without* preemption.
 //@compile-flags: -Zmiri-preemption-rate=0
+//@ignore-target-wasm: wasm does not support threads
 
 use std::cell::Cell;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};

--- a/tests/pass/concurrency/sync.rs
+++ b/tests/pass/concurrency/sync.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-disable-isolation -Zmiri-strict-provenance
+//@ignore-target-wasm: wasm does not support threads
 
 use std::sync::{Arc, Barrier, Condvar, Mutex, Once, RwLock};
 use std::thread;

--- a/tests/pass/concurrency/sync_nopreempt.rs
+++ b/tests/pass/concurrency/sync_nopreempt.rs
@@ -1,5 +1,6 @@
 // We are making scheduler assumptions here.
 //@compile-flags: -Zmiri-strict-provenance -Zmiri-preemption-rate=0
+//@ignore-target-wasm: wasm does not support threads
 
 use std::sync::{Arc, Condvar, Mutex, RwLock};
 use std::thread;

--- a/tests/pass/concurrency/thread_locals.rs
+++ b/tests/pass/concurrency/thread_locals.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-strict-provenance
+//@ignore-target-wasm: wasm does not support threads
 
 //! The main purpose of this test is to check that if we take a pointer to
 //! thread's `t1` thread-local `A` and send it to another thread `t2`,

--- a/tests/pass/concurrency/thread_park_isolated.rs
+++ b/tests/pass/concurrency/thread_park_isolated.rs
@@ -1,4 +1,6 @@
 //@ignore-target-apple: park_timeout on macOS uses the system clock
+//@ignore-target-wasm: wasm does not support threads
+
 use std::thread;
 use std::time::{Duration, Instant};
 

--- a/tests/pass/concurrency/tls_lib_drop.rs
+++ b/tests/pass/concurrency/tls_lib_drop.rs
@@ -1,3 +1,4 @@
+//@ignore-target-wasm: wasm does not support threads
 use std::cell::RefCell;
 use std::thread;
 

--- a/tests/pass/concurrency/tls_lib_drop_single_thread.rs
+++ b/tests/pass/concurrency/tls_lib_drop_single_thread.rs
@@ -1,4 +1,5 @@
 //! Check that destructors of the thread locals are executed on all OSes.
+//@ignore-target-wasm: wasm does not support threads
 
 use std::cell::RefCell;
 

--- a/tests/pass/extern_types.rs
+++ b/tests/pass/extern_types.rs
@@ -1,4 +1,5 @@
 #![feature(extern_types)]
+//@ignore-target-wasm: Enable this when we have a better way of turning on permissive provenance per-test.
 
 extern "C" {
     type Foo;

--- a/tests/pass/getpid.rs
+++ b/tests/pass/getpid.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-disable-isolation
+//@ignore-target-wasm: wasm does not support threads
 
 fn getpid() -> u32 {
     std::process::id()

--- a/tests/pass/heap_allocator.rs
+++ b/tests/pass/heap_allocator.rs
@@ -1,4 +1,5 @@
 #![feature(allocator_api, slice_ptr_get)]
+//@ignore-target-wasm: Not yet implemented
 
 use std::alloc::{Allocator, Global, Layout, System};
 use std::ptr::NonNull;

--- a/tests/pass/panic/catch_panic.rs
+++ b/tests/pass/panic/catch_panic.rs
@@ -1,5 +1,6 @@
 // We test the `align_offset` panic below, make sure we test the interpreter impl and not the "real" one.
 //@compile-flags: -Zmiri-symbolic-alignment-check -Zmiri-permissive-provenance
+//@ignore-target-wasm: wasm does not support catch_unwind
 #![feature(never_type)]
 #![allow(unconditional_panic, non_fmt_panics)]
 

--- a/tests/pass/panic/concurrent-panic.rs
+++ b/tests/pass/panic/concurrent-panic.rs
@@ -1,5 +1,6 @@
 // We are making scheduler assumptions here.
 //@compile-flags: -Zmiri-preemption-rate=0
+//@ignore-target-wasm: wasm does not support threads
 
 //! Cause a panic in one thread while another thread is unwinding. This checks
 //! that separate threads have their own panicking state.

--- a/tests/pass/panic/std-panic-locations.rs
+++ b/tests/pass/panic/std-panic-locations.rs
@@ -1,5 +1,6 @@
 //! Test that panic locations for `#[track_caller]` functions in std have the correct
 //! location reported.
+//@ignore-target-wasm: wasm does not support catch_unwind
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 

--- a/tests/pass/shims/env/current_dir.rs
+++ b/tests/pass/shims/env/current_dir.rs
@@ -1,4 +1,6 @@
 //@compile-flags: -Zmiri-disable-isolation
+//@ignore-target-wasm: wasm does not support errno thread_local extern
+
 use std::env;
 use std::io::ErrorKind;
 

--- a/tests/pass/shims/env/current_dir_with_isolation.rs
+++ b/tests/pass/shims/env/current_dir_with_isolation.rs
@@ -1,6 +1,7 @@
 //@compile-flags: -Zmiri-isolation-error=warn-nobacktrace
 //@normalize-stderr-test: "(getcwd|GetCurrentDirectoryW)" -> "$$GETCWD"
 //@normalize-stderr-test: "(chdir|SetCurrentDirectoryW)" -> "$$SETCWD"
+//@ignore-target-wasm: wasm does not support errno thread_local extern
 
 use std::env;
 use std::io::ErrorKind;

--- a/tests/pass/shims/env/home.rs
+++ b/tests/pass/shims/env/home.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: home_dir is not supported on Windows
+//@ignore-target-wasi: home_dir is not supported on wasi
 //@compile-flags: -Zmiri-disable-isolation
 use std::env;
 

--- a/tests/pass/shims/fs-with-isolation.rs
+++ b/tests/pass/shims/fs-with-isolation.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: File handling is not implemented yet
+//@ignore-target-wasm: Does not have std::os::unix
 //@compile-flags: -Zmiri-isolation-error=warn-nobacktrace
 //@normalize-stderr-test: "(stat(x)?)" -> "$$STAT"
 

--- a/tests/pass/shims/fs.rs
+++ b/tests/pass/shims/fs.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: File handling is not implemented yet
+//@ignore-target-wasm: File handling is not yet implemented
 //@compile-flags: -Zmiri-disable-isolation
 
 #![feature(io_error_more)]

--- a/tests/pass/shims/sleep_long.rs
+++ b/tests/pass/shims/sleep_long.rs
@@ -1,4 +1,6 @@
 //@compile-flags: -Zmiri-ignore-leaks -Zmiri-disable-isolation
+//@ignore-target-wasm: wasm does not support threads
+
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;

--- a/tests/pass/shims/time-with-isolation.rs
+++ b/tests/pass/shims/time-with-isolation.rs
@@ -1,3 +1,4 @@
+//@ignore-target-wasm: clock_time_get not yet implemented
 use std::time::{Duration, Instant};
 
 fn test_sleep() {

--- a/tests/pass/shims/time.rs
+++ b/tests/pass/shims/time.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-disable-isolation
+//@ignore-target-wasm: clock_time_get not yet implemented
 
 use std::time::{Duration, Instant, SystemTime};
 

--- a/tests/pass/stacked-borrows/issue-miri-2389.rs
+++ b/tests/pass/stacked-borrows/issue-miri-2389.rs
@@ -1,3 +1,4 @@
+//@ignore-target-wasm: Enable this when we have a better way of turning off permissive provenance per-test.
 use std::cell::Cell;
 
 fn main() {

--- a/tests/pass/threadleak_ignored.rs
+++ b/tests/pass/threadleak_ignored.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-ignore-leaks
+//@ignore-target-wasm: wasm does not support threads
 
 //! Test that leaking threads works, and that their destructors are not executed.
 

--- a/tests/pass/vecdeque.rs
+++ b/tests/pass/vecdeque.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-strict-provenance
+//@ignore-target-wasm: wasi requires permissive provenance for syscalls to work
 use std::collections::VecDeque;
 
 fn test_all_refs<'a, T: 'a>(dummy: &mut T, iter: impl Iterator<Item = &'a mut T>) {

--- a/tests/pass/weak_memory/extra_cpp.rs
+++ b/tests/pass/weak_memory/extra_cpp.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-ignore-leaks
+//@ignore-target-wasm: wasm does not support threads
 
 // Tests operations not perfomable through C++'s atomic API
 // but doable in safe (at least sound) Rust.

--- a/tests/pass/weak_memory/extra_cpp_unsafe.rs
+++ b/tests/pass/weak_memory/extra_cpp_unsafe.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-ignore-leaks
+//@ignore-target-wasm: wasm does not support threads
 
 // Tests operations not perfomable through C++'s atomic API
 // but doable in unsafe Rust which we think *should* be fine.

--- a/tests/pass/weak_memory/weak.rs
+++ b/tests/pass/weak_memory/weak.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-ignore-leaks -Zmiri-preemption-rate=0
+//@ignore-target-wasm: wasm does not support threads
 
 // Tests showing weak memory behaviours are exhibited. All tests
 // return true when the desired behaviour is seen.


### PR DESCRIPTION
This allows a basic "hello world" to run, as well as `cargo miri test --target wasm32-wasi`

Wasi is a somewhat unusual platform. Rust doesn't consider it to be unix-like (std::os::unix is not available, and the target spec doesnt have "unix" as a target family). However, it has a partial unix libc implementation based on wasi-specific syscalls (https://github.com/WebAssembly/wasi-libc), and libstd relies on this in order to call libc functions in wasi-specific code.

As a reuslt, I've decided to mark wasi as a unix platform in Miri. This lets us re-use all of the unix libc function implementations, which are needed for things like environment variables to work properly.

wasm32-wasi currently lacks support for threads, though a proposal for thread support is being actively developed
(https://github.com/WebAssembly/wasi-threads).
As a result, I've had to disable a very large number of tests which rely on on thread support. While this requires editing a large number of files, we still run the majority of tests under wasm32-wasi. Assuming that wasi eventually gains thread support, we can re-enable these tests on wasi at some point in the future.

Some other wasm32-wasi limitations:
* The wasm32 target only supports panic=abort. While Miri could technically ignore this limitation and attempt to unwind anyway, I suspect that this could have weird consequences. As a result, I've ignored any tests that depend on `catch_unwind`
* Unfortunately, the current version of the `wasi` syscall crate passes all pointers arguments by first performing a ptr-to-integer cast. As a result, virtually any wasm32-wasi program will trigger Miri provenance warnings by default. When running the test suite against wasm32-wasi, I've set MIRIFLAGS="-Zmiri-permissive-provenance" which allows almost all tests to pass. There are a few tests which specifically rely on the *default* provenance setting (they expect provenance warnings in the test stderr). Since we currently lack a way to reset the provenance setting back to the default, I've disabled these tests on wasm.