### PR TITLE
Implement epoll_wait

### DIFF
--- a/src/shims/unix/linux/fd/event.rs
+++ b/src/shims/unix/linux/fd/event.rs
@@ -2,6 +2,7 @@ use crate::shims::unix::fs::FileDescriptor;
 
 use rustc_const_eval::interpret::InterpResult;
 
+use std::cell::Cell;
 use std::io;
 
 /// A kind of file descriptor created by `eventfd`.
@@ -13,7 +14,9 @@ use std::io;
 /// <https://man.netbsd.org/eventfd.2>
 #[derive(Debug)]
 pub struct Event {
-    pub val: u32,
+    /// The object contains an unsigned 64-bit integer (uint64_t) counter that is maintained by the
+    /// kernel. This counter is initialized with the value specified in the argument initval.
+    pub val: Cell<u64>,
 }
 
 impl FileDescriptor for Event {
@@ -22,7 +25,7 @@ impl FileDescriptor for Event {
     }
 
     fn dup(&mut self) -> io::Result<Box<dyn FileDescriptor>> {
-        Ok(Box::new(Event { val: self.val }))
+        Ok(Box::new(Event { val: self.val.clone() }))
     }
 
     fn is_tty(&self) -> bool {
@@ -34,5 +37,33 @@ impl FileDescriptor for Event {
         _communicate_allowed: bool,
     ) -> InterpResult<'tcx, io::Result<i32>> {
         Ok(Ok(0))
+    }
+
+    /// A write call adds the 8-byte integer value supplied in
+    /// its buffer to the counter.  The maximum value that may be
+    /// stored in the counter is the largest unsigned 64-bit value
+    /// minus 1 (i.e., 0xfffffffffffffffe).  If the addition would
+    /// cause the counter's value to exceed the maximum, then the
+    /// write either blocks until a read is performed on the
+    /// file descriptor, or fails with the error EAGAIN if the
+    /// file descriptor has been made nonblocking.
+
+    /// A write fails with the error EINVAL if the size of the
+    /// supplied buffer is less than 8 bytes, or if an attempt is
+    /// made to write the value 0xffffffffffffffff.
+    ///
+    /// FIXME: use endianness
+    fn write<'tcx>(
+        &self,
+        _communicate_allowed: bool,
+        bytes: &[u8],
+    ) -> InterpResult<'tcx, io::Result<usize>> {
+        let v1 = self.val.get();
+        // FIXME handle blocking when addition results in exceeding the max u64 value
+        // or fail with EAGAIN if the file descriptor is nonblocking.
+        let v2 = v1.checked_add(u64::from_be_bytes(bytes.try_into().unwrap())).unwrap();
+        self.val.set(v2);
+        assert_eq!(8, bytes.len());
+        Ok(Ok(8))
     }
 }

--- a/src/shims/unix/linux/foreign_items.rs
+++ b/src/shims/unix/linux/foreign_items.rs
@@ -55,6 +55,12 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                 let result = this.epoll_ctl(epfd, op, fd, event)?;
                 this.write_scalar(result, dest)?;
             }
+            "epoll_wait" => {
+                let [epfd, events, maxevents, timeout] =
+                    this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let result = this.epoll_wait(epfd, events, maxevents, timeout)?;
+                this.write_scalar(result, dest)?;
+            }
             "eventfd" => {
                 let [val, flag] =
                     this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;

--- a/tests/pass-dep/tokio/sleep.rs
+++ b/tests/pass-dep/tokio/sleep.rs
@@ -1,0 +1,14 @@
+//@compile-flags: -Zmiri-disable-isolation -Zmiri-permissive-provenance -Zmiri-backtrace=full
+//@only-target-x86_64-unknown-linux: support for tokio only on linux and x86
+
+use tokio::time::{sleep, Duration, Instant};
+
+#[tokio::main]
+async fn main() {
+    let start = Instant::now();
+    sleep(Duration::from_secs(1)).await;
+    // It takes 96 millisecond to sleep for 1 millisecond
+    // It takes 1025 millisecond to sleep for 1 second
+    let time_elapsed = &start.elapsed().as_millis();
+    assert!(time_elapsed > &1000, "{}", time_elapsed);
+}

--- a/tests/pass-dep/tokio/tokio_mvp.rs
+++ b/tests/pass-dep/tokio/tokio_mvp.rs
@@ -1,5 +1,5 @@
 // Need to disable preemption to stay on the supported MVP codepath in mio.
-//@compile-flags: -Zmiri-disable-isolation -Zmiri-permissive-provenance -Zmiri-preemption-rate=0
+//@compile-flags: -Zmiri-disable-isolation -Zmiri-permissive-provenance
 //@only-target-x86_64-unknown-linux: support for tokio exists only on linux and x86
 
 #[tokio::main]


### PR DESCRIPTION
This PR continues working on https://github.com/rust-lang/miri/issues/602.

This is an implementation for `sleep`, though admittedly not a good one. It just does busy waiting.