### PR TITLE
move reject with isolation logic in fcntl

### DIFF
--- a/tests/pass-dep/shims/fcntl_f-fullfsync_apple.rs
+++ b/tests/pass-dep/shims/fcntl_f-fullfsync_apple.rs
@@ -1,0 +1,12 @@
+//@only-target-apple: F_FULLFSYNC only on apple systems
+//@compile-flags: -Zmiri-isolation-error=warn-nobacktrace
+
+use std::io::Error;
+
+fn main() {
+    // test `fcntl(F_FULLFSYNC)`
+    unsafe {
+        assert_eq!(libc::fcntl(1, libc::F_FULLFSYNC, 0), -1);
+        assert_eq!(Error::last_os_error().raw_os_error(), Some(libc::EPERM));
+    }
+}

--- a/tests/pass-dep/shims/fcntl_f-fullfsync_apple.stderr
+++ b/tests/pass-dep/shims/fcntl_f-fullfsync_apple.stderr
@@ -1,0 +1,2 @@
+warning: `fcntl` was made to return an error due to isolation
+

--- a/tests/pass-dep/shims/libc-fs-with-isolation.rs
+++ b/tests/pass-dep/shims/libc-fs-with-isolation.rs
@@ -7,10 +7,9 @@ use std::fs;
 use std::io::{Error, ErrorKind};
 
 fn main() {
-    // test `fcntl`
+    // test `fcntl(F_DUPFD): should work even with isolation.`
     unsafe {
-        assert_eq!(libc::fcntl(1, libc::F_DUPFD, 0), -1);
-        assert_eq!(Error::last_os_error().raw_os_error(), Some(libc::EPERM));
+        assert!(libc::fcntl(1, libc::F_DUPFD, 0) >= 0);
     }
 
     // test `readlink`

--- a/tests/pass-dep/shims/libc-fs-with-isolation.stderr
+++ b/tests/pass-dep/shims/libc-fs-with-isolation.stderr
@@ -1,5 +1,3 @@
-warning: `fcntl` was made to return an error due to isolation
-
 warning: `readlink` was made to return an error due to isolation
 
 warning: `$STAT` was made to return an error due to isolation

--- a/tests/pass-dep/tokio/sleep.rs
+++ b/tests/pass-dep/tokio/sleep.rs
@@ -1,4 +1,4 @@
-//@compile-flags: -Zmiri-disable-isolation -Zmiri-permissive-provenance -Zmiri-backtrace=full
+//@compile-flags: -Zmiri-permissive-provenance -Zmiri-backtrace=full
 //@only-target-x86_64-unknown-linux: support for tokio only on linux and x86
 
 use tokio::time::{sleep, Duration, Instant};
@@ -7,8 +7,6 @@ use tokio::time::{sleep, Duration, Instant};
 async fn main() {
     let start = Instant::now();
     sleep(Duration::from_secs(1)).await;
-    // It takes 96 millisecond to sleep for 1 millisecond
-    // It takes 1025 millisecond to sleep for 1 second
     let time_elapsed = &start.elapsed().as_millis();
-    assert!(time_elapsed > &1000, "{}", time_elapsed);
+    assert!((1000..1100).contains(time_elapsed), "{}", time_elapsed);
 }

--- a/tests/pass-dep/tokio/tokio_mvp.rs
+++ b/tests/pass-dep/tokio/tokio_mvp.rs
@@ -1,5 +1,5 @@
 // Need to disable preemption to stay on the supported MVP codepath in mio.
-//@compile-flags: -Zmiri-disable-isolation -Zmiri-permissive-provenance
+//@compile-flags: -Zmiri-permissive-provenance
 //@only-target-x86_64-unknown-linux: support for tokio exists only on linux and x86
 
 #[tokio::main]


### PR DESCRIPTION
This PR moves the block of logic inside `fcntl` to reject if isolation is enabled into the branch checking if the command is `F_FULLFSYNC` on apple. This allows `fcntl` to duplicate file descriptors while using isolation.

This means we can now run the tokio tests with isolation.

This PR allows moves the now passing `fcntl` logic from `libc-fs-with-isolation.rs` into two different tests: 
- `fcntl(1, libc::F_DUPFD, 0)` succeeds with isolation 
- `fcntl(1, libc::F_FULLFSYNC, 0)` fails with isolation on MacOS