### PR TITLE
a bit of FileDescriptor trait cleanup

### DIFF
--- a/src/shims/unix/linux/fd/epoll.rs
+++ b/src/shims/unix/linux/fd/epoll.rs
@@ -32,16 +32,8 @@ impl FileDescriptor for Epoll {
         "epoll"
     }
 
-    fn as_epoll_handle<'tcx>(&mut self) -> InterpResult<'tcx, &mut Epoll> {
-        Ok(self)
-    }
-
     fn dup(&mut self) -> io::Result<Box<dyn FileDescriptor>> {
         Ok(Box::new(self.clone()))
-    }
-
-    fn is_tty(&self) -> bool {
-        false
     }
 
     fn close<'tcx>(

--- a/src/shims/unix/linux/fd/event.rs
+++ b/src/shims/unix/linux/fd/event.rs
@@ -28,10 +28,6 @@ impl FileDescriptor for Event {
         Ok(Box::new(Event { val: self.val.clone() }))
     }
 
-    fn is_tty(&self) -> bool {
-        false
-    }
-
     fn close<'tcx>(
         self: Box<Self>,
         _communicate_allowed: bool,

--- a/src/shims/unix/linux/fd/socketpair.rs
+++ b/src/shims/unix/linux/fd/socketpair.rs
@@ -19,10 +19,6 @@ impl FileDescriptor for SocketPair {
         Ok(Box::new(SocketPair))
     }
 
-    fn is_tty(&self) -> bool {
-        false
-    }
-
     fn close<'tcx>(
         self: Box<Self>,
         _communicate_allowed: bool,


### PR DESCRIPTION
- add default impl for `is_tty`
- `as_epoll_handle` was just dyn downcasting in disguise; this can be done more generally