### PR TITLE
prevent epoll_wait from failing silently

### DIFF
--- a/src/shims/unix/linux/fd.rs
+++ b/src/shims/unix/linux/fd.rs
@@ -1,4 +1,5 @@
 use rustc_middle::ty::ScalarInt;
+use rustc_target::abi::HasDataLayout;
 
 use crate::*;
 use epoll::{Epoll, EpollEvent};
@@ -191,6 +192,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
             throw_unsup_format!("{flags} is unsupported");
         }
         // FIXME handle the cloexec and nonblock flags
+        let endianness = this.data_layout().endian;
         if flags & efd_cloexec == efd_cloexec {}
         if flags & efd_nonblock == efd_nonblock {}
         if flags & efd_semaphore == efd_semaphore {
@@ -198,7 +200,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
         }
 
         let fh = &mut this.machine.file_handler;
-        let fd = fh.insert_fd(Box::new(Event { val: Cell::new(val.into()) }));
+        let fd = fh.insert_fd(Box::new(Event { val: Cell::new(val.into()), endianness }));
         Ok(Scalar::from_i32(fd))
     }
 

--- a/src/shims/unix/linux/fd/event.rs
+++ b/src/shims/unix/linux/fd/event.rs
@@ -42,10 +42,12 @@ impl FileDescriptor for Event {
     /// A write call adds the 8-byte integer value supplied in
     /// its buffer to the counter.  The maximum value that may be
     /// stored in the counter is the largest unsigned 64-bit value
-    /// minus 1 (i.e., 0xfffffffffffffffe).  If the addition would
+    /// minus 1 (i.e., 0xfffffffffffffffe).
+    ///
+    /// When write is supported in eventfd, if the addition would
     /// cause the counter's value to exceed the maximum, then the
-    /// write either blocks until a read is performed on the
-    /// file descriptor, or fails with the error EAGAIN if the
+    /// write should either block until a read is performed on the
+    /// file descriptor, or fail with the error EAGAIN if the
     /// file descriptor has been made nonblocking.
 
     /// A write fails with the error EINVAL if the size of the

--- a/src/shims/unix/linux/fd/event.rs
+++ b/src/shims/unix/linux/fd/event.rs
@@ -62,9 +62,13 @@ impl FileDescriptor for Event {
         let bytes = bytes
             .try_into()
             .map_err(|_| err_unsup_format!("we expected 8 bytes and got {}", bytes.len()))?;
-        // FIXME handle blocking when addition results in exceeding the max u64 value
-        // or fail with EAGAIN if the file descriptor is nonblocking.
-        let v2 = v1.checked_add(u64::from_be_bytes(bytes)).unwrap();
+        let v2 = v1.checked_add(u64::from_be_bytes(bytes)).ok_or_else(|| {
+            err_unsup_format!(
+                "handle blocking when addition results \
+                in exceeding the max u64 value or fail with \
+                EAGAIN if the file descriptor is nonblocking."
+            )
+        })?;
         self.val.set(v2);
         Ok(Ok(8))
     }

--- a/src/shims/unix/linux/fd/event.rs
+++ b/src/shims/unix/linux/fd/event.rs
@@ -18,7 +18,7 @@ pub struct Event {
     /// The object contains an unsigned 64-bit integer (uint64_t) counter that is maintained by the
     /// kernel. This counter is initialized with the value specified in the argument initval.
     pub val: Cell<u64>,
-    /// We don't have access to interpcx in the file descriptor method, so we use this for passing
+    /// FIXME HACK: We don't have access to interpcx in the file descriptor method, so we use this for passing
     /// the machine's context.
     pub endianness: Endian,
 }

--- a/src/shims/unix/linux/fd/event.rs
+++ b/src/shims/unix/linux/fd/event.rs
@@ -66,9 +66,10 @@ impl FileDescriptor for Event {
             .map_err(|_| err_unsup_format!("we expected 8 bytes and got {}", bytes.len()))?;
         let v2 = v1.checked_add(u64::from_be_bytes(bytes)).ok_or_else(|| {
             err_unsup_format!(
-                "handle blocking when addition results \
-                in exceeding the max u64 value or fail with \
-                EAGAIN if the file descriptor is nonblocking."
+                "Miri currently has an incomplete epoll implementation. \
+                This operation would overflow if all the numbers written \
+                to it would overflow a 64-bit integer. The correct \
+                behavior is to block or retry, which is not yet implemented."
             )
         })?;
         self.val.set(v2);

--- a/src/shims/unix/linux/fd/event.rs
+++ b/src/shims/unix/linux/fd/event.rs
@@ -59,11 +59,13 @@ impl FileDescriptor for Event {
         bytes: &[u8],
     ) -> InterpResult<'tcx, io::Result<usize>> {
         let v1 = self.val.get();
+        let bytes = bytes
+            .try_into()
+            .map_err(|_| err_unsup_format!("we expected 8 bytes and got {}", bytes.len()))?;
         // FIXME handle blocking when addition results in exceeding the max u64 value
         // or fail with EAGAIN if the file descriptor is nonblocking.
-        let v2 = v1.checked_add(u64::from_be_bytes(bytes.try_into().unwrap())).unwrap();
+        let v2 = v1.checked_add(u64::from_be_bytes(bytes)).unwrap();
         self.val.set(v2);
-        assert_eq!(8, bytes.len());
         Ok(Ok(8))
     }
 }

--- a/src/shims/unix/linux/fd/event.rs
+++ b/src/shims/unix/linux/fd/event.rs
@@ -61,7 +61,7 @@ impl FileDescriptor for Event {
         bytes: &[u8],
     ) -> InterpResult<'tcx, io::Result<usize>> {
         let v1 = self.val.get();
-        let bytes = bytes
+        let bytes: [u8; 8] = bytes
             .try_into()
             .map_err(|_| err_unsup_format!("we expected 8 bytes and got {}", bytes.len()))?;
         let v2 = v1.checked_add(u64::from_be_bytes(bytes)).ok_or_else(|| {


### PR DESCRIPTION
This is a WIP PR to handle issues raised in https://github.com/rust-lang/miri/issues/2800.

So far, this handles checking `Event::write` to ensure we get 8 bytes or appropriately fail & that the `checked_add` does not exceed the max u64 value.

This still needs to handle `epoll_wait` correctly.