### PR TITLE
Remove a test that wasn't carrying its weight

### DIFF
--- a/tests/pass/track-alloc-1.rs
+++ b/tests/pass/track-alloc-1.rs
@@ -1,6 +1,0 @@
-// Ensure that tracking early allocations doesn't ICE Miri.
-// Early allocations are probably part of the runtime and therefore uninteresting, but they
-// shouldn't cause a crash.
-//@compile-flags: -Zmiri-track-alloc-id=1
-//@normalize-stderr-test: "[48] bytes" -> "SIZE bytes"
-fn main() {}

--- a/tests/pass/track-alloc-1.stderr
+++ b/tests/pass/track-alloc-1.stderr
@@ -1,5 +1,0 @@
-note: tracking was triggered
-   |
-   = note: created extern static allocation of SIZE bytes (alignment ALIGN bytes) with id 1
-   = note: (no span available)
-


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/110107#discussion_r1170361671 for discussion.

TLDR: it keeps breaking out of unrelated reasons and the real thing to check (early alloc ids can be tracked without ICEing miri) is hard to check otherwise.