### PR TITLE
Avoid interpreting code that has lint errors

### DIFF
--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -63,7 +63,9 @@ impl rustc_driver::Callbacks for MiriCompilerCalls {
         queries: &'tcx rustc_interface::Queries<'tcx>,
     ) -> Compilation {
         queries.global_ctxt().unwrap().enter(|tcx| {
-            tcx.sess.abort_if_errors();
+            if tcx.sess.compile_status().is_err() {
+                tcx.sess.fatal("miri cannot be run on programs that fail compilation");
+            }
 
             init_late_loggers(tcx);
             if !tcx.sess.crate_types().contains(&CrateType::Executable) {

--- a/tests/fail/deny_lint.rs
+++ b/tests/fail/deny_lint.rs
@@ -1,0 +1,8 @@
+//@error-pattern: miri cannot be run on programs that fail compilation
+
+#![deny(warnings)]
+
+struct Foo;
+//~^ ERROR: struct `Foo` is never constructed
+
+fn main() {}

--- a/tests/fail/deny_lint.stderr
+++ b/tests/fail/deny_lint.stderr
@@ -1,0 +1,12 @@
+error: struct `Foo` is never constructed
+  --> $DIR/deny_lint.rs:LL:CC
+   |
+LL | struct Foo;
+   |        ^^^
+   |
+   = note: `-D dead-code` implied by `-D unused`
+
+error: miri cannot be run on programs that fail compilation
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
fixes #2608

we previously only checked for actual errors, as deny lints are handled differently.