### PR TITLE
miri-script: Transform Windows paths to Unix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
           rustc -Vv
           cargo -V
 
+      - name: Install hyperfine
+        run: cargo install hyperfine
+
       - name: Test
         run: bash ./ci.sh
 

--- a/ci.sh
+++ b/ci.sh
@@ -83,7 +83,7 @@ function run_tests {
   fi
   # Ensure that `./miri bench` works on all relevant platforms.
   # `slice-get-unchecked` is the least complex of all available benchmarks.
-  ./miri bench slice-get-unchecked
+  CARGO_EXTRA_FLAGS="" ./miri bench slice-get-unchecked
 
   endgroup
 }

--- a/ci.sh
+++ b/ci.sh
@@ -51,6 +51,11 @@ function run_tests {
     for FILE in tests/many-seeds/*.rs; do
       MIRI_SEEDS=64 CARGO_EXTRA_FLAGS="$CARGO_EXTRA_FLAGS -q" ./miri many-seeds ./miri run "$FILE"
     done
+
+    # Ensure that `./miri bench` works on all relevant platforms.
+    # `slice-get-unchecked` is the least complex of all available benchmarks.
+    # CARGO_EXTRA_FLAGS are cleared as `--locked` is already passed internally by miri bench.
+    CARGO_EXTRA_FLAGS="" ./miri bench slice-get-unchecked
   fi
 
   ## test-cargo-miri
@@ -81,9 +86,6 @@ function run_tests {
       cargo miri run --manifest-path bench-cargo-miri/$BENCH/Cargo.toml
     done
   fi
-  # Ensure that `./miri bench` works on all relevant platforms.
-  # `slice-get-unchecked` is the least complex of all available benchmarks.
-  CARGO_EXTRA_FLAGS="" ./miri bench slice-get-unchecked
 
   endgroup
 }

--- a/ci.sh
+++ b/ci.sh
@@ -81,6 +81,9 @@ function run_tests {
       cargo miri run --manifest-path bench-cargo-miri/$BENCH/Cargo.toml
     done
   fi
+  # Ensure that `./miri bench` works on all relevant platforms.
+  # `slice-get-unchecked` is the least complex of all available benchmarks.
+  ./miri bench slice-get-unchecked
 
   endgroup
 }

--- a/miri
+++ b/miri
@@ -77,7 +77,7 @@ if [ -z "$COMMAND" ]; then
 fi
 shift
 # macOS does not have a useful readlink/realpath so we have to use Python instead...
-MIRIDIR=$(python3 -c 'import os, sys; print(os.path.dirname(os.path.realpath(sys.argv[1])))' "$0")
+MIRIDIR=$(python3 -c 'import pathlib, sys; print(pathlib.Path(sys.argv[1]).resolve().parent.as_posix())' "$0")
 # Used for rustc syncs.
 JOSH_FILTER=":rev(75dd959a3a40eb5b4574f8d2e23aa6efbeb33573:prefix=src/tools/miri):/src/tools/miri"
 # Needed for `./miri bench`.


### PR DESCRIPTION
python3 snippet used to fill $MIRIDIR variable returns native paths. Down the line in `bench` subcommand this leads to benchmark setup failure, preventing contributors from running benchmarks on Windows hosts.

This commit replaces usage of native os.path module with pathlib, which explicitly converts paths to Unix flavour.

pathlib is available from Python 3.4. There's also [a nice comparison of features](https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module) with os module.

On current master, running `./miri bench` under MinGW results in an error from cargo-metadata about path format.
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: CargoMetadata { stderr: "error: manifest path `D:Programmingmiri/bench-cargo-miri/backtraces/Cargo.toml` does not exist\n" }', src\util.rs:224:80
```
With this commit, it is not an issue anymore.