### PR TITLE
Include the current Crate name in the measureme output name

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ to Miri failing to detect cases of undefined behavior in a program.
   Follow [the discussion on supporting other types](https://github.com/rust-lang/miri/issues/2365).
 * `-Zmiri-measureme=<name>` enables `measureme` profiling for the interpreted program.
    This can be used to find which parts of your program are executing slowly under Miri.
-   The profile is written out to a file with the prefix `<name>`, and can be processed
+   The profile is written out to a file inside a directory called `<name>`, and can be processed
    using the tools in the repository https://github.com/rust-lang/measureme.
 * `-Zmiri-mute-stdout-stderr` silently ignores all writes to stdout and stderr,
   but reports to the program that it did actually write. This is useful when you

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -508,6 +508,10 @@ impl<'mir, 'tcx> MiriMachine<'mir, 'tcx> {
                 .clone()
                 .unwrap_or_else(|| "unknown-crate".to_string());
             let pid = process::id();
+            // We adopt the same naming scheme for the profiler output that rustc uses. In rustc,
+            // the PID is padded so that the nondeterministic value of the PID does not spread
+            // nondeterminisim to the allocator. In Miri we are not aiming for such performance
+            // control, we just pad for consistency with rustc.
             let filename = format!("{crate_name}-{pid:07}");
             let path = Path::new(out).join(filename);
             measureme::Profiler::new(path).expect("Couldn't create `measureme` profiler")


### PR DESCRIPTION
See https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/measureme.20flamegraph.20panics/near/356367013
cc @andjo403

Currently, attempting to use `MIRIFLAGS=-Zmiri-measureme=miri cargo miri test` on a crate with multiple test targets (which is very common) will produce a corrupted measureme output file, because the various interpreter processes will stomp each other's output.

This change does not entirely prevent this, but the various test targets seem to always have different crate names, so if nothing else this will make the broken measureme files much harder to encounter by accident, while also making it clear what they are all for.