### PR TITLE
Add `./miri run-dep` for running a file with test dependencies available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,9 +820,9 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95033b0e41b8018013d99a6f1486c1ae5bd080378ced60c5f797e93842423b33"
+checksum = "191a442639ea102fa62671026047e51d574bfda44b7fdf32151d7314624c1cd2"
 dependencies = [
  "bstr",
  "cargo-platform",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ libloading = "0.7"
 
 [dev-dependencies]
 colored = "2"
-ui_test = "0.9"
+ui_test = "0.10"
 rustc_version = "0.4"
 # Features chosen to match those required by env_logger, to avoid rebuilds
 regex = { version = "1.5.5", default-features = false, features = ["perf", "std"] }

--- a/miri
+++ b/miri
@@ -330,7 +330,7 @@ run|run-dep)
     # Then run the actual command.
     
     if [ "$COMMAND" = "run-dep" ]; then
-        exec $CARGO test --test compiletest -- miri-run-dep-mode $CARGO_EXTRA_FLAGS --manifest-path "$MIRIDIR"/Cargo.toml -- $MIRIFLAGS "$@"
+        exec $CARGO test --test compiletest $CARGO_EXTRA_FLAGS --manifest-path "$MIRIDIR"/Cargo.toml -- --miri-run-dep-mode $MIRIFLAGS "$@"
     else
         exec $CARGO run $CARGO_EXTRA_FLAGS --manifest-path "$MIRIDIR"/Cargo.toml -- $MIRIFLAGS "$@"
     fi

--- a/miri
+++ b/miri
@@ -306,7 +306,7 @@ test|bless)
     # Only in root project as `cargo-miri` has no tests.
     $CARGO test $CARGO_EXTRA_FLAGS --manifest-path "$MIRIDIR"/Cargo.toml "$@"
     ;;
-run)
+run|run-dep)
     # Scan for "--target" to overwrite the "MIRI_TEST_TARGET" env var so
     # that we set the MIRI_SYSROOT up the right way.
     FOUND_TARGET_OPT=0
@@ -323,11 +323,17 @@ run)
         # Make sure Miri actually uses this target.
         MIRIFLAGS="$MIRIFLAGS --target $MIRI_TEST_TARGET"
     fi
+
     # First build and get a sysroot.
     $CARGO build $CARGO_EXTRA_FLAGS --manifest-path "$MIRIDIR"/Cargo.toml
     find_sysroot
     # Then run the actual command.
-    exec $CARGO run $CARGO_EXTRA_FLAGS --manifest-path "$MIRIDIR"/Cargo.toml -- $MIRIFLAGS "$@"
+    
+    if [ "$COMMAND" = "run-dep" ]; then
+        exec $CARGO test --test compiletest -- miri-run-dep-mode $CARGO_EXTRA_FLAGS --manifest-path "$MIRIDIR"/Cargo.toml -- $MIRIFLAGS "$@"
+    else
+        exec $CARGO run $CARGO_EXTRA_FLAGS --manifest-path "$MIRIDIR"/Cargo.toml -- $MIRIFLAGS "$@"
+    fi
     ;;
 fmt)
     find "$MIRIDIR" -not \( -name target -prune \) -name '*.rs' \

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -242,7 +242,7 @@ fn main() -> Result<()> {
     let target = get_target();
 
     if let Some(first) = std::env::args().nth(1) {
-        if first == "miri-run-dep-mode" {
+        if first == "--miri-run-dep-mode" {
             return run_dep_mode(target);
         }
     }
@@ -270,7 +270,7 @@ fn main() -> Result<()> {
 }
 
 fn run_dep_mode(target: String) -> Result<()> {
-    let files = std::env::args().skip_while(|arg| arg != "--").skip(1);
+    let files = std::env::args().skip(2);
     for path in files {
         let mut config = run_test_config(std::iter::empty(), &target, &path, Mode::Yolo, true);
         config.program.args.remove(0); // remove the `--error-format=json` argument

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -268,11 +268,13 @@ fn main() -> Result<()> {
 
 fn run_dep_mode(target: String, mut args: impl Iterator<Item = OsString>) -> Result<()> {
     let path = args.next().expect("./miri run-dep must be followed by a file name");
-    let mut config = test_config(&target, "", Mode::Yolo, true);
+    let mut config = test_config(&target, "", Mode::Yolo, /* with dependencies */ true);
     config.program.args.remove(0); // remove the `--error-format=json` argument
     config.program.args.push("--color".into());
     config.program.args.push("always".into());
     let mut cmd = ui_test::test_command(config, Path::new(&path))?;
+    // Separate the arguments to the `cargo miri` invocation from
+    // the arguments to the interpreted prog
     cmd.arg("--");
     cmd.args(args);
     println!("{cmd:?}");

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -46,7 +46,7 @@ fn build_so_for_c_ffi_tests() -> PathBuf {
     so_file_path
 }
 
-fn run_test_config(
+fn test_config(
     args: impl Iterator<Item = String>,
     target: &str,
     path: &str,
@@ -151,7 +151,7 @@ fn run_test_config(
 }
 
 fn run_tests(mode: Mode, path: &str, target: &str, with_dependencies: bool) -> Result<()> {
-    let config = run_test_config(std::env::args().skip(1), target, path, mode, with_dependencies);
+    let config = test_config(std::env::args().skip(1), target, path, mode, with_dependencies);
 
     eprintln!("   Compiler: {}", config.program.display());
     ui_test::run_tests_generic(
@@ -272,7 +272,7 @@ fn main() -> Result<()> {
 fn run_dep_mode(target: String) -> Result<()> {
     let files = std::env::args().skip(2);
     for path in files {
-        let mut config = run_test_config(std::iter::empty(), &target, &path, Mode::Yolo, true);
+        let mut config = test_config(std::iter::empty(), &target, &path, Mode::Yolo, true);
         config.program.args.remove(0); // remove the `--error-format=json` argument
         config.program.args.push("--color".into());
         config.program.args.push("always".into());


### PR DESCRIPTION
fixes #2443