### PR TITLE
Remove rustc-workspace-hack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,6 @@ dependencies = [
  "measureme",
  "rand",
  "regex",
- "rustc-workspace-hack",
  "rustc_version",
  "smallvec",
  "ui_test",
@@ -627,12 +626,6 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-workspace-hack"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc71d2faa173b74b232dedc235e3ee1696581bb132fc116fa3626d6151a1a8fb"
 
 [[package]]
 name = "rustc_version"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,6 @@ log = "0.4"
 rand = "0.8"
 smallvec = "1.7"
 
-# A noop dependency that changes in the Rust repository, it's a bit of a hack.
-# See the `src/tools/rustc-workspace-hack/README.md` file in `rust-lang/rust`
-# for more information.
-rustc-workspace-hack = "1.0.0"
 measureme = "10.0.0"
 ctrlc = "3.2.5"
 

--- a/cargo-miri/Cargo.lock
+++ b/cargo-miri/Cargo.lock
@@ -30,7 +30,6 @@ dependencies = [
  "cargo_metadata",
  "directories",
  "rustc-build-sysroot",
- "rustc-workspace-hack",
  "rustc_tools_util",
  "rustc_version",
  "serde",
@@ -234,12 +233,6 @@ dependencies = [
  "rustc_version",
  "tempfile",
 ]
-
-[[package]]
-name = "rustc-workspace-hack"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc71d2faa173b74b232dedc235e3ee1696581bb132fc116fa3626d6151a1a8fb"
 
 [[package]]
 name = "rustc_tools_util"

--- a/cargo-miri/Cargo.toml
+++ b/cargo-miri/Cargo.toml
@@ -20,11 +20,6 @@ serde_json = "1.0.40"
 cargo_metadata = "0.15.0"
 rustc-build-sysroot = "0.4.1"
 
-# A noop dependency that changes in the Rust repository, it's a bit of a hack.
-# See the `src/tools/rustc-workspace-hack/README.md` file in `rust-lang/rust`
-# for more information.
-rustc-workspace-hack = "1.0.0"
-
 # Enable some feature flags that dev-dependencies need but dependencies
 # do not.  This makes `./miri install` after `./miri build` faster.
 serde = { version = "*", features = ["derive"] }


### PR DESCRIPTION
The `rustc-workspace-hack` dependency was removed in https://github.com/rust-lang/rust/pull/109133 and should no longer be needed.
