### PR TITLE
TB: improve error messages (distinguish between accesses and reborrows)

### DIFF
--- a/src/borrow_tracker/tree_borrows/diagnostics.rs
+++ b/src/borrow_tracker/tree_borrows/diagnostics.rs
@@ -12,16 +12,46 @@ use crate::borrow_tracker::tree_borrows::{
 use crate::borrow_tracker::{AccessKind, ProtectorKind};
 use crate::*;
 
+/// Cause of an access: either a real access or one
+/// inserted by Tree Borrows due to a reborrow or a deallocation.
+#[derive(Clone, Copy, Debug)]
+pub enum AccessCause {
+    Explicit(AccessKind),
+    Reborrow,
+    Dealloc,
+}
+
+impl fmt::Display for AccessCause {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Explicit(kind) => write!(f, "{kind}"),
+            Self::Reborrow => write!(f, "reborrow"),
+            Self::Dealloc => write!(f, "deallocation"),
+        }
+    }
+}
+
+impl AccessCause {
+    fn print_as_access(self, is_foreign: bool) -> String {
+        let rel = if is_foreign { "foreign" } else { "child" };
+        match self {
+            Self::Explicit(kind) => format!("{rel} {kind}"),
+            Self::Reborrow => format!("reborrow (acting as a {rel} read access)"),
+            Self::Dealloc => format!("deallocation (acting as a {rel} write access)"),
+        }
+    }
+}
+
 /// Complete data for an event:
 #[derive(Clone, Debug)]
 pub struct Event {
     /// Transformation of permissions that occured because of this event
     pub transition: PermTransition,
     /// Kind of the access that triggered this event
-    pub access_kind: AccessKind,
+    pub access_cause: AccessCause,
     /// Relative position of the tag to the one used for the access
     pub is_foreign: bool,
-    /// User-visible range of the access
+    /// Whether this access was explicit or inserted implicitly by Tree Borrows.
     pub access_range: AllocRange,
     /// The transition recorded by this event only occured on a subrange of
     /// `access_range`: a single access on `access_range` triggers several events,
@@ -83,8 +113,8 @@ impl HistoryData {
         self.events.push((Some(created.0.data()), msg_creation));
         for &Event {
             transition,
-            access_kind,
             is_foreign,
+            access_cause,
             access_range,
             span,
             transition_range: _,
@@ -92,8 +122,10 @@ impl HistoryData {
         {
             // NOTE: `transition_range` is explicitly absent from the error message, it has no significance
             // to the user. The meaningful one is `access_range`.
-            self.events.push((Some(span.data()), format!("{this} later transitioned to {endpoint} due to a {rel} {access_kind} at offsets {access_range:?}", endpoint = transition.endpoint(), rel = if is_foreign { "foreign" } else { "child" })));
-            self.events.push((None, format!("this corresponds to {}", transition.summary())));
+            let access = access_cause.print_as_access(is_foreign);
+            self.events.push((Some(span.data()), format!("{this} later transitioned to {endpoint} due to a {access} at offsets {access_range:?}", endpoint = transition.endpoint())));
+            self.events
+                .push((None, format!("this transition corresponds to {}", transition.summary())));
         }
     }
 }
@@ -238,9 +270,8 @@ pub(super) struct TbError<'node> {
     /// On accesses rejected due to insufficient permissions, this is the
     /// tag that lacked those permissions.
     pub conflicting_info: &'node NodeDebugInfo,
-    /// Whether this was a Read or Write access. This field is ignored
-    /// when the error was triggered by a deallocation.
-    pub access_kind: AccessKind,
+    // What kind of access caused this error (read, write, reborrow, deallocation)
+    pub access_cause: AccessCause,
     /// Which tag the access that caused this error was made through, i.e.
     /// which tag was used to read/write/deallocate.
     pub accessed_info: &'node NodeDebugInfo,
@@ -250,38 +281,39 @@ impl TbError<'_> {
     /// Produce a UB error.
     pub fn build<'tcx>(self) -> InterpError<'tcx> {
         use TransitionError::*;
-        let kind = self.access_kind;
+        let cause = self.access_cause;
         let accessed = self.accessed_info;
         let conflicting = self.conflicting_info;
         let accessed_is_conflicting = accessed.tag == conflicting.tag;
+        let title = format!("{cause} through {accessed} is forbidden");
         let (title, details, conflicting_tag_name) = match self.error_kind {
             ChildAccessForbidden(perm) => {
                 let conflicting_tag_name =
                     if accessed_is_conflicting { "accessed" } else { "conflicting" };
-                let title = format!("{kind} through {accessed} is forbidden");
                 let mut details = Vec::new();
                 if !accessed_is_conflicting {
                     details.push(format!(
                         "the accessed tag {accessed} is a child of the conflicting tag {conflicting}"
                     ));
                 }
+                let access = cause.print_as_access(/* is_foreign */ false);
                 details.push(format!(
-                    "the {conflicting_tag_name} tag {conflicting} has state {perm} which forbids child {kind}es"
+                    "the {conflicting_tag_name} tag {conflicting} has state {perm} which forbids this {access}"
                 ));
                 (title, details, conflicting_tag_name)
             }
             ProtectedTransition(transition) => {
                 let conflicting_tag_name = "protected";
-                let title = format!("{kind} through {accessed} is forbidden");
+                let access = cause.print_as_access(/* is_foreign */ true);
                 let details = vec![
                     format!(
                         "the accessed tag {accessed} is foreign to the {conflicting_tag_name} tag {conflicting} (i.e., it is not a child)"
                     ),
                     format!(
-                        "the access would cause the {conflicting_tag_name} tag {conflicting} to transition {transition}"
+                        "this {access} would cause the {conflicting_tag_name} tag {conflicting} to transition {transition}"
                     ),
                     format!(
-                        "this is {loss}, which is not allowed for protected tags",
+                        "this transition would be {loss}, which is not allowed for protected tags",
                         loss = transition.summary(),
                     ),
                 ];
@@ -289,7 +321,6 @@ impl TbError<'_> {
             }
             ProtectedDealloc => {
                 let conflicting_tag_name = "strongly protected";
-                let title = format!("deallocation through {accessed} is forbidden");
                 let details = vec![
                     format!(
                         "the allocation of the accessed tag {accessed} also contains the {conflicting_tag_name} tag {conflicting}"

--- a/src/borrow_tracker/tree_borrows/mod.rs
+++ b/src/borrow_tracker/tree_borrows/mod.rs
@@ -62,7 +62,14 @@ impl<'tcx> Tree {
         };
         let global = machine.borrow_tracker.as_ref().unwrap();
         let span = machine.current_span();
-        self.perform_access(access_kind, tag, range, global, span)
+        self.perform_access(
+            access_kind,
+            tag,
+            range,
+            global,
+            span,
+            diagnostics::AccessCause::Explicit(access_kind),
+        )
     }
 
     /// Check that this pointer has permission to deallocate this range.
@@ -273,7 +280,14 @@ trait EvalContextPrivExt<'mir: 'ecx, 'tcx: 'mir, 'ecx>: crate::MiriInterpCxExt<'
             // Count this reborrow as a read access
             let global = &this.machine.borrow_tracker.as_ref().unwrap();
             let span = this.machine.current_span();
-            tree_borrows.perform_access(AccessKind::Read, orig_tag, range, global, span)?;
+            tree_borrows.perform_access(
+                AccessKind::Read,
+                orig_tag,
+                range,
+                global,
+                span,
+                diagnostics::AccessCause::Reborrow,
+            )?;
             if let Some(data_race) = alloc_extra.data_race.as_ref() {
                 data_race.read(alloc_id, range, &this.machine)?;
             }

--- a/tests/fail/both_borrows/alias_through_mutation.tree.stderr
+++ b/tests/fail/both_borrows/alias_through_mutation.tree.stderr
@@ -6,7 +6,7 @@ LL |     let _val = *target_alias;
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>
-   = help: the conflicting tag <TAG> has state Disabled which forbids child read accesses
+   = help: the conflicting tag <TAG> has state Disabled which forbids this child read access
 help: the accessed tag <TAG> was created here
   --> $DIR/alias_through_mutation.rs:LL:CC
    |
@@ -22,7 +22,7 @@ help: the conflicting tag <TAG> later transitioned to Disabled due to a foreign 
    |
 LL |     *target = 13;
    |     ^^^^^^^^^^^^
-   = help: this corresponds to a loss of read and write permissions
+   = help: this transition corresponds to a loss of read and write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/alias_through_mutation.rs:LL:CC
 

--- a/tests/fail/both_borrows/aliasing_mut1.tree.stderr
+++ b/tests/fail/both_borrows/aliasing_mut1.tree.stderr
@@ -5,18 +5,18 @@ LL |     *x = 1;
    |     ^^^^^^ write access through <TAG> is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
-   = help: the accessed tag <TAG> has state Frozen which forbids child write accesses
+   = help: the accessed tag <TAG> has state Frozen which forbids this child write access
 help: the accessed tag <TAG> was created here, in the initial state Reserved
   --> $DIR/aliasing_mut1.rs:LL:CC
    |
 LL | pub fn safe(x: &mut i32, y: &mut i32) {
    |             ^
-help: the accessed tag <TAG> later transitioned to Frozen due to a foreign read access at offsets [0x0..0x4]
+help: the accessed tag <TAG> later transitioned to Frozen due to a reborrow (acting as a foreign read access) at offsets [0x0..0x4]
   --> $DIR/aliasing_mut1.rs:LL:CC
    |
 LL | pub fn safe(x: &mut i32, y: &mut i32) {
    |                          ^
-   = help: this corresponds to a loss of write permissions
+   = help: this transition corresponds to a loss of write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `safe` at $DIR/aliasing_mut1.rs:LL:CC
 note: inside `main`

--- a/tests/fail/both_borrows/aliasing_mut2.tree.stderr
+++ b/tests/fail/both_borrows/aliasing_mut2.tree.stderr
@@ -5,7 +5,7 @@ LL |     *y = 2;
    |     ^^^^^^ write access through <TAG> is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
-   = help: the accessed tag <TAG> has state Frozen which forbids child write accesses
+   = help: the accessed tag <TAG> has state Frozen which forbids this child write access
 help: the accessed tag <TAG> was created here, in the initial state Reserved
   --> $DIR/aliasing_mut2.rs:LL:CC
    |
@@ -16,7 +16,7 @@ help: the accessed tag <TAG> later transitioned to Frozen due to a foreign read 
    |
 LL |     let _v = *x;
    |              ^^
-   = help: this corresponds to a loss of write permissions
+   = help: this transition corresponds to a loss of write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `safe` at $DIR/aliasing_mut2.rs:LL:CC
 note: inside `main`

--- a/tests/fail/both_borrows/aliasing_mut3.tree.stderr
+++ b/tests/fail/both_borrows/aliasing_mut3.tree.stderr
@@ -5,18 +5,18 @@ LL |     *x = 1;
    |     ^^^^^^ write access through <TAG> is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
-   = help: the accessed tag <TAG> has state Frozen which forbids child write accesses
+   = help: the accessed tag <TAG> has state Frozen which forbids this child write access
 help: the accessed tag <TAG> was created here, in the initial state Reserved
   --> $DIR/aliasing_mut3.rs:LL:CC
    |
 LL | pub fn safe(x: &mut i32, y: &i32) {
    |             ^
-help: the accessed tag <TAG> later transitioned to Frozen due to a foreign read access at offsets [0x0..0x4]
+help: the accessed tag <TAG> later transitioned to Frozen due to a reborrow (acting as a foreign read access) at offsets [0x0..0x4]
   --> $DIR/aliasing_mut3.rs:LL:CC
    |
 LL | pub fn safe(x: &mut i32, y: &i32) {
    |                          ^
-   = help: this corresponds to a loss of write permissions
+   = help: this transition corresponds to a loss of write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `safe` at $DIR/aliasing_mut3.rs:LL:CC
 note: inside `main`

--- a/tests/fail/both_borrows/aliasing_mut4.tree.stderr
+++ b/tests/fail/both_borrows/aliasing_mut4.tree.stderr
@@ -6,8 +6,8 @@ LL |         ptr::write(dest, src);
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is foreign to the protected tag <TAG> (i.e., it is not a child)
-   = help: the access would cause the protected tag <TAG> to transition from Frozen to Disabled
-   = help: this is a loss of read permissions, which is not allowed for protected tags
+   = help: this foreign write access would cause the protected tag <TAG> to transition from Frozen to Disabled
+   = help: this transition would be a loss of read permissions, which is not allowed for protected tags
 help: the accessed tag <TAG> was created here
   --> $DIR/aliasing_mut4.rs:LL:CC
    |

--- a/tests/fail/both_borrows/box_noalias_violation.tree.stderr
+++ b/tests/fail/both_borrows/box_noalias_violation.tree.stderr
@@ -6,8 +6,8 @@ LL |     *y
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is foreign to the protected tag <TAG> (i.e., it is not a child)
-   = help: the access would cause the protected tag <TAG> to transition from Active to Frozen
-   = help: this is a loss of write permissions, which is not allowed for protected tags
+   = help: this foreign read access would cause the protected tag <TAG> to transition from Active to Frozen
+   = help: this transition would be a loss of write permissions, which is not allowed for protected tags
 help: the accessed tag <TAG> was created here
   --> $DIR/box_noalias_violation.rs:LL:CC
    |
@@ -23,7 +23,7 @@ help: the protected tag <TAG> later transitioned to Active due to a child write 
    |
 LL |     *x = 5;
    |     ^^^^^^
-   = help: this corresponds to the first write to a 2-phase borrowed mutable reference
+   = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
    = note: BACKTRACE (of the first span):
    = note: inside `test` at $DIR/box_noalias_violation.rs:LL:CC
 note: inside `main`

--- a/tests/fail/both_borrows/buggy_as_mut_slice.tree.stderr
+++ b/tests/fail/both_borrows/buggy_as_mut_slice.tree.stderr
@@ -6,7 +6,7 @@ LL |     v2[1] = 7;
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>
-   = help: the conflicting tag <TAG> has state Disabled which forbids child write accesses
+   = help: the conflicting tag <TAG> has state Disabled which forbids this child write access
 help: the accessed tag <TAG> was created here
   --> $DIR/buggy_as_mut_slice.rs:LL:CC
    |
@@ -22,7 +22,7 @@ help: the conflicting tag <TAG> later transitioned to Disabled due to a foreign 
    |
 LL |     v1[1] = 5;
    |     ^^^^^^^^^
-   = help: this corresponds to a loss of read and write permissions
+   = help: this transition corresponds to a loss of read and write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/buggy_as_mut_slice.rs:LL:CC
 

--- a/tests/fail/both_borrows/buggy_split_at_mut.tree.stderr
+++ b/tests/fail/both_borrows/buggy_split_at_mut.tree.stderr
@@ -6,7 +6,7 @@ LL |     b[1] = 6;
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>
-   = help: the conflicting tag <TAG> has state Disabled which forbids child write accesses
+   = help: the conflicting tag <TAG> has state Disabled which forbids this child write access
 help: the accessed tag <TAG> was created here
   --> $DIR/buggy_split_at_mut.rs:LL:CC
    |
@@ -22,7 +22,7 @@ help: the conflicting tag <TAG> later transitioned to Disabled due to a foreign 
    |
 LL |     a[1] = 5;
    |     ^^^^^^^^
-   = help: this corresponds to a loss of read and write permissions
+   = help: this transition corresponds to a loss of read and write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/buggy_split_at_mut.rs:LL:CC
 

--- a/tests/fail/both_borrows/illegal_write1.tree.stderr
+++ b/tests/fail/both_borrows/illegal_write1.tree.stderr
@@ -5,7 +5,7 @@ LL |         unsafe { *x = 42 };
    |                  ^^^^^^^ write access through <TAG> is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
-   = help: the accessed tag <TAG> has state Frozen which forbids child write accesses
+   = help: the accessed tag <TAG> has state Frozen which forbids this child write access
 help: the accessed tag <TAG> was created here, in the initial state Frozen
   --> $DIR/illegal_write1.rs:LL:CC
    |

--- a/tests/fail/both_borrows/illegal_write5.tree.stderr
+++ b/tests/fail/both_borrows/illegal_write5.tree.stderr
@@ -6,7 +6,7 @@ LL |     let _val = *xref;
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>
-   = help: the conflicting tag <TAG> has state Disabled which forbids child read accesses
+   = help: the conflicting tag <TAG> has state Disabled which forbids this child read access
 help: the accessed tag <TAG> was created here
   --> $DIR/illegal_write5.rs:LL:CC
    |
@@ -22,7 +22,7 @@ help: the conflicting tag <TAG> later transitioned to Disabled due to a foreign 
    |
 LL |     unsafe { *xraw = 15 };
    |              ^^^^^^^^^^
-   = help: this corresponds to a loss of read and write permissions
+   = help: this transition corresponds to a loss of read and write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_write5.rs:LL:CC
 

--- a/tests/fail/both_borrows/illegal_write6.tree.stderr
+++ b/tests/fail/both_borrows/illegal_write6.tree.stderr
@@ -6,8 +6,8 @@ LL |     unsafe { *y = 2 };
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is foreign to the protected tag <TAG> (i.e., it is not a child)
-   = help: the access would cause the protected tag <TAG> to transition from Active to Disabled
-   = help: this is a loss of read and write permissions, which is not allowed for protected tags
+   = help: this foreign write access would cause the protected tag <TAG> to transition from Active to Disabled
+   = help: this transition would be a loss of read and write permissions, which is not allowed for protected tags
 help: the accessed tag <TAG> was created here
   --> $DIR/illegal_write6.rs:LL:CC
    |
@@ -23,7 +23,7 @@ help: the protected tag <TAG> later transitioned to Active due to a child write 
    |
 LL |     *a = 1;
    |     ^^^^^^
-   = help: this corresponds to the first write to a 2-phase borrowed mutable reference
+   = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
    = note: BACKTRACE (of the first span):
    = note: inside `foo` at $DIR/illegal_write6.rs:LL:CC
 note: inside `main`

--- a/tests/fail/both_borrows/invalidate_against_protector2.tree.stderr
+++ b/tests/fail/both_borrows/invalidate_against_protector2.tree.stderr
@@ -6,8 +6,8 @@ LL |     unsafe { *x = 0 };
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is foreign to the protected tag <TAG> (i.e., it is not a child)
-   = help: the access would cause the protected tag <TAG> to transition from Frozen to Disabled
-   = help: this is a loss of read permissions, which is not allowed for protected tags
+   = help: this foreign write access would cause the protected tag <TAG> to transition from Frozen to Disabled
+   = help: this transition would be a loss of read permissions, which is not allowed for protected tags
 help: the accessed tag <TAG> was created here
   --> $DIR/invalidate_against_protector2.rs:LL:CC
    |

--- a/tests/fail/both_borrows/invalidate_against_protector3.tree.stderr
+++ b/tests/fail/both_borrows/invalidate_against_protector3.tree.stderr
@@ -6,8 +6,8 @@ LL |     unsafe { *x = 0 };
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> (root of the allocation) is foreign to the protected tag <TAG> (i.e., it is not a child)
-   = help: the access would cause the protected tag <TAG> to transition from Frozen to Disabled
-   = help: this is a loss of read permissions, which is not allowed for protected tags
+   = help: this foreign write access would cause the protected tag <TAG> to transition from Frozen to Disabled
+   = help: this transition would be a loss of read permissions, which is not allowed for protected tags
 help: the accessed tag <TAG> was created here
   --> $DIR/invalidate_against_protector3.rs:LL:CC
    |

--- a/tests/fail/both_borrows/load_invalid_shr.rs
+++ b/tests/fail/both_borrows/load_invalid_shr.rs
@@ -12,5 +12,5 @@ fn main() {
     unsafe { *xraw = 42 }; // unfreeze
     let _val = *xref_in_mem;
     //~[stack]^ ERROR: /retag .* tag does not exist in the borrow stack/
-    //~[tree]| ERROR: /read access through .* is forbidden/
+    //~[tree]| ERROR: /reborrow through .* is forbidden/
 }

--- a/tests/fail/both_borrows/load_invalid_shr.tree.stderr
+++ b/tests/fail/both_borrows/load_invalid_shr.tree.stderr
@@ -1,12 +1,12 @@
-error: Undefined Behavior: read access through <TAG> is forbidden
+error: Undefined Behavior: reborrow through <TAG> is forbidden
   --> $DIR/load_invalid_shr.rs:LL:CC
    |
 LL |     let _val = *xref_in_mem;
-   |                ^^^^^^^^^^^^ read access through <TAG> is forbidden
+   |                ^^^^^^^^^^^^ reborrow through <TAG> is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>
-   = help: the conflicting tag <TAG> has state Disabled which forbids child read accesses
+   = help: the conflicting tag <TAG> has state Disabled which forbids this reborrow (acting as a child read access)
 help: the accessed tag <TAG> was created here
   --> $DIR/load_invalid_shr.rs:LL:CC
    |
@@ -22,7 +22,7 @@ help: the conflicting tag <TAG> later transitioned to Disabled due to a foreign 
    |
 LL |     unsafe { *xraw = 42 }; // unfreeze
    |              ^^^^^^^^^^
-   = help: this corresponds to a loss of read permissions
+   = help: this transition corresponds to a loss of read permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/load_invalid_shr.rs:LL:CC
 

--- a/tests/fail/both_borrows/mut_exclusive_violation1.tree.stderr
+++ b/tests/fail/both_borrows/mut_exclusive_violation1.tree.stderr
@@ -6,7 +6,7 @@ LL |         *LEAK = 7;
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>
-   = help: the conflicting tag <TAG> has state Disabled which forbids child write accesses
+   = help: the conflicting tag <TAG> has state Disabled which forbids this child write access
 help: the accessed tag <TAG> was created here
   --> $DIR/mut_exclusive_violation1.rs:LL:CC
    |
@@ -22,7 +22,7 @@ help: the conflicting tag <TAG> later transitioned to Disabled due to a foreign 
    |
 LL |     *our = 5;
    |     ^^^^^^^^
-   = help: this corresponds to a loss of read permissions
+   = help: this transition corresponds to a loss of read permissions
    = note: BACKTRACE (of the first span):
    = note: inside `unknown_code_2` at $DIR/mut_exclusive_violation1.rs:LL:CC
 note: inside `demo_mut_advanced_unique`

--- a/tests/fail/both_borrows/mut_exclusive_violation2.tree.stderr
+++ b/tests/fail/both_borrows/mut_exclusive_violation2.tree.stderr
@@ -6,7 +6,7 @@ LL |         *raw1 = 3;
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>
-   = help: the conflicting tag <TAG> has state Disabled which forbids child write accesses
+   = help: the conflicting tag <TAG> has state Disabled which forbids this child write access
 help: the accessed tag <TAG> was created here
   --> $DIR/mut_exclusive_violation2.rs:LL:CC
    |
@@ -22,7 +22,7 @@ help: the conflicting tag <TAG> later transitioned to Disabled due to a foreign 
    |
 LL |         *raw2 = 2;
    |         ^^^^^^^^^
-   = help: this corresponds to a loss of read and write permissions
+   = help: this transition corresponds to a loss of read and write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/mut_exclusive_violation2.rs:LL:CC
 

--- a/tests/fail/both_borrows/newtype_pair_retagging.rs
+++ b/tests/fail/both_borrows/newtype_pair_retagging.rs
@@ -2,7 +2,7 @@
 //@[tree]compile-flags: -Zmiri-tree-borrows
 
 //@[stack]error-in-other-file: which is strongly protected
-//@[tree]error-in-other-file: /write access through .* is forbidden/
+//@[tree]error-in-other-file: /deallocation through .* is forbidden/
 struct Newtype<'a>(&'a mut i32, i32);
 
 fn dealloc_while_running(_n: Newtype<'_>, dealloc: impl FnOnce()) {

--- a/tests/fail/both_borrows/newtype_pair_retagging.tree.stderr
+++ b/tests/fail/both_borrows/newtype_pair_retagging.tree.stderr
@@ -1,13 +1,13 @@
-error: Undefined Behavior: write access through <TAG> is forbidden
+error: Undefined Behavior: deallocation through <TAG> is forbidden
   --> RUSTLIB/alloc/src/alloc.rs:LL:CC
    |
 LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ write access through <TAG> is forbidden
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocation through <TAG> is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is foreign to the protected tag <TAG> (i.e., it is not a child)
-   = help: the access would cause the protected tag <TAG> to transition from Frozen to Disabled
-   = help: this is a loss of read permissions, which is not allowed for protected tags
+   = help: this deallocation (acting as a foreign write access) would cause the protected tag <TAG> to transition from Frozen to Disabled
+   = help: this transition would be a loss of read permissions, which is not allowed for protected tags
 help: the accessed tag <TAG> was created here
   --> $DIR/newtype_pair_retagging.rs:LL:CC
    |
@@ -18,12 +18,12 @@ help: the protected tag <TAG> was created here, in the initial state Reserved
    |
 LL | fn dealloc_while_running(_n: Newtype<'_>, dealloc: impl FnOnce()) {
    |                          ^^
-help: the protected tag <TAG> later transitioned to Frozen due to a foreign read access at offsets [0x0..0x4]
+help: the protected tag <TAG> later transitioned to Frozen due to a reborrow (acting as a foreign read access) at offsets [0x0..0x4]
   --> $DIR/newtype_pair_retagging.rs:LL:CC
    |
 LL |             || drop(Box::from_raw(ptr)),
    |                     ^^^^^^^^^^^^^^^^^^
-   = help: this corresponds to a loss of write permissions
+   = help: this transition corresponds to a loss of write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `std::alloc::dealloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
    = note: inside `<std::alloc::Global as std::alloc::Allocator>::deallocate` at RUSTLIB/alloc/src/alloc.rs:LL:CC

--- a/tests/fail/both_borrows/newtype_retagging.rs
+++ b/tests/fail/both_borrows/newtype_retagging.rs
@@ -2,7 +2,7 @@
 //@[tree]compile-flags: -Zmiri-tree-borrows
 
 //@[stack]error-in-other-file: which is strongly protected
-//@[tree]error-in-other-file: /write access through .* is forbidden/
+//@[tree]error-in-other-file: /deallocation through .* is forbidden/
 
 struct Newtype<'a>(&'a mut i32);
 

--- a/tests/fail/both_borrows/newtype_retagging.tree.stderr
+++ b/tests/fail/both_borrows/newtype_retagging.tree.stderr
@@ -1,13 +1,13 @@
-error: Undefined Behavior: write access through <TAG> is forbidden
+error: Undefined Behavior: deallocation through <TAG> is forbidden
   --> RUSTLIB/alloc/src/alloc.rs:LL:CC
    |
 LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ write access through <TAG> is forbidden
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocation through <TAG> is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is foreign to the protected tag <TAG> (i.e., it is not a child)
-   = help: the access would cause the protected tag <TAG> to transition from Frozen to Disabled
-   = help: this is a loss of read permissions, which is not allowed for protected tags
+   = help: this deallocation (acting as a foreign write access) would cause the protected tag <TAG> to transition from Frozen to Disabled
+   = help: this transition would be a loss of read permissions, which is not allowed for protected tags
 help: the accessed tag <TAG> was created here
   --> $DIR/newtype_retagging.rs:LL:CC
    |
@@ -18,12 +18,12 @@ help: the protected tag <TAG> was created here, in the initial state Reserved
    |
 LL | fn dealloc_while_running(_n: Newtype<'_>, dealloc: impl FnOnce()) {
    |                          ^^
-help: the protected tag <TAG> later transitioned to Frozen due to a foreign read access at offsets [0x0..0x4]
+help: the protected tag <TAG> later transitioned to Frozen due to a reborrow (acting as a foreign read access) at offsets [0x0..0x4]
   --> $DIR/newtype_retagging.rs:LL:CC
    |
 LL |             || drop(Box::from_raw(ptr)),
    |                     ^^^^^^^^^^^^^^^^^^
-   = help: this corresponds to a loss of write permissions
+   = help: this transition corresponds to a loss of write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `std::alloc::dealloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
    = note: inside `<std::alloc::Global as std::alloc::Allocator>::deallocate` at RUSTLIB/alloc/src/alloc.rs:LL:CC

--- a/tests/fail/both_borrows/outdated_local.tree.stderr
+++ b/tests/fail/both_borrows/outdated_local.tree.stderr
@@ -5,7 +5,7 @@ LL |     assert_eq!(unsafe { *y }, 1);
    |                         ^^ read access through <TAG> is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
-   = help: the accessed tag <TAG> has state Disabled which forbids child read accesses
+   = help: the accessed tag <TAG> has state Disabled which forbids this child read access
 help: the accessed tag <TAG> was created here, in the initial state Frozen
   --> $DIR/outdated_local.rs:LL:CC
    |
@@ -16,7 +16,7 @@ help: the accessed tag <TAG> later transitioned to Disabled due to a foreign wri
    |
 LL |     x = 1; // this invalidates y by reactivating the lowermost uniq borrow for this local
    |     ^^^^^
-   = help: this corresponds to a loss of read permissions
+   = help: this transition corresponds to a loss of read permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/outdated_local.rs:LL:CC
 

--- a/tests/fail/both_borrows/pass_invalid_shr.rs
+++ b/tests/fail/both_borrows/pass_invalid_shr.rs
@@ -11,5 +11,5 @@ fn main() {
     unsafe { *xraw = 42 }; // unfreeze
     foo(xref);
     //~[stack]^ ERROR: /retag .* tag does not exist in the borrow stack/
-    //~[tree]| ERROR: /read access through .* is forbidden/
+    //~[tree]| ERROR: /reborrow through .* is forbidden/
 }

--- a/tests/fail/both_borrows/pass_invalid_shr.tree.stderr
+++ b/tests/fail/both_borrows/pass_invalid_shr.tree.stderr
@@ -1,11 +1,11 @@
-error: Undefined Behavior: read access through <TAG> is forbidden
+error: Undefined Behavior: reborrow through <TAG> is forbidden
   --> $DIR/pass_invalid_shr.rs:LL:CC
    |
 LL |     foo(xref);
-   |         ^^^^ read access through <TAG> is forbidden
+   |         ^^^^ reborrow through <TAG> is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
-   = help: the accessed tag <TAG> has state Disabled which forbids child read accesses
+   = help: the accessed tag <TAG> has state Disabled which forbids this reborrow (acting as a child read access)
 help: the accessed tag <TAG> was created here, in the initial state Frozen
   --> $DIR/pass_invalid_shr.rs:LL:CC
    |
@@ -16,7 +16,7 @@ help: the accessed tag <TAG> later transitioned to Disabled due to a foreign wri
    |
 LL |     unsafe { *xraw = 42 }; // unfreeze
    |              ^^^^^^^^^^
-   = help: this corresponds to a loss of read permissions
+   = help: this transition corresponds to a loss of read permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/pass_invalid_shr.rs:LL:CC
 

--- a/tests/fail/both_borrows/pass_invalid_shr_option.rs
+++ b/tests/fail/both_borrows/pass_invalid_shr_option.rs
@@ -11,5 +11,5 @@ fn main() {
     unsafe { *xraw = 42 }; // unfreeze
     foo(some_xref);
     //~[stack]^ ERROR: /retag .* tag does not exist in the borrow stack/
-    //~[tree]| ERROR: /read access through .* is forbidden/
+    //~[tree]| ERROR: /reborrow through .* is forbidden/
 }

--- a/tests/fail/both_borrows/pass_invalid_shr_option.tree.stderr
+++ b/tests/fail/both_borrows/pass_invalid_shr_option.tree.stderr
@@ -1,12 +1,12 @@
-error: Undefined Behavior: read access through <TAG> is forbidden
+error: Undefined Behavior: reborrow through <TAG> is forbidden
   --> $DIR/pass_invalid_shr_option.rs:LL:CC
    |
 LL |     foo(some_xref);
-   |         ^^^^^^^^^ read access through <TAG> is forbidden
+   |         ^^^^^^^^^ reborrow through <TAG> is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>
-   = help: the conflicting tag <TAG> has state Disabled which forbids child read accesses
+   = help: the conflicting tag <TAG> has state Disabled which forbids this reborrow (acting as a child read access)
 help: the accessed tag <TAG> was created here
   --> $DIR/pass_invalid_shr_option.rs:LL:CC
    |
@@ -22,7 +22,7 @@ help: the conflicting tag <TAG> later transitioned to Disabled due to a foreign 
    |
 LL |     unsafe { *xraw = 42 }; // unfreeze
    |              ^^^^^^^^^^
-   = help: this corresponds to a loss of read permissions
+   = help: this transition corresponds to a loss of read permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/pass_invalid_shr_option.rs:LL:CC
 

--- a/tests/fail/both_borrows/pass_invalid_shr_tuple.rs
+++ b/tests/fail/both_borrows/pass_invalid_shr_tuple.rs
@@ -12,5 +12,5 @@ fn main() {
     unsafe { *xraw0 = 42 }; // unfreeze
     foo(pair_xref);
     //~[stack]^ ERROR: /retag .* tag does not exist in the borrow stack/
-    //~[tree]| ERROR: /read access through .* is forbidden/
+    //~[tree]| ERROR: /reborrow through .* is forbidden/
 }

--- a/tests/fail/both_borrows/pass_invalid_shr_tuple.tree.stderr
+++ b/tests/fail/both_borrows/pass_invalid_shr_tuple.tree.stderr
@@ -1,12 +1,12 @@
-error: Undefined Behavior: read access through <TAG> is forbidden
+error: Undefined Behavior: reborrow through <TAG> is forbidden
   --> $DIR/pass_invalid_shr_tuple.rs:LL:CC
    |
 LL |     foo(pair_xref);
-   |         ^^^^^^^^^ read access through <TAG> is forbidden
+   |         ^^^^^^^^^ reborrow through <TAG> is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>
-   = help: the conflicting tag <TAG> has state Disabled which forbids child read accesses
+   = help: the conflicting tag <TAG> has state Disabled which forbids this reborrow (acting as a child read access)
 help: the accessed tag <TAG> was created here
   --> $DIR/pass_invalid_shr_tuple.rs:LL:CC
    |
@@ -22,7 +22,7 @@ help: the conflicting tag <TAG> later transitioned to Disabled due to a foreign 
    |
 LL |     unsafe { *xraw0 = 42 }; // unfreeze
    |              ^^^^^^^^^^^
-   = help: this corresponds to a loss of read permissions
+   = help: this transition corresponds to a loss of read permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/pass_invalid_shr_tuple.rs:LL:CC
 

--- a/tests/fail/both_borrows/return_invalid_shr.rs
+++ b/tests/fail/both_borrows/return_invalid_shr.rs
@@ -8,7 +8,7 @@ fn foo(x: &mut (i32, i32)) -> &i32 {
     unsafe { *xraw = (42, 23) }; // unfreeze
     ret
     //~[stack]^ ERROR: /retag .* tag does not exist in the borrow stack/
-    //~[tree]| ERROR: /read access through .* is forbidden/
+    //~[tree]| ERROR: /reborrow through .* is forbidden/
 }
 
 fn main() {

--- a/tests/fail/both_borrows/return_invalid_shr.tree.stderr
+++ b/tests/fail/both_borrows/return_invalid_shr.tree.stderr
@@ -1,11 +1,11 @@
-error: Undefined Behavior: read access through <TAG> is forbidden
+error: Undefined Behavior: reborrow through <TAG> is forbidden
   --> $DIR/return_invalid_shr.rs:LL:CC
    |
 LL |     ret
-   |     ^^^ read access through <TAG> is forbidden
+   |     ^^^ reborrow through <TAG> is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
-   = help: the accessed tag <TAG> has state Disabled which forbids child read accesses
+   = help: the accessed tag <TAG> has state Disabled which forbids this reborrow (acting as a child read access)
 help: the accessed tag <TAG> was created here, in the initial state Frozen
   --> $DIR/return_invalid_shr.rs:LL:CC
    |
@@ -16,7 +16,7 @@ help: the accessed tag <TAG> later transitioned to Disabled due to a foreign wri
    |
 LL |     unsafe { *xraw = (42, 23) }; // unfreeze
    |              ^^^^^^^^^^^^^^^^
-   = help: this corresponds to a loss of read permissions
+   = help: this transition corresponds to a loss of read permissions
    = note: BACKTRACE (of the first span):
    = note: inside `foo` at $DIR/return_invalid_shr.rs:LL:CC
 note: inside `main`

--- a/tests/fail/both_borrows/return_invalid_shr_option.rs
+++ b/tests/fail/both_borrows/return_invalid_shr_option.rs
@@ -8,7 +8,7 @@ fn foo(x: &mut (i32, i32)) -> Option<&i32> {
     unsafe { *xraw = (42, 23) }; // unfreeze
     ret
     //~[stack]^ ERROR: /retag .* tag does not exist in the borrow stack/
-    //~[tree]| ERROR: /read access through .* is forbidden/
+    //~[tree]| ERROR: /reborrow through .* is forbidden/
 }
 
 fn main() {

--- a/tests/fail/both_borrows/return_invalid_shr_option.tree.stderr
+++ b/tests/fail/both_borrows/return_invalid_shr_option.tree.stderr
@@ -1,12 +1,12 @@
-error: Undefined Behavior: read access through <TAG> is forbidden
+error: Undefined Behavior: reborrow through <TAG> is forbidden
   --> $DIR/return_invalid_shr_option.rs:LL:CC
    |
 LL |     ret
-   |     ^^^ read access through <TAG> is forbidden
+   |     ^^^ reborrow through <TAG> is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>
-   = help: the conflicting tag <TAG> has state Disabled which forbids child read accesses
+   = help: the conflicting tag <TAG> has state Disabled which forbids this reborrow (acting as a child read access)
 help: the accessed tag <TAG> was created here
   --> $DIR/return_invalid_shr_option.rs:LL:CC
    |
@@ -22,7 +22,7 @@ help: the conflicting tag <TAG> later transitioned to Disabled due to a foreign 
    |
 LL |     unsafe { *xraw = (42, 23) }; // unfreeze
    |              ^^^^^^^^^^^^^^^^
-   = help: this corresponds to a loss of read permissions
+   = help: this transition corresponds to a loss of read permissions
    = note: BACKTRACE (of the first span):
    = note: inside `foo` at $DIR/return_invalid_shr_option.rs:LL:CC
 note: inside `main`

--- a/tests/fail/both_borrows/return_invalid_shr_tuple.rs
+++ b/tests/fail/both_borrows/return_invalid_shr_tuple.rs
@@ -8,7 +8,7 @@ fn foo(x: &mut (i32, i32)) -> (&i32,) {
     unsafe { *xraw = (42, 23) }; // unfreeze
     ret
     //~[stack]^ ERROR: /retag .* tag does not exist in the borrow stack/
-    //~[tree]| ERROR: /read access through .* is forbidden/
+    //~[tree]| ERROR: /reborrow through .* is forbidden/
 }
 
 fn main() {

--- a/tests/fail/both_borrows/return_invalid_shr_tuple.tree.stderr
+++ b/tests/fail/both_borrows/return_invalid_shr_tuple.tree.stderr
@@ -1,12 +1,12 @@
-error: Undefined Behavior: read access through <TAG> is forbidden
+error: Undefined Behavior: reborrow through <TAG> is forbidden
   --> $DIR/return_invalid_shr_tuple.rs:LL:CC
    |
 LL |     ret
-   |     ^^^ read access through <TAG> is forbidden
+   |     ^^^ reborrow through <TAG> is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>
-   = help: the conflicting tag <TAG> has state Disabled which forbids child read accesses
+   = help: the conflicting tag <TAG> has state Disabled which forbids this reborrow (acting as a child read access)
 help: the accessed tag <TAG> was created here
   --> $DIR/return_invalid_shr_tuple.rs:LL:CC
    |
@@ -22,7 +22,7 @@ help: the conflicting tag <TAG> later transitioned to Disabled due to a foreign 
    |
 LL |     unsafe { *xraw = (42, 23) }; // unfreeze
    |              ^^^^^^^^^^^^^^^^
-   = help: this corresponds to a loss of read permissions
+   = help: this transition corresponds to a loss of read permissions
    = note: BACKTRACE (of the first span):
    = note: inside `foo` at $DIR/return_invalid_shr_tuple.rs:LL:CC
 note: inside `main`

--- a/tests/fail/both_borrows/shr_frozen_violation1.tree.stderr
+++ b/tests/fail/both_borrows/shr_frozen_violation1.tree.stderr
@@ -6,7 +6,7 @@ LL |         *(x as *const i32 as *mut i32) = 7;
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>
-   = help: the conflicting tag <TAG> has state Frozen which forbids child write accesses
+   = help: the conflicting tag <TAG> has state Frozen which forbids this child write access
 help: the accessed tag <TAG> was created here
   --> $DIR/shr_frozen_violation1.rs:LL:CC
    |

--- a/tests/fail/both_borrows/shr_frozen_violation2.tree.stderr
+++ b/tests/fail/both_borrows/shr_frozen_violation2.tree.stderr
@@ -5,7 +5,7 @@ LL |         let _val = *frozen;
    |                    ^^^^^^^ read access through <TAG> is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
-   = help: the accessed tag <TAG> has state Disabled which forbids child read accesses
+   = help: the accessed tag <TAG> has state Disabled which forbids this child read access
 help: the accessed tag <TAG> was created here, in the initial state Frozen
   --> $DIR/shr_frozen_violation2.rs:LL:CC
    |
@@ -16,7 +16,7 @@ help: the accessed tag <TAG> later transitioned to Disabled due to a foreign wri
    |
 LL |         x = 1;
    |         ^^^^^
-   = help: this corresponds to a loss of read permissions
+   = help: this transition corresponds to a loss of read permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/shr_frozen_violation2.rs:LL:CC
 

--- a/tests/fail/tree_borrows/alternate-read-write.stderr
+++ b/tests/fail/tree_borrows/alternate-read-write.stderr
@@ -6,7 +6,7 @@ LL |     *y += 1; // Failure
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>
-   = help: the conflicting tag <TAG> has state Frozen which forbids child write accesses
+   = help: the conflicting tag <TAG> has state Frozen which forbids this child write access
 help: the accessed tag <TAG> was created here
   --> $DIR/alternate-read-write.rs:LL:CC
    |
@@ -22,13 +22,13 @@ help: the conflicting tag <TAG> later transitioned to Active due to a child writ
    |
 LL |     *y += 1; // Success
    |     ^^^^^^^
-   = help: this corresponds to the first write to a 2-phase borrowed mutable reference
+   = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
 help: the conflicting tag <TAG> later transitioned to Frozen due to a foreign read access at offsets [0x0..0x1]
   --> $DIR/alternate-read-write.rs:LL:CC
    |
 LL |     let _val = *x;
    |                ^^
-   = help: this corresponds to a loss of write permissions
+   = help: this transition corresponds to a loss of write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/alternate-read-write.rs:LL:CC
 

--- a/tests/fail/tree_borrows/error-range.stderr
+++ b/tests/fail/tree_borrows/error-range.stderr
@@ -6,7 +6,7 @@ LL |         rmut[5] += 1;
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>
-   = help: the conflicting tag <TAG> has state Disabled which forbids child read accesses
+   = help: the conflicting tag <TAG> has state Disabled which forbids this child read access
 help: the accessed tag <TAG> was created here
   --> $DIR/error-range.rs:LL:CC
    |
@@ -22,7 +22,7 @@ help: the conflicting tag <TAG> later transitioned to Disabled due to a foreign 
    |
 LL |         data[5] = 1;
    |         ^^^^^^^^^^^
-   = help: this corresponds to a loss of read permissions
+   = help: this transition corresponds to a loss of read permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/error-range.rs:LL:CC
 

--- a/tests/fail/tree_borrows/fnentry_invalidation.stderr
+++ b/tests/fail/tree_borrows/fnentry_invalidation.stderr
@@ -5,7 +5,7 @@ LL |         *z = 2;
    |         ^^^^^^ write access through <TAG> is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
-   = help: the accessed tag <TAG> has state Frozen which forbids child write accesses
+   = help: the accessed tag <TAG> has state Frozen which forbids this child write access
 help: the accessed tag <TAG> was created here, in the initial state Reserved
   --> $DIR/fnentry_invalidation.rs:LL:CC
    |
@@ -16,13 +16,13 @@ help: the accessed tag <TAG> later transitioned to Active due to a child write a
    |
 LL |         *z = 1;
    |         ^^^^^^
-   = help: this corresponds to the first write to a 2-phase borrowed mutable reference
-help: the accessed tag <TAG> later transitioned to Frozen due to a foreign read access at offsets [0x0..0x4]
+   = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
+help: the accessed tag <TAG> later transitioned to Frozen due to a reborrow (acting as a foreign read access) at offsets [0x0..0x4]
   --> $DIR/fnentry_invalidation.rs:LL:CC
    |
 LL |     x.do_bad();
    |     ^^^^^^^^^^
-   = help: this corresponds to a loss of write permissions
+   = help: this transition corresponds to a loss of write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/fnentry_invalidation.rs:LL:CC
 

--- a/tests/fail/tree_borrows/fragile-data-race.stderr
+++ b/tests/fail/tree_borrows/fragile-data-race.stderr
@@ -6,7 +6,7 @@ LL |     unsafe { *p = 1 };
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>
-   = help: the conflicting tag <TAG> has state Frozen which forbids child write accesses
+   = help: the conflicting tag <TAG> has state Frozen which forbids this child write access
 help: the accessed tag <TAG> was created here
   --> $DIR/fragile-data-race.rs:LL:CC
    |
@@ -17,12 +17,12 @@ help: the conflicting tag <TAG> was created here, in the initial state Reserved
    |
 LL | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
    |                                                       ^
-help: the conflicting tag <TAG> later transitioned to Frozen due to a foreign read access at offsets [0x0..0x1]
+help: the conflicting tag <TAG> later transitioned to Frozen due to a reborrow (acting as a foreign read access) at offsets [0x0..0x1]
   --> RUSTLIB/core/src/ptr/mod.rs:LL:CC
    |
 LL |         crate::intrinsics::read_via_copy(src)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: this corresponds to a loss of write permissions
+   = help: this transition corresponds to a loss of write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/fragile-data-race.rs:LL:CC
 

--- a/tests/fail/tree_borrows/outside-range.stderr
+++ b/tests/fail/tree_borrows/outside-range.stderr
@@ -6,8 +6,8 @@ LL |     *y.add(3) = 42;
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is foreign to the protected tag <TAG> (i.e., it is not a child)
-   = help: the access would cause the protected tag <TAG> to transition from Reserved to Disabled
-   = help: this is a loss of read and write permissions, which is not allowed for protected tags
+   = help: this foreign write access would cause the protected tag <TAG> to transition from Reserved to Disabled
+   = help: this transition would be a loss of read and write permissions, which is not allowed for protected tags
 help: the accessed tag <TAG> was created here
   --> $DIR/outside-range.rs:LL:CC
    |

--- a/tests/fail/tree_borrows/parent_read_freezes_raw_mut.stderr
+++ b/tests/fail/tree_borrows/parent_read_freezes_raw_mut.stderr
@@ -5,7 +5,7 @@ LL |         *ptr = 0;
    |         ^^^^^^^^ write access through <TAG> is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
-   = help: the accessed tag <TAG> has state Frozen which forbids child write accesses
+   = help: the accessed tag <TAG> has state Frozen which forbids this child write access
 help: the accessed tag <TAG> was created here, in the initial state Reserved
   --> $DIR/parent_read_freezes_raw_mut.rs:LL:CC
    |
@@ -16,13 +16,13 @@ help: the accessed tag <TAG> later transitioned to Active due to a child write a
    |
 LL |         *ptr = 0; // Write
    |         ^^^^^^^^
-   = help: this corresponds to the first write to a 2-phase borrowed mutable reference
-help: the accessed tag <TAG> later transitioned to Frozen due to a foreign read access at offsets [0x0..0x1]
+   = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
+help: the accessed tag <TAG> later transitioned to Frozen due to a reborrow (acting as a foreign read access) at offsets [0x0..0x1]
   --> $DIR/parent_read_freezes_raw_mut.rs:LL:CC
    |
 LL |         assert_eq!(root, 0); // Parent Read
    |         ^^^^^^^^^^^^^^^^^^^
-   = help: this corresponds to a loss of write permissions
+   = help: this transition corresponds to a loss of write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/parent_read_freezes_raw_mut.rs:LL:CC
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/fail/tree_borrows/pass_invalid_mut.stderr
+++ b/tests/fail/tree_borrows/pass_invalid_mut.stderr
@@ -6,7 +6,7 @@ LL |     *nope = 31;
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>
-   = help: the conflicting tag <TAG> has state Frozen which forbids child write accesses
+   = help: the conflicting tag <TAG> has state Frozen which forbids this child write access
 help: the accessed tag <TAG> was created here
   --> $DIR/pass_invalid_mut.rs:LL:CC
    |
@@ -22,13 +22,13 @@ help: the conflicting tag <TAG> later transitioned to Active due to a child writ
    |
 LL |     *xref = 18; // activate xref
    |     ^^^^^^^^^^
-   = help: this corresponds to the first write to a 2-phase borrowed mutable reference
+   = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
 help: the conflicting tag <TAG> later transitioned to Frozen due to a foreign read access at offsets [0x0..0x4]
   --> $DIR/pass_invalid_mut.rs:LL:CC
    |
 LL |     let _val = unsafe { *xraw }; // invalidate xref for writing
    |                         ^^^^^
-   = help: this corresponds to a loss of write permissions
+   = help: this transition corresponds to a loss of write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `foo` at $DIR/pass_invalid_mut.rs:LL:CC
 note: inside `main`

--- a/tests/fail/tree_borrows/reserved/cell-protected-write.stderr
+++ b/tests/fail/tree_borrows/reserved/cell-protected-write.stderr
@@ -16,8 +16,8 @@ LL |             *y = 1;
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> (y, callee:y, caller:y) is foreign to the protected tag <TAG> (callee:x) (i.e., it is not a child)
-   = help: the access would cause the protected tag <TAG> (callee:x) to transition from Reserved to Disabled
-   = help: this is a loss of read and write permissions, which is not allowed for protected tags
+   = help: this foreign write access would cause the protected tag <TAG> (callee:x) to transition from Reserved to Disabled
+   = help: this transition would be a loss of read and write permissions, which is not allowed for protected tags
 help: the accessed tag <TAG> was created here
   --> $DIR/cell-protected-write.rs:LL:CC
    |

--- a/tests/fail/tree_borrows/reserved/int-protected-write.stderr
+++ b/tests/fail/tree_borrows/reserved/int-protected-write.stderr
@@ -16,8 +16,8 @@ LL |             *y = 0;
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> (y, callee:y, caller:y) is foreign to the protected tag <TAG> (callee:x) (i.e., it is not a child)
-   = help: the access would cause the protected tag <TAG> (callee:x) to transition from Reserved to Disabled
-   = help: this is a loss of read and write permissions, which is not allowed for protected tags
+   = help: this foreign write access would cause the protected tag <TAG> (callee:x) to transition from Reserved to Disabled
+   = help: this transition would be a loss of read and write permissions, which is not allowed for protected tags
 help: the accessed tag <TAG> was created here
   --> $DIR/int-protected-write.rs:LL:CC
    |

--- a/tests/fail/tree_borrows/return_invalid_mut.stderr
+++ b/tests/fail/tree_borrows/return_invalid_mut.stderr
@@ -6,7 +6,7 @@ LL |     *ret = 3;
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>
-   = help: the conflicting tag <TAG> has state Frozen which forbids child write accesses
+   = help: the conflicting tag <TAG> has state Frozen which forbids this child write access
 help: the accessed tag <TAG> was created here
   --> $DIR/return_invalid_mut.rs:LL:CC
    |
@@ -22,13 +22,13 @@ help: the conflicting tag <TAG> later transitioned to Active due to a child writ
    |
 LL |     *ret = *ret; // activate
    |     ^^^^^^^^^^^
-   = help: this corresponds to the first write to a 2-phase borrowed mutable reference
+   = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
 help: the conflicting tag <TAG> later transitioned to Frozen due to a foreign read access at offsets [0x0..0x8]
   --> $DIR/return_invalid_mut.rs:LL:CC
    |
 LL |     let _val = unsafe { *xraw }; // invalidate xref for writing
    |                         ^^^^^
-   = help: this corresponds to a loss of write permissions
+   = help: this transition corresponds to a loss of write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/return_invalid_mut.rs:LL:CC
 

--- a/tests/fail/tree_borrows/write-during-2phase.rs
+++ b/tests/fail/tree_borrows/write-during-2phase.rs
@@ -9,7 +9,7 @@
 struct Foo(u64);
 impl Foo {
     #[rustfmt::skip] // rustfmt is wrong about which line contains an error
-    fn add(&mut self, n: u64) -> u64 { //~ ERROR: /read access through .* is forbidden/
+    fn add(&mut self, n: u64) -> u64 { //~ ERROR: /reborrow through .* is forbidden/
         self.0 + n
     }
 }

--- a/tests/fail/tree_borrows/write-during-2phase.stderr
+++ b/tests/fail/tree_borrows/write-during-2phase.stderr
@@ -1,11 +1,11 @@
-error: Undefined Behavior: read access through <TAG> is forbidden
+error: Undefined Behavior: reborrow through <TAG> is forbidden
   --> $DIR/write-during-2phase.rs:LL:CC
    |
 LL |     fn add(&mut self, n: u64) -> u64 {
-   |            ^^^^^^^^^ read access through <TAG> is forbidden
+   |            ^^^^^^^^^ reborrow through <TAG> is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
-   = help: the accessed tag <TAG> has state Disabled which forbids child read accesses
+   = help: the accessed tag <TAG> has state Disabled which forbids this reborrow (acting as a child read access)
 help: the accessed tag <TAG> was created here, in the initial state Reserved
   --> $DIR/write-during-2phase.rs:LL:CC
    |
@@ -23,7 +23,7 @@ help: the accessed tag <TAG> later transitioned to Disabled due to a foreign wri
    |
 LL |         *inner = 42;
    |         ^^^^^^^^^^^
-   = help: this corresponds to a loss of read and write permissions
+   = help: this transition corresponds to a loss of read and write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `Foo::add` at $DIR/write-during-2phase.rs:LL:CC
 note: inside `main`


### PR DESCRIPTION
I don't remember where, but there was a complaint that while SB's error messages distinguish between "invalidated by an access" and "invalidated by a reborrow", TB's error messages do not.