### PR TITLE
Provenance forging for `miri_pointer_name`

### DIFF
--- a/src/borrow_tracker/tree_borrows/unimap.rs
+++ b/src/borrow_tracker/tree_borrows/unimap.rs
@@ -17,7 +17,7 @@ use std::hash::Hash;
 use rustc_data_structures::fx::FxHashMap;
 
 /// Intermediate key between a UniKeyMap and a UniValMap.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct UniIndex {
     idx: u32,
 }

--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -455,15 +455,28 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
             "miri_pointer_name" => {
                 // This associates a name to a tag. Very useful for debugging, and also makes
                 // tests more strict.
-                let [ptr, nth_parent, name] = this.check_shim(abi, Abi::Rust, link_name, args)?;
+                let [ptr, name] = this.check_shim(abi, Abi::Rust, link_name, args)?;
                 let ptr = this.read_pointer(ptr)?;
-                let nth_parent = this.read_scalar(nth_parent)?.to_u8()?;
                 let name = this.read_byte_slice(name)?;
                 // We must make `name` owned because we need to
                 // end the shared borrow from `read_byte_slice` before we can
                 // start the mutable borrow for `give_pointer_debug_name`.
                 let name = String::from_utf8_lossy(name).into_owned();
-                this.give_pointer_debug_name(ptr, nth_parent, &name)?;
+                this.give_pointer_debug_name(ptr, &name)?;
+            }
+            "miri_tree_nth_parent" => {
+                let [ptr, nb] = this.check_shim(abi, Abi::Rust, link_name, args)?;
+                let ptr = this.read_pointer(ptr)?;
+                let nb = this.read_scalar(nb)?.to_u8()?;
+                let res = this.forge_ptr_nth_parent(ptr, nb)?;
+                this.write_pointer(res, dest)?;
+            }
+            "miri_tree_common_ancestor" => {
+                let [ptr1, ptr2] = this.check_shim(abi, Abi::Rust, link_name, args)?;
+                let ptr1 = this.read_pointer(ptr1)?;
+                let ptr2 = this.read_pointer(ptr2)?;
+                let res = this.forge_ptr_common_ancestor(ptr1, ptr2)?;
+                this.write_pointer(res, dest)?;
             }
             "miri_static_root" => {
                 let [ptr] = this.check_shim(abi, Abi::Rust, link_name, args)?;

--- a/tests/fail/tree_borrows/reserved/cell-protected-write.rs
+++ b/tests/fail/tree_borrows/reserved/cell-protected-write.rs
@@ -19,8 +19,8 @@ fn main() {
         write_second(x, y);
         unsafe fn write_second(x: &mut UnsafeCell<u8>, y: *mut u8) {
             let alloc_id = alloc_id!(x.get());
-            name!(x.get(), "callee:x");
-            name!(x.get()=>1, "caller:x");
+            name!(ancestor!(x.get(), x.get()), "callee:x");
+            name!(parent!(ancestor!(x.get(), x.get())), "caller:x");
             name!(y, "callee:y");
             name!(y, "caller:y");
             print_state!(alloc_id);

--- a/tests/fail/tree_borrows/reserved/int-protected-write.rs
+++ b/tests/fail/tree_borrows/reserved/int-protected-write.rs
@@ -18,7 +18,7 @@ fn main() {
         unsafe fn write_second(x: &mut u8, y: *mut u8) {
             let alloc_id = alloc_id!(x);
             name!(x, "callee:x");
-            name!(x=>1, "caller:x");
+            name!(parent!(x), "caller:x");
             name!(y, "callee:y");
             name!(y, "caller:y");
             print_state!(alloc_id);

--- a/tests/pass/tree_borrows/end-of-protector.rs
+++ b/tests/pass/tree_borrows/end-of-protector.rs
@@ -26,7 +26,7 @@ fn main() {
 
 unsafe fn do_nothing(x: &mut u8) {
     name!(x, "callee:x");
-    name!(x=>1, "caller:x");
+    name!(parent!(x), "caller:x");
     let alloc_id = alloc_id!(x);
     print_state!(alloc_id);
 }

--- a/tests/pass/tree_borrows/formatting.rs
+++ b/tests/pass/tree_borrows/formatting.rs
@@ -16,7 +16,7 @@ fn main() {
 // decimal digits to verify proper padding.
 unsafe fn alignment_check() {
     let data: &mut [u8] = &mut [0; 1024];
-    name!(data.as_ptr()=>2, "data");
+    name!(ancestor!(data.as_ptr(), data.as_ptr()), "data");
     let alloc_id = alloc_id!(data.as_ptr());
     let x = &mut data[1];
     name!(x as *mut _, "data[1]");

--- a/tests/pass/tree_borrows/reserved.rs
+++ b/tests/pass/tree_borrows/reserved.rs
@@ -33,7 +33,7 @@ unsafe fn print(msg: &str) {
 }
 
 unsafe fn read_second<T>(x: &mut T, y: *mut u8) {
-    name!(x as *mut T as *mut u8=>1, "caller:x");
+    name!(parent!(x as *mut T as *mut u8), "caller:x");
     name!(x as *mut T as *mut u8, "callee:x");
     name!(y, "caller:y");
     name!(y, "callee:y");


### PR DESCRIPTION
Shims to give `miri_pointer_name` a tag in a non-hacky way that is compatible with current `Unique` experiments as well as possible future GC developments.

Previous way of naming an unreachable tag was to refer to the nth parent of a reachable tag. This is very unreliable in the presence of `-Zmiri-unique-is-unique` which changes the number of intermediate tags between reachable tags (`unique.as_ptr()`) and interesting tags (`unique.ptr`).

A more reliable method is proposed here, with
- no more nth parent handling in `miri_pointer_name` itself,
- nth parent accessor still available but extracted to its own function and discouraged for n > 1 (only a macro for the direct parent),
- refering to a tag as the nearest common ancestor of two reachable tags.

This will provide the tools to easily solve the diagnostics aspect of the recent blocker for #2936 