### PR TITLE
Update ui test crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,9 +842,9 @@ dependencies = [
 
 [[package]]
 name = "ui_test"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "191a442639ea102fa62671026047e51d574bfda44b7fdf32151d7314624c1cd2"
+checksum = "b75049e51d3db204b2de79c8ff7a8675c628d81ceef6ec97598c1ab7d4d66802"
 dependencies = [
  "bstr",
  "cargo-platform",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ libloading = "0.7"
 
 [dev-dependencies]
 colored = "2"
-ui_test = "0.10"
+ui_test = "0.11"
 rustc_version = "0.4"
 # Features chosen to match those required by env_logger, to avoid rebuilds
 regex = { version = "1.5.5", default-features = false, features = ["perf", "std"] }

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -3,7 +3,6 @@ use regex::bytes::Regex;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::{env, process::Command};
-use ui_test::status_emitter::StatusEmitter;
 use ui_test::CommandBuilder;
 use ui_test::{color_eyre::Result, Config, Match, Mode, OutputConflictHandling};
 
@@ -76,7 +75,7 @@ fn test_config(target: &str, path: &str, mode: Mode, with_dependencies: bool) ->
     let skip_ui_checks = env::var_os("MIRI_SKIP_UI_CHECKS").is_some();
 
     let output_conflict_handling = match (env::var_os("MIRI_BLESS").is_some(), skip_ui_checks) {
-        (false, false) => OutputConflictHandling::Error,
+        (false, false) => OutputConflictHandling::Error("./miri bless".into()),
         (true, false) => OutputConflictHandling::Bless,
         (false, true) => OutputConflictHandling::Ignore,
         (true, true) => panic!("cannot use MIRI_BLESS and MIRI_SKIP_UI_CHECKS at the same time"),
@@ -86,13 +85,11 @@ fn test_config(target: &str, path: &str, mode: Mode, with_dependencies: bool) ->
         target: Some(target.to_owned()),
         stderr_filters: STDERR.clone(),
         stdout_filters: STDOUT.clone(),
-        root_dir: PathBuf::from(path),
         mode,
         program,
         output_conflict_handling,
-        quiet: false,
         edition: Some("2021".into()),
-        ..Config::default()
+        ..Config::rustc(path.into())
     };
 
     let use_std = env::var_os("MIRI_NO_STD").is_none();
@@ -113,39 +110,48 @@ fn test_config(target: &str, path: &str, mode: Mode, with_dependencies: bool) ->
 }
 
 fn run_tests(mode: Mode, path: &str, target: &str, with_dependencies: bool) -> Result<()> {
-    let mut config = test_config(target, path, mode, with_dependencies);
+    let config = test_config(target, path, mode, with_dependencies);
 
     // Handle command-line arguments.
     let mut after_dashdash = false;
-    config.path_filter.extend(std::env::args().skip(1).filter(|arg| {
-        if after_dashdash {
-            // Just propagate everything.
-            return true;
-        }
-        match &**arg {
-            "--quiet" => {
-                config.quiet = true;
-                false
+    let mut quiet = false;
+    let filters = std::env::args()
+        .skip(1)
+        .filter(|arg| {
+            if after_dashdash {
+                // Just propagate everything.
+                return true;
             }
-            "--" => {
-                after_dashdash = true;
-                false
+            match &**arg {
+                "--quiet" => {
+                    quiet = true;
+                    false
+                }
+                "--" => {
+                    after_dashdash = true;
+                    false
+                }
+                s if s.starts_with('-') => {
+                    panic!("unknown compiletest flag `{s}`");
+                }
+                _ => true,
             }
-            s if s.starts_with('-') => {
-                panic!("unknown compiletest flag `{s}`");
-            }
-            _ => true,
-        }
-    }));
-
+        })
+        .collect::<Vec<_>>();
     eprintln!("   Compiler: {}", config.program.display());
     ui_test::run_tests_generic(
         config,
         // The files we're actually interested in (all `.rs` files).
-        |path| path.extension().is_some_and(|ext| ext == "rs"),
+        |path| {
+            path.extension().is_some_and(|ext| ext == "rs")
+                && (filters.is_empty() || filters.iter().any(|f| path.starts_with(f)))
+        },
         // This could be used to overwrite the `Config` on a per-test basis.
         |_, _| None,
-        TextAndGha,
+        (
+            ui_test::status_emitter::Text,
+            ui_test::status_emitter::Gha::<false> { name: format!("{mode:?} {path} ({target})") },
+        ),
     )
 }
 
@@ -269,46 +275,4 @@ fn run_dep_mode(target: String, mut args: impl Iterator<Item = OsString>) -> Res
     cmd.arg("--");
     cmd.args(args);
     if cmd.spawn()?.wait()?.success() { Ok(()) } else { std::process::exit(1) }
-}
-
-/// This is a custom renderer for `ui_test` output that does not emit github actions
-/// `group`s, while still producing regular github actions messages on test failures.
-struct TextAndGha;
-impl StatusEmitter for TextAndGha {
-    fn failed_test<'a>(
-        &'a self,
-        revision: &'a str,
-        path: &'a Path,
-        cmd: &'a Command,
-        stderr: &'a [u8],
-    ) -> Box<dyn std::fmt::Debug + 'a> {
-        Box::new((
-            ui_test::status_emitter::Gha::<false>.failed_test(revision, path, cmd, stderr),
-            ui_test::status_emitter::Text.failed_test(revision, path, cmd, stderr),
-        ))
-    }
-
-    fn run_tests(&self, _config: &Config) -> Box<dyn ui_test::status_emitter::DuringTestRun> {
-        Box::new(TextAndGha)
-    }
-
-    fn finalize(
-        &self,
-        failures: usize,
-        succeeded: usize,
-        ignored: usize,
-        filtered: usize,
-    ) -> Box<dyn ui_test::status_emitter::Summary> {
-        Box::new((
-            ui_test::status_emitter::Gha::<false>.finalize(failures, succeeded, ignored, filtered),
-            ui_test::status_emitter::Text.finalize(failures, succeeded, ignored, filtered),
-        ))
-    }
-}
-
-impl ui_test::status_emitter::DuringTestRun for TextAndGha {
-    fn test_result(&mut self, path: &Path, revision: &str, result: &ui_test::TestResult) {
-        ui_test::status_emitter::Text.test_result(path, revision, result);
-        ui_test::status_emitter::Gha::<false>.test_result(path, revision, result);
-    }
 }


### PR DESCRIPTION
The main changes:

* we don't need to roll our own `status_emitter` anymore 
* there's only one way to filter now: with the closure passed to `run_tests_generic`