### PR TITLE
cargo-miri: better error message when RUSTC is not set

### DIFF
--- a/cargo-miri/src/main.rs
+++ b/cargo-miri/src/main.rs
@@ -80,7 +80,11 @@ fn main() {
     match first.as_str() {
         "miri" => phase_cargo_miri(args),
         "runner" => phase_runner(args, RunnerPhase::Cargo),
-        arg if arg == env::var("RUSTC").unwrap() => {
+        arg if arg == env::var("RUSTC").unwrap_or_else(|_| {
+            show_error!(
+                "`cargo-miri` called without RUSTC set; please only invoke this binary through `cargo miri`"
+            )
+        }) => {
             // If the first arg is equal to the RUSTC env variable (which should be set at this
             // point), then we need to behave as rustc. This is the somewhat counter-intuitive
             // behavior of having both RUSTC and RUSTC_WRAPPER set


### PR DESCRIPTION
Currently, when running `cargo-miri` instead of `cargo miri` you get a very confusing.

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: NotPresent', src/tools/miri/cargo-miri/src/main.rs:83:41
```

error. This replaces that with a message telling them to use `cargo miri`