### PR TITLE
vec tets: ensure pointer is still writeable

### DIFF
--- a/tests/pass/vec.rs
+++ b/tests/pass/vec.rs
@@ -100,7 +100,7 @@ fn vec_push_ptr_stable() {
     v.push(0);
     let v0 = unsafe { &mut *(&mut v[0] as *mut _) }; // laundering the lifetime -- we take care that `v` does not reallocate, so that's okay.
     v.push(1);
-    let _val = *v0;
+    *v0 = *v0;
 }
 
 fn vec_extend_ptr_stable() {
@@ -109,23 +109,23 @@ fn vec_extend_ptr_stable() {
     let v0 = unsafe { &mut *(&mut v[0] as *mut _) }; // laundering the lifetime -- we take care that `v` does not reallocate, so that's okay.
     // `slice::Iter` (with `T: Copy`) specialization
     v.extend(&[1]);
-    let _val = *v0;
+    *v0 = *v0;
     // `vec::IntoIter` specialization
     v.extend(vec![2]);
-    let _val = *v0;
+    *v0 = *v0;
     // `TrustedLen` specialization
     v.extend(std::iter::once(3));
-    let _val = *v0;
+    *v0 = *v0;
     // base case
     v.extend(std::iter::once(3).filter(|_| true));
-    let _val = *v0;
+    *v0 = *v0;
 }
 
 fn vec_truncate_ptr_stable() {
     let mut v = vec![0; 10];
     let v0 = unsafe { &mut *(&mut v[0] as *mut _) }; // laundering the lifetime -- we take care that `v` does not reallocate, so that's okay.
     v.truncate(5);
-    let _val = *v0;
+    *v0 = *v0;
 }
 
 fn push_str_ptr_stable() {


### PR DESCRIPTION
Under Tree Borrows, a pointer can become read-only: still allowing reads but not permitting writes any more. So these tests that want to check that pointers remain valid need to do writes to ensure that pointers indeed remain fully valid.