### PR TITLE
C "memcpy" shim: ensure the pointers are valid

### DIFF
--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -763,6 +763,12 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                 let ptr_dest = this.read_pointer(ptr_dest)?;
                 let ptr_src = this.read_pointer(ptr_src)?;
                 let n = this.read_target_usize(n)?;
+
+                // C requires that this must always be a valid pointer, even if `n` is zero, so we better check that.
+                // (This is more than Rust requires, so `mem_copy` is not sufficient.)
+                this.ptr_get_alloc_id(ptr_dest)?;
+                this.ptr_get_alloc_id(ptr_src)?;
+
                 this.mem_copy(
                     ptr_src,
                     Align::ONE,

--- a/tests/fail/shims/memchr_null.rs
+++ b/tests/fail/shims/memchr_null.rs
@@ -1,0 +1,10 @@
+//@ignore-target-windows: No libc on Windows
+
+use std::ptr;
+
+// null is explicitly called out as UB in the C docs.
+fn main() {
+    unsafe {
+        libc::memchr(ptr::null(), 0, 0); //~ERROR: dangling
+    }
+}

--- a/tests/fail/shims/memchr_null.stderr
+++ b/tests/fail/shims/memchr_null.stderr
@@ -1,0 +1,15 @@
+error: Undefined Behavior: memory access failed: null pointer is a dangling pointer (it has no provenance)
+  --> $DIR/memchr_null.rs:LL:CC
+   |
+LL |         libc::memchr(ptr::null(), 0, 0);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ memory access failed: null pointer is a dangling pointer (it has no provenance)
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+   = note: BACKTRACE:
+   = note: inside `main` at $DIR/memchr_null.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to previous error
+

--- a/tests/fail/shims/memcmp_null.rs
+++ b/tests/fail/shims/memcmp_null.rs
@@ -1,0 +1,10 @@
+//@ignore-target-windows: No libc on Windows
+
+use std::ptr;
+
+// null is explicitly called out as UB in the C docs.
+fn main() {
+    unsafe {
+        libc::memcmp(ptr::null(), ptr::null(), 0); //~ERROR: dangling
+    }
+}

--- a/tests/fail/shims/memcmp_null.stderr
+++ b/tests/fail/shims/memcmp_null.stderr
@@ -1,0 +1,15 @@
+error: Undefined Behavior: memory access failed: null pointer is a dangling pointer (it has no provenance)
+  --> $DIR/memcmp_null.rs:LL:CC
+   |
+LL |         libc::memcmp(ptr::null(), ptr::null(), 0);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ memory access failed: null pointer is a dangling pointer (it has no provenance)
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+   = note: BACKTRACE:
+   = note: inside `main` at $DIR/memcmp_null.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to previous error
+

--- a/tests/fail/shims/memcpy_zero.rs
+++ b/tests/fail/shims/memcpy_zero.rs
@@ -1,0 +1,12 @@
+//@ignore-target-windows: No libc on Windows
+//@compile-flags: -Zmiri-permissive-provenance
+// C's memcpy is 0 bytes is UB for some pointers that are allowed in Rust's `copy_nonoverlapping`.
+
+fn main() {
+    let from = 42 as *const u8;
+    let to = 23 as *mut u8;
+    unsafe {
+        to.copy_from(from, 0); // this is fine
+        libc::memcpy(to.cast(), from.cast(), 0); //~ERROR: dangling
+    }
+}

--- a/tests/fail/shims/memcpy_zero.stderr
+++ b/tests/fail/shims/memcpy_zero.stderr
@@ -1,0 +1,15 @@
+error: Undefined Behavior: out-of-bounds pointer use: 0x17[noalloc] is a dangling pointer (it has no provenance)
+  --> $DIR/memcpy_zero.rs:LL:CC
+   |
+LL |         libc::memcpy(to.cast(), from.cast(), 0);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ out-of-bounds pointer use: 0x17[noalloc] is a dangling pointer (it has no provenance)
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+   = note: BACKTRACE:
+   = note: inside `main` at $DIR/memcpy_zero.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to previous error
+

--- a/tests/fail/shims/memrchr_null.rs
+++ b/tests/fail/shims/memrchr_null.rs
@@ -1,4 +1,5 @@
 //@ignore-target-windows: No libc on Windows
+//@ignore-target-apple: No `memrchr` on some apple targets
 
 use std::ptr;
 

--- a/tests/fail/shims/memrchr_null.rs
+++ b/tests/fail/shims/memrchr_null.rs
@@ -1,0 +1,10 @@
+//@ignore-target-windows: No libc on Windows
+
+use std::ptr;
+
+// null is explicitly called out as UB in the C docs.
+fn main() {
+    unsafe {
+        libc::memrchr(ptr::null(), 0, 0); //~ERROR: dangling
+    }
+}

--- a/tests/fail/shims/memrchr_null.stderr
+++ b/tests/fail/shims/memrchr_null.stderr
@@ -1,0 +1,15 @@
+error: Undefined Behavior: memory access failed: null pointer is a dangling pointer (it has no provenance)
+  --> $DIR/memrchr_null.rs:LL:CC
+   |
+LL |         libc::memrchr(ptr::null(), 0, 0);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ memory access failed: null pointer is a dangling pointer (it has no provenance)
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+   = note: BACKTRACE:
+   = note: inside `main` at $DIR/memrchr_null.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to previous error
+


### PR DESCRIPTION
Also add tests for some other shims that already behave correctly

Fixes https://github.com/rust-lang/miri/issues/2966