### PR TITLE
remove compile-flags that are no longer needed

### DIFF
--- a/tests/fail/dangling_pointers/dangling_zst_deref.rs
+++ b/tests/fail/dangling_pointers/dangling_zst_deref.rs
@@ -1,6 +1,5 @@
 // Make sure we find these even with many checks disabled.
-// Some optimizations remove ZST accesses, thus masking this UB.
-//@compile-flags: -Zmir-opt-level=0 -Zmiri-disable-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-disable-validation
+//@compile-flags: -Zmiri-disable-alignment-check -Zmiri-disable-stacked-borrows -Zmiri-disable-validation
 
 fn main() {
     let p = {

--- a/tests/fail/dangling_pointers/dyn_size.rs
+++ b/tests/fail/dangling_pointers/dyn_size.rs
@@ -1,5 +1,5 @@
-// should find the bug even without these, but gets masked by optimizations
-//@compile-flags: -Zmiri-disable-validation -Zmiri-disable-stacked-borrows -Zmir-opt-level=0
+// should find the bug even without these
+//@compile-flags: -Zmiri-disable-validation -Zmiri-disable-stacked-borrows
 
 struct SliceWithHead(u8, [u8]);
 

--- a/tests/fail/dangling_pointers/maybe_null_pointer_deref_zst.rs
+++ b/tests/fail/dangling_pointers/maybe_null_pointer_deref_zst.rs
@@ -1,6 +1,3 @@
-// Some optimizations remove ZST accesses, thus masking this UB.
-//@compile-flags: -Zmir-opt-level=0
-
 fn main() {
     // This pointer *could* be NULL so we cannot load from it, not even at ZST
     let ptr = (&0u8 as *const u8).wrapping_sub(0x800) as *const ();

--- a/tests/fail/dangling_pointers/maybe_null_pointer_write_zst.rs
+++ b/tests/fail/dangling_pointers/maybe_null_pointer_write_zst.rs
@@ -1,6 +1,3 @@
-// Some optimizations remove ZST accesses, thus masking this UB.
-//@compile-flags: -Zmir-opt-level=0
-
 fn main() {
     // This pointer *could* be NULL so we cannot load from it, not even at ZST.
     // Not using the () type here, as writes of that type do not even have MIR generated.

--- a/tests/fail/dangling_pointers/null_pointer_deref_zst.rs
+++ b/tests/fail/dangling_pointers/null_pointer_deref_zst.rs
@@ -1,6 +1,3 @@
-// Some optimizations remove ZST accesses, thus masking this UB.
-//@compile-flags: -Zmir-opt-level=0
-
 #[allow(deref_nullptr)]
 fn main() {
     let x: () = unsafe { *std::ptr::null() }; //~ ERROR: dereferencing pointer failed: null pointer is a dangling pointer

--- a/tests/fail/dangling_pointers/null_pointer_write_zst.rs
+++ b/tests/fail/dangling_pointers/null_pointer_write_zst.rs
@@ -1,6 +1,3 @@
-// Some optimizations remove ZST accesses, thus masking this UB.
-//@compile-flags: -Zmir-opt-level=0
-
 #[allow(deref_nullptr)]
 fn main() {
     // Not using the () type here, as writes of that type do not even have MIR generated.

--- a/tests/fail/dangling_pointers/stack_temporary.rs
+++ b/tests/fail/dangling_pointers/stack_temporary.rs
@@ -1,5 +1,5 @@
-// This should fail even without validation, but some MIR opts mask the error
-//@compile-flags: -Zmiri-disable-validation -Zmir-opt-level=0
+// This should fail even without validation
+//@compile-flags: -Zmiri-disable-validation
 
 unsafe fn make_ref<'a>(x: *mut i32) -> &'a mut i32 {
     &mut *x

--- a/tests/fail/dangling_pointers/storage_dead_dangling.rs
+++ b/tests/fail/dangling_pointers/storage_dead_dangling.rs
@@ -1,5 +1,5 @@
-// This should fail even without validation, but some MIR opts mask the error
-//@compile-flags: -Zmiri-disable-validation -Zmir-opt-level=0 -Zmiri-permissive-provenance
+// This should fail even without validation
+//@compile-flags: -Zmiri-disable-validation -Zmiri-permissive-provenance
 
 static mut LEAK: usize = 0;
 

--- a/tests/fail/data_race/read_write_race_stack.rs
+++ b/tests/fail/data_race/read_write_race_stack.rs
@@ -1,7 +1,4 @@
-//@compile-flags: -Zmir-opt-level=0 -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
-
-// Note: mir-opt-level set to 0 to prevent the read of stack_var in thread 1
-// from being optimized away and preventing the detection of the data-race.
+//@compile-flags: -Zmiri-disable-weak-memory-emulation -Zmiri-preemption-rate=0 -Zmiri-disable-stacked-borrows
 
 use std::ptr::null_mut;
 use std::sync::atomic::{AtomicPtr, Ordering};

--- a/tests/fail/erroneous_const.rs
+++ b/tests/fail/erroneous_const.rs
@@ -1,7 +1,5 @@
 //! Make sure we detect erroneous constants post-monomorphization even when they are unused.
 //! (https://github.com/rust-lang/miri/issues/1382)
-// Inlining changes the error location
-//@compile-flags: -Zmir-opt-level=0
 #![feature(never_type)]
 
 struct PrintName<T>(T);

--- a/tests/fail/unaligned_pointers/dyn_alignment.rs
+++ b/tests/fail/unaligned_pointers/dyn_alignment.rs
@@ -1,5 +1,5 @@
 // should find the bug even without, but gets masked by optimizations
-//@compile-flags: -Zmiri-disable-stacked-borrows -Zmir-opt-level=0 -Cdebug-assertions=no
+//@compile-flags: -Zmiri-disable-stacked-borrows -Cdebug-assertions=no
 //@normalize-stderr-test: "but found [0-9]+" -> "but found $$ALIGN"
 
 #[repr(align(256))]

--- a/tests/fail/unaligned_pointers/unaligned_ptr_zst.rs
+++ b/tests/fail/unaligned_pointers/unaligned_ptr_zst.rs
@@ -1,6 +1,5 @@
 // This should fail even without validation
-// Some optimizations remove ZST accesses, thus masking this UB.
-//@compile-flags: -Zmir-opt-level=0 -Zmiri-disable-validation -Cdebug-assertions=no
+//@compile-flags: -Zmiri-disable-validation -Cdebug-assertions=no
 
 fn main() {
     // Try many times as this might work by chance.

--- a/tests/fail/validity/nonzero.rs
+++ b/tests/fail/validity/nonzero.rs
@@ -1,5 +1,3 @@
-// gets masked by optimizations
-//@compile-flags: -Zmir-opt-level=0
 #![feature(rustc_attrs)]
 #![allow(unused_attributes)]
 

--- a/tests/fail/zst2.rs
+++ b/tests/fail/zst2.rs
@@ -1,6 +1,3 @@
-// Some optimizations remove ZST accesses, thus masking this UB.
-//@compile-flags: -Zmir-opt-level=0
-
 fn main() {
     // Not using the () type here, as writes of that type do not even have MIR generated.
     // Also not assigning directly as that's array initialization, not assignment.

--- a/tests/fail/zst3.rs
+++ b/tests/fail/zst3.rs
@@ -1,6 +1,3 @@
-// Some optimizations remove ZST accesses, thus masking this UB.
-//@compile-flags: -Zmir-opt-level=0
-
 fn main() {
     // Not using the () type here, as writes of that type do not even have MIR generated.
     // Also not assigning directly as that's array initialization, not assignment.


### PR DESCRIPTION
We stopped running fail-tests with optimizations a while ago, so we don't need to explicitly set the opt-level to 0 any more.