### PR TITLE
Avoid unnecessary Vec resize.

### DIFF
--- a/src/range_map.rs
+++ b/src/range_map.rs
@@ -27,11 +27,8 @@ impl<T> RangeMap<T> {
     #[inline(always)]
     pub fn new(size: Size, init: T) -> RangeMap<T> {
         let size = size.bytes();
-        let mut map = RangeMap { v: Vec::new() };
-        if size > 0 {
-            map.v.push(Elem { range: 0..size, data: init });
-        }
-        map
+        let v = if size > 0 { vec![Elem { range: 0..size, data: init }] } else { Vec::new() };
+        RangeMap { v }
     }
 
     /// Finds the index containing the given offset.


### PR DESCRIPTION
If `size > 0` current implementation will first create an empty vec and then push an element into it, which will cause a resize that can be easily avoided.

It's obviously not a big deal, but this also gets rid of `mut` local variable.