### PR TITLE
on out-of-bounds error, show where the allocation was created

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -309,7 +309,7 @@ pub fn report_error<'tcx, 'mir>(
                     (None, format!("this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior")),
                     (None, format!("see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information")),
                 ];
-                if let UndefinedBehaviorInfo::PointerUseAfterFree(alloc_id, _) = info {
+                if let UndefinedBehaviorInfo::PointerUseAfterFree(alloc_id, _) | UndefinedBehaviorInfo::PointerOutOfBounds { alloc_id, .. } = info {
                     if let Some(span) = ecx.machine.allocated_span(*alloc_id) {
                         helps.push((Some(span), format!("{:?} was allocated here:", alloc_id)));
                     }

--- a/tests/fail/both_borrows/issue-miri-1050-1.stack.stderr
+++ b/tests/fail/both_borrows/issue-miri-1050-1.stack.stderr
@@ -6,7 +6,12 @@ LL |         Box(unsafe { Unique::new_unchecked(raw) }, alloc)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+help: ALLOC was allocated here:
+  --> $DIR/issue-miri-1050-1.rs:LL:CC
+   |
+LL |         let ptr = Box::into_raw(Box::new(0u16));
+   |                                 ^^^^^^^^^^^^^^
+   = note: BACKTRACE (of the first span):
    = note: inside `std::boxed::Box::<u32>::from_raw_in` at RUSTLIB/alloc/src/boxed.rs:LL:CC
    = note: inside `std::boxed::Box::<u32>::from_raw` at RUSTLIB/alloc/src/boxed.rs:LL:CC
 note: inside `main`

--- a/tests/fail/both_borrows/issue-miri-1050-1.tree.stderr
+++ b/tests/fail/both_borrows/issue-miri-1050-1.tree.stderr
@@ -6,7 +6,12 @@ LL |         Box(unsafe { Unique::new_unchecked(raw) }, alloc)
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+help: ALLOC was allocated here:
+  --> $DIR/issue-miri-1050-1.rs:LL:CC
+   |
+LL |         let ptr = Box::into_raw(Box::new(0u16));
+   |                                 ^^^^^^^^^^^^^^
+   = note: BACKTRACE (of the first span):
    = note: inside `std::boxed::Box::<u32>::from_raw_in` at RUSTLIB/alloc/src/boxed.rs:LL:CC
    = note: inside `std::boxed::Box::<u32>::from_raw` at RUSTLIB/alloc/src/boxed.rs:LL:CC
 note: inside `main`

--- a/tests/fail/dangling_pointers/out_of_bounds_read1.stderr
+++ b/tests/fail/dangling_pointers/out_of_bounds_read1.stderr
@@ -6,8 +6,14 @@ LL |     let x = unsafe { *v.as_ptr().wrapping_offset(5) };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+help: ALLOC was allocated here:
+  --> $DIR/out_of_bounds_read1.rs:LL:CC
+   |
+LL |     let v: Vec<u8> = vec![1, 2];
+   |                      ^^^^^^^^^^
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/out_of_bounds_read1.rs:LL:CC
+   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/dangling_pointers/out_of_bounds_read2.stderr
+++ b/tests/fail/dangling_pointers/out_of_bounds_read2.stderr
@@ -6,8 +6,14 @@ LL |     let x = unsafe { *v.as_ptr().wrapping_offset(5) };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+help: ALLOC was allocated here:
+  --> $DIR/out_of_bounds_read2.rs:LL:CC
+   |
+LL |     let v: Vec<u8> = vec![1, 2];
+   |                      ^^^^^^^^^^
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/out_of_bounds_read2.rs:LL:CC
+   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/ptr_offset_ptr_plus_0.stderr
+++ b/tests/fail/intrinsics/ptr_offset_ptr_plus_0.stderr
@@ -6,7 +6,12 @@ LL |     let _x = unsafe { x.offset(0) }; // UB despite offset 0, the pointer is
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+help: ALLOC was allocated here:
+  --> $DIR/ptr_offset_ptr_plus_0.rs:LL:CC
+   |
+LL |     let x = Box::into_raw(Box::new(0u32));
+   |                           ^^^^^^^^^^^^^^
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/ptr_offset_ptr_plus_0.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/simd-scatter.stderr
+++ b/tests/fail/intrinsics/simd-scatter.stderr
@@ -11,8 +11,14 @@ LL | |         );
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+help: ALLOC was allocated here:
+  --> $DIR/simd-scatter.rs:LL:CC
+   |
+LL |         let mut vec: Vec<i8> = vec![10, 11, 12, 13, 14, 15, 16, 17, 18];
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/simd-scatter.rs:LL:CC
+   = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/zst3.stderr
+++ b/tests/fail/zst3.stderr
@@ -6,7 +6,12 @@ LL |     unsafe { *(x as *mut [u8; 0]) = zst_val };
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
-   = note: BACKTRACE:
+help: ALLOC was allocated here:
+  --> $DIR/zst3.rs:LL:CC
+   |
+LL |     let mut x_box = Box::new(1u8);
+   |                     ^^^^^^^^^^^^^
+   = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/zst3.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace


### PR DESCRIPTION
This seems useful, I think?
r? @saethlin 