### PR TITLE
pin a version of serde without intransparent unreproducible binary blobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,6 +443,7 @@ dependencies = [
  "rand",
  "regex",
  "rustc_version",
+ "serde",
  "smallvec",
  "ui_test",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,8 @@ rustc_version = "0.4"
 # Features chosen to match those required by env_logger, to avoid rebuilds
 regex = { version = "1.5.5", default-features = false, features = ["perf", "std"] }
 lazy_static = "1.4.0"
+# Pin a version of serde without intransparent unreproducible binary blobs.
+serde = { version = "1.0, < 1.0.172", features = ["derive"] }
 
 [package.metadata.rust-analyzer]
 # This crate uses #[feature(rustc_private)].

--- a/cargo-miri/Cargo.toml
+++ b/cargo-miri/Cargo.toml
@@ -22,7 +22,8 @@ rustc-build-sysroot = "0.4.1"
 
 # Enable some feature flags that dev-dependencies need but dependencies
 # do not.  This makes `./miri install` after `./miri build` faster.
-serde = { version = "*", features = ["derive"] }
+# Pin a version of serde without intransparent unreproducible binary blobs.
+serde = { version = "1.0, < 1.0.172", features = ["derive"] }
 
 [build-dependencies]
 rustc_tools_util = "0.3"

--- a/test-cargo-miri/Cargo.toml
+++ b/test-cargo-miri/Cargo.toml
@@ -20,7 +20,9 @@ issue_rust_86261 = { path = "issue-rust-86261" }
 
 [dev-dependencies]
 byteorder_2 = { package = "byteorder", version = "0.5" } # to test dev-dependencies behave as expected, with renaming
-serde_derive = "1.0" # not actually used, but exercises some unique code path (`--extern` .so file)
+# Not actually used, but exercises some unique code path (`--extern` .so file).
+# Pin a version without intransparent unreproducible binary blobs.
+serde_derive = "=1.0.152"
 
 [build-dependencies]
 autocfg = "1"


### PR DESCRIPTION
Serde is [shipping a binary blob in its derive crate](https://github.com/serde-rs/serde/issues/2538), which is highly unexpected and subverts user trust. To make matters worse, the binary is [not even reproducible](https://github.com/serde-rs/serde/issues/2575), making the crate largely unauditable and relinquishing the security benefits of open-source software. Build times are not nearly painful enough to justify forcing users to trust binary blobs.