### PR TITLE
add '--skip-children' to rustfmt invocation

### DIFF
--- a/miri-script/src/commands.rs
+++ b/miri-script/src/commands.rs
@@ -510,7 +510,7 @@ impl Command {
 
         let mut cmd = cmd!(
             e.sh,
-            "rustfmt +{toolchain} --edition=2021 --config-path {config_path} {flags...}"
+            "rustfmt +{toolchain} --edition=2021 --config-path {config_path} --unstable-features --skip-children {flags...}"
         );
         eprintln!("$ {cmd} ...");
 


### PR DESCRIPTION
This finally fixes the issue that we format the same file many times (and `./miri fmt --check` shows duplicate diffs). :)