### PR TITLE
Use `#!/usr/bin/env` shebang

### DIFF
--- a/miri
+++ b/miri
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 # Instead of doing just `cargo run --manifest-path .. $@`, we invoke miri-script binary directly. Invoking `cargo run` goes through
 # rustup (that sets it's own environmental variables), which is undesirable.


### PR DESCRIPTION
```
$ ls /bin/bash
ls: cannot access '/bin/bash': No such file or directory
```

On certain systems, `/bin` and `/usr/bin` are nothing but wastelands, with just `env`around as the last survivor of the great purge. The binaries have cowardly hidden away and only `env` can show us the way to greatness (bash). ❄️