### PR TITLE
disable no-merges check for now

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -10,5 +10,6 @@ allow-unauthenticated = [
 # Gives us the commands 'ready', 'author', 'blocked'
 [shortcut]
 
-[no-merges]
-exclude_titles = ["Rollup of", "sync from rustc"]
+# disabled until https://github.com/rust-lang/triagebot/pull/1720 lands
+#[no-merges]
+#exclude_titles = ["Rollup of", "sync from rustc"]


### PR DESCRIPTION
It leads to false warnings on sync PRs until https://github.com/rust-lang/triagebot/pull/1720 lands.