### PR TITLE
deprecate -Zmiri-disable-abi-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ Some of these are **unsound**, which means they can lead
 to Miri failing to detect cases of undefined behavior in a program.
 
 * `-Zmiri-disable-abi-check` disables checking [function ABI]. Using this flag
-  is **unsound**.
+  is **unsound**. This flag is **deprecated**.
 * `-Zmiri-disable-alignment-check` disables checking pointer alignment, so you
   can focus on other failures, but it means Miri can miss bugs in your program.
   Using this flag is **unsound**.

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -358,6 +358,10 @@ fn main() {
                         since it is now enabled by default"
             );
         } else if arg == "-Zmiri-disable-abi-check" {
+            eprintln!(
+                "WARNING: the flag `-Zmiri-disable-abi-check` is deprecated and planned to be removed.\n\
+                If you have a use-case for it, please file an issue."
+            );
             miri_config.check_abi = false;
         } else if arg == "-Zmiri-disable-isolation" {
             if matches!(isolation_enabled, Some(true)) {

--- a/tests/fail/concurrency/unwind_top_of_stack.stderr
+++ b/tests/fail/concurrency/unwind_top_of_stack.stderr
@@ -1,3 +1,5 @@
+WARNING: the flag `-Zmiri-disable-abi-check` is deprecated and planned to be removed.
+If you have a use-case for it, please file an issue.
 thread '<unnamed>' panicked at $DIR/unwind_top_of_stack.rs:LL:CC:
 explicit panic
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/fail/function_calls/exported_symbol_bad_unwind1.stderr
+++ b/tests/fail/function_calls/exported_symbol_bad_unwind1.stderr
@@ -1,3 +1,5 @@
+WARNING: the flag `-Zmiri-disable-abi-check` is deprecated and planned to be removed.
+If you have a use-case for it, please file an issue.
 thread 'main' panicked at $DIR/exported_symbol_bad_unwind1.rs:LL:CC:
 explicit panic
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/fail/panic/bad_miri_start_panic.stderr
+++ b/tests/fail/panic/bad_miri_start_panic.stderr
@@ -1,3 +1,5 @@
+WARNING: the flag `-Zmiri-disable-abi-check` is deprecated and planned to be removed.
+If you have a use-case for it, please file an issue.
 error: Undefined Behavior: unwinding past a stack frame that does not allow unwinding
   --> $DIR/bad_miri_start_panic.rs:LL:CC
    |

--- a/tests/pass/function_calls/disable_abi_check.stderr
+++ b/tests/pass/function_calls/disable_abi_check.stderr
@@ -1,0 +1,2 @@
+WARNING: the flag `-Zmiri-disable-abi-check` is deprecated and planned to be removed.
+If you have a use-case for it, please file an issue.


### PR DESCRIPTION
This was added in https://github.com/rust-lang/miri/pull/1776 but I couldn't find any discussion or motivation.