### PR TITLE
Support when `build-std` is set for Cargo

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ binaries, and as such worth documenting:
   perform verbose logging.
 * `MIRI_HOST_SYSROOT` is set by bootstrap to tell `cargo-miri` which sysroot to use for *host*
   operations.
+* `MIRI_STD_AWARE_CARGO` is set by `cargo-miri` when Cargo has `build-std` set to tell the Miri driver not to use the value of `MIRI_SYSROOT` and to inject compiler flags typically used for building the Miri sysroot whenever a crate from the standard library is compiled.
 
 [testing-miri]: CONTRIBUTING.md#testing-the-miri-driver
 

--- a/cargo-miri/src/phases.rs
+++ b/cargo-miri/src/phases.rs
@@ -103,7 +103,7 @@ pub fn phase_cargo_miri(mut args: impl Iterator<Item = String>) {
         }
     }
     let cargo_cmd = match subcommand {
-        MiriCommand::Forward(s) => s,
+        MiriCommand::Forward(ref s) => s,
         MiriCommand::Setup => {
             if has_build_std {
                 println!(
@@ -131,7 +131,7 @@ pub fn phase_cargo_miri(mut args: impl Iterator<Item = String>) {
         .expect("current executable path is not valid UTF-8");
     let metadata = get_cargo_metadata();
     let mut cmd = cargo();
-    cmd.arg(&cargo_cmd);
+    cmd.arg(cargo_cmd);
     // In nextest we have to also forward the main `verb`.
     if cargo_cmd == "nextest" {
         cmd.arg(

--- a/cargo-miri/src/util.rs
+++ b/cargo-miri/src/util.rs
@@ -252,3 +252,20 @@ pub fn debug_cmd(prefix: &str, verbose: usize, cmd: &Command) {
     }
     eprintln!("{prefix} running command: {cmd:?}");
 }
+
+/// Checks if Cargo's build-std setting is enabled for one or more crates.
+pub fn is_build_std_set() -> bool {
+    let cmd = cargo()
+        // TODO: remove the -Z argument when this subcommand is stabilized;
+        // see <https://github.com/rust-lang/cargo/issues/9301>
+        .args(&["-Zunstable-options", "config", "get", "--format=json-value", "unstable.build-std"])
+        .output()
+        .expect("failed to get Cargo config");
+    // TODO: Cargo will exit with an error code if the `unstable.build-std` key is not set. Should
+    // we still return false if an unrelated error has occurred?
+    if !cmd.status.success() {
+        return false;
+    }
+
+    cmd.stdout.get(0..2) == Some(b"[\"")
+}

--- a/test-cargo-miri/Cargo.toml
+++ b/test-cargo-miri/Cargo.toml
@@ -16,6 +16,7 @@ issue_1567 = { path = "issue-1567" }
 issue_1691 = { path = "issue-1691" }
 issue_1705 = { path = "issue-1705" }
 issue_1760 = { path = "issue-1760" }
+issue_2705 = { path = "issue-2705" }
 issue_rust_86261 = { path = "issue-rust-86261" }
 
 [dev-dependencies]

--- a/test-cargo-miri/issue-2705/.cargo/config.toml
+++ b/test-cargo-miri/issue-2705/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+target = "ee.json"
+
+[unstable]
+build-std = ["core"]

--- a/test-cargo-miri/issue-2705/Cargo.toml
+++ b/test-cargo-miri/issue-2705/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "issue_2705"
+version = "0.1.0"
+authors = ["Miri Team"]
+edition = "2018"

--- a/test-cargo-miri/issue-2705/ee.json
+++ b/test-cargo-miri/issue-2705/ee.json
@@ -1,0 +1,18 @@
+{
+    "arch": "mips",
+    "cpu": "mips2",
+    "data-layout": "e-m:m-p:32:32-i8:8:32-i16:16:32-i64:64-n32-S64",
+    "features": "+mips2,+soft-float",
+    "linker-flavor": "ld.lld",
+    "llvm-abiname": "o32",
+    "llvm-target": "mipsel-none-elf",
+    "max-atomic-width": 32,
+    "os": "none",
+    "panic-strategy": "abort",
+    "position-independent-executables": false,
+    "relro-level": "full",
+    "target-c-int-width": "32",
+    "target-endian": "little",
+    "target-pointer-width": "32",
+    "relocation-model": "static"
+}

--- a/test-cargo-miri/issue-2705/src/lib.rs
+++ b/test-cargo-miri/issue-2705/src/lib.rs
@@ -1,0 +1,5 @@
+use byteorder::{ByteOrder, LittleEndian};
+
+pub fn use_the_dependency() {
+    let _n = <LittleEndian as ByteOrder>::read_u32(&[1, 2, 3, 4]);
+}


### PR DESCRIPTION
See #2705. This is my first contribution to a rust-lang project, and I am not extremely familiar with the internals of Miri and Cargo, so I apologize if there obvious deficiencies in this PR (besides the ones I am about to list, which are:)

- in the case that `build-std` is set, `cargo-miri` will not set `MIRI_SYSROOT`, which may be problematic for things that expect `MIRI_SYSROOT` to always be set after `cargo miri setup`
- `--print-syroot` is ignored by `cargo miri setup` when `build-std` is set (but what else can it do)
- the Miri driver parses the value of `--crate-name` from the CLI arguments using a dedicated function, but ideally we'd want to borrow functionality from the `arg` module in `cargo-miri`?
- it may be possible for a user to name their crate `std` or `core` or something, in which case, if `build-std` is also set, the Miri driver will naively assume that crate is really part of the standard library and disable debug assertions, enable overflow checks, etc. (I'm not actually sure if this can happen or not; someone please clarify if I'm wrong here)
- there may be some special flags we set for the Miri sysroot that I have forgotten to pass along in the `build-std` case

I have created a test crate with `build-std` set and a target spec for the PlayStation 2 CPU, with the expectation that Miri will see that `build-std` is set and skip building the sysroot. I am not actually able to test this at the moment.