### PR TITLE
Support getentropy on macOS as a foreign item

### DIFF
--- a/src/shims/unix/macos/dlsym.rs
+++ b/src/shims/unix/macos/dlsym.rs
@@ -2,6 +2,7 @@ use rustc_middle::mir;
 
 use log::trace;
 
+use super::foreign_items::EvalContextExt as _;
 use crate::*;
 use helpers::check_arg_count;
 
@@ -38,10 +39,8 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
         match dlsym {
             Dlsym::getentropy => {
                 let [ptr, len] = check_arg_count(args)?;
-                let ptr = this.read_pointer(ptr)?;
-                let len = this.read_target_usize(len)?;
-                this.gen_random(ptr, len)?;
-                this.write_null(dest)?;
+                let result = this.getentropy(ptr, len)?;
+                this.write_scalar(result, dest)?;
             }
         }
 


### PR DESCRIPTION
Prior this was always assumed to be accessed via `dlsym` shim, but in `std` I'm attempting to start [unconditionally linking](https://github.com/rust-lang/rust/pull/116319) to `getentropy` on macOS now that Rust's platform version support allows it.

This just moves the main logic of the previous `dlsym` handler into an eval context extension so it can be used via both call paths. The `dlsym` handler is still needed as `getrandom` uses it.