### PR TITLE
triagebot: re-enable merge commit check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
           git push -u origin $BRANCH
       - name: Create Pull Request
         run: |
-          PR=$(gh pr create -B master --title 'Automatic sync from rustc' --body '')
+          PR=$(gh pr create -B master --title 'Automatic Rustup' --body '')
           ~/.local/bin/zulip-send --user $ZULIP_BOT_EMAIL --api-key $ZULIP_API_TOKEN --site https://rust-lang.zulipchat.com \
             --stream miri --subject "Cron Job Failure (miri, $(date -u +%Y-%m))" \
             --message "A PR doing a rustc-pull [has been automatically created]($PR) for your convenience."

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -10,6 +10,5 @@ allow-unauthenticated = [
 # Gives us the commands 'ready', 'author', 'blocked'
 [shortcut]
 
-# disabled until https://github.com/rust-lang/triagebot/pull/1720 lands
-#[no-merges]
-#exclude_titles = ["Rollup of", "sync from rustc"]
+[no-merges]
+exclude_titles = ["Rustup"]


### PR DESCRIPTION
https://github.com/rust-lang/triagebot/pull/1720 has landed.

Also make the keyword "Rustup", which is what we've been already using for such PRs for a while. Just adjust the bot to also put that in the title.