### PR TITLE
run the provenance-gc=1 test on all targets, but only for the host tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set the tag GC interval to 1 on linux
-        if: runner.os == 'Linux'
-        run: echo "MIRIFLAGS=-Zmiri-provenance-gc=1" >> $GITHUB_ENV
-
       # Cache the global cargo directory, but NOT the local `target` directory which
       # we cannot reuse anyway when the nightly changes (and it grows quite large
       # over time).

--- a/ci.sh
+++ b/ci.sh
@@ -95,7 +95,8 @@ function run_tests_minimal {
   if [ -n "${MIRI_TEST_TARGET:-}" ]; then
     begingroup "Testing MINIMAL foreign architecture $MIRI_TEST_TARGET: only testing $@"
   else
-    begingroup "Testing MINIMAL host architecture: only testing $@"
+    echo "run_tests_minimal requires MIRI_TEST_TARGET to be set"
+    exit 1
   fi
 
   ./miri test -- "$@"
@@ -106,15 +107,20 @@ function run_tests_minimal {
   endgroup
 }
 
-# host
+## Main Testing Logic ##
+
+# Host target.
 run_tests
 
+# Extra targets.
+# In particular, fully cover all tier 1 targets.
 case $HOST_TARGET in
   x86_64-unknown-linux-gnu)
     MIRI_TEST_TARGET=i686-unknown-linux-gnu run_tests
     MIRI_TEST_TARGET=aarch64-unknown-linux-gnu run_tests
     MIRI_TEST_TARGET=aarch64-apple-darwin run_tests
     MIRI_TEST_TARGET=i686-pc-windows-gnu run_tests
+    # Some targets are only partially supported.
     MIRI_TEST_TARGET=x86_64-unknown-freebsd run_tests_minimal hello integer vec panic/panic concurrency/simple pthread-threadname libc-getentropy libc-getrandom libc-misc libc-fs atomic env align
     MIRI_TEST_TARGET=aarch64-linux-android run_tests_minimal hello integer vec panic/panic
     MIRI_TEST_TARGET=wasm32-wasi run_tests_minimal no_std integer strings wasm


### PR DESCRIPTION
No need to slow down *all those tests* running on the Linux host... but lets cover each major OS at least once. We've had bugs that only some macOS-specific code in `getrandom` found, after all.

Let's see how much this affects timing on the macOS / Windows runners.