### PR TITLE
Remove Stacked Borrows GC heuristics

### DIFF
--- a/tests/pass/stacked-borrows/stack-printing.rs
+++ b/tests/pass/stacked-borrows/stack-printing.rs
@@ -1,4 +1,7 @@
-//@compile-flags: -Zmiri-permissive-provenance
+// We disable the GC for this test because it would change what is printed. We are testing the
+// printing, not how it interacts with the GC.
+//@compile-flags: -Zmiri-permissive-provenance -Zmiri-provenance-gc=0
+
 #![feature(strict_provenance)]
 use std::{
     alloc::{self, Layout},


### PR DESCRIPTION
Removing these has no impact on our benchmarks. I think I initially added these because they have a significant impact on runtime at shorter GC intervals. But both these heuristics result in undesirable memory growth in real programs, especially `modified_since_last_gc`. I didn't realize at the time that required state becomes garbage as a result of changes to _other_ allocations.

I think this nets even primarily because we get better heap reuse. With this change I see almost all the mmap calls coming from our diagnostics infrastructure go away. Not that there were many to start with, but it's an indicator that our memory locality has improved.

Before:
```
Benchmark 1: cargo miri run  --manifest-path "/home/ben/miri/bench-cargo-miri/backtraces/Cargo.toml"
  Time (mean ± σ):      4.046 s ±  0.087 s    [User: 3.952 s, System: 0.085 s]
  Range (min … max):    3.952 s …  4.139 s    5 runs
 
Benchmark 1: cargo miri run  --manifest-path "/home/ben/miri/bench-cargo-miri/invalidate/Cargo.toml"
  Time (mean ± σ):      6.271 s ±  0.073 s    [User: 6.206 s, System: 0.054 s]
  Range (min … max):    6.195 s …  6.365 s    5 runs
 
Benchmark 1: cargo miri run  --manifest-path "/home/ben/miri/bench-cargo-miri/mse/Cargo.toml"
  Time (mean ± σ):     570.3 ms ±   6.7 ms    [User: 505.5 ms, System: 61.8 ms]
  Range (min … max):   559.6 ms … 576.0 ms    5 runs
 
Benchmark 1: cargo miri run  --manifest-path "/home/ben/miri/bench-cargo-miri/serde1/Cargo.toml"
  Time (mean ± σ):      2.013 s ±  0.012 s    [User: 1.938 s, System: 0.069 s]
  Range (min … max):    1.994 s …  2.024 s    5 runs
 
Benchmark 1: cargo miri run  --manifest-path "/home/ben/miri/bench-cargo-miri/serde2/Cargo.toml"
  Time (mean ± σ):      4.155 s ±  0.082 s    [User: 4.078 s, System: 0.067 s]
  Range (min … max):    4.011 s …  4.211 s    5 runs
 
Benchmark 1: cargo miri run  --manifest-path "/home/ben/miri/bench-cargo-miri/slice-get-unchecked/Cargo.toml"
  Time (mean ± σ):     541.5 ms ±   3.9 ms    [User: 477.3 ms, System: 60.0 ms]
  Range (min … max):   536.1 ms … 545.1 ms    5 runs
 
Benchmark 1: cargo miri run  --manifest-path "/home/ben/miri/bench-cargo-miri/unicode/Cargo.toml"
  Time (mean ± σ):      1.496 s ±  0.002 s    [User: 1.442 s, System: 0.050 s]
  Range (min … max):    1.494 s …  1.500 s    5 runs
 
Benchmark 1: cargo miri run  --manifest-path "/home/ben/miri/bench-cargo-miri/zip-equal/Cargo.toml"
  Time (mean ± σ):      2.190 s ±  0.043 s    [User: 2.109 s, System: 0.075 s]
  Range (min … max):    2.114 s …  2.215 s    5 runs

```
After:
```
Benchmark 1: cargo miri run  --manifest-path "/home/ben/miri/bench-cargo-miri/backtraces/Cargo.toml"
  Time (mean ± σ):      3.954 s ±  0.057 s    [User: 3.871 s, System: 0.075 s]
  Range (min … max):    3.912 s …  4.052 s    5 runs
 
Benchmark 1: cargo miri run  --manifest-path "/home/ben/miri/bench-cargo-miri/invalidate/Cargo.toml"
  Time (mean ± σ):      6.200 s ±  0.108 s    [User: 6.129 s, System: 0.060 s]
  Range (min … max):    6.072 s …  6.295 s    5 runs
 
Benchmark 1: cargo miri run  --manifest-path "/home/ben/miri/bench-cargo-miri/mse/Cargo.toml"
  Time (mean ± σ):     575.3 ms ±   9.3 ms    [User: 511.5 ms, System: 60.2 ms]
  Range (min … max):   558.9 ms … 580.8 ms    5 runs
 
Benchmark 1: cargo miri run  --manifest-path "/home/ben/miri/bench-cargo-miri/serde1/Cargo.toml"
  Time (mean ± σ):      1.966 s ±  0.007 s    [User: 1.903 s, System: 0.058 s]
  Range (min … max):    1.959 s …  1.974 s    5 runs
 
Benchmark 1: cargo miri run  --manifest-path "/home/ben/miri/bench-cargo-miri/serde2/Cargo.toml"
  Time (mean ± σ):      4.138 s ±  0.040 s    [User: 4.057 s, System: 0.072 s]
  Range (min … max):    4.110 s …  4.207 s    5 runs
 
Benchmark 1: cargo miri run  --manifest-path "/home/ben/miri/bench-cargo-miri/slice-get-unchecked/Cargo.toml"
  Time (mean ± σ):     541.8 ms ±   5.6 ms    [User: 470.7 ms, System: 66.9 ms]
  Range (min … max):   535.6 ms … 549.1 ms    5 runs
 
Benchmark 1: cargo miri run  --manifest-path "/home/ben/miri/bench-cargo-miri/unicode/Cargo.toml"
  Time (mean ± σ):      1.490 s ±  0.021 s    [User: 1.424 s, System: 0.060 s]
  Range (min … max):    1.454 s …  1.505 s    5 runs
 
Benchmark 1: cargo miri run  --manifest-path "/home/ben/miri/bench-cargo-miri/zip-equal/Cargo.toml"
  Time (mean ± σ):      2.215 s ±  0.048 s    [User: 2.113 s, System: 0.072 s]
  Range (min … max):    2.183 s …  2.299 s    5 runs
```