### PR TITLE
Fix miri script target dir and update doc link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ to run the other checks while ignoring the ui output, use `MIRI_SKIP_UI_CHECKS=1
 
 For more info on how to configure ui tests see [the documentation on the ui test crate][ui_test]
 
-[ui_test]: ui_test/README.md
+[ui_test]: https://github.com/oli-obk/ui_test/blob/main/README.md
 
 ### Testing `cargo miri`
 

--- a/miri
+++ b/miri
@@ -2,5 +2,6 @@
 set -e
 # Instead of doing just `cargo run --manifest-path .. $@`, we invoke miri-script binary directly. Invoking `cargo run` goes through
 # rustup (that sets it's own environmental variables), which is undesirable.
-cargo build $CARGO_EXTRA_FLAGS -q --manifest-path "$(dirname "$0")"/miri-script/Cargo.toml
-"$(dirname "$0")"/miri-script/target/debug/miri-script "$@"
+MIRI_SCRIPT_TARGET_DIR="$(dirname "$0")"/miri-script/target
+cargo build $CARGO_EXTRA_FLAGS -q --target-dir "$MIRI_SCRIPT_TARGET_DIR" --manifest-path "$(dirname "$0")"/miri-script/Cargo.toml
+"$MIRI_SCRIPT_TARGET_DIR"/debug/miri-script "$@"


### PR DESCRIPTION
Fix ui_test doc link in `CONTRIBUTING.md`

Explicitly set `--target-dir` in `miri` script when building to expected location

- I have `build.target-dir` cargo config set to be some other location so miri script was erroring out since compiled binary was not in expected location