### PR TITLE
Don't explicitly warn against `semicolon_in_expressions_from_macros`

### DIFF
--- a/miri-script/src/util.rs
+++ b/miri-script/src/util.rs
@@ -73,7 +73,9 @@ impl MiriEnv {
             flags.push("-C link-args=-Wl,-rpath,");
             flags.push(libdir);
             // Enable rustc-specific lints (ignored without `-Zunstable-options`).
-            flags.push(" -Zunstable-options -Wrustc::internal -Wrust_2018_idioms -Wunused_lifetimes");
+            flags.push(
+                " -Zunstable-options -Wrustc::internal -Wrust_2018_idioms -Wunused_lifetimes",
+            );
             // Add user-defined flags.
             if let Some(value) = std::env::var_os("RUSTFLAGS") {
                 flags.push(" ");

--- a/miri-script/src/util.rs
+++ b/miri-script/src/util.rs
@@ -73,7 +73,7 @@ impl MiriEnv {
             flags.push("-C link-args=-Wl,-rpath,");
             flags.push(libdir);
             // Enable rustc-specific lints (ignored without `-Zunstable-options`).
-            flags.push(" -Zunstable-options -Wrustc::internal -Wrust_2018_idioms -Wunused_lifetimes -Wsemicolon_in_expressions_from_macros");
+            flags.push(" -Zunstable-options -Wrustc::internal -Wrust_2018_idioms -Wunused_lifetimes");
             // Add user-defined flags.
             if let Some(value) = std::env::var_os("RUSTFLAGS") {
                 flags.push(" ");


### PR DESCRIPTION
This warns-by-default since 2 years and already has been added to the future-incompat group since Rust 1.68.

See https://github.com/rust-lang/rust/issues/79813 for the tracking issue.

Just something I noticed when trying to wrap my head around lints warned against in the rust-lang/rust and noticed it's not warned against anymore; let me know if the change makes sense :pray: 