### PR TITLE
remove unnecesary `-Zunstable-options`

### DIFF
--- a/cargo-miri/src/util.rs
+++ b/cargo-miri/src/util.rs
@@ -200,9 +200,6 @@ pub fn ask_to_run(mut cmd: Command, ask: bool, text: &str) {
 // cargo invocation.
 fn cargo_extra_flags() -> Vec<String> {
     let mut flags = Vec::new();
-    // `-Zunstable-options` is required by `--config`.
-    flags.push("-Zunstable-options".to_string());
-
     // Forward `--config` flags.
     let config_flag = "--config";
     for arg in get_arg_flag_values(config_flag) {

--- a/test-cargo-miri/run-test.py
+++ b/test-cargo-miri/run-test.py
@@ -181,7 +181,7 @@ def test_cargo_miri_test():
     )
     del os.environ["CARGO_TARGET_DIR"] # this overrides `build.target-dir` passed by `--config`, so unset it
     test("`cargo miri test` (config-cli)",
-        cargo_miri("test") + ["--config=build.target-dir=\"config-cli\"", "-Zunstable-options"],
+        cargo_miri("test") + ["--config=build.target-dir=\"config-cli\""],
         default_ref, "test.stderr-empty.ref",
         env={'MIRIFLAGS': "-Zmiri-permissive-provenance"},
     )


### PR DESCRIPTION
AFAIK `-Zunstable-options` is for `cargo --config` CLI, which was stabilized in 1.63

https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#config-cli