### PR TITLE
Add portable-atomic-util bug to "bugs found" list

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,7 @@ Definite bugs found:
 * [Incorrect use of `compare_exchange_weak` in `once_cell`](https://github.com/matklad/once_cell/issues/186)
 * [Dropping with unaligned pointers in `vec::IntoIter`](https://github.com/rust-lang/rust/pull/106084)
 * [Deallocating with the wrong layout in new specializations for in-place `Iterator::collect`](https://github.com/rust-lang/rust/pull/118460)
+* [Incorrect offset computation for highly-aligned types in `portable-atomic-util`](https://github.com/taiki-e/portable-atomic/pull/138)
 
 Violations of [Stacked Borrows] found that are likely bugs (but Stacked Borrows is currently just an experiment):
 


### PR DESCRIPTION
At least, reading https://notgull.net/cautionary-unsafe-tale/ it seems fair to say Miri found this bug. @notgull please let me know if you are okay with having this listed here.