### PR TITLE
accommodate CARGO_TARGET_DIR being set

### DIFF
--- a/miri-script/Cargo.toml
+++ b/miri-script/Cargo.toml
@@ -21,3 +21,6 @@ xshell = "0.2"
 rustc_version = "0.4"
 dunce = "1.0.4"
 directories = "5"
+
+[build]
+target-dir = "target"


### PR DESCRIPTION
Hello, when looking to locally build Miri, I found that setting CARGO_TARGET_DIR, which I set globally to centralize build directories, causes miri-script to fail, as it assumes cargo uses the default target dir and thus uses the contents of the "target" directory. I resolved this by explicitly setting the target-dir build option in Cargo.toml, which is preferred over CARGO_TARGET_DIR.

It may be preferable to query where cargo is putting build products and use that location in miri-script, but that would require modifying miri-script itself to query cargo, which seems unnecessary.