### PR TITLE
Fix integer overflow ICEs from round_up_to_next_multiple_of

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1233,11 +1233,3 @@ pub(crate) fn simd_element_to_bool(elem: ImmTy<'_, Provenance>) -> InterpResult<
         _ => throw_ub_format!("each element of a SIMD mask must be all-0-bits or all-1-bits"),
     })
 }
-
-// This looks like something that would be nice to have in the standard library...
-pub(crate) fn round_to_next_multiple_of(x: u64, divisor: u64) -> u64 {
-    assert_ne!(divisor, 0);
-    // divisor is nonzero; multiplication cannot overflow since we just divided
-    #[allow(clippy::arithmetic_side_effects)]
-    return (x.checked_add(divisor - 1).unwrap() / divisor) * divisor;
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 #![feature(round_ties_even)]
 #![feature(let_chains)]
 #![feature(lint_reasons)]
+#![feature(int_roundings)]
 // Configure clippy and other lints
 #![allow(
     clippy::collapsible_else_if,

--- a/src/shims/intrinsics/simd.rs
+++ b/src/shims/intrinsics/simd.rs
@@ -4,10 +4,7 @@ use rustc_middle::{mir, ty, ty::FloatTy};
 use rustc_span::{sym, Symbol};
 use rustc_target::abi::{Endian, HasDataLayout};
 
-use crate::helpers::{
-    bool_to_simd_element, check_arg_count, round_to_next_multiple_of, simd_element_to_bool, ToHost,
-    ToSoft,
-};
+use crate::helpers::{bool_to_simd_element, check_arg_count, simd_element_to_bool, ToHost, ToSoft};
 use crate::*;
 
 #[derive(Copy, Clone)]
@@ -407,7 +404,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                 let (yes, yes_len) = this.operand_to_simd(yes)?;
                 let (no, no_len) = this.operand_to_simd(no)?;
                 let (dest, dest_len) = this.place_to_simd(dest)?;
-                let bitmask_len = round_to_next_multiple_of(dest_len, 8);
+                let bitmask_len = dest_len.next_multiple_of(8);
 
                 // The mask must be an integer or an array.
                 assert!(
@@ -453,7 +450,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
             "bitmask" => {
                 let [op] = check_arg_count(args)?;
                 let (op, op_len) = this.operand_to_simd(op)?;
-                let bitmask_len = round_to_next_multiple_of(op_len, 8);
+                let bitmask_len = op_len.next_multiple_of(8);
 
                 // Returns either an unsigned integer or array of `u8`.
                 assert!(

--- a/tests/pass-dep/shims/mmap.rs
+++ b/tests/pass-dep/shims/mmap.rs
@@ -90,7 +90,28 @@ fn test_mmap() {
         assert_eq!(Error::last_os_error().raw_os_error().unwrap(), libc::ENOTSUP);
     }
 
+    // We report an error for mappings whose length cannot be rounded up to a multiple of
+    // the page size.
+    let ptr = unsafe {
+        libc::mmap(
+            ptr::null_mut(),
+            usize::MAX - 1,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+            -1,
+            0,
+        )
+    };
+    assert_eq!(ptr, libc::MAP_FAILED);
+
+    // We report an error when trying to munmap an address which is not a multiple of the page size
     let res = unsafe { libc::munmap(ptr::invalid_mut(1), page_size) };
+    assert_eq!(res, -1);
+    assert_eq!(Error::last_os_error().raw_os_error().unwrap(), libc::EINVAL);
+
+    // We report an error when trying to munmap a length that cannot be rounded up to a multiple of
+    // the page size.
+    let res = unsafe { libc::munmap(ptr::invalid_mut(page_size), usize::MAX - 1) };
     assert_eq!(res, -1);
     assert_eq!(Error::last_os_error().raw_os_error().unwrap(), libc::EINVAL);
 }


### PR DESCRIPTION
Turns out the standard library _does_ have the function we need. So I swapped us to using the checked version in mmap/munmap where we can return an error, and we're still using the ICEy version in SIMD.

I found one of the ICE cases by running this test: https://github.com/wbcchsyn/rust-mmap-allocator/blob/765bcaab6e3bfd1cb1e6eaac80ac7e821fb5979b/src/mmap_allocator.rs#L195-L210