### PR TITLE
Run the tier 2 sysroots job on a schedule, not push

### DIFF
--- a/.github/workflows/sysroots.yml
+++ b/.github/workflows/sysroots.yml
@@ -1,8 +1,8 @@
 name: Tier 2 sysroots
 
-on: push
-#  schedule:
-#    - cron: '44 4 * * *' # At 4:44 UTC every day.
+on:
+  schedule:
+    - cron: '44 4 * * *' # At 4:44 UTC every day.
 
 defaults:
   run:


### PR DESCRIPTION
I had this running on push instead of on a schedule so that I could verify that it worked, then forgot to switch it back to cron before merging.