### PR TITLE
Update `ctrlc` version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rand = "0.8"
 smallvec = "1.7"
 aes = { version = "0.8.3", features = ["hazmat"] }
 measureme = "11"
-ctrlc = "3.2.5"
+ctrlc = "3.4.2"
 
 # Copied from `compiler/rustc/Cargo.toml`.
 # But only for some targets, it fails for others. Rustc configures this in its CI, but we can't


### PR DESCRIPTION
Removes one duplicate dependency on `bitflags` in rustc
```
bitflags v1.3.2
├── nix v0.26.2
│   └── ctrlc v3.4.0
│       └── miri v0.1.0 (rust/src/tools/miri)
[ ... ]
bitflags v2.4.1
├── rustc_abi v0.0.0 (rust/compiler/rustc_abi)
├── rustc_ast v0.0.0 (rust/compiler/rustc_ast)
├── rustc_codegen_llvm v0.0.0 (rust/compiler/rustc_codegen_llvm)
├── rustc_codegen_ssa v0.0.0 (rust/compiler/rustc_codegen_ssa)
├── rustc_data_structures v0.0.0 (rust/compiler/rustc_data_structures)
├── rustc_metadata v0.0.0 (rust/compiler/rustc_metadata)
[ ... ]
```