### PR TITLE
Stop recommending cargo clean in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,8 @@ assume the right toolchain is pinned via `rustup override set nightly` or
 
 Now you can run your project in Miri:
 
-1. Run `cargo clean` to eliminate any cached dependencies. Miri needs your
-   dependencies to be compiled the right way, that would not happen if they have
-   previously already been compiled.
-2. To run all tests in your project through Miri, use `cargo miri test`.
-3. If you have a binary project, you can run it through Miri using `cargo miri run`.
+- To run all tests in your project through Miri, use `cargo miri test`.
+- If you have a binary project, you can run it through Miri using `cargo miri run`.
 
 The first time you run Miri, it will perform some extra setup and install some
 dependencies. It will ask you for confirmation before installing anything.


### PR DESCRIPTION
Miri has used the `target/miri` subdirectory since 2021 to keep itself separate from non-miri builds, so this should not be necessary.

See commit 6a18683d09f74ead9438aa7fdd323b18821f7709

Since the items are no longer a sequence of steps to do in order ("first, make sure that ..."), switch to an unordered list while we're at it.

Closes #3289