### PR TITLE
Force panic=unwind for sysroot

### DIFF
--- a/cargo-miri/src/phases.rs
+++ b/cargo-miri/src/phases.rs
@@ -415,6 +415,9 @@ pub fn phase_rustc(mut args: impl Iterator<Item = String>, phase: RustcPhase) {
             && get_arg_flag_value("--crate-name").as_deref() == Some("panic_abort")
         {
             cmd.arg("-C").arg("panic=abort");
+        } else if phase == RustcPhase::Setup {
+            // If the user has a custom profile, this overrides it so that the sysroot is built properly.
+            cmd.arg("-C").arg("panic=unwind");
         }
     } else {
         // For host crates (but not when we are just printing some info),


### PR DESCRIPTION
This fixed #3313 partially for me. Previously, none of the miri tests could even build. Now they all pass :). 

There is a lingering issue that I don't quite understand yet, which is that attempting to do `miri test` with another crate can still having aborting behavior. 

The motivating example I have is https://github.com/PSeitz/lz4_flex, and how I found the issue to begin with. I can now build the test binaries, but now it immediately fails upon test execution with `(exit code: 0xc0000005, STATUS_ACCESS_VIOLATION)` (Windows). 

It appears something is still being build with `panic="abort"` somewhere, but adding it to the other cargo invocation did not seem to solve it
https://github.com/rust-lang/miri/blob/92110c2c9353d70db7146c661b087f53c033075d/cargo-miri/src/phases.rs#L115 somewhere after here I unconditionally put `-Cpanic=unwind` as a test but the abort still occurred. And to note, the tests run fine without touching the cargo config and running `cargo test`. 

