### PR TITLE
Windows miri-script execution egronomics

### DIFF
--- a/miri.bat
+++ b/miri.bat
@@ -1,0 +1,10 @@
+:: This makes execution of ./miri on Linux and Windows the same.
+:: Windows will not execute the bash script, and select this.
+@echo off
+set MIRI_SCRIPT_TARGET_DIR=%0\..\miri-script\target
+cargo build %CARGO_EXTRA_FLAGS% -q --target-dir %MIRI_SCRIPT_TARGET_DIR% --manifest-path %0\..\miri-script\Cargo.toml
+
+:: Forwards all arguments to this file to the executable.
+:: We invoke the binary directly to avoid going through rustup, which would set some extra
+:: env vars that we do not want.
+%MIRI_SCRIPT_TARGET_DIR%\debug\miri-script %*


### PR DESCRIPTION
This allows for Windows users to use miri-script without pain. As working on miri earlier I was doing
`.\miri-script\target\debug\miri-script.exe { install | build | ... }` which wasn't fun.