### PR TITLE
more dealing with macOS CI runners being slow

### DIFF
--- a/tests/pass/shims/time.rs
+++ b/tests/pass/shims/time.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant, SystemTime};
 fn duration_sanity(diff: Duration) {
     // On my laptop, I observed times around 15-40ms. Add 10x lee-way both ways.
     assert!(diff.as_millis() > 1);
-    assert!(diff.as_millis() < 500);
+    assert!(diff.as_millis() < 1000); // macOS is very slow sometimes
 }
 
 fn test_sleep() {


### PR DESCRIPTION
500ms seems to still sometimes not enough... so let's double it...