### PR TITLE
Add clippy cross-checking support to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,8 @@ jobs:
             echo "Building against latest rustc git version"
             git ls-remote https://github.com/rust-lang/rust/ HEAD | cut -f 1 > rust-version
           fi
-          ./miri toolchain
+          ./miri toolchain -t x86_64-pc-windows-msvc -t  x86_64-unknown-linux-gnu -t x86_64-apple-darwin
+          sudo apt install crossbuild-essential-arm64 crossbuild-essential-amd64
 
       - name: Show Rust version
         run: |
@@ -124,7 +125,7 @@ jobs:
       - name: rustfmt
         run: ./miri fmt --check
       - name: clippy
-        run: ./miri clippy -- -D warnings
+        run: ./miri clippy --no-default-features --features stack-cache --target x86_64-pc-windows-msvc --target x86_64-unknown-linux-gnu --target x86_64-apple-darwin -- -D warnings
       - name: rustdoc
         run: RUSTDOCFLAGS="-Dwarnings" ./miri cargo doc --document-private-items
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ ctrlc = "3.2.5"
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies.jemalloc-sys]
 version = "0.5.0"
 features = ['unprefixed_malloc_on_supported_platforms']
+optional = true
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -56,8 +57,9 @@ name = "compiletest"
 harness = false
 
 [features]
-default = ["stack-cache"]
+default = ["stack-cache", "jemalloc"]
 stack-cache = []
+jemalloc = ["dep:jemalloc-sys"]
 
 # Be aware that this file is inside a workspace when used via the
 # submodule in the rustc repo. That means there are many cargo features

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -296,7 +296,7 @@ fn parse_comma_list<T: FromStr>(input: &str) -> Result<Vec<T>, T::Err> {
     input.split(',').map(str::parse::<T>).collect()
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(all(any(target_os = "linux", target_os = "macos"), feature = "jemalloc"))]
 fn jemalloc_magic() {
     // These magic runes are copied from
     // <https://github.com/rust-lang/rust/blob/e89bd9428f621545c979c0ec686addc6563a394e/compiler/rustc/src/main.rs#L39>.
@@ -333,7 +333,7 @@ fn jemalloc_magic() {
 }
 
 fn main() {
-    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[cfg(all(any(target_os = "linux", target_os = "macos"), feature = "jemalloc"))]
     jemalloc_magic();
 
     let early_dcx = EarlyDiagCtxt::new(ErrorOutputType::default());

--- a/src/shims/os_str.rs
+++ b/src/shims/os_str.rs
@@ -279,20 +279,20 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                     // If this is an absolute Windows path that starts with a drive letter (`C:/...`
                     // after separator conversion), it would not be considered absolute by Unix
                     // target code.
-                    if converted.get(1).copied() == Some(b':' as u16)
-                        && converted.get(2).copied() == Some(b'/' as u16)
+                    if converted.get(1).copied() == Some(u16::from(b':'))
+                        && converted.get(2).copied() == Some(u16::from(b'/'))
                     {
                         // We add a `/` at the beginning, to store the absolute Windows
                         // path in something that looks like an absolute Unix path.
-                        converted.insert(0, b'/' as u16);
+                        converted.insert(0, u16::from(b'/'));
                     }
                 }
                 PathConversion::TargetToHost => {
                     // If the path is `\C:\`, the leading backslash was probably added by the above code
                     // and we should get rid of it again.
-                    if converted.get(0).copied() == Some(b'\\' as u16)
-                        && converted.get(2).copied() == Some(b':' as u16)
-                        && converted.get(3).copied() == Some(b'\\' as u16)
+                    if converted.get(0).copied() == Some(u16::from(b'\\'))
+                        && converted.get(2).copied() == Some(u16::from(b':'))
+                        && converted.get(3).copied() == Some(u16::from(b'\\'))
                     {
                         converted.remove(0);
                     }


### PR DESCRIPTION
I can't run this on my computer because jemallocator isn't supported on Windows. So let's see if CI is happy with this.