### PR TITLE
Fix miri.bat not bailing early on error

### DIFF
--- a/miri.bat
+++ b/miri.bat
@@ -2,7 +2,10 @@
 :: Windows will not execute the bash script, and select this.
 @echo off
 set MIRI_SCRIPT_TARGET_DIR=%0\..\miri-script\target
-cargo build %CARGO_EXTRA_FLAGS% -q --target-dir %MIRI_SCRIPT_TARGET_DIR% --manifest-path %0\..\miri-script\Cargo.toml
+
+:: If any other steps are added, the "|| exit /b" must be appended to early
+:: return from the script. If not, it will continue execution.
+cargo build %CARGO_EXTRA_FLAGS% -q --target-dir %MIRI_SCRIPT_TARGET_DIR% --manifest-path %0\..\miri-script\Cargo.toml || exit /b
 
 :: Forwards all arguments to this file to the executable.
 :: We invoke the binary directly to avoid going through rustup, which would set some extra


### PR DESCRIPTION
There is a logical error in the batch script that I did not think about. Currently, if the build step for miri-script fails, it will continue on and attempt to execute the next line. This will either lead to a file not found error, or running an old miri-script. 

With this, it will bail upon erroring in the build step.