### PR TITLE
remove a wrong bitwise negation

### DIFF
--- a/src/shims/tls.rs
+++ b/src/shims/tls.rs
@@ -354,7 +354,7 @@ trait EvalContextPrivExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
             state.last_key = Some(key);
             trace!("Running TLS dtor {:?} on {:?} at {:?}", instance, ptr, active_thread);
             assert!(
-                !ptr.to_target_usize(this).unwrap() != 0,
+                ptr.to_target_usize(this).unwrap() != 0,
                 "data can't be NULL when dtor is called!"
             );
 


### PR DESCRIPTION
This is a silly mistake I introduced in https://github.com/rust-lang/miri/commit/a1233a721d0832071a2c1b1a95895cc0b924b553.