### PR TITLE
Tree Borrows diagnostic improvements

### DIFF
--- a/src/borrow_tracker/mod.rs
+++ b/src/borrow_tracker/mod.rs
@@ -377,7 +377,12 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
             if matches!(kind, AllocKind::LiveData) {
                 let alloc_extra = this.get_alloc_extra(*alloc_id)?; // can still fail for `extern static`
                 let alloc_borrow_tracker = &alloc_extra.borrow_tracker.as_ref().unwrap();
-                alloc_borrow_tracker.release_protector(&this.machine, borrow_tracker, *tag)?;
+                alloc_borrow_tracker.release_protector(
+                    &this.machine,
+                    borrow_tracker,
+                    *tag,
+                    *alloc_id,
+                )?;
             }
         }
         borrow_tracker.borrow_mut().end_call(&frame.extra);
@@ -491,10 +496,12 @@ impl AllocState {
         machine: &MiriMachine<'_, 'tcx>,
         global: &GlobalState,
         tag: BorTag,
+        alloc_id: AllocId, // diagnostics
     ) -> InterpResult<'tcx> {
         match self {
             AllocState::StackedBorrows(_sb) => Ok(()),
-            AllocState::TreeBorrows(tb) => tb.borrow_mut().release_protector(machine, global, tag),
+            AllocState::TreeBorrows(tb) =>
+                tb.borrow_mut().release_protector(machine, global, tag, alloc_id),
         }
     }
 }

--- a/src/borrow_tracker/tree_borrows/diagnostics.rs
+++ b/src/borrow_tracker/tree_borrows/diagnostics.rs
@@ -278,6 +278,8 @@ impl History {
 pub(super) struct TbError<'node> {
     /// What failure occurred.
     pub error_kind: TransitionError,
+    /// The allocation in which the error is happening.
+    pub alloc_id: AllocId,
     /// The offset (into the allocation) at which the conflict occurred.
     pub error_offset: u64,
     /// The tag on which the error was triggered.
@@ -300,7 +302,11 @@ impl TbError<'_> {
         let accessed = self.accessed_info;
         let conflicting = self.conflicting_info;
         let accessed_is_conflicting = accessed.tag == conflicting.tag;
-        let title = format!("{cause} through {accessed} is forbidden");
+        let title = format!(
+            "{cause} through {accessed} at {alloc_id:?}[{offset:#x}] is forbidden",
+            alloc_id = self.alloc_id,
+            offset = self.error_offset
+        );
         let (title, details, conflicting_tag_name) = match self.error_kind {
             ChildAccessForbidden(perm) => {
                 let conflicting_tag_name =

--- a/src/borrow_tracker/tree_borrows/mod.rs
+++ b/src/borrow_tracker/tree_borrows/mod.rs
@@ -1,6 +1,3 @@
-use rustc_target::abi::{Abi, Size};
-
-use crate::borrow_tracker::{GlobalState, GlobalStateInner, ProtectorKind};
 use rustc_middle::{
     mir::{Mutability, RetagKind},
     ty::{
@@ -10,7 +7,9 @@ use rustc_middle::{
     },
 };
 use rustc_span::def_id::DefId;
+use rustc_target::abi::{Abi, Size};
 
+use crate::borrow_tracker::{GlobalState, GlobalStateInner, ProtectorKind};
 use crate::*;
 
 pub mod diagnostics;
@@ -70,6 +69,7 @@ impl<'tcx> Tree {
             tag,
             Some(range),
             global,
+            alloc_id,
             span,
             diagnostics::AccessCause::Explicit(access_kind),
         )
@@ -78,7 +78,7 @@ impl<'tcx> Tree {
     /// Check that this pointer has permission to deallocate this range.
     pub fn before_memory_deallocation(
         &mut self,
-        _alloc_id: AllocId,
+        alloc_id: AllocId,
         prov: ProvenanceExtra,
         range: AllocRange,
         machine: &MiriMachine<'_, 'tcx>,
@@ -91,7 +91,7 @@ impl<'tcx> Tree {
         };
         let global = machine.borrow_tracker.as_ref().unwrap();
         let span = machine.current_span();
-        self.dealloc(tag, range, global, span)
+        self.dealloc(tag, range, global, alloc_id, span)
     }
 
     pub fn expose_tag(&mut self, _tag: BorTag) {
@@ -109,6 +109,7 @@ impl<'tcx> Tree {
         machine: &MiriMachine<'_, 'tcx>,
         global: &GlobalState,
         tag: BorTag,
+        alloc_id: AllocId, // diagnostics
     ) -> InterpResult<'tcx> {
         let span = machine.current_span();
         self.perform_access(
@@ -116,6 +117,7 @@ impl<'tcx> Tree {
             tag,
             None, // no specified range because it occurs on the entire allocation
             global,
+            alloc_id,
             span,
             diagnostics::AccessCause::FnExit,
         )
@@ -211,7 +213,7 @@ trait EvalContextPrivExt<'mir: 'ecx, 'tcx: 'mir, 'ecx>: crate::MiriInterpCxExt<'
             let global = this.machine.borrow_tracker.as_ref().unwrap().borrow();
             let ty = place.layout.ty;
             if global.tracked_pointer_tags.contains(&new_tag) {
-                let kind_str = format!("{new_perm:?} (pointee type {ty})");
+                let kind_str = format!("initial state {} (pointee type {ty})", new_perm.initial_state);
                 this.emit_diagnostic(NonHaltingDiagnostic::CreatedPointerTag(
                     new_tag.inner(),
                     Some(kind_str),
@@ -299,6 +301,7 @@ trait EvalContextPrivExt<'mir: 'ecx, 'tcx: 'mir, 'ecx>: crate::MiriInterpCxExt<'
             orig_tag,
             Some(range),
             this.machine.borrow_tracker.as_ref().unwrap(),
+            alloc_id,
             this.machine.current_span(),
             diagnostics::AccessCause::Reborrow,
         )?;

--- a/src/borrow_tracker/tree_borrows/tree.rs
+++ b/src/borrow_tracker/tree_borrows/tree.rs
@@ -516,13 +516,15 @@ impl<'tcx> Tree {
         tag: BorTag,
         access_range: AllocRange,
         global: &GlobalState,
-        span: Span, // diagnostics
+        alloc_id: AllocId, // diagnostics
+        span: Span,        // diagnostics
     ) -> InterpResult<'tcx> {
         self.perform_access(
             AccessKind::Write,
             tag,
             Some(access_range),
             global,
+            alloc_id,
             span,
             diagnostics::AccessCause::Dealloc,
         )?;
@@ -545,6 +547,7 @@ impl<'tcx> Tree {
                         TbError {
                             conflicting_info,
                             access_cause: diagnostics::AccessCause::Dealloc,
+                            alloc_id,
                             error_offset: perms_range.start,
                             error_kind,
                             accessed_info,
@@ -576,6 +579,7 @@ impl<'tcx> Tree {
         tag: BorTag,
         access_range: Option<AllocRange>,
         global: &GlobalState,
+        alloc_id: AllocId,                      // diagnostics
         span: Span,                             // diagnostics
         access_cause: diagnostics::AccessCause, // diagnostics
     ) -> InterpResult<'tcx> {
@@ -628,6 +632,7 @@ impl<'tcx> Tree {
             TbError {
                 conflicting_info,
                 access_cause,
+                alloc_id,
                 error_offset: perms_range.start,
                 error_kind,
                 accessed_info,

--- a/tests/fail/both_borrows/alias_through_mutation.tree.stderr
+++ b/tests/fail/both_borrows/alias_through_mutation.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: read access through <TAG> is forbidden
+error: Undefined Behavior: read access through <TAG> at ALLOC[0x0] is forbidden
   --> $DIR/alias_through_mutation.rs:LL:CC
    |
 LL |     let _val = *target_alias;
-   |                ^^^^^^^^^^^^^ read access through <TAG> is forbidden
+   |                ^^^^^^^^^^^^^ read access through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>

--- a/tests/fail/both_borrows/aliasing_mut1.tree.stderr
+++ b/tests/fail/both_borrows/aliasing_mut1.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: write access through <TAG> is forbidden
+error: Undefined Behavior: write access through <TAG> at ALLOC[0x0] is forbidden
   --> $DIR/aliasing_mut1.rs:LL:CC
    |
 LL |     *x = 1;
-   |     ^^^^^^ write access through <TAG> is forbidden
+   |     ^^^^^^ write access through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> has state Reserved (conflicted) which forbids this child write access

--- a/tests/fail/both_borrows/aliasing_mut2.tree.stderr
+++ b/tests/fail/both_borrows/aliasing_mut2.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: write access through <TAG> is forbidden
+error: Undefined Behavior: write access through <TAG> at ALLOC[0x0] is forbidden
   --> $DIR/aliasing_mut2.rs:LL:CC
    |
 LL |     *y = 2;
-   |     ^^^^^^ write access through <TAG> is forbidden
+   |     ^^^^^^ write access through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> has state Reserved (conflicted) which forbids this child write access

--- a/tests/fail/both_borrows/aliasing_mut3.tree.stderr
+++ b/tests/fail/both_borrows/aliasing_mut3.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: write access through <TAG> is forbidden
+error: Undefined Behavior: write access through <TAG> at ALLOC[0x0] is forbidden
   --> $DIR/aliasing_mut3.rs:LL:CC
    |
 LL |     *x = 1;
-   |     ^^^^^^ write access through <TAG> is forbidden
+   |     ^^^^^^ write access through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> has state Reserved (conflicted) which forbids this child write access

--- a/tests/fail/both_borrows/aliasing_mut4.tree.stderr
+++ b/tests/fail/both_borrows/aliasing_mut4.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: write access through <TAG> is forbidden
+error: Undefined Behavior: write access through <TAG> at ALLOC[0x0] is forbidden
   --> RUSTLIB/core/src/mem/mod.rs:LL:CC
    |
 LL |         ptr::write(dest, src);
-   |         ^^^^^^^^^^^^^^^^^^^^^ write access through <TAG> is forbidden
+   |         ^^^^^^^^^^^^^^^^^^^^^ write access through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is foreign to the protected tag <TAG> (i.e., it is not a child)

--- a/tests/fail/both_borrows/box_exclusive_violation1.tree.stderr
+++ b/tests/fail/both_borrows/box_exclusive_violation1.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: write access through <TAG> is forbidden
+error: Undefined Behavior: write access through <TAG> at ALLOC[0x0] is forbidden
   --> $DIR/box_exclusive_violation1.rs:LL:CC
    |
 LL |         *LEAK = 7;
-   |         ^^^^^^^^^ write access through <TAG> is forbidden
+   |         ^^^^^^^^^ write access through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>

--- a/tests/fail/both_borrows/box_noalias_violation.tree.stderr
+++ b/tests/fail/both_borrows/box_noalias_violation.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: read access through <TAG> is forbidden
+error: Undefined Behavior: read access through <TAG> at ALLOC[0x0] is forbidden
   --> $DIR/box_noalias_violation.rs:LL:CC
    |
 LL |     *y
-   |     ^^ read access through <TAG> is forbidden
+   |     ^^ read access through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is foreign to the protected tag <TAG> (i.e., it is not a child)

--- a/tests/fail/both_borrows/buggy_as_mut_slice.tree.stderr
+++ b/tests/fail/both_borrows/buggy_as_mut_slice.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: write access through <TAG> is forbidden
+error: Undefined Behavior: write access through <TAG> at ALLOC[0x4] is forbidden
   --> $DIR/buggy_as_mut_slice.rs:LL:CC
    |
 LL |     v2[1] = 7;
-   |     ^^^^^^^^^ write access through <TAG> is forbidden
+   |     ^^^^^^^^^ write access through <TAG> at ALLOC[0x4] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>

--- a/tests/fail/both_borrows/buggy_split_at_mut.tree.stderr
+++ b/tests/fail/both_borrows/buggy_split_at_mut.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: write access through <TAG> is forbidden
+error: Undefined Behavior: write access through <TAG> at ALLOC[0x4] is forbidden
   --> $DIR/buggy_split_at_mut.rs:LL:CC
    |
 LL |     b[1] = 6;
-   |     ^^^^^^^^ write access through <TAG> is forbidden
+   |     ^^^^^^^^ write access through <TAG> at ALLOC[0x4] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>

--- a/tests/fail/both_borrows/illegal_write1.tree.stderr
+++ b/tests/fail/both_borrows/illegal_write1.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: write access through <TAG> is forbidden
+error: Undefined Behavior: write access through <TAG> at ALLOC[0x0] is forbidden
   --> $DIR/illegal_write1.rs:LL:CC
    |
 LL |         unsafe { *x = 42 };
-   |                  ^^^^^^^ write access through <TAG> is forbidden
+   |                  ^^^^^^^ write access through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> has state Frozen which forbids this child write access

--- a/tests/fail/both_borrows/illegal_write5.tree.stderr
+++ b/tests/fail/both_borrows/illegal_write5.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: read access through <TAG> is forbidden
+error: Undefined Behavior: read access through <TAG> at ALLOC[0x0] is forbidden
   --> $DIR/illegal_write5.rs:LL:CC
    |
 LL |     let _val = *xref;
-   |                ^^^^^ read access through <TAG> is forbidden
+   |                ^^^^^ read access through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>

--- a/tests/fail/both_borrows/illegal_write6.tree.stderr
+++ b/tests/fail/both_borrows/illegal_write6.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: write access through <TAG> is forbidden
+error: Undefined Behavior: write access through <TAG> at ALLOC[0x0] is forbidden
   --> $DIR/illegal_write6.rs:LL:CC
    |
 LL |     unsafe { *y = 2 };
-   |              ^^^^^^ write access through <TAG> is forbidden
+   |              ^^^^^^ write access through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is foreign to the protected tag <TAG> (i.e., it is not a child)

--- a/tests/fail/both_borrows/invalidate_against_protector2.tree.stderr
+++ b/tests/fail/both_borrows/invalidate_against_protector2.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: write access through <TAG> is forbidden
+error: Undefined Behavior: write access through <TAG> at ALLOC[0x0] is forbidden
   --> $DIR/invalidate_against_protector2.rs:LL:CC
    |
 LL |     unsafe { *x = 0 };
-   |              ^^^^^^ write access through <TAG> is forbidden
+   |              ^^^^^^ write access through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is foreign to the protected tag <TAG> (i.e., it is not a child)

--- a/tests/fail/both_borrows/invalidate_against_protector3.tree.stderr
+++ b/tests/fail/both_borrows/invalidate_against_protector3.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: write access through <TAG> (root of the allocation) is forbidden
+error: Undefined Behavior: write access through <TAG> (root of the allocation) at ALLOC[0x0] is forbidden
   --> $DIR/invalidate_against_protector3.rs:LL:CC
    |
 LL |     unsafe { *x = 0 };
-   |              ^^^^^^ write access through <TAG> (root of the allocation) is forbidden
+   |              ^^^^^^ write access through <TAG> (root of the allocation) at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> (root of the allocation) is foreign to the protected tag <TAG> (i.e., it is not a child)

--- a/tests/fail/both_borrows/load_invalid_shr.tree.stderr
+++ b/tests/fail/both_borrows/load_invalid_shr.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: reborrow through <TAG> is forbidden
+error: Undefined Behavior: reborrow through <TAG> at ALLOC[0x0] is forbidden
   --> $DIR/load_invalid_shr.rs:LL:CC
    |
 LL |     let _val = *xref_in_mem;
-   |                ^^^^^^^^^^^^ reborrow through <TAG> is forbidden
+   |                ^^^^^^^^^^^^ reborrow through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>

--- a/tests/fail/both_borrows/mut_exclusive_violation1.tree.stderr
+++ b/tests/fail/both_borrows/mut_exclusive_violation1.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: write access through <TAG> is forbidden
+error: Undefined Behavior: write access through <TAG> at ALLOC[0x0] is forbidden
   --> $DIR/mut_exclusive_violation1.rs:LL:CC
    |
 LL |         *LEAK = 7;
-   |         ^^^^^^^^^ write access through <TAG> is forbidden
+   |         ^^^^^^^^^ write access through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>

--- a/tests/fail/both_borrows/mut_exclusive_violation2.tree.stderr
+++ b/tests/fail/both_borrows/mut_exclusive_violation2.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: write access through <TAG> is forbidden
+error: Undefined Behavior: write access through <TAG> at ALLOC[0x0] is forbidden
   --> $DIR/mut_exclusive_violation2.rs:LL:CC
    |
 LL |         *raw1 = 3;
-   |         ^^^^^^^^^ write access through <TAG> is forbidden
+   |         ^^^^^^^^^ write access through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>

--- a/tests/fail/both_borrows/newtype_pair_retagging.tree.stderr
+++ b/tests/fail/both_borrows/newtype_pair_retagging.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: deallocation through <TAG> is forbidden
+error: Undefined Behavior: deallocation through <TAG> at ALLOC[0x0] is forbidden
   --> RUSTLIB/alloc/src/alloc.rs:LL:CC
    |
 LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocation through <TAG> is forbidden
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocation through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is foreign to the protected tag <TAG> (i.e., it is not a child)

--- a/tests/fail/both_borrows/newtype_retagging.tree.stderr
+++ b/tests/fail/both_borrows/newtype_retagging.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: deallocation through <TAG> is forbidden
+error: Undefined Behavior: deallocation through <TAG> at ALLOC[0x0] is forbidden
   --> RUSTLIB/alloc/src/alloc.rs:LL:CC
    |
 LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocation through <TAG> is forbidden
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocation through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is foreign to the protected tag <TAG> (i.e., it is not a child)

--- a/tests/fail/both_borrows/outdated_local.tree.stderr
+++ b/tests/fail/both_borrows/outdated_local.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: read access through <TAG> is forbidden
+error: Undefined Behavior: read access through <TAG> at ALLOC[0x0] is forbidden
   --> $DIR/outdated_local.rs:LL:CC
    |
 LL |     assert_eq!(unsafe { *y }, 1);
-   |                         ^^ read access through <TAG> is forbidden
+   |                         ^^ read access through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> has state Disabled which forbids this child read access

--- a/tests/fail/both_borrows/pass_invalid_shr.tree.stderr
+++ b/tests/fail/both_borrows/pass_invalid_shr.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: reborrow through <TAG> is forbidden
+error: Undefined Behavior: reborrow through <TAG> at ALLOC[0x0] is forbidden
   --> $DIR/pass_invalid_shr.rs:LL:CC
    |
 LL |     foo(xref);
-   |         ^^^^ reborrow through <TAG> is forbidden
+   |         ^^^^ reborrow through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> has state Disabled which forbids this reborrow (acting as a child read access)

--- a/tests/fail/both_borrows/pass_invalid_shr_option.tree.stderr
+++ b/tests/fail/both_borrows/pass_invalid_shr_option.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: reborrow through <TAG> is forbidden
+error: Undefined Behavior: reborrow through <TAG> at ALLOC[0x0] is forbidden
   --> $DIR/pass_invalid_shr_option.rs:LL:CC
    |
 LL |     foo(some_xref);
-   |         ^^^^^^^^^ reborrow through <TAG> is forbidden
+   |         ^^^^^^^^^ reborrow through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>

--- a/tests/fail/both_borrows/pass_invalid_shr_tuple.tree.stderr
+++ b/tests/fail/both_borrows/pass_invalid_shr_tuple.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: reborrow through <TAG> is forbidden
+error: Undefined Behavior: reborrow through <TAG> at ALLOC[0x0] is forbidden
   --> $DIR/pass_invalid_shr_tuple.rs:LL:CC
    |
 LL |     foo(pair_xref);
-   |         ^^^^^^^^^ reborrow through <TAG> is forbidden
+   |         ^^^^^^^^^ reborrow through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>

--- a/tests/fail/both_borrows/return_invalid_shr.tree.stderr
+++ b/tests/fail/both_borrows/return_invalid_shr.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: reborrow through <TAG> is forbidden
+error: Undefined Behavior: reborrow through <TAG> at ALLOC[0x4] is forbidden
   --> $DIR/return_invalid_shr.rs:LL:CC
    |
 LL |     ret
-   |     ^^^ reborrow through <TAG> is forbidden
+   |     ^^^ reborrow through <TAG> at ALLOC[0x4] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> has state Disabled which forbids this reborrow (acting as a child read access)

--- a/tests/fail/both_borrows/return_invalid_shr_option.tree.stderr
+++ b/tests/fail/both_borrows/return_invalid_shr_option.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: reborrow through <TAG> is forbidden
+error: Undefined Behavior: reborrow through <TAG> at ALLOC[0x4] is forbidden
   --> $DIR/return_invalid_shr_option.rs:LL:CC
    |
 LL |     ret
-   |     ^^^ reborrow through <TAG> is forbidden
+   |     ^^^ reborrow through <TAG> at ALLOC[0x4] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>

--- a/tests/fail/both_borrows/return_invalid_shr_tuple.tree.stderr
+++ b/tests/fail/both_borrows/return_invalid_shr_tuple.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: reborrow through <TAG> is forbidden
+error: Undefined Behavior: reborrow through <TAG> at ALLOC[0x4] is forbidden
   --> $DIR/return_invalid_shr_tuple.rs:LL:CC
    |
 LL |     ret
-   |     ^^^ reborrow through <TAG> is forbidden
+   |     ^^^ reborrow through <TAG> at ALLOC[0x4] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>

--- a/tests/fail/both_borrows/shr_frozen_violation1.tree.stderr
+++ b/tests/fail/both_borrows/shr_frozen_violation1.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: write access through <TAG> is forbidden
+error: Undefined Behavior: write access through <TAG> at ALLOC[0x0] is forbidden
   --> $DIR/shr_frozen_violation1.rs:LL:CC
    |
 LL |         *(x as *const i32 as *mut i32) = 7;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ write access through <TAG> is forbidden
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ write access through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>

--- a/tests/fail/both_borrows/shr_frozen_violation2.tree.stderr
+++ b/tests/fail/both_borrows/shr_frozen_violation2.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: read access through <TAG> is forbidden
+error: Undefined Behavior: read access through <TAG> at ALLOC[0x0] is forbidden
   --> $DIR/shr_frozen_violation2.rs:LL:CC
    |
 LL |         let _val = *frozen;
-   |                    ^^^^^^^ read access through <TAG> is forbidden
+   |                    ^^^^^^^ read access through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> has state Disabled which forbids this child read access

--- a/tests/fail/function_calls/arg_inplace_mutate.tree.stderr
+++ b/tests/fail/function_calls/arg_inplace_mutate.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: write access through <TAG> (root of the allocation) is forbidden
+error: Undefined Behavior: write access through <TAG> (root of the allocation) at ALLOC[0x0] is forbidden
   --> $DIR/arg_inplace_mutate.rs:LL:CC
    |
 LL |     unsafe { ptr.write(S(0)) };
-   |              ^^^^^^^^^^^^^^^ write access through <TAG> (root of the allocation) is forbidden
+   |              ^^^^^^^^^^^^^^^ write access through <TAG> (root of the allocation) at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> (root of the allocation) is foreign to the protected tag <TAG> (i.e., it is not a child)

--- a/tests/fail/function_calls/arg_inplace_observe_during.tree.stderr
+++ b/tests/fail/function_calls/arg_inplace_observe_during.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: read access through <TAG> (root of the allocation) is forbidden
+error: Undefined Behavior: read access through <TAG> (root of the allocation) at ALLOC[0x0] is forbidden
   --> $DIR/arg_inplace_observe_during.rs:LL:CC
    |
 LL |     unsafe { ptr.read() };
-   |              ^^^^^^^^^^ read access through <TAG> (root of the allocation) is forbidden
+   |              ^^^^^^^^^^ read access through <TAG> (root of the allocation) at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> (root of the allocation) is foreign to the protected tag <TAG> (i.e., it is not a child)

--- a/tests/fail/function_calls/return_pointer_aliasing.tree.stderr
+++ b/tests/fail/function_calls/return_pointer_aliasing.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: read access through <TAG> (root of the allocation) is forbidden
+error: Undefined Behavior: read access through <TAG> (root of the allocation) at ALLOC[0x0] is forbidden
   --> $DIR/return_pointer_aliasing.rs:LL:CC
    |
 LL |     unsafe { ptr.read() };
-   |              ^^^^^^^^^^ read access through <TAG> (root of the allocation) is forbidden
+   |              ^^^^^^^^^^ read access through <TAG> (root of the allocation) at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> (root of the allocation) is foreign to the protected tag <TAG> (i.e., it is not a child)

--- a/tests/fail/function_calls/return_pointer_aliasing2.tree.stderr
+++ b/tests/fail/function_calls/return_pointer_aliasing2.tree.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: write access through <TAG> (root of the allocation) is forbidden
+error: Undefined Behavior: write access through <TAG> (root of the allocation) at ALLOC[0x0] is forbidden
   --> $DIR/return_pointer_aliasing2.rs:LL:CC
    |
 LL |     unsafe { ptr.write(0) };
-   |              ^^^^^^^^^^^^ write access through <TAG> (root of the allocation) is forbidden
+   |              ^^^^^^^^^^^^ write access through <TAG> (root of the allocation) at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> (root of the allocation) is foreign to the protected tag <TAG> (i.e., it is not a child)

--- a/tests/fail/tree_borrows/alternate-read-write.stderr
+++ b/tests/fail/tree_borrows/alternate-read-write.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: write access through <TAG> is forbidden
+error: Undefined Behavior: write access through <TAG> at ALLOC[0x0] is forbidden
   --> $DIR/alternate-read-write.rs:LL:CC
    |
 LL |     *y += 1; // Failure
-   |     ^^^^^^^ write access through <TAG> is forbidden
+   |     ^^^^^^^ write access through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>

--- a/tests/fail/tree_borrows/children-can-alias.uniq.stderr
+++ b/tests/fail/tree_borrows/children-can-alias.uniq.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: write access through <TAG> is forbidden
+error: Undefined Behavior: write access through <TAG> at ALLOC[0x0] is forbidden
   --> $DIR/children-can-alias.rs:LL:CC
    |
 LL |     child2.write(2);
-   |     ^^^^^^^^^^^^^^^ write access through <TAG> is forbidden
+   |     ^^^^^^^^^^^^^^^ write access through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>

--- a/tests/fail/tree_borrows/error-range.stderr
+++ b/tests/fail/tree_borrows/error-range.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: read access through <TAG> is forbidden
+error: Undefined Behavior: read access through <TAG> at ALLOC[0x5] is forbidden
   --> $DIR/error-range.rs:LL:CC
    |
 LL |         rmut[5] += 1;
-   |         ^^^^^^^^^^^^ read access through <TAG> is forbidden
+   |         ^^^^^^^^^^^^ read access through <TAG> at ALLOC[0x5] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>

--- a/tests/fail/tree_borrows/fnentry_invalidation.stderr
+++ b/tests/fail/tree_borrows/fnentry_invalidation.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: write access through <TAG> is forbidden
+error: Undefined Behavior: write access through <TAG> at ALLOC[0x0] is forbidden
   --> $DIR/fnentry_invalidation.rs:LL:CC
    |
 LL |         *z = 2;
-   |         ^^^^^^ write access through <TAG> is forbidden
+   |         ^^^^^^ write access through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> has state Frozen which forbids this child write access

--- a/tests/fail/tree_borrows/outside-range.stderr
+++ b/tests/fail/tree_borrows/outside-range.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: write access through <TAG> is forbidden
+error: Undefined Behavior: write access through <TAG> at ALLOC[0x3] is forbidden
   --> $DIR/outside-range.rs:LL:CC
    |
 LL |     *y.add(3) = 42;
-   |     ^^^^^^^^^^^^^^ write access through <TAG> is forbidden
+   |     ^^^^^^^^^^^^^^ write access through <TAG> at ALLOC[0x3] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is foreign to the protected tag <TAG> (i.e., it is not a child)

--- a/tests/fail/tree_borrows/parent_read_freezes_raw_mut.stderr
+++ b/tests/fail/tree_borrows/parent_read_freezes_raw_mut.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: write access through <TAG> is forbidden
+error: Undefined Behavior: write access through <TAG> at ALLOC[0x0] is forbidden
   --> $DIR/parent_read_freezes_raw_mut.rs:LL:CC
    |
 LL |         *ptr = 0;
-   |         ^^^^^^^^ write access through <TAG> is forbidden
+   |         ^^^^^^^^ write access through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> has state Frozen which forbids this child write access

--- a/tests/fail/tree_borrows/pass_invalid_mut.stderr
+++ b/tests/fail/tree_borrows/pass_invalid_mut.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: write access through <TAG> is forbidden
+error: Undefined Behavior: write access through <TAG> at ALLOC[0x0] is forbidden
   --> $DIR/pass_invalid_mut.rs:LL:CC
    |
 LL |     *nope = 31;
-   |     ^^^^^^^^^^ write access through <TAG> is forbidden
+   |     ^^^^^^^^^^ write access through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>

--- a/tests/fail/tree_borrows/reserved/cell-protected-write.stderr
+++ b/tests/fail/tree_borrows/reserved/cell-protected-write.stderr
@@ -8,11 +8,11 @@ Warning: this tree is indicative only. Some tags may have been hidden.
 | RsM |        │   └────<TAG=callee:x> Strongly protected
 | RsM |        └────<TAG=y, callee:y, caller:y>
 ──────────────────────────────────────────────────
-error: Undefined Behavior: write access through <TAG> (y, callee:y, caller:y) is forbidden
+error: Undefined Behavior: write access through <TAG> (y, callee:y, caller:y) at ALLOC[0x0] is forbidden
   --> $DIR/cell-protected-write.rs:LL:CC
    |
 LL |             *y = 1;
-   |             ^^^^^^ write access through <TAG> (y, callee:y, caller:y) is forbidden
+   |             ^^^^^^ write access through <TAG> (y, callee:y, caller:y) at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> (y, callee:y, caller:y) is foreign to the protected tag <TAG> (callee:x) (i.e., it is not a child)

--- a/tests/fail/tree_borrows/reserved/int-protected-write.stderr
+++ b/tests/fail/tree_borrows/reserved/int-protected-write.stderr
@@ -8,11 +8,11 @@ Warning: this tree is indicative only. Some tags may have been hidden.
 | Rs  |        │   └────<TAG=callee:x> Strongly protected
 | Rs  |        └────<TAG=y, callee:y, caller:y>
 ──────────────────────────────────────────────────
-error: Undefined Behavior: write access through <TAG> (y, callee:y, caller:y) is forbidden
+error: Undefined Behavior: write access through <TAG> (y, callee:y, caller:y) at ALLOC[0x0] is forbidden
   --> $DIR/int-protected-write.rs:LL:CC
    |
 LL |             *y = 0;
-   |             ^^^^^^ write access through <TAG> (y, callee:y, caller:y) is forbidden
+   |             ^^^^^^ write access through <TAG> (y, callee:y, caller:y) at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> (y, callee:y, caller:y) is foreign to the protected tag <TAG> (callee:x) (i.e., it is not a child)

--- a/tests/fail/tree_borrows/return_invalid_mut.stderr
+++ b/tests/fail/tree_borrows/return_invalid_mut.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: write access through <TAG> is forbidden
+error: Undefined Behavior: write access through <TAG> at ALLOC[0x4] is forbidden
   --> $DIR/return_invalid_mut.rs:LL:CC
    |
 LL |     *ret = 3;
-   |     ^^^^^^^^ write access through <TAG> is forbidden
+   |     ^^^^^^^^ write access through <TAG> at ALLOC[0x4] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>

--- a/tests/fail/tree_borrows/spurious_read.stderr
+++ b/tests/fail/tree_borrows/spurious_read.stderr
@@ -11,11 +11,11 @@ Thread 2 executing: ret x
 Thread 2 executing: write y
 Thread 1 executing: write y
 Thread 1 executing: ret y
-error: Undefined Behavior: write access through <TAG> is forbidden
+error: Undefined Behavior: write access through <TAG> at ALLOC[0x0] is forbidden
   --> $DIR/spurious_read.rs:LL:CC
    |
 LL |                 *y = 2;
-   |                 ^^^^^^ write access through <TAG> is forbidden
+   |                 ^^^^^^ write access through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> has state Reserved (conflicted) which forbids this child write access

--- a/tests/fail/tree_borrows/strongly-protected.stderr
+++ b/tests/fail/tree_borrows/strongly-protected.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: deallocation through <TAG> is forbidden
+error: Undefined Behavior: deallocation through <TAG> at ALLOC[0x0] is forbidden
   --> RUSTLIB/alloc/src/alloc.rs:LL:CC
    |
 LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocation through <TAG> is forbidden
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocation through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the allocation of the accessed tag <TAG> also contains the strongly protected tag <TAG>

--- a/tests/fail/tree_borrows/unique.default.stderr
+++ b/tests/fail/tree_borrows/unique.default.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: write access through <TAG> is forbidden
+error: Undefined Behavior: write access through <TAG> at ALLOC[0x0] is forbidden
   --> $DIR/unique.rs:LL:CC
    |
 LL |         *uniq.as_ptr() = 3;
-   |         ^^^^^^^^^^^^^^^^^^ write access through <TAG> is forbidden
+   |         ^^^^^^^^^^^^^^^^^^ write access through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> has state Frozen which forbids this child write access

--- a/tests/fail/tree_borrows/unique.uniq.stderr
+++ b/tests/fail/tree_borrows/unique.uniq.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: write access through <TAG> is forbidden
+error: Undefined Behavior: write access through <TAG> at ALLOC[0x0] is forbidden
   --> $DIR/unique.rs:LL:CC
    |
 LL |         *uniq.as_ptr() = 2;
-   |         ^^^^^^^^^^^^^^^^^^ write access through <TAG> is forbidden
+   |         ^^^^^^^^^^^^^^^^^^ write access through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>

--- a/tests/fail/tree_borrows/write-during-2phase.stderr
+++ b/tests/fail/tree_borrows/write-during-2phase.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: reborrow through <TAG> is forbidden
+error: Undefined Behavior: reborrow through <TAG> at ALLOC[0x0] is forbidden
   --> $DIR/write-during-2phase.rs:LL:CC
    |
 LL |     fn add(&mut self, n: u64) -> u64 {
-   |            ^^^^^^^^^ reborrow through <TAG> is forbidden
+   |            ^^^^^^^^^ reborrow through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> has state Disabled which forbids this reborrow (acting as a child read access)


### PR DESCRIPTION
print where the forbidden access happens; make tag tracking less verbose