### PR TITLE
disable diagnostic deduplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,8 +318,8 @@ environment variable. We first document the most relevant and most commonly used
   and `warn-nobacktrace` are the supported actions. The default is to `abort`,
   which halts the machine. Some (but not all) operations also support continuing
   execution with a "permission denied" error being returned to the program.
-  `warn` prints a full backtrace when that happens; `warn-nobacktrace` is less
-  verbose. `hide` hides the warning entirely.
+  `warn` prints a full backtrace each time that happens; `warn-nobacktrace` is less
+  verbose and shown at most once per operation. `hide` hides the warning entirely.
 * `-Zmiri-num-cpus` states the number of available CPUs to be reported by miri. By default, the
   number of available CPUs is `1`. Note that this flag does not affect how miri handles threads in
   any way.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,4 +143,7 @@ pub const MIRI_DEFAULT_ARGS: &[&str] = &[
     "-Zmir-keep-place-mention",
     "-Zmir-opt-level=0",
     "-Zmir-enable-passes=-CheckAlignment",
+    // Deduplicating diagnostics means we miss events when tracking what happens during an
+    // execution. Let's not do that.
+    "-Zdeduplicate-diagnostics=no",
 ];

--- a/tests/fail/const-ub-checks.stderr
+++ b/tests/fail/const-ub-checks.stderr
@@ -10,6 +10,14 @@ note: erroneous constant encountered
 LL |     let _x = UNALIGNED_READ;
    |              ^^^^^^^^^^^^^^
 
+note: erroneous constant encountered
+  --> $DIR/const-ub-checks.rs:LL:CC
+   |
+LL |     let _x = UNALIGNED_READ;
+   |              ^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/fail/erroneous_const2.stderr
+++ b/tests/fail/erroneous_const2.stderr
@@ -16,6 +16,14 @@ note: erroneous constant encountered
 LL |     println!("{}", FOO);
    |                    ^^^
    |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+note: erroneous constant encountered
+  --> $DIR/erroneous_const2.rs:LL:CC
+   |
+LL |     println!("{}", FOO);
+   |                    ^^^
+   |
    = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/pass-dep/concurrency/linux-futex.rs
+++ b/tests/pass-dep/concurrency/linux-futex.rs
@@ -219,6 +219,7 @@ fn wait_wake_bitset() {
     t.join().unwrap();
 }
 
+// Crucial test which relies on the SeqCst fences in futex wait/wake.
 fn concurrent_wait_wake() {
     const FREE: i32 = 0;
     const HELD: i32 = 1;


### PR DESCRIPTION
@oli-obk is there a better way to do this? Ideally we'd only set this when interpretation starts but the value in the compiler session seems to be immutable. I assume people will do `cargo check` before `cargo miri` so hopefully this won't lead to too much confusion.

Fixes https://github.com/rust-lang/miri/issues/3350