### PR TITLE
we properly rebuild the cache now when MIRI_LIB_SRC contents change

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,11 +465,7 @@ Moreover, Miri recognizes some environment variables:
 * `MIRI_LIB_SRC` defines the directory where Miri expects the sources of the
   standard library that it will build and use for interpretation. This directory
   must point to the `library` subdirectory of a `rust-lang/rust` repository
-  checkout. Note that changing files in that directory does not automatically
-  trigger a re-build of the standard library; you have to clear the Miri build
-  cache with `cargo miri clean` or deleting it manually (on Linux, `rm -rf ~/.cache/miri`;
-  on Windows, `rmdir /S "%LOCALAPPDATA%\rust-lang\miri\cache"`;
-  and on macOS, `rm -rf ~/Library/Caches/org.rust-lang.miri`).
+  checkout.
 * `MIRI_SYSROOT` (recognized by `cargo miri` and the Miri driver) indicates the sysroot to use. When
   using `cargo miri`, this skips the automatic setup -- only set this if you do not want to use the
   automatically created sysroot. For directly invoking the Miri driver, this variable (or a


### PR DESCRIPTION
Thanks to https://github.com/RalfJung/rustc-build-sysroot/pull/16