### PR TITLE
rename tests/compiletest → tests/ui

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ tempfile = "3"
 rustc_private = true
 
 [[test]]
-name = "compiletest"
+name = "ui"
 harness = false
 
 [features]

--- a/miri-script/src/commands.rs
+++ b/miri-script/src/commands.rs
@@ -510,11 +510,11 @@ impl Command {
         let miri_flags = flagsplit(&miri_flags);
         let toolchain = &e.toolchain;
         let extra_flags = &e.cargo_extra_flags;
-        let edition_flags = (!have_edition).then_some("--edition=2021"); // keep in sync with `compiletest.rs`.`
+        let edition_flags = (!have_edition).then_some("--edition=2021"); // keep in sync with `tests/ui.rs`.`
         if dep {
             cmd!(
                 e.sh,
-                "cargo +{toolchain} --quiet test --test compiletest {extra_flags...} --manifest-path {miri_manifest} -- --miri-run-dep-mode {miri_flags...} {edition_flags...} {flags...}"
+                "cargo +{toolchain} --quiet test {extra_flags...} --manifest-path {miri_manifest} --test ui -- --miri-run-dep-mode {miri_flags...} {edition_flags...} {flags...}"
             ).quiet().run()?;
         } else {
             cmd!(

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -241,7 +241,7 @@ fn main() -> Result<()> {
     ui_test::color_eyre::install()?;
 
     let target = get_target();
-    let tmpdir = tempfile::Builder::new().prefix("miri-compiletest-").tempdir()?;
+    let tmpdir = tempfile::Builder::new().prefix("miri-uitest-").tempdir()?;
 
     let mut args = std::env::args_os();
 


### PR DESCRIPTION
This hasn't been `compiletest` in a while.