### PR TITLE
Improve sysroots notification

### DIFF
--- a/.github/workflows/sysroots.yml
+++ b/.github/workflows/sysroots.yml
@@ -21,6 +21,13 @@ jobs:
           ./miri install
           python3 -m pip install beautifulsoup4
           ./ci/build-all-targets.sh
+      - name: Upload build errors
+        # We don't want to skip this step on failure
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: failures
+          path: failures.tar.gz
 
   sysroots-cron-fail-notify:
     name: sysroots cronjob failure notification
@@ -28,6 +35,11 @@ jobs:
     needs: [sysroots]
     if: failure() || cancelled()
     steps:
+      # Download our build error logs
+      - name: Download build errors
+        uses: actions/download-artifact@v4
+        with:
+          name: failures
       # Send a Zulip notification
       - name: Install zulip-send
         run: pip3 install zulip
@@ -36,11 +48,12 @@ jobs:
           ZULIP_BOT_EMAIL: ${{ secrets.ZULIP_BOT_EMAIL }}
           ZULIP_API_TOKEN: ${{ secrets.ZULIP_API_TOKEN }}
         run: |
+          tar xf failures.tar.gz
+          ls failures
           ~/.local/bin/zulip-send --user $ZULIP_BOT_EMAIL --api-key $ZULIP_API_TOKEN --site https://rust-lang.zulipchat.com \
-            --stream miri --subject "Cron Job Failure (miri, $(date -u +%Y-%m))" \
-            --message 'Dear @*T-miri*,
-
-          It would appear that the [Miri sysroots cron job build]('"https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"') failed.
+            --stream miri --subject "Sysroot Build Errors (miri, $(date -u +%Y-%m))" \
+            --message 'It would appear that the [Miri sysroots cron job build]('"https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"') failed to build these targets:
+          $(ls failures)
 
           Would you mind investigating this issue?
 

--- a/ci/build-all-targets.sh
+++ b/ci/build-all-targets.sh
@@ -3,6 +3,7 @@
 set -eu
 set -o pipefail
 
+# .github/workflows/sysroots.yml relies on this name this to report which sysroots didn't build
 FAILS_DIR=failures
 
 rm -rf $FAILS_DIR
@@ -13,14 +14,16 @@ PLATFORM_SUPPORT_FILE=$(rustc +miri --print sysroot)/share/doc/rust/html/rustc/p
 for target in $(python3 ci/scrape-targets.py $PLATFORM_SUPPORT_FILE); do
     # Wipe the cache before every build to minimize disk usage
     cargo +miri miri clean
-    if cargo +miri miri setup --target $target 2>&1 | tee failures/$target; then
+    if cargo +miri miri setup --target $target 2>&1 | tee $FAILS_DIR/$target; then
         # If the build succeeds, delete its output. If we have output, a build failed.
         rm $FAILS_DIR/$target
     fi
 done
 
+tar czf $FAILS_DIR.tar.gz $FAILS_DIR
+
 # If the sysroot for any target fails to build, we will have a file in FAILS_DIR.
-if [[ $(ls failures | wc -l) -ne 0 ]]; then
+if [[ $(ls $FAILS_DIR | wc -l) -ne 0 ]]; then
     echo "Sysroots for the following targets failed to build:"
     ls $FAILS_DIR
     exit 1


### PR DESCRIPTION
* Removes the T-miri ping (because these failures can't be acted on quickly, ergo they cannot be urgent)
* Puts the message in a separate Zulip topic
* Lists which targets failed to build in the Zulip message