### PR TITLE
make 'invalidate' benchmark shorter

### DIFF
--- a/bench-cargo-miri/invalidate/src/main.rs
+++ b/bench-cargo-miri/invalidate/src/main.rs
@@ -1,4 +1,4 @@
 fn main() {
     // The end of the range is just chosen to make the benchmark run for a few seconds.
-    for _ in 0..200_000 {}
+    for _ in 0..50_000 {}
 }

--- a/bench-cargo-miri/range-iteration/Cargo.lock
+++ b/bench-cargo-miri/range-iteration/Cargo.lock
@@ -3,5 +3,5 @@
 version = 3
 
 [[package]]
-name = "invalidate"
+name = "range-iteration"
 version = "0.1.0"

--- a/bench-cargo-miri/range-iteration/Cargo.toml
+++ b/bench-cargo-miri/range-iteration/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "invalidate"
+name = "range-iteration"
 version = "0.1.0"
 edition = "2021"
 

--- a/bench-cargo-miri/range-iteration/src/main.rs
+++ b/bench-cargo-miri/range-iteration/src/main.rs
@@ -1,3 +1,4 @@
+//! This generates a lot of work for the AllocId part of the GC.
 fn main() {
     // The end of the range is just chosen to make the benchmark run for a few seconds.
     for _ in 0..50_000 {}


### PR DESCRIPTION
This is currently by far the slowest benchmark in our suite, taking >9s, when the second slowest takes 2.7s. So let's speed this up to 2.3s, making it still the second-slowest in the benchmark suite.

@saethlin any objections? Also, why is this called "invalidate"? It got added in https://github.com/rust-lang/miri/pull/3083 but I can't figure out the point of that name even after looking at the PR.^^ There should be a comment in the benchmark explaining what it is testing.