### PR TITLE
Allow `llvm.x86.sse2.pause` instrinsic to be called without SSE2

### DIFF
--- a/src/shims/x86/sse2.rs
+++ b/src/shims/x86/sse2.rs
@@ -580,12 +580,6 @@ pub(super) trait EvalContextExt<'mir, 'tcx: 'mir>:
                     this.copy_op(&this.project_index(&left, i)?, &this.project_index(&dest, i)?)?;
                 }
             }
-            // Used to implement the `_mm_pause` function.
-            // The intrinsic is used to hint the processor that the code is in a spin-loop.
-            "pause" => {
-                let [] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
-                this.yield_active_thread();
-            }
             _ => return Ok(EmulateForeignItemResult::NotSupported),
         }
         Ok(EmulateForeignItemResult::NeedsJumping)

--- a/tests/pass/intrinsics-x86-pause-without-sse2.rs
+++ b/tests/pass/intrinsics-x86-pause-without-sse2.rs
@@ -1,0 +1,25 @@
+// Ignore everything except x86 and x86_64
+// Any new targets that are added to CI should be ignored here.
+// (We cannot use `cfg`-based tricks here since the `target-feature` flags below only work on x86.)
+//@ignore-target-aarch64
+//@ignore-target-arm
+//@ignore-target-avr
+//@ignore-target-s390x
+//@ignore-target-thumbv7em
+//@ignore-target-wasm32
+//@compile-flags: -C target-feature=-sse2
+
+#[cfg(target_arch = "x86")]
+use std::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64::*;
+
+fn main() {
+    assert!(!is_x86_feature_detected!("sse2"));
+
+    unsafe {
+        // This is a SSE2 intrinsic, but it behaves as a no-op when SSE2
+        // is not available, so it is always safe to call.
+        _mm_pause();
+    }
+}

--- a/tests/pass/intrinsics-x86-sse2.rs
+++ b/tests/pass/intrinsics-x86-sse2.rs
@@ -54,6 +54,11 @@ mod tests {
             }
         }
 
+        fn test_mm_pause() {
+            unsafe { _mm_pause() }
+        }
+        test_mm_pause();
+
         #[target_feature(enable = "sse2")]
         unsafe fn test_mm_avg_epu8() {
             let (a, b) = (_mm_set1_epi8(3), _mm_set1_epi8(9));


### PR DESCRIPTION
The instrinsic is compiled to a `pause` instruction, which behaves like a no-op when SSE2 is not available.

https://www.felixcloutier.com/x86/pause.html