### PR TITLE
make CI failures easier to interpret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
             host_target: i686-pc-windows-msvc
     runs-on: ${{ matrix.os }}
     env:
-      RUST_BACKTRACE: 1
       HOST_TARGET: ${{ matrix.host_target }}
     steps:
       - uses: actions/checkout@v3

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -4,6 +4,7 @@ use std::ffi::OsString;
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::{env, process::Command};
+use ui_test::color_eyre::eyre::Context;
 use ui_test::{color_eyre::Result, Config, Match, Mode, OutputConflictHandling};
 use ui_test::{status_emitter, CommandBuilder, Format, RustfixMode};
 
@@ -231,6 +232,7 @@ fn ui(
         WithoutDependencies => false,
     };
     run_tests(mode, path, target, with_dependencies, tmpdir)
+        .with_context(|| format!("ui tests in {path} for {target} failed"))
 }
 
 fn get_target() -> String {

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -4,9 +4,11 @@ use std::ffi::OsString;
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::{env, process::Command};
-use ui_test::color_eyre::eyre::Context;
-use ui_test::{color_eyre::Result, Config, Match, Mode, OutputConflictHandling};
-use ui_test::{status_emitter, CommandBuilder, Format, RustfixMode};
+use ui_test::color_eyre::eyre::{Context, Result};
+use ui_test::{
+    status_emitter, CommandBuilder, Config, Format, Match, Mode, OutputConflictHandling,
+    RustfixMode,
+};
 
 fn miri_path() -> PathBuf {
     PathBuf::from(option_env!("MIRI").unwrap_or(env!("CARGO_BIN_EXE_miri")))
@@ -125,6 +127,9 @@ fn run_tests(
     // Let the tests know where to store temp files (they might run for a different target, which can make this hard to find).
     config.program.envs.push(("MIRI_TEMP".into(), Some(tmpdir.to_owned().into())));
 
+    // If a test ICEs, we want to see a backtrace.
+    config.program.envs.push(("RUST_BACKTRACE".into(), Some("1".into())));
+
     // Handle command-line arguments.
     let args = ui_test::Args::test()?;
     let default_bless = env::var_os("RUSTC_BLESS").is_some_and(|v| v != "0");
@@ -224,7 +229,7 @@ fn ui(
     with_dependencies: Dependencies,
     tmpdir: &Path,
 ) -> Result<()> {
-    let msg = format!("## Running ui tests in {path} against miri for {target}");
+    let msg = format!("## Running ui tests in {path} for {target}");
     eprintln!("{}", msg.green().bold());
 
     let with_dependencies = match with_dependencies {


### PR DESCRIPTION
RUST_BACKTRACE=1 means we show 2 backtraces that are almost always irrelevant: from ui_test and from the miri script. Instead let's set the env var inside the test harness so we see backtraces of Miri ICEing but nothing else.