### PR TITLE
miri script: build with stable toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Show Rust version (stable toolchain)
+        run: |
+          rustup show
+          rustc -Vv
+          cargo -V
+
       # Cache the global cargo directory, but NOT the local `target` directory which
       # we cannot reuse anyway when the nightly changes (and it grows quite large
       # over time).
@@ -57,7 +63,7 @@ jobs:
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: cargo install -f rustup-toolchain-install-master
 
-      - name: Install "master" toolchain
+      - name: Install miri toolchain
         run: |
           if [[ ${{ github.event_name }} == 'schedule' ]]; then
             echo "Building against latest rustc git version"
@@ -65,13 +71,13 @@ jobs:
           fi
           ./miri toolchain --host ${{ matrix.host_target }}
 
-      - name: Show Rust version
+      - name: Show Rust version (miri toolchain)
         run: |
           rustup show
           rustc -Vv
           cargo -V
 
-      - name: Test
+      - name: Test Miri
         run: ./ci/ci.sh
 
   style:

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -13,6 +13,15 @@ function endgroup {
 
 begingroup "Building Miri"
 
+# Special Windows hacks
+if [ "$HOST_TARGET" = i686-pc-windows-msvc ]; then
+  # The $BASH variable is `/bin/bash` here, but that path does not actually work. There are some
+  # hacks in place somewhere to try to paper over this, but the hacks dont work either (see
+  # <https://github.com/rust-lang/miri/pull/3402>). So we hard-code the correct location for Github
+  # CI instead.
+  BASH="C:/Program Files/Git/usr/bin/bash"
+fi
+
 # Determine configuration for installed build
 echo "Installing release version of Miri"
 export RUSTFLAGS="-D warnings"
@@ -63,7 +72,7 @@ function run_tests {
     done
 
     # Check that the benchmarks build and run, but without actually benchmarking.
-    HYPERFINE="bash -c" ./miri bench
+    HYPERFINE="'$BASH' -c" ./miri bench
   fi
 
   ## test-cargo-miri

--- a/miri
+++ b/miri
@@ -3,5 +3,5 @@ set -e
 # Instead of doing just `cargo run --manifest-path .. $@`, we invoke miri-script binary directly. Invoking `cargo run` goes through
 # rustup (that sets it's own environmental variables), which is undesirable.
 MIRI_SCRIPT_TARGET_DIR="$(dirname "$0")"/miri-script/target
-cargo build $CARGO_EXTRA_FLAGS -q --target-dir "$MIRI_SCRIPT_TARGET_DIR" --manifest-path "$(dirname "$0")"/miri-script/Cargo.toml
+cargo +stable build $CARGO_EXTRA_FLAGS -q --target-dir "$MIRI_SCRIPT_TARGET_DIR" --manifest-path "$(dirname "$0")"/miri-script/Cargo.toml
 "$MIRI_SCRIPT_TARGET_DIR"/debug/miri-script "$@"

--- a/miri.bat
+++ b/miri.bat
@@ -5,7 +5,7 @@ set MIRI_SCRIPT_TARGET_DIR=%0\..\miri-script\target
 
 :: If any other steps are added, the "|| exit /b" must be appended to early
 :: return from the script. If not, it will continue execution.
-cargo build %CARGO_EXTRA_FLAGS% -q --target-dir %MIRI_SCRIPT_TARGET_DIR% --manifest-path %0\..\miri-script\Cargo.toml || exit /b
+cargo +stable build %CARGO_EXTRA_FLAGS% -q --target-dir %MIRI_SCRIPT_TARGET_DIR% --manifest-path %0\..\miri-script\Cargo.toml || exit /b
 
 :: Forwards all arguments to this file to the executable.
 :: We invoke the binary directly to avoid going through rustup, which would set some extra


### PR DESCRIPTION
`./miri toolchain` sets up a `rustup override miri`. But then if something goes wrong and the `miri` toolchain doesn't work, one can't even run `./miri toolchain` again as building miri-script needs a toolchain...

So let's always use stable to build miri-script, making it override-independent. I assume everyone will have that installed.