### PR TITLE
avoid mutating the global environment

### DIFF
--- a/cargo-miri/src/phases.rs
+++ b/cargo-miri/src/phases.rs
@@ -301,11 +301,6 @@ pub fn phase_rustc(mut args: impl Iterator<Item = String>, phase: RustcPhase) {
         }
     }
 
-    // phase_cargo_miri set `MIRI_BE_RUSTC` for when build scripts directly invoke the driver;
-    // however, if we get called back by cargo here, we'll carefully compute the right flags
-    // ourselves, so we first un-do what the earlier phase did.
-    env::remove_var("MIRI_BE_RUSTC");
-
     let verbose = std::env::var("MIRI_VERBOSE")
         .map_or(0, |verbose| verbose.parse().expect("verbosity flag must be an integer"));
     let target_crate = is_target_crate();
@@ -489,11 +484,6 @@ pub enum RunnerPhase {
 }
 
 pub fn phase_runner(mut binary_args: impl Iterator<Item = String>, phase: RunnerPhase) {
-    // phase_cargo_miri set `MIRI_BE_RUSTC` for when build scripts directly invoke the driver;
-    // however, if we get called back by cargo here, we'll carefully compute the right flags
-    // ourselves, so we first un-do what the earlier phase did.
-    env::remove_var("MIRI_BE_RUSTC");
-
     let verbose = std::env::var("MIRI_VERBOSE")
         .map_or(0, |verbose| verbose.parse().expect("verbosity flag must be an integer"));
 

--- a/cargo-miri/src/util.rs
+++ b/cargo-miri/src/util.rs
@@ -101,7 +101,12 @@ pub fn find_miri() -> PathBuf {
 }
 
 pub fn miri() -> Command {
-    Command::new(find_miri())
+    let mut cmd = Command::new(find_miri());
+    // We never want to inherit this from the environment.
+    // However, this is sometimes set in the environment to work around build scripts that don't
+    // honor RUSTC_WRAPPER. So remove it again in case it is set.
+    cmd.env_remove("MIRI_BE_RUSTC");
+    cmd
 }
 
 pub fn miri_for_host() -> Command {


### PR DESCRIPTION
`remove_var` is just as bad as `set_var`, let's not do that.