### PR TITLE
make 'missing extern static' error consistent with missing shim

### DIFF
--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1066,7 +1066,7 @@ impl<'mir, 'tcx> Machine<'mir, 'tcx> for MiriMachine<'mir, 'tcx> {
             let extern_decl_layout = ecx.tcx.layout_of(ty::ParamEnv::empty().and(def_ty)).unwrap();
             if extern_decl_layout.size != shim_size || extern_decl_layout.align.abi != shim_align {
                 throw_unsup_format!(
-                    "`extern` static `{name}` from crate `{krate}` has been declared \
+                    "extern static `{link_name}` has been declared as `{krate}::{name}` \
                     with a size of {decl_size} bytes and alignment of {decl_align} bytes, \
                     but Miri emulates it via an extern static shim \
                     with a size of {shim_size} bytes and alignment of {shim_align} bytes",
@@ -1080,11 +1080,7 @@ impl<'mir, 'tcx> Machine<'mir, 'tcx> for MiriMachine<'mir, 'tcx> {
             }
             Ok(ptr)
         } else {
-            throw_unsup_format!(
-                "`extern` static `{name}` from crate `{krate}` is not supported by Miri",
-                name = ecx.tcx.def_path_str(def_id),
-                krate = ecx.tcx.crate_name(def_id.krate),
-            )
+            throw_unsup_format!("extern static `{link_name}` is not supported by Miri",)
         }
     }
 

--- a/tests/fail/extern_static.stderr
+++ b/tests/fail/extern_static.stderr
@@ -1,8 +1,8 @@
-error: unsupported operation: `extern` static `FOO` from crate `extern_static` is not supported by Miri
+error: unsupported operation: extern static `FOO` is not supported by Miri
   --> $DIR/extern_static.rs:LL:CC
    |
 LL |     let _val = unsafe { std::ptr::addr_of!(FOO) };
-   |                                            ^^^ `extern` static `FOO` from crate `extern_static` is not supported by Miri
+   |                                            ^^^ extern static `FOO` is not supported by Miri
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
    = note: BACKTRACE:

--- a/tests/fail/extern_static_in_const.stderr
+++ b/tests/fail/extern_static_in_const.stderr
@@ -1,8 +1,8 @@
-error: unsupported operation: `extern` static `E` from crate `extern_static_in_const` is not supported by Miri
+error: unsupported operation: extern static `E` is not supported by Miri
   --> $DIR/extern_static_in_const.rs:LL:CC
    |
 LL |     let _val = X;
-   |                ^ `extern` static `E` from crate `extern_static_in_const` is not supported by Miri
+   |                ^ extern static `E` is not supported by Miri
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
    = note: BACKTRACE:

--- a/tests/fail/extern_static_wrong_size.rs
+++ b/tests/fail/extern_static_wrong_size.rs
@@ -6,5 +6,5 @@ extern "C" {
 }
 
 fn main() {
-    let _val = unsafe { environ }; //~ ERROR: /has been declared with a size of 1 bytes and alignment of 1 bytes, but Miri emulates it via an extern static shim with a size of [48] bytes and alignment of [48] bytes/
+    let _val = unsafe { environ }; //~ ERROR: /with a size of 1 bytes and alignment of 1 bytes, but Miri emulates it via an extern static shim with a size of [48] bytes and alignment of [48] bytes/
 }

--- a/tests/fail/extern_static_wrong_size.stderr
+++ b/tests/fail/extern_static_wrong_size.stderr
@@ -1,8 +1,8 @@
-error: unsupported operation: `extern` static `environ` from crate `extern_static_wrong_size` has been declared with a size of 1 bytes and alignment of 1 bytes, but Miri emulates it via an extern static shim with a size of N bytes and alignment of N bytes
+error: unsupported operation: extern static `environ` has been declared as `extern_static_wrong_size::environ` with a size of 1 bytes and alignment of 1 bytes, but Miri emulates it via an extern static shim with a size of N bytes and alignment of N bytes
   --> $DIR/extern_static_wrong_size.rs:LL:CC
    |
 LL |     let _val = unsafe { environ };
-   |                         ^^^^^^^ `extern` static `environ` from crate `extern_static_wrong_size` has been declared with a size of 1 bytes and alignment of 1 bytes, but Miri emulates it via an extern static shim with a size of N bytes and alignment of N bytes
+   |                         ^^^^^^^ extern static `environ` has been declared as `extern_static_wrong_size::environ` with a size of 1 bytes and alignment of 1 bytes, but Miri emulates it via an extern static shim with a size of N bytes and alignment of N bytes
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
    = note: BACKTRACE:

--- a/tests/fail/issue-miri-3288-ice-symbolic-alignment-extern-static.stderr
+++ b/tests/fail/issue-miri-3288-ice-symbolic-alignment-extern-static.stderr
@@ -1,8 +1,8 @@
-error: unsupported operation: `extern` static `_dispatch_queue_attr_concurrent` from crate `issue_miri_3288_ice_symbolic_alignment_extern_static` is not supported by Miri
+error: unsupported operation: extern static `_dispatch_queue_attr_concurrent` is not supported by Miri
   --> $DIR/issue-miri-3288-ice-symbolic-alignment-extern-static.rs:LL:CC
    |
 LL |     let _val = *DISPATCH_QUEUE_CONCURRENT;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ `extern` static `_dispatch_queue_attr_concurrent` from crate `issue_miri_3288_ice_symbolic_alignment_extern_static` is not supported by Miri
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ extern static `_dispatch_queue_attr_concurrent` is not supported by Miri
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
    = note: BACKTRACE:


### PR DESCRIPTION
What's relevant is mostly the link name of the external symbol, not its Rust path.