### PR TITLE
directly call handle_alloc_error

### DIFF
--- a/tests/fail/alloc/alloc_error_handler.rs
+++ b/tests/fail/alloc/alloc_error_handler.rs
@@ -4,22 +4,7 @@
 #![feature(allocator_api)]
 
 use std::alloc::*;
-use std::ptr::NonNull;
-
-struct BadAlloc;
-
-// Create a failing allocator; Miri's native allocator never fails so this is the only way to
-// actually call the alloc error handler.
-unsafe impl Allocator for BadAlloc {
-    fn allocate(&self, _l: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        Err(AllocError)
-    }
-
-    unsafe fn deallocate(&self, _ptr: NonNull<u8>, _layout: Layout) {
-        unreachable!();
-    }
-}
 
 fn main() {
-    let _b = Box::new_in(0, BadAlloc);
+    handle_alloc_error(Layout::for_value(&0));
 }

--- a/tests/fail/alloc/alloc_error_handler.stderr
+++ b/tests/fail/alloc/alloc_error_handler.stderr
@@ -12,12 +12,10 @@ LL |     ABORT();
    = note: inside `std::alloc::_::__rg_oom` at RUSTLIB/std/src/alloc.rs:LL:CC
    = note: inside `std::alloc::handle_alloc_error::rt_error` at RUSTLIB/alloc/src/alloc.rs:LL:CC
    = note: inside `std::alloc::handle_alloc_error` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `std::boxed::Box::<i32, BadAlloc>::new_uninit_in` at RUSTLIB/alloc/src/boxed.rs:LL:CC
-   = note: inside `std::boxed::Box::<i32, BadAlloc>::new_in` at RUSTLIB/alloc/src/boxed.rs:LL:CC
 note: inside `main`
   --> $DIR/alloc_error_handler.rs:LL:CC
    |
-LL |     let _b = Box::new_in(0, BadAlloc);
+LL |     handle_alloc_error(Layout::for_value(&0));
    | ^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/alloc/alloc_error_handler_custom.rs
+++ b/tests/fail/alloc/alloc_error_handler_custom.rs
@@ -12,11 +12,9 @@ extern "Rust" {
     fn miri_write_to_stderr(bytes: &[u8]);
 }
 
-// The default no_std alloc_error_handler is a panic.
-
-#[panic_handler]
-fn panic_handler(_panic_info: &core::panic::PanicInfo) -> ! {
-    let msg = "custom panic handler called!\n";
+#[alloc_error_handler]
+fn alloc_error_handler(_: Layout) -> ! {
+    let msg = "custom alloc error handler called!\n";
     unsafe { miri_write_to_stderr(msg.as_bytes()) };
     core::intrinsics::abort(); //~ERROR: aborted
 }
@@ -24,6 +22,13 @@ fn panic_handler(_panic_info: &core::panic::PanicInfo) -> ! {
 // rustc requires us to provide some more things that aren't actually used by this test
 mod plumbing {
     use super::*;
+
+    #[panic_handler]
+    fn panic_handler(_: &core::panic::PanicInfo) -> ! {
+        let msg = "custom panic handler called!\n";
+        unsafe { miri_write_to_stderr(msg.as_bytes()) };
+        core::intrinsics::abort();
+    }
 
     struct NoAlloc;
 

--- a/tests/fail/alloc/alloc_error_handler_custom.rs
+++ b/tests/fail/alloc/alloc_error_handler_custom.rs
@@ -7,15 +7,14 @@
 extern crate alloc;
 
 use alloc::alloc::*;
+use core::fmt::Write;
 
-extern "Rust" {
-    fn miri_write_to_stderr(bytes: &[u8]);
-}
+#[path = "../../utils/mod.no_std.rs"]
+mod utils;
 
 #[alloc_error_handler]
-fn alloc_error_handler(_: Layout) -> ! {
-    let msg = "custom alloc error handler called!\n";
-    unsafe { miri_write_to_stderr(msg.as_bytes()) };
+fn alloc_error_handler(layout: Layout) -> ! {
+    let _ = writeln!(utils::MiriStderr, "custom alloc error handler: {layout:?}");
     core::intrinsics::abort(); //~ERROR: aborted
 }
 
@@ -25,9 +24,7 @@ mod plumbing {
 
     #[panic_handler]
     fn panic_handler(_: &core::panic::PanicInfo) -> ! {
-        let msg = "custom panic handler called!\n";
-        unsafe { miri_write_to_stderr(msg.as_bytes()) };
-        core::intrinsics::abort();
+        loop {}
     }
 
     struct NoAlloc;

--- a/tests/fail/alloc/alloc_error_handler_custom.stderr
+++ b/tests/fail/alloc/alloc_error_handler_custom.stderr
@@ -1,0 +1,27 @@
+custom alloc error handler called!
+error: abnormal termination: the program aborted execution
+  --> $DIR/alloc_error_handler_custom.rs:LL:CC
+   |
+LL |     core::intrinsics::abort();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ the program aborted execution
+   |
+   = note: BACKTRACE:
+   = note: inside `alloc_error_handler` at $DIR/alloc_error_handler_custom.rs:LL:CC
+note: inside `_::__rg_oom`
+  --> $DIR/alloc_error_handler_custom.rs:LL:CC
+   |
+LL | #[alloc_error_handler]
+   | ---------------------- in this procedural macro expansion
+LL | fn alloc_error_handler(_: Layout) -> ! {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: inside `alloc::alloc::handle_alloc_error::rt_error` at RUSTLIB/alloc/src/alloc.rs:LL:CC
+   = note: inside `alloc::alloc::handle_alloc_error` at RUSTLIB/alloc/src/alloc.rs:LL:CC
+note: inside `start`
+  --> $DIR/alloc_error_handler_custom.rs:LL:CC
+   |
+LL |     handle_alloc_error(Layout::for_value(&0));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the attribute macro `alloc_error_handler` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 1 previous error
+

--- a/tests/fail/alloc/alloc_error_handler_custom.stderr
+++ b/tests/fail/alloc/alloc_error_handler_custom.stderr
@@ -1,4 +1,4 @@
-custom alloc error handler called!
+custom alloc error handler: Layout { size: 4, align: 4 (1 << 2) }
 error: abnormal termination: the program aborted execution
   --> $DIR/alloc_error_handler_custom.rs:LL:CC
    |
@@ -12,8 +12,8 @@ note: inside `_::__rg_oom`
    |
 LL | #[alloc_error_handler]
    | ---------------------- in this procedural macro expansion
-LL | fn alloc_error_handler(_: Layout) -> ! {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn alloc_error_handler(layout: Layout) -> ! {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: inside `alloc::alloc::handle_alloc_error::rt_error` at RUSTLIB/alloc/src/alloc.rs:LL:CC
    = note: inside `alloc::alloc::handle_alloc_error` at RUSTLIB/alloc/src/alloc.rs:LL:CC
 note: inside `start`

--- a/tests/fail/alloc/alloc_error_handler_no_std.rs
+++ b/tests/fail/alloc/alloc_error_handler_no_std.rs
@@ -7,17 +7,17 @@
 extern crate alloc;
 
 use alloc::alloc::*;
+use core::fmt::Write;
 
-extern "Rust" {
-    fn miri_write_to_stderr(bytes: &[u8]);
-}
+#[path = "../../utils/mod.no_std.rs"]
+mod utils;
 
 // The default no_std alloc_error_handler is a panic.
 
 #[panic_handler]
-fn panic_handler(_panic_info: &core::panic::PanicInfo) -> ! {
-    let msg = "custom panic handler called!\n";
-    unsafe { miri_write_to_stderr(msg.as_bytes()) };
+fn panic_handler(panic_info: &core::panic::PanicInfo) -> ! {
+    let _ = writeln!(utils::MiriStderr, "custom panic handler called!");
+    let _ = writeln!(utils::MiriStderr, "{panic_info}");
     core::intrinsics::abort(); //~ERROR: aborted
 }
 

--- a/tests/fail/alloc/alloc_error_handler_no_std.stderr
+++ b/tests/fail/alloc/alloc_error_handler_no_std.stderr
@@ -1,4 +1,4 @@
-custom alloc error handler called!
+custom panic handler called!
 error: abnormal termination: the program aborted execution
   --> $DIR/alloc_error_handler_no_std.rs:LL:CC
    |
@@ -6,24 +6,17 @@ LL |     core::intrinsics::abort();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^ the program aborted execution
    |
    = note: BACKTRACE:
-   = note: inside `alloc_error_handler` at $DIR/alloc_error_handler_no_std.rs:LL:CC
-note: inside `_::__rg_oom`
-  --> $DIR/alloc_error_handler_no_std.rs:LL:CC
-   |
-LL | #[alloc_error_handler]
-   | ---------------------- in this procedural macro expansion
-LL | fn alloc_error_handler(_: Layout) -> ! {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: inside `panic_handler` at $DIR/alloc_error_handler_no_std.rs:LL:CC
+   = note: inside `alloc::alloc::__alloc_error_handler::__rdl_oom` at RUSTLIB/alloc/src/alloc.rs:LL:CC
    = note: inside `alloc::alloc::handle_alloc_error::rt_error` at RUSTLIB/alloc/src/alloc.rs:LL:CC
    = note: inside `alloc::alloc::handle_alloc_error` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `alloc::boxed::Box::<i32, BadAlloc>::new_uninit_in` at RUSTLIB/alloc/src/boxed.rs:LL:CC
-   = note: inside `alloc::boxed::Box::<i32, BadAlloc>::new_in` at RUSTLIB/alloc/src/boxed.rs:LL:CC
 note: inside `start`
   --> $DIR/alloc_error_handler_no_std.rs:LL:CC
    |
-LL |     let _b = Box::new_in(0, BadAlloc);
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: this error originates in the attribute macro `alloc_error_handler` (in Nightly builds, run with -Z macro-backtrace for more info)
+LL |     handle_alloc_error(Layout::for_value(&0));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 
 error: aborting due to 1 previous error
 

--- a/tests/fail/alloc/alloc_error_handler_no_std.stderr
+++ b/tests/fail/alloc/alloc_error_handler_no_std.stderr
@@ -1,4 +1,6 @@
 custom panic handler called!
+panicked at RUSTLIB/alloc/src/alloc.rs:LL:CC:
+memory allocation of 4 bytes failed
 error: abnormal termination: the program aborted execution
   --> $DIR/alloc_error_handler_no_std.rs:LL:CC
    |

--- a/tests/panic/alloc_error_handler_hook.rs
+++ b/tests/panic/alloc_error_handler_hook.rs
@@ -1,5 +1,4 @@
-//@compile-flags: -Zoom=panic
-#![feature(allocator_api)]
+#![feature(allocator_api, alloc_error_hook)]
 
 use std::alloc::*;
 
@@ -12,6 +11,9 @@ impl Drop for Bomb {
 
 #[allow(unreachable_code, unused_variables)]
 fn main() {
+    // This is a particularly tricky hook, since it unwinds, which the default one does not.
+    set_alloc_error_hook(|_layout| panic!("alloc error hook called"));
+
     let bomb = Bomb;
     handle_alloc_error(Layout::for_value(&0));
     std::mem::forget(bomb); // defuse unwinding bomb

--- a/tests/panic/alloc_error_handler_hook.stderr
+++ b/tests/panic/alloc_error_handler_hook.stderr
@@ -1,0 +1,4 @@
+thread 'main' panicked at $DIR/alloc_error_handler_hook.rs:LL:CC:
+alloc error hook called
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+yes we are unwinding!

--- a/tests/pass/no_std.rs
+++ b/tests/pass/no_std.rs
@@ -2,30 +2,14 @@
 #![feature(start)]
 #![no_std]
 
-// Plumbing to let us use `writeln!` to host stdout:
-
-extern "Rust" {
-    fn miri_write_to_stdout(bytes: &[u8]);
-}
-
-struct Host;
-
 use core::fmt::Write;
 
-impl Write for Host {
-    fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        unsafe {
-            miri_write_to_stdout(s.as_bytes());
-        }
-        Ok(())
-    }
-}
-
-// Aaaand the test:
+#[path = "../utils/mod.no_std.rs"]
+mod utils;
 
 #[start]
 fn start(_: isize, _: *const *const u8) -> isize {
-    writeln!(Host, "hello, world!").unwrap();
+    writeln!(utils::MiriStdout, "hello, world!").unwrap();
     0
 }
 

--- a/tests/pass/tree_borrows/reserved.rs
+++ b/tests/pass/tree_borrows/reserved.rs
@@ -27,9 +27,8 @@ fn main() {
     }
 }
 
-unsafe fn print(msg: &str) {
-    utils::miri_write_to_stderr(msg.as_bytes());
-    utils::miri_write_to_stderr("\n".as_bytes());
+fn print(msg: &str) {
+    eprintln!("{msg}");
 }
 
 unsafe fn read_second<T>(x: &mut T, y: *mut u8) {

--- a/tests/utils/io.rs
+++ b/tests/utils/io.rs
@@ -1,0 +1,25 @@
+use core::fmt::{self, Write};
+
+use super::miri_extern;
+
+pub struct MiriStderr;
+
+impl Write for MiriStderr {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        unsafe {
+            miri_extern::miri_write_to_stderr(s.as_bytes());
+        }
+        Ok(())
+    }
+}
+
+pub struct MiriStdout;
+
+impl Write for MiriStdout {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        unsafe {
+            miri_extern::miri_write_to_stdout(s.as_bytes());
+        }
+        Ok(())
+    }
+}

--- a/tests/utils/miri_extern.rs
+++ b/tests/utils/miri_extern.rs
@@ -133,8 +133,8 @@ extern "Rust" {
     /// with a null terminator.
     /// Returns 0 if the `out` buffer was large enough, and the required size otherwise.
     pub fn miri_host_to_target_path(
-        path: *const std::ffi::c_char,
-        out: *mut std::ffi::c_char,
+        path: *const core::ffi::c_char,
+        out: *mut core::ffi::c_char,
         out_size: usize,
     ) -> usize;
 

--- a/tests/utils/mod.no_std.rs
+++ b/tests/utils/mod.no_std.rs
@@ -1,0 +1,11 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
+#[macro_use]
+mod macros;
+
+mod io;
+mod miri_extern;
+
+pub use self::io::*;
+pub use self::miri_extern::*;

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -5,9 +5,11 @@
 mod macros;
 
 mod fs;
+mod io;
 mod miri_extern;
 
 pub use self::fs::*;
+pub use self::io::*;
 pub use self::miri_extern::*;
 
 pub fn run_provenance_gc() {


### PR DESCRIPTION
Also test more codepaths. There's like 5 different things that can happen on allocation failure! Between `-Zoom`, `#[alloc_error_handler]`, and `set_alloc_error_hook`, we have 3 layers of behavior overrides. It's all a bit messy.

https://github.com/rust-lang/rust/pull/112331 seems intended to clean this up, but has not yet reached consensus.