### PR TITLE
CI: don't run cron-fail-notify when the job just got canceled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
     name: cronjob failure notification
     runs-on: ubuntu-latest
     needs: [build, style]
-    if: github.event_name == 'schedule' && (failure() || cancelled())
+    if: github.event_name == 'schedule' && failure()
     steps:
       # Send a Zulip notification
       - name: Install zulip-send


### PR DESCRIPTION
Doesn't seem right to prepare a PR in that case