### PR TITLE
CI: run benches with hyperfine rather than bash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,12 +57,12 @@ jobs:
             ~/.cargo/bin
             ~/.cargo/.crates.toml
             ~/.cargo/.crates2.json
-          key: cargo-${{ runner.os }}-reset20240331-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-${{ runner.os }}-reset20240331
+          key: cargo-${{ runner.os }}-reset20240425-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: cargo-${{ runner.os }}-reset20240425
 
-      - name: Install rustup-toolchain-install-master
+      - name: Install tools
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        run: cargo install -f rustup-toolchain-install-master
+        run: cargo install -f rustup-toolchain-install-master hyperfine
 
       - name: Install miri toolchain
         run: |

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -78,8 +78,8 @@ function run_tests {
     done
   fi
   if [ -n "${TEST_BENCH-}" ]; then
-    # Check that the benchmarks build and run, but without actually benchmarking.
-    time HYPERFINE="'$BASH' -c" ./miri bench
+    # Check that the benchmarks build and run, but only once.
+    time HYPERFINE="hyperfine -w0 -r1" ./miri bench
   fi
 
   ## test-cargo-miri


### PR DESCRIPTION
The hyperfine installation is cached so this should not cost a lot of CI time.

This is step 1/2 to getting rid of the BASH variable hack.