### PR TITLE
Don’t print `Preparing a sysroot` when `-q`/`--quiet` is passed

### DIFF
--- a/cargo-miri/src/phases.rs
+++ b/cargo-miri/src/phases.rs
@@ -28,7 +28,7 @@ Examples:
     cargo miri run
     cargo miri test -- test-suite-filter
 
-    cargo miri setup --print sysroot
+    cargo miri setup --print-sysroot
         This will print the path to the generated sysroot (and nothing else) on stdout.
         stderr will still contain progress information about how the build is doing.
 

--- a/cargo-miri/src/phases.rs
+++ b/cargo-miri/src/phases.rs
@@ -87,6 +87,7 @@ pub fn phase_cargo_miri(mut args: impl Iterator<Item = String>) {
             ),
     };
     let verbose = num_arg_flag("-v");
+    let quiet = has_arg_flag("-q") || has_arg_flag("--quiet");
 
     // Determine the involved architectures.
     let rustc_version = VersionMeta::for_command(miri_for_host()).unwrap_or_else(|err| {
@@ -110,7 +111,7 @@ pub fn phase_cargo_miri(mut args: impl Iterator<Item = String>) {
     }
 
     // We always setup.
-    let miri_sysroot = setup(&subcommand, target, &rustc_version, verbose);
+    let miri_sysroot = setup(&subcommand, target, &rustc_version, verbose, quiet);
 
     // Invoke actual cargo for the job, but with different flags.
     // We re-use `cargo test` and `cargo run`, which makes target and binary handling very easy but

--- a/cargo-miri/src/setup.rs
+++ b/cargo-miri/src/setup.rs
@@ -19,6 +19,7 @@ pub fn setup(
     target: &str,
     rustc_version: &VersionMeta,
     verbose: usize,
+    quiet: bool,
 ) -> PathBuf {
     let only_setup = matches!(subcommand, MiriCommand::Setup);
     let ask_user = !only_setup;
@@ -119,6 +120,9 @@ pub fn setup(
             for _ in 0..verbose {
                 command.arg("-v");
             }
+            if quiet {
+                command.arg("--quiet");
+            }
         } else {
             // Suppress output.
             command.stdout(process::Stdio::null());
@@ -134,7 +138,7 @@ pub fn setup(
     let rustflags = &["-Cdebug-assertions=off", "-Coverflow-checks=on"];
 
     // Do the build.
-    if print_sysroot {
+    if print_sysroot || quiet {
         // Be silent.
     } else {
         let mut msg = String::new();
@@ -169,7 +173,7 @@ pub fn setup(
                 )
             }
         });
-    if print_sysroot {
+    if print_sysroot || quiet {
         // Be silent.
     } else if only_setup {
         eprintln!("A sysroot for Miri is now available in `{}`.", sysroot_dir.display());

--- a/test-cargo-miri/run-test.py
+++ b/test-cargo-miri/run-test.py
@@ -34,10 +34,6 @@ def normalize_stdout(str):
     str = re.sub("finished in \\d+\\.\\d\\ds", "finished in $TIME", str) # the time keeps changing, obviously
     return str
 
-def normalize_stderr(str):
-    str = re.sub("Preparing a sysroot for Miri \\(target: [a-z0-9_-]+\\)\\.\\.\\. done\n", "", str) # remove leading cargo-miri setup output
-    return str
-
 def check_output(actual, path, name):
     if os.environ.get("RUSTC_BLESS", "0") != "0":
         # Write the output only if bless is set
@@ -69,7 +65,7 @@ def test(name, cmd, stdout_ref, stderr_ref, stdin=b'', env=None):
     )
     (stdout, stderr) = p.communicate(input=stdin)
     stdout = normalize_stdout(stdout.decode("UTF-8"))
-    stderr = normalize_stderr(stderr.decode("UTF-8"))
+    stderr = stderr.decode("UTF-8")
 
     stdout_matches = check_output(stdout, stdout_ref, "stdout")
     stderr_matches = check_output(stderr, stderr_ref, "stderr")


### PR DESCRIPTION
Resolves #3530.

This also fixes a typo in `cargo miri --help` that I found while trying to run the `--print-sysroot` example.