### PR TITLE
CI: no need to surround if: condition in expansion braces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           restore-keys: cargo-${{ runner.os }}-reset20240425
 
       - name: Install tools
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        if: steps.cache.outputs.cache-hit != 'true'
         run: cargo install -f rustup-toolchain-install-master hyperfine
 
       - name: Install miri toolchain
@@ -81,7 +81,7 @@ jobs:
       # The `style` job only runs on Linux; this makes sure the Windows-host-specific
       # code is also covered by clippy.
       - name: Check clippy
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: matrix.os == 'windows-latest'
         run: ./miri clippy -- -D warnings
 
       - name: Test Miri
@@ -117,7 +117,7 @@ jobs:
           restore-keys: cargo-${{ runner.os }}-reset20240331
 
       - name: Install rustup-toolchain-install-master
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        if: steps.cache.outputs.cache-hit != 'true'
         run: cargo install -f rustup-toolchain-install-master
 
       - name: Install "master" toolchain


### PR DESCRIPTION
That seems to be implicit for `if:` (but interestingly, redundant braces are tolerated).