### PR TITLE
Move sched_getaffinity back to Linux

### DIFF
--- a/src/shims/unix/linux/foreign_items.rs
+++ b/src/shims/unix/linux/foreign_items.rs
@@ -195,6 +195,19 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
 
                 this.write_scalar(Scalar::from_i32(SIGRTMAX), dest)?;
             }
+            "sched_getaffinity" => {
+                // This shim isn't useful, aside from the fact that it makes `num_cpus`
+                // fall back to `sysconf` where it will successfully determine the number of CPUs.
+                let [pid, cpusetsize, mask] =
+                    this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                this.read_scalar(pid)?.to_i32()?;
+                this.read_target_usize(cpusetsize)?;
+                this.deref_pointer_as(mask, this.libc_ty_layout("cpu_set_t"))?;
+                // FIXME: we just return an error.
+                let einval = this.eval_libc("EINVAL");
+                this.set_last_error(einval)?;
+                this.write_scalar(Scalar::from_i32(-1), dest)?;
+            }
 
             // Incomplete shims that we "stub out" just to get pre-main initialization code to work.
             // These shims are enabled only when the caller is in the standard library.


### PR DESCRIPTION
This reverts commit c1a3f8576ea12b0bed68ad3dedf4069ca3d9816f. The shim isn't actually useful for anything, and it is untested on FreeBSD. On Linux it exists solely because std and num_cpus are trying this before falling back to `sysconf`, but on FreeBSD that's not how they work, so there's no reason I can see to have this stub shim on FreeBSD.