### PR TITLE
update 'unsupported' message

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ interpreter will explicitly tell you when it finds something unsupported:
 error: unsupported operation: can't call foreign function: bind
     ...
     = help: this is likely not a bug in the program; it indicates that the program \
-            performed an operation that the interpreter does not support
+            performed an operation that Miri does not support
 ```
 
 ### Cross-interpretation: running for different targets

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -320,7 +320,10 @@ pub fn report_error<'tcx, 'mir>(
         #[rustfmt::skip]
         let helps = match e.kind() {
             Unsupported(_) =>
-                vec![(None, format!("this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support"))],
+                vec![
+                    (None, format!("this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support")),
+                    (None, format!("if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there")),
+                ],
             UndefinedBehavior(AlignmentCheckFailed { .. })
                 if ecx.machine.check_alignment == AlignmentCheck::Symbolic
             =>

--- a/tests/extern-so/fail/function_not_in_so.stderr
+++ b/tests/extern-so/fail/function_not_in_so.stderr
@@ -4,7 +4,8 @@ error: unsupported operation: can't call foreign function `foo` on $OS
 LL |         foo();
    |         ^^^^^ can't call foreign function `foo` on $OS
    |
-   = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
+   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
+   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/function_not_in_so.rs:LL:CC
 

--- a/tests/fail-dep/shims/fs/close_stdout.stderr
+++ b/tests/fail-dep/shims/fs/close_stdout.stderr
@@ -4,7 +4,8 @@ error: unsupported operation: cannot close stdout
 LL |         libc::close(1);
    |         ^^^^^^^^^^^^^^ cannot close stdout
    |
-   = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
+   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
+   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/close_stdout.rs:LL:CC
 

--- a/tests/fail-dep/shims/fs/read_from_stdout.stderr
+++ b/tests/fail-dep/shims/fs/read_from_stdout.stderr
@@ -4,7 +4,8 @@ error: unsupported operation: cannot read from stdout
 LL |         libc::read(1, bytes.as_mut_ptr() as *mut libc::c_void, 512);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot read from stdout
    |
-   = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
+   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
+   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/read_from_stdout.rs:LL:CC
 

--- a/tests/fail-dep/shims/fs/write_to_stdin.stderr
+++ b/tests/fail-dep/shims/fs/write_to_stdin.stderr
@@ -4,7 +4,8 @@ error: unsupported operation: cannot write to stdin
 LL |         libc::write(0, bytes.as_ptr() as *const libc::c_void, 5);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot write to stdin
    |
-   = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
+   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
+   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/write_to_stdin.rs:LL:CC
 

--- a/tests/fail-dep/tokio/sleep.stderr
+++ b/tests/fail-dep/tokio/sleep.stderr
@@ -9,7 +9,8 @@ LL | |             timeout,
 LL | |         ))
    | |__________^ returning ready events from epoll_wait is not yet implemented
    |
-   = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
+   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
+   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
 
 error: aborting due to 1 previous error
 

--- a/tests/fail-dep/unsupported_incomplete_function.stderr
+++ b/tests/fail-dep/unsupported_incomplete_function.stderr
@@ -4,7 +4,8 @@ error: unsupported operation: can't call foreign function `signal` on $OS
 LL |         libc::signal(libc::SIGPIPE, libc::SIG_IGN);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't call foreign function `signal` on $OS
    |
-   = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
+   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
+   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/unsupported_incomplete_function.rs:LL:CC
 

--- a/tests/fail/alloc/no_global_allocator.stderr
+++ b/tests/fail/alloc/no_global_allocator.stderr
@@ -4,7 +4,8 @@ error: unsupported operation: can't call foreign function `__rust_alloc` on $OS
 LL |         __rust_alloc(1, 1);
    |         ^^^^^^^^^^^^^^^^^^ can't call foreign function `__rust_alloc` on $OS
    |
-   = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
+   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
+   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `start` at $DIR/no_global_allocator.rs:LL:CC
 

--- a/tests/fail/extern-type-field-offset.stderr
+++ b/tests/fail/extern-type-field-offset.stderr
@@ -4,7 +4,8 @@ error: unsupported operation: `extern type` does not have a known offset
 LL |     let _field = &x.a;
    |                  ^^^^ `extern type` does not have a known offset
    |
-   = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
+   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
+   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/extern-type-field-offset.rs:LL:CC
 

--- a/tests/fail/extern_static.stderr
+++ b/tests/fail/extern_static.stderr
@@ -4,7 +4,8 @@ error: unsupported operation: extern static `FOO` is not supported by Miri
 LL |     let _val = unsafe { std::ptr::addr_of!(FOO) };
    |                                            ^^^ extern static `FOO` is not supported by Miri
    |
-   = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
+   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
+   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/extern_static.rs:LL:CC
 

--- a/tests/fail/extern_static_in_const.stderr
+++ b/tests/fail/extern_static_in_const.stderr
@@ -4,7 +4,8 @@ error: unsupported operation: extern static `E` is not supported by Miri
 LL |     let _val = X;
    |                ^ extern static `E` is not supported by Miri
    |
-   = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
+   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
+   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/extern_static_in_const.rs:LL:CC
 

--- a/tests/fail/extern_static_wrong_size.stderr
+++ b/tests/fail/extern_static_wrong_size.stderr
@@ -4,7 +4,8 @@ error: unsupported operation: extern static `environ` has been declared as `exte
 LL |     let _val = unsafe { environ };
    |                         ^^^^^^^ extern static `environ` has been declared as `extern_static_wrong_size::environ` with a size of 1 bytes and alignment of 1 bytes, but Miri emulates it via an extern static shim with a size of N bytes and alignment of N bytes
    |
-   = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
+   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
+   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/extern_static_wrong_size.rs:LL:CC
 

--- a/tests/fail/issue-miri-3288-ice-symbolic-alignment-extern-static.stderr
+++ b/tests/fail/issue-miri-3288-ice-symbolic-alignment-extern-static.stderr
@@ -4,7 +4,8 @@ error: unsupported operation: extern static `_dispatch_queue_attr_concurrent` is
 LL |     let _val = *DISPATCH_QUEUE_CONCURRENT;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ extern static `_dispatch_queue_attr_concurrent` is not supported by Miri
    |
-   = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
+   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
+   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/issue-miri-3288-ice-symbolic-alignment-extern-static.rs:LL:CC
 

--- a/tests/fail/shims/backtrace/bad-backtrace-flags.stderr
+++ b/tests/fail/shims/backtrace/bad-backtrace-flags.stderr
@@ -4,7 +4,8 @@ error: unsupported operation: unknown `miri_get_backtrace` flags 2
 LL |         miri_get_backtrace(2, std::ptr::null_mut());
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown `miri_get_backtrace` flags 2
    |
-   = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
+   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
+   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/bad-backtrace-flags.rs:LL:CC
 

--- a/tests/fail/shims/backtrace/bad-backtrace-resolve-flags.stderr
+++ b/tests/fail/shims/backtrace/bad-backtrace-resolve-flags.stderr
@@ -4,7 +4,8 @@ error: unsupported operation: unknown `miri_resolve_frame` flags 2
 LL |         miri_resolve_frame(buf[0], 2);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown `miri_resolve_frame` flags 2
    |
-   = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
+   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
+   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/bad-backtrace-resolve-flags.rs:LL:CC
 

--- a/tests/fail/shims/backtrace/bad-backtrace-resolve-names-flags.stderr
+++ b/tests/fail/shims/backtrace/bad-backtrace-resolve-names-flags.stderr
@@ -4,7 +4,8 @@ error: unsupported operation: unknown `miri_resolve_frame_names` flags 2
 LL | ...   miri_resolve_frame_names(buf[0], 2, std::ptr::null_mut(), std::ptr::null_mut());
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown `miri_resolve_frame_names` flags 2
    |
-   = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
+   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
+   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/bad-backtrace-resolve-names-flags.rs:LL:CC
 

--- a/tests/fail/shims/backtrace/bad-backtrace-size-flags.stderr
+++ b/tests/fail/shims/backtrace/bad-backtrace-size-flags.stderr
@@ -4,7 +4,8 @@ error: unsupported operation: unknown `miri_backtrace_size` flags 2
 LL |         miri_backtrace_size(2);
    |         ^^^^^^^^^^^^^^^^^^^^^^ unknown `miri_backtrace_size` flags 2
    |
-   = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
+   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
+   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/bad-backtrace-size-flags.rs:LL:CC
 

--- a/tests/fail/unaligned_pointers/promise_alignment.call_unaligned_ptr.stderr
+++ b/tests/fail/unaligned_pointers/promise_alignment.call_unaligned_ptr.stderr
@@ -4,7 +4,8 @@ error: unsupported operation: `miri_promise_symbolic_alignment`: pointer is not 
 LL |         unsafe { utils::miri_promise_symbolic_alignment(align8.add(1).cast(), 8) };
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `miri_promise_symbolic_alignment`: pointer is not actually aligned
    |
-   = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
+   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
+   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/promise_alignment.rs:LL:CC
 

--- a/tests/fail/unaligned_pointers/promise_alignment_zero.stderr
+++ b/tests/fail/unaligned_pointers/promise_alignment_zero.stderr
@@ -4,7 +4,8 @@ error: unsupported operation: `miri_promise_symbolic_alignment`: alignment must 
 LL |     unsafe { utils::miri_promise_symbolic_alignment(buffer.as_ptr().cast(), 0) };
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `miri_promise_symbolic_alignment`: alignment must be a power of 2, got 0
    |
-   = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
+   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
+   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/promise_alignment_zero.rs:LL:CC
 

--- a/tests/fail/unsized-local.stderr
+++ b/tests/fail/unsized-local.stderr
@@ -4,7 +4,8 @@ error: unsupported operation: unsized locals are not supported
 LL |     let x = *(Box::new(A) as Box<dyn Foo>);
    |         ^ unsized locals are not supported
    |
-   = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
+   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
+   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/unsized-local.rs:LL:CC
 

--- a/tests/fail/unsupported_foreign_function.stderr
+++ b/tests/fail/unsupported_foreign_function.stderr
@@ -4,7 +4,8 @@ error: unsupported operation: can't call foreign function `foo` on $OS
 LL |         foo();
    |         ^^^^^ can't call foreign function `foo` on $OS
    |
-   = help: this is likely not a bug in the program; it indicates that the program performed an operation that the interpreter does not support
+   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
+   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/unsupported_foreign_function.rs:LL:CC
 


### PR DESCRIPTION
Instead of "the interpreter", just say Miri.

Also be a more more clear about what is expected to be supported and what not (Cc https://github.com/rust-lang/miri/issues/2325).