### PR TITLE
only show the 'basic API common for this target' message when this is a missing foreign function

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -48,6 +48,7 @@ pub enum TerminationInfo {
         extra: Option<&'static str>,
         retag_explain: bool,
     },
+    UnsupportedForeignItem(String),
 }
 
 pub struct RacingOp {
@@ -85,6 +86,7 @@ impl fmt::Display for TerminationInfo {
                     op2.action,
                     op2.thread_info
                 ),
+            UnsupportedForeignItem(msg) => write!(f, "{msg}"),
         }
     }
 }
@@ -214,7 +216,7 @@ pub fn report_error<'tcx, 'mir>(
         let title = match info {
             Exit { code, leak_check } => return Some((*code, *leak_check)),
             Abort(_) => Some("abnormal termination"),
-            UnsupportedInIsolation(_) | Int2PtrWithStrictProvenance =>
+            UnsupportedInIsolation(_) | Int2PtrWithStrictProvenance | UnsupportedForeignItem(_) =>
                 Some("unsupported operation"),
             StackedBorrowsUb { .. } | TreeBorrowsUb { .. } | DataRace { .. } =>
                 Some("Undefined Behavior"),
@@ -228,6 +230,12 @@ pub fn report_error<'tcx, 'mir>(
                     (None, format!("pass the flag `-Zmiri-disable-isolation` to disable isolation;")),
                     (None, format!("or pass `-Zmiri-isolation-error=warn` to configure Miri to return an error code from isolated operations (if supported for that operation) and continue with a warning")),
                 ],
+            UnsupportedForeignItem(_) => {
+                vec![
+                    (None, format!("if this is a basic API commonly used on this target, please report an issue with Miri")),
+                    (None, format!("however, note that Miri does not aim to support every FFI function out there; for instance, we will not support APIs for things such as GUIs, scripting languages, or databases")),
+                ]
+            }
             StackedBorrowsUb { help, history, .. } => {
                 msg.extend(help.clone());
                 let mut helps = vec![
@@ -322,7 +330,6 @@ pub fn report_error<'tcx, 'mir>(
             Unsupported(_) =>
                 vec![
                     (None, format!("this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support")),
-                    (None, format!("if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there")),
                 ],
             UndefinedBehavior(AlignmentCheckFailed { .. })
                 if ecx.machine.check_alignment == AlignmentCheck::Symbolic
@@ -347,7 +354,7 @@ pub fn report_error<'tcx, 'mir>(
                     }
                     AbiMismatchArgument { .. } | AbiMismatchReturn { .. } => {
                         helps.push((None, format!("this means these two types are not *guaranteed* to be ABI-compatible across all targets")));
-                        helps.push((None, format!("if you think this code should be accepted anyway, please report an issue")));
+                        helps.push((None, format!("if you think this code should be accepted anyway, please report an issue with Miri")));
                     }
                     _ => {},
                 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1067,20 +1067,18 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
         crate_name == "std" || crate_name == "std_miri_test"
     }
 
-    /// Handler that should be called when unsupported functionality is encountered.
+    /// Handler that should be called when an unsupported foreign item is encountered.
     /// This function will either panic within the context of the emulated application
     /// or return an error in the Miri process context
-    ///
-    /// Return value of `Ok(bool)` indicates whether execution should continue.
-    fn handle_unsupported<S: AsRef<str>>(&mut self, error_msg: S) -> InterpResult<'tcx, ()> {
+    fn handle_unsupported_foreign_item(&mut self, error_msg: String) -> InterpResult<'tcx, ()> {
         let this = self.eval_context_mut();
         if this.machine.panic_on_unsupported {
             // message is slightly different here to make automated analysis easier
-            let error_msg = format!("unsupported Miri functionality: {}", error_msg.as_ref());
+            let error_msg = format!("unsupported Miri functionality: {error_msg}");
             this.start_panic(error_msg.as_ref(), mir::UnwindAction::Continue)?;
             Ok(())
         } else {
-            throw_unsup_format!("{}", error_msg.as_ref());
+            throw_machine_stop!(TerminationInfo::UnsupportedForeignItem(error_msg));
         }
     }
 

--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -119,7 +119,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                         if let Some(body) = this.lookup_exported_symbol(link_name)? {
                             return Ok(Some(body));
                         }
-                        this.handle_unsupported(format!(
+                        this.handle_unsupported_foreign_item(format!(
                             "can't call (diverging) foreign function: {link_name}"
                         ))?;
                         return Ok(None);
@@ -140,7 +140,7 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                     return Ok(Some(body));
                 }
 
-                this.handle_unsupported(format!(
+                this.handle_unsupported_foreign_item(format!(
                     "can't call foreign function `{link_name}` on OS `{os}`",
                     os = this.tcx.sess.target.os,
                 ))?;

--- a/src/shims/unix/linux/foreign_items.rs
+++ b/src/shims/unix/linux/foreign_items.rs
@@ -144,7 +144,9 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                         futex(this, &args[1..], dest)?;
                     }
                     id => {
-                        this.handle_unsupported(format!("can't execute syscall with ID {id}"))?;
+                        this.handle_unsupported_foreign_item(format!(
+                            "can't execute syscall with ID {id}"
+                        ))?;
                         return Ok(EmulateForeignItemResult::AlreadyJumped);
                     }
                 }

--- a/tests/extern-so/fail/function_not_in_so.stderr
+++ b/tests/extern-so/fail/function_not_in_so.stderr
@@ -4,8 +4,8 @@ error: unsupported operation: can't call foreign function `foo` on $OS
 LL |         foo();
    |         ^^^^^ can't call foreign function `foo` on $OS
    |
-   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
-   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
+   = help: if this is a basic API commonly used on this target, please report an issue with Miri
+   = help: however, note that Miri does not aim to support every FFI function out there; for instance, we will not support APIs for things such as GUIs, scripting languages, or databases
    = note: BACKTRACE:
    = note: inside `main` at $DIR/function_not_in_so.rs:LL:CC
 

--- a/tests/fail-dep/shims/fs/close_stdout.stderr
+++ b/tests/fail-dep/shims/fs/close_stdout.stderr
@@ -5,7 +5,6 @@ LL |         libc::close(1);
    |         ^^^^^^^^^^^^^^ cannot close stdout
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
-   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/close_stdout.rs:LL:CC
 

--- a/tests/fail-dep/shims/fs/read_from_stdout.stderr
+++ b/tests/fail-dep/shims/fs/read_from_stdout.stderr
@@ -5,7 +5,6 @@ LL |         libc::read(1, bytes.as_mut_ptr() as *mut libc::c_void, 512);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot read from stdout
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
-   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/read_from_stdout.rs:LL:CC
 

--- a/tests/fail-dep/shims/fs/write_to_stdin.stderr
+++ b/tests/fail-dep/shims/fs/write_to_stdin.stderr
@@ -5,7 +5,6 @@ LL |         libc::write(0, bytes.as_ptr() as *const libc::c_void, 5);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot write to stdin
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
-   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/write_to_stdin.rs:LL:CC
 

--- a/tests/fail-dep/tokio/sleep.stderr
+++ b/tests/fail-dep/tokio/sleep.stderr
@@ -10,7 +10,6 @@ LL | |         ))
    | |__________^ returning ready events from epoll_wait is not yet implemented
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
-   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
 
 error: aborting due to 1 previous error
 

--- a/tests/fail-dep/unsupported_incomplete_function.stderr
+++ b/tests/fail-dep/unsupported_incomplete_function.stderr
@@ -4,8 +4,8 @@ error: unsupported operation: can't call foreign function `signal` on $OS
 LL |         libc::signal(libc::SIGPIPE, libc::SIG_IGN);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't call foreign function `signal` on $OS
    |
-   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
-   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
+   = help: if this is a basic API commonly used on this target, please report an issue with Miri
+   = help: however, note that Miri does not aim to support every FFI function out there; for instance, we will not support APIs for things such as GUIs, scripting languages, or databases
    = note: BACKTRACE:
    = note: inside `main` at $DIR/unsupported_incomplete_function.rs:LL:CC
 

--- a/tests/fail/alloc/no_global_allocator.stderr
+++ b/tests/fail/alloc/no_global_allocator.stderr
@@ -4,8 +4,8 @@ error: unsupported operation: can't call foreign function `__rust_alloc` on $OS
 LL |         __rust_alloc(1, 1);
    |         ^^^^^^^^^^^^^^^^^^ can't call foreign function `__rust_alloc` on $OS
    |
-   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
-   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
+   = help: if this is a basic API commonly used on this target, please report an issue with Miri
+   = help: however, note that Miri does not aim to support every FFI function out there; for instance, we will not support APIs for things such as GUIs, scripting languages, or databases
    = note: BACKTRACE:
    = note: inside `start` at $DIR/no_global_allocator.rs:LL:CC
 

--- a/tests/fail/extern-type-field-offset.stderr
+++ b/tests/fail/extern-type-field-offset.stderr
@@ -5,7 +5,6 @@ LL |     let _field = &x.a;
    |                  ^^^^ `extern type` does not have a known offset
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
-   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/extern-type-field-offset.rs:LL:CC
 

--- a/tests/fail/extern_static.stderr
+++ b/tests/fail/extern_static.stderr
@@ -5,7 +5,6 @@ LL |     let _val = unsafe { std::ptr::addr_of!(FOO) };
    |                                            ^^^ extern static `FOO` is not supported by Miri
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
-   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/extern_static.rs:LL:CC
 

--- a/tests/fail/extern_static_in_const.stderr
+++ b/tests/fail/extern_static_in_const.stderr
@@ -5,7 +5,6 @@ LL |     let _val = X;
    |                ^ extern static `E` is not supported by Miri
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
-   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/extern_static_in_const.rs:LL:CC
 

--- a/tests/fail/extern_static_wrong_size.stderr
+++ b/tests/fail/extern_static_wrong_size.stderr
@@ -5,7 +5,6 @@ LL |     let _val = unsafe { environ };
    |                         ^^^^^^^ extern static `environ` has been declared as `extern_static_wrong_size::environ` with a size of 1 bytes and alignment of 1 bytes, but Miri emulates it via an extern static shim with a size of N bytes and alignment of N bytes
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
-   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/extern_static_wrong_size.rs:LL:CC
 

--- a/tests/fail/function_pointers/abi_mismatch_array_vs_struct.stderr
+++ b/tests/fail/function_pointers/abi_mismatch_array_vs_struct.stderr
@@ -7,7 +7,7 @@ LL |     g(Default::default())
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = help: this means these two types are not *guaranteed* to be ABI-compatible across all targets
-   = help: if you think this code should be accepted anyway, please report an issue
+   = help: if you think this code should be accepted anyway, please report an issue with Miri
    = note: BACKTRACE:
    = note: inside `main` at $DIR/abi_mismatch_array_vs_struct.rs:LL:CC
 

--- a/tests/fail/function_pointers/abi_mismatch_int_vs_float.stderr
+++ b/tests/fail/function_pointers/abi_mismatch_int_vs_float.stderr
@@ -7,7 +7,7 @@ LL |     g(42)
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = help: this means these two types are not *guaranteed* to be ABI-compatible across all targets
-   = help: if you think this code should be accepted anyway, please report an issue
+   = help: if you think this code should be accepted anyway, please report an issue with Miri
    = note: BACKTRACE:
    = note: inside `main` at $DIR/abi_mismatch_int_vs_float.rs:LL:CC
 

--- a/tests/fail/function_pointers/abi_mismatch_raw_pointer.stderr
+++ b/tests/fail/function_pointers/abi_mismatch_raw_pointer.stderr
@@ -7,7 +7,7 @@ LL |     g(&42 as *const i32)
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = help: this means these two types are not *guaranteed* to be ABI-compatible across all targets
-   = help: if you think this code should be accepted anyway, please report an issue
+   = help: if you think this code should be accepted anyway, please report an issue with Miri
    = note: BACKTRACE:
    = note: inside `main` at $DIR/abi_mismatch_raw_pointer.rs:LL:CC
 

--- a/tests/fail/function_pointers/abi_mismatch_repr_C.stderr
+++ b/tests/fail/function_pointers/abi_mismatch_repr_C.stderr
@@ -7,7 +7,7 @@ LL |     fnptr(S1(NonZeroI32::new(1).unwrap()));
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = help: this means these two types are not *guaranteed* to be ABI-compatible across all targets
-   = help: if you think this code should be accepted anyway, please report an issue
+   = help: if you think this code should be accepted anyway, please report an issue with Miri
    = note: BACKTRACE:
    = note: inside `main` at $DIR/abi_mismatch_repr_C.rs:LL:CC
 

--- a/tests/fail/function_pointers/abi_mismatch_return_type.stderr
+++ b/tests/fail/function_pointers/abi_mismatch_return_type.stderr
@@ -7,7 +7,7 @@ LL |     g()
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = help: this means these two types are not *guaranteed* to be ABI-compatible across all targets
-   = help: if you think this code should be accepted anyway, please report an issue
+   = help: if you think this code should be accepted anyway, please report an issue with Miri
    = note: BACKTRACE:
    = note: inside `main` at $DIR/abi_mismatch_return_type.rs:LL:CC
 

--- a/tests/fail/function_pointers/abi_mismatch_simple.stderr
+++ b/tests/fail/function_pointers/abi_mismatch_simple.stderr
@@ -7,7 +7,7 @@ LL |     g(42)
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = help: this means these two types are not *guaranteed* to be ABI-compatible across all targets
-   = help: if you think this code should be accepted anyway, please report an issue
+   = help: if you think this code should be accepted anyway, please report an issue with Miri
    = note: BACKTRACE:
    = note: inside `main` at $DIR/abi_mismatch_simple.rs:LL:CC
 

--- a/tests/fail/function_pointers/abi_mismatch_vector.stderr
+++ b/tests/fail/function_pointers/abi_mismatch_vector.stderr
@@ -7,7 +7,7 @@ LL |     g(Default::default())
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = help: this means these two types are not *guaranteed* to be ABI-compatible across all targets
-   = help: if you think this code should be accepted anyway, please report an issue
+   = help: if you think this code should be accepted anyway, please report an issue with Miri
    = note: BACKTRACE:
    = note: inside `main` at $DIR/abi_mismatch_vector.rs:LL:CC
 

--- a/tests/fail/intrinsic_fallback_checks_ub.stderr
+++ b/tests/fail/intrinsic_fallback_checks_ub.stderr
@@ -5,7 +5,6 @@ LL |     ptr_guaranteed_cmp::<()>(std::ptr::null(), std::ptr::null());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ miri can only use intrinsic fallback bodies that check UB. After verifying that `ptr_guaranteed_cmp` does so, add the `#[miri::intrinsic_fallback_checks_ub]` attribute to it; also ping @rust-lang/miri when you do that
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
-   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/intrinsic_fallback_checks_ub.rs:LL:CC
 

--- a/tests/fail/issue-miri-3288-ice-symbolic-alignment-extern-static.stderr
+++ b/tests/fail/issue-miri-3288-ice-symbolic-alignment-extern-static.stderr
@@ -5,7 +5,6 @@ LL |     let _val = *DISPATCH_QUEUE_CONCURRENT;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ extern static `_dispatch_queue_attr_concurrent` is not supported by Miri
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
-   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/issue-miri-3288-ice-symbolic-alignment-extern-static.rs:LL:CC
 

--- a/tests/fail/shims/backtrace/bad-backtrace-flags.stderr
+++ b/tests/fail/shims/backtrace/bad-backtrace-flags.stderr
@@ -5,7 +5,6 @@ LL |         miri_get_backtrace(2, std::ptr::null_mut());
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown `miri_get_backtrace` flags 2
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
-   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/bad-backtrace-flags.rs:LL:CC
 

--- a/tests/fail/shims/backtrace/bad-backtrace-resolve-flags.stderr
+++ b/tests/fail/shims/backtrace/bad-backtrace-resolve-flags.stderr
@@ -5,7 +5,6 @@ LL |         miri_resolve_frame(buf[0], 2);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown `miri_resolve_frame` flags 2
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
-   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/bad-backtrace-resolve-flags.rs:LL:CC
 

--- a/tests/fail/shims/backtrace/bad-backtrace-resolve-names-flags.stderr
+++ b/tests/fail/shims/backtrace/bad-backtrace-resolve-names-flags.stderr
@@ -5,7 +5,6 @@ LL | ...   miri_resolve_frame_names(buf[0], 2, std::ptr::null_mut(), std::ptr::n
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown `miri_resolve_frame_names` flags 2
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
-   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/bad-backtrace-resolve-names-flags.rs:LL:CC
 

--- a/tests/fail/shims/backtrace/bad-backtrace-size-flags.stderr
+++ b/tests/fail/shims/backtrace/bad-backtrace-size-flags.stderr
@@ -5,7 +5,6 @@ LL |         miri_backtrace_size(2);
    |         ^^^^^^^^^^^^^^^^^^^^^^ unknown `miri_backtrace_size` flags 2
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
-   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/bad-backtrace-size-flags.rs:LL:CC
 

--- a/tests/fail/unaligned_pointers/promise_alignment.call_unaligned_ptr.stderr
+++ b/tests/fail/unaligned_pointers/promise_alignment.call_unaligned_ptr.stderr
@@ -5,7 +5,6 @@ LL |         unsafe { utils::miri_promise_symbolic_alignment(align8.add(1).cast(
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `miri_promise_symbolic_alignment`: pointer is not actually aligned
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
-   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/promise_alignment.rs:LL:CC
 

--- a/tests/fail/unaligned_pointers/promise_alignment_zero.stderr
+++ b/tests/fail/unaligned_pointers/promise_alignment_zero.stderr
@@ -5,7 +5,6 @@ LL |     unsafe { utils::miri_promise_symbolic_alignment(buffer.as_ptr().cast(),
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `miri_promise_symbolic_alignment`: alignment must be a power of 2, got 0
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
-   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/promise_alignment_zero.rs:LL:CC
 

--- a/tests/fail/unsized-local.stderr
+++ b/tests/fail/unsized-local.stderr
@@ -5,7 +5,6 @@ LL |     let x = *(Box::new(A) as Box<dyn Foo>);
    |         ^ unsized locals are not supported
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
-   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
    = note: BACKTRACE:
    = note: inside `main` at $DIR/unsized-local.rs:LL:CC
 

--- a/tests/fail/unsupported_foreign_function.stderr
+++ b/tests/fail/unsupported_foreign_function.stderr
@@ -4,8 +4,8 @@ error: unsupported operation: can't call foreign function `foo` on $OS
 LL |         foo();
    |         ^^^^^ can't call foreign function `foo` on $OS
    |
-   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
-   = help: if this is a basic API commonly used on this target, please report an issue; but note that Miri does not aim to support every FFI function out there
+   = help: if this is a basic API commonly used on this target, please report an issue with Miri
+   = help: however, note that Miri does not aim to support every FFI function out there; for instance, we will not support APIs for things such as GUIs, scripting languages, or databases
    = note: BACKTRACE:
    = note: inside `main` at $DIR/unsupported_foreign_function.rs:LL:CC
 


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/miri/pull/3558