### PR TITLE
Implement non-null pointer for malloc(0)

### DIFF
--- a/tests/fail-dep/libc/malloc_zero_double_free.rs
+++ b/tests/fail-dep/libc/malloc_zero_double_free.rs
@@ -1,0 +1,7 @@
+fn main() {
+    unsafe {
+        let ptr = libc::malloc(0);
+        libc::free(ptr);
+        libc::free(ptr); //~ERROR: dangling
+    }
+}

--- a/tests/fail-dep/libc/malloc_zero_double_free.stderr
+++ b/tests/fail-dep/libc/malloc_zero_double_free.stderr
@@ -1,0 +1,25 @@
+error: Undefined Behavior: memory access failed: ALLOC has been freed, so this pointer is dangling
+  --> $DIR/malloc_zero_double_free.rs:LL:CC
+   |
+LL |         libc::free(ptr);
+   |         ^^^^^^^^^^^^^^^ memory access failed: ALLOC has been freed, so this pointer is dangling
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+help: ALLOC was allocated here:
+  --> $DIR/malloc_zero_double_free.rs:LL:CC
+   |
+LL |         let ptr = libc::malloc(0);
+   |                   ^^^^^^^^^^^^^^^
+help: ALLOC was deallocated here:
+  --> $DIR/malloc_zero_double_free.rs:LL:CC
+   |
+LL |         libc::free(ptr);
+   |         ^^^^^^^^^^^^^^^
+   = note: BACKTRACE (of the first span):
+   = note: inside `main` at $DIR/malloc_zero_double_free.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/tests/fail-dep/libc/malloc_zero_memory_leak.rs
+++ b/tests/fail-dep/libc/malloc_zero_memory_leak.rs
@@ -1,0 +1,5 @@
+fn main() {
+    unsafe {
+        let _ptr = libc::malloc(0); //~ERROR: memory leak
+    }
+}

--- a/tests/fail-dep/libc/malloc_zero_memory_leak.stderr
+++ b/tests/fail-dep/libc/malloc_zero_memory_leak.stderr
@@ -1,0 +1,15 @@
+error: memory leaked: ALLOC (C heap, size: 0, align: 1), allocated here:
+  --> $DIR/malloc_zero_memory_leak.rs:LL:CC
+   |
+LL |         let _ptr = libc::malloc(0);
+   |                    ^^^^^^^^^^^^^^^
+   |
+   = note: BACKTRACE:
+   = note: inside `main` at $DIR/malloc_zero_memory_leak.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+note: the evaluated program leaked memory, pass `-Zmiri-ignore-leaks` to disable this check
+
+error: aborting due to 1 previous error
+

--- a/tests/pass-dep/libc/libc-mem.rs
+++ b/tests/pass-dep/libc/libc-mem.rs
@@ -110,9 +110,10 @@ fn test_malloc() {
     }
 
     unsafe {
-        // Realloc with size 0 is okay for the null pointer
+        // Realloc with size 0 is okay for the null pointer (and acts like `malloc(0)`)
         let p2 = libc::realloc(ptr::null_mut(), 0);
-        assert!(p2.is_null());
+        assert!(!p2.is_null());
+        libc::free(p2);
     }
 
     unsafe {
@@ -126,13 +127,16 @@ fn test_malloc() {
 fn test_calloc() {
     unsafe {
         let p1 = libc::calloc(0, 0);
-        assert!(p1.is_null());
+        assert!(!p1.is_null());
+        libc::free(p1);
 
         let p2 = libc::calloc(20, 0);
-        assert!(p2.is_null());
+        assert!(!p2.is_null());
+        libc::free(p2);
 
         let p3 = libc::calloc(0, 20);
-        assert!(p3.is_null());
+        assert!(!p3.is_null());
+        libc::free(p3);
 
         let p4 = libc::calloc(4, 8);
         assert!(!p4.is_null());


### PR DESCRIPTION
Use non-null pointer for malloc(0) as mentioned in  #3576 to detect leaks and double free of ``malloc(0)`` addresses. 