### PR TITLE
Add the machine seed to the diagnostic output

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -539,6 +539,7 @@ pub fn report_msg<'tcx>(
             err.note(note);
         }
     }
+
     for (span_data, help) in helps {
         if let Some(span_data) = span_data {
             err.span_help(span_data.span(), help);
@@ -573,6 +574,8 @@ pub fn report_msg<'tcx>(
             err.note(format!("{frame_info} at {span}"));
         }
     }
+
+    err.note(format!("This occured with miri seed: {}", machine.rng_seed));
 
     err.emit();
 }

--- a/tests/fail-dep/concurrency/windows_join_detached.stderr
+++ b/tests/fail-dep/concurrency/windows_join_detached.stderr
@@ -15,6 +15,7 @@ note: inside `main`
    |
 LL |     thread.join().unwrap();
    |     ^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail-dep/concurrency/windows_join_main.stderr
+++ b/tests/fail-dep/concurrency/windows_join_main.stderr
@@ -6,6 +6,7 @@ LL |             assert_eq!(WaitForSingleObject(MAIN_THREAD, INFINITE), WAIT_OBJ
    |
    = note: BACKTRACE on thread `unnamed-ID`:
    = note: inside closure at RUSTLIB/core/src/macros/mod.rs:LL:CC
+   = note: This occured with miri seed: 0
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: deadlock: the evaluated program deadlocked
@@ -28,6 +29,7 @@ LL | |         }
 LL | |     })
 LL | |     .join()
    | |___________^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail-dep/concurrency/windows_join_self.stderr
+++ b/tests/fail-dep/concurrency/windows_join_self.stderr
@@ -6,6 +6,7 @@ LL |             assert_eq!(WaitForSingleObject(native, INFINITE), WAIT_OBJECT_0
    |
    = note: BACKTRACE on thread `unnamed-ID`:
    = note: inside closure at $DIR/windows_join_self.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 error: deadlock: the evaluated program deadlocked
   --> RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
@@ -28,6 +29,7 @@ LL | |         }
 LL | |     })
 LL | |     .join()
    | |___________^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail-dep/libc/memchr_null.stderr
+++ b/tests/fail-dep/libc/memchr_null.stderr
@@ -8,6 +8,7 @@ LL |         libc::memchr(ptr::null(), 0, 0);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/memchr_null.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail-dep/libc/memcmp_null.stderr
+++ b/tests/fail-dep/libc/memcmp_null.stderr
@@ -8,6 +8,7 @@ LL |         libc::memcmp(ptr::null(), ptr::null(), 0);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/memcmp_null.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail-dep/libc/memcmp_zero.stderr
+++ b/tests/fail-dep/libc/memcmp_zero.stderr
@@ -8,6 +8,7 @@ LL |         libc::memcmp(ptr.cast(), ptr.cast(), 0);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/memcmp_zero.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail-dep/libc/memcpy_zero.stderr
+++ b/tests/fail-dep/libc/memcpy_zero.stderr
@@ -8,6 +8,7 @@ LL |         libc::memcpy(to.cast(), from.cast(), 0);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/memcpy_zero.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail-dep/libc/realloc-zero.stderr
+++ b/tests/fail-dep/libc/realloc-zero.stderr
@@ -8,6 +8,7 @@ LL |         let p2 = libc::realloc(p1, 0);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/realloc-zero.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/alloc/alloc_error_handler.stderr
+++ b/tests/fail/alloc/alloc_error_handler.stderr
@@ -17,6 +17,7 @@ note: inside `main`
    |
 LL |     handle_alloc_error(Layout::for_value(&0));
    | ^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/alloc/alloc_error_handler_custom.stderr
+++ b/tests/fail/alloc/alloc_error_handler_custom.stderr
@@ -21,6 +21,7 @@ note: inside `start`
    |
 LL |     handle_alloc_error(Layout::for_value(&0));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
    = note: this error originates in the attribute macro `alloc_error_handler` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: aborting due to 1 previous error

--- a/tests/fail/alloc/alloc_error_handler_no_std.stderr
+++ b/tests/fail/alloc/alloc_error_handler_no_std.stderr
@@ -17,6 +17,7 @@ note: inside `start`
    |
 LL |     handle_alloc_error(Layout::for_value(&0));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/alloc/deallocate-bad-alignment.stderr
+++ b/tests/fail/alloc/deallocate-bad-alignment.stderr
@@ -13,6 +13,7 @@ note: inside `main`
    |
 LL |         dealloc(x, Layout::from_size_align_unchecked(1, 2));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/alloc/deallocate-bad-size.stderr
+++ b/tests/fail/alloc/deallocate-bad-size.stderr
@@ -13,6 +13,7 @@ note: inside `main`
    |
 LL |         dealloc(x, Layout::from_size_align_unchecked(2, 1));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/alloc/deallocate-twice.stderr
+++ b/tests/fail/alloc/deallocate-twice.stderr
@@ -23,6 +23,7 @@ note: inside `main`
    |
 LL |         dealloc(x, Layout::from_size_align_unchecked(1, 1));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/alloc/global_system_mixup.stderr
+++ b/tests/fail/alloc/global_system_mixup.stderr
@@ -14,6 +14,7 @@ note: inside `main`
    |
 LL |         System.deallocate(ptr, l);
    | ^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/alloc/no_global_allocator.stderr
+++ b/tests/fail/alloc/no_global_allocator.stderr
@@ -8,6 +8,7 @@ LL |         __rust_alloc(1, 1);
    = help: however, note that Miri does not aim to support every FFI function out there; for instance, we will not support APIs for things such as GUIs, scripting languages, or databases
    = note: BACKTRACE:
    = note: inside `start` at $DIR/no_global_allocator.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 error: aborting due to 1 previous error
 

--- a/tests/fail/alloc/reallocate-bad-size.stderr
+++ b/tests/fail/alloc/reallocate-bad-size.stderr
@@ -13,6 +13,7 @@ note: inside `main`
    |
 LL |         let _y = realloc(x, Layout::from_size_align_unchecked(2, 1), 1);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/alloc/reallocate-change-alloc.stderr
+++ b/tests/fail/alloc/reallocate-change-alloc.stderr
@@ -18,6 +18,7 @@ LL |         let _y = realloc(x, Layout::from_size_align_unchecked(1, 1), 1);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/reallocate-change-alloc.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/alloc/reallocate-dangling.stderr
+++ b/tests/fail/alloc/reallocate-dangling.stderr
@@ -23,6 +23,7 @@ note: inside `main`
    |
 LL |         let _z = realloc(x, Layout::from_size_align_unchecked(1, 1), 1);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/alloc/stack_free.stderr
+++ b/tests/fail/alloc/stack_free.stderr
@@ -17,6 +17,7 @@ note: inside `main`
    |
 LL |     drop(bad_box);
    |     ^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/alias_through_mutation.stack.stderr
+++ b/tests/fail/both_borrows/alias_through_mutation.stack.stderr
@@ -21,6 +21,7 @@ LL |     *target = 13;
    |     ^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/alias_through_mutation.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/alias_through_mutation.tree.stderr
+++ b/tests/fail/both_borrows/alias_through_mutation.tree.stderr
@@ -25,6 +25,7 @@ LL |     *target = 13;
    = help: this transition corresponds to a loss of read and write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/alias_through_mutation.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/aliasing_mut1.stack.stderr
+++ b/tests/fail/both_borrows/aliasing_mut1.stack.stderr
@@ -23,6 +23,7 @@ note: inside `main`
    |
 LL |     safe_raw(xraw, xraw);
    |     ^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/aliasing_mut1.tree.stderr
+++ b/tests/fail/both_borrows/aliasing_mut1.tree.stderr
@@ -24,6 +24,7 @@ note: inside `main`
    |
 LL |     safe_raw(xraw, xraw);
    |     ^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/aliasing_mut2.stack.stderr
+++ b/tests/fail/both_borrows/aliasing_mut2.stack.stderr
@@ -23,6 +23,7 @@ note: inside `main`
    |
 LL |     safe_raw(xshr, xraw);
    |     ^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/aliasing_mut2.tree.stderr
+++ b/tests/fail/both_borrows/aliasing_mut2.tree.stderr
@@ -24,6 +24,7 @@ note: inside `main`
    |
 LL |     safe_raw(xshr, xraw);
    |     ^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/aliasing_mut3.stack.stderr
+++ b/tests/fail/both_borrows/aliasing_mut3.stack.stderr
@@ -26,6 +26,7 @@ note: inside `main`
    |
 LL |     safe_raw(xraw, xshr);
    |     ^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/aliasing_mut3.tree.stderr
+++ b/tests/fail/both_borrows/aliasing_mut3.tree.stderr
@@ -24,6 +24,7 @@ note: inside `main`
    |
 LL |     safe_raw(xraw, xshr);
    |     ^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/aliasing_mut4.stack.stderr
+++ b/tests/fail/both_borrows/aliasing_mut4.stack.stderr
@@ -23,6 +23,7 @@ note: inside `main`
    |
 LL |     safe_raw(xshr, xraw as *mut _);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/aliasing_mut4.tree.stderr
+++ b/tests/fail/both_borrows/aliasing_mut4.tree.stderr
@@ -32,6 +32,7 @@ note: inside `main`
    |
 LL |     safe_raw(xshr, xraw as *mut _);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/box_exclusive_violation1.stack.stderr
+++ b/tests/fail/both_borrows/box_exclusive_violation1.stack.stderr
@@ -31,6 +31,7 @@ note: inside `main`
    |
 LL |     demo_box_advanced_unique(Box::new(0));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/box_exclusive_violation1.tree.stderr
+++ b/tests/fail/both_borrows/box_exclusive_violation1.tree.stderr
@@ -35,6 +35,7 @@ note: inside `main`
    |
 LL |     demo_box_advanced_unique(Box::new(0));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/box_noalias_violation.stack.stderr
+++ b/tests/fail/both_borrows/box_noalias_violation.stack.stderr
@@ -23,6 +23,7 @@ note: inside `main`
    |
 LL |         test(Box::from_raw(ptr), ptr);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/box_noalias_violation.tree.stderr
+++ b/tests/fail/both_borrows/box_noalias_violation.tree.stderr
@@ -31,6 +31,7 @@ note: inside `main`
    |
 LL |         test(Box::from_raw(ptr), ptr);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/buggy_as_mut_slice.stack.stderr
+++ b/tests/fail/both_borrows/buggy_as_mut_slice.stack.stderr
@@ -21,6 +21,7 @@ LL |         unsafe { from_raw_parts_mut(self_.as_ptr() as *mut T, self_.len()) 
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/buggy_as_mut_slice.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/buggy_as_mut_slice.tree.stderr
+++ b/tests/fail/both_borrows/buggy_as_mut_slice.tree.stderr
@@ -25,6 +25,7 @@ LL |     v1[1] = 5;
    = help: this transition corresponds to a loss of read and write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/buggy_as_mut_slice.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/buggy_split_at_mut.stack.stderr
+++ b/tests/fail/both_borrows/buggy_split_at_mut.stack.stderr
@@ -30,6 +30,7 @@ note: inside `main`
    |
 LL |     let (a, b) = safe::split_at_mut(&mut array, 0);
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/buggy_split_at_mut.tree.stderr
+++ b/tests/fail/both_borrows/buggy_split_at_mut.tree.stderr
@@ -25,6 +25,7 @@ LL |     a[1] = 5;
    = help: this transition corresponds to a loss of read and write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/buggy_split_at_mut.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/illegal_write1.stack.stderr
+++ b/tests/fail/both_borrows/illegal_write1.stack.stderr
@@ -16,6 +16,7 @@ LL |         let x: *mut u32 = xref as *const _ as *mut _;
    |                           ^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_write1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/illegal_write1.tree.stderr
+++ b/tests/fail/both_borrows/illegal_write1.tree.stderr
@@ -13,6 +13,7 @@ LL |     let xref = &*target;
    |                ^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_write1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/illegal_write5.stack.stderr
+++ b/tests/fail/both_borrows/illegal_write5.stack.stderr
@@ -21,6 +21,7 @@ LL |     unsafe { *xraw = 15 };
    |              ^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_write5.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/illegal_write5.tree.stderr
+++ b/tests/fail/both_borrows/illegal_write5.tree.stderr
@@ -25,6 +25,7 @@ LL |     unsafe { *xraw = 15 };
    = help: this transition corresponds to a loss of read and write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_write5.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/illegal_write6.stack.stderr
+++ b/tests/fail/both_borrows/illegal_write6.stack.stderr
@@ -23,6 +23,7 @@ note: inside `main`
    |
 LL |     foo(x, p);
    |     ^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/illegal_write6.tree.stderr
+++ b/tests/fail/both_borrows/illegal_write6.tree.stderr
@@ -31,6 +31,7 @@ note: inside `main`
    |
 LL |     foo(x, p);
    |     ^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/invalidate_against_protector2.stack.stderr
+++ b/tests/fail/both_borrows/invalidate_against_protector2.stack.stderr
@@ -23,6 +23,7 @@ note: inside `main`
    |
 LL |     inner(xraw, xref);
    |     ^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/invalidate_against_protector2.tree.stderr
+++ b/tests/fail/both_borrows/invalidate_against_protector2.tree.stderr
@@ -25,6 +25,7 @@ note: inside `main`
    |
 LL |     inner(xraw, xref);
    |     ^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/invalidate_against_protector3.stack.stderr
+++ b/tests/fail/both_borrows/invalidate_against_protector3.stack.stderr
@@ -23,6 +23,7 @@ note: inside `main`
    |
 LL |         inner(ptr, &*ptr);
    |         ^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/invalidate_against_protector3.tree.stderr
+++ b/tests/fail/both_borrows/invalidate_against_protector3.tree.stderr
@@ -25,6 +25,7 @@ note: inside `main`
    |
 LL |         inner(ptr, &*ptr);
    |         ^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/issue-miri-1050-1.stack.stderr
+++ b/tests/fail/both_borrows/issue-miri-1050-1.stack.stderr
@@ -19,6 +19,7 @@ note: inside `main`
    |
 LL |         drop(Box::from_raw(ptr as *mut u32));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/issue-miri-1050-1.tree.stderr
+++ b/tests/fail/both_borrows/issue-miri-1050-1.tree.stderr
@@ -19,6 +19,7 @@ note: inside `main`
    |
 LL |         drop(Box::from_raw(ptr as *mut u32));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/issue-miri-1050-2.stack.stderr
+++ b/tests/fail/both_borrows/issue-miri-1050-2.stack.stderr
@@ -14,6 +14,7 @@ note: inside `main`
    |
 LL |         drop(Box::from_raw(ptr.as_ptr()));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/issue-miri-1050-2.tree.stderr
+++ b/tests/fail/both_borrows/issue-miri-1050-2.tree.stderr
@@ -14,6 +14,7 @@ note: inside `main`
    |
 LL |         drop(Box::from_raw(ptr.as_ptr()));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/load_invalid_shr.stack.stderr
+++ b/tests/fail/both_borrows/load_invalid_shr.stack.stderr
@@ -21,6 +21,7 @@ LL |     unsafe { *xraw = 42 }; // unfreeze
    |              ^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/load_invalid_shr.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/load_invalid_shr.tree.stderr
+++ b/tests/fail/both_borrows/load_invalid_shr.tree.stderr
@@ -25,6 +25,7 @@ LL |     unsafe { *xraw = 42 }; // unfreeze
    = help: this transition corresponds to a loss of read permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/load_invalid_shr.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/mut_exclusive_violation1.stack.stderr
+++ b/tests/fail/both_borrows/mut_exclusive_violation1.stack.stderr
@@ -31,6 +31,7 @@ note: inside `main`
    |
 LL |     demo_mut_advanced_unique(&mut 0);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/mut_exclusive_violation1.tree.stderr
+++ b/tests/fail/both_borrows/mut_exclusive_violation1.tree.stderr
@@ -35,6 +35,7 @@ note: inside `main`
    |
 LL |     demo_mut_advanced_unique(&mut 0);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/mut_exclusive_violation2.stack.stderr
+++ b/tests/fail/both_borrows/mut_exclusive_violation2.stack.stderr
@@ -21,6 +21,7 @@ LL |         let raw2 = ptr2.as_mut();
    |                    ^^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/mut_exclusive_violation2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/mut_exclusive_violation2.tree.stderr
+++ b/tests/fail/both_borrows/mut_exclusive_violation2.tree.stderr
@@ -25,6 +25,7 @@ LL |         *raw2 = 2;
    = help: this transition corresponds to a loss of read and write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/mut_exclusive_violation2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/newtype_pair_retagging.stack.stderr
+++ b/tests/fail/both_borrows/newtype_pair_retagging.stack.stderr
@@ -37,6 +37,7 @@ LL | |             Newtype(&mut *ptr, 0),
 LL | |             || drop(Box::from_raw(ptr)),
 LL | |         )
    | |_________^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/newtype_pair_retagging.tree.stderr
+++ b/tests/fail/both_borrows/newtype_pair_retagging.tree.stderr
@@ -48,6 +48,7 @@ LL | |             Newtype(&mut *ptr, 0),
 LL | |             || drop(Box::from_raw(ptr)),
 LL | |         )
    | |_________^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/newtype_retagging.stack.stderr
+++ b/tests/fail/both_borrows/newtype_retagging.stack.stderr
@@ -37,6 +37,7 @@ LL | |             Newtype(&mut *ptr),
 LL | |             || drop(Box::from_raw(ptr)),
 LL | |         )
    | |_________^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/newtype_retagging.tree.stderr
+++ b/tests/fail/both_borrows/newtype_retagging.tree.stderr
@@ -48,6 +48,7 @@ LL | |             Newtype(&mut *ptr),
 LL | |             || drop(Box::from_raw(ptr)),
 LL | |         )
    | |_________^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/outdated_local.stack.stderr
+++ b/tests/fail/both_borrows/outdated_local.stack.stderr
@@ -21,6 +21,7 @@ LL |     x = 1; // this invalidates y by reactivating the lowermost uniq borrow 
    |     ^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/outdated_local.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/outdated_local.tree.stderr
+++ b/tests/fail/both_borrows/outdated_local.tree.stderr
@@ -19,6 +19,7 @@ LL |     x = 1; // this invalidates y by reactivating the lowermost uniq borrow 
    = help: this transition corresponds to a loss of read permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/outdated_local.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/pass_invalid_shr.stack.stderr
+++ b/tests/fail/both_borrows/pass_invalid_shr.stack.stderr
@@ -21,6 +21,7 @@ LL |     unsafe { *xraw = 42 }; // unfreeze
    |              ^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/pass_invalid_shr.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/pass_invalid_shr.tree.stderr
+++ b/tests/fail/both_borrows/pass_invalid_shr.tree.stderr
@@ -19,6 +19,7 @@ LL |     unsafe { *xraw = 42 }; // unfreeze
    = help: this transition corresponds to a loss of read permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/pass_invalid_shr.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/pass_invalid_shr_option.stack.stderr
+++ b/tests/fail/both_borrows/pass_invalid_shr_option.stack.stderr
@@ -22,6 +22,7 @@ LL |     unsafe { *xraw = 42 }; // unfreeze
    |              ^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/pass_invalid_shr_option.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/pass_invalid_shr_option.tree.stderr
+++ b/tests/fail/both_borrows/pass_invalid_shr_option.tree.stderr
@@ -25,6 +25,7 @@ LL |     unsafe { *xraw = 42 }; // unfreeze
    = help: this transition corresponds to a loss of read permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/pass_invalid_shr_option.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/pass_invalid_shr_tuple.stack.stderr
+++ b/tests/fail/both_borrows/pass_invalid_shr_tuple.stack.stderr
@@ -22,6 +22,7 @@ LL |     unsafe { *xraw0 = 42 }; // unfreeze
    |              ^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/pass_invalid_shr_tuple.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/pass_invalid_shr_tuple.tree.stderr
+++ b/tests/fail/both_borrows/pass_invalid_shr_tuple.tree.stderr
@@ -25,6 +25,7 @@ LL |     unsafe { *xraw0 = 42 }; // unfreeze
    = help: this transition corresponds to a loss of read permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/pass_invalid_shr_tuple.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/retag_data_race_write.stack.stderr
+++ b/tests/fail/both_borrows/retag_data_race_write.stack.stderr
@@ -21,6 +21,7 @@ note: inside closure
    |
 LL |     let t2 = std::thread::spawn(move || thread_2(p));
    |                                         ^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/retag_data_race_write.tree.stderr
+++ b/tests/fail/both_borrows/retag_data_race_write.tree.stderr
@@ -21,6 +21,7 @@ note: inside closure
    |
 LL |     let t2 = std::thread::spawn(move || thread_2(p));
    |                                         ^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/return_invalid_shr.stack.stderr
+++ b/tests/fail/both_borrows/return_invalid_shr.stack.stderr
@@ -26,6 +26,7 @@ note: inside `main`
    |
 LL |     foo(&mut (1, 2));
    |     ^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/return_invalid_shr.tree.stderr
+++ b/tests/fail/both_borrows/return_invalid_shr.tree.stderr
@@ -24,6 +24,7 @@ note: inside `main`
    |
 LL |     foo(&mut (1, 2));
    |     ^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/return_invalid_shr_option.stack.stderr
+++ b/tests/fail/both_borrows/return_invalid_shr_option.stack.stderr
@@ -27,6 +27,7 @@ note: inside `main`
    |
 LL |     match foo(&mut (1, 2)) {
    |           ^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/return_invalid_shr_option.tree.stderr
+++ b/tests/fail/both_borrows/return_invalid_shr_option.tree.stderr
@@ -30,6 +30,7 @@ note: inside `main`
    |
 LL |     match foo(&mut (1, 2)) {
    |           ^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/return_invalid_shr_tuple.stack.stderr
+++ b/tests/fail/both_borrows/return_invalid_shr_tuple.stack.stderr
@@ -27,6 +27,7 @@ note: inside `main`
    |
 LL |     foo(&mut (1, 2)).0;
    |     ^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/return_invalid_shr_tuple.tree.stderr
+++ b/tests/fail/both_borrows/return_invalid_shr_tuple.tree.stderr
@@ -30,6 +30,7 @@ note: inside `main`
    |
 LL |     foo(&mut (1, 2)).0;
    |     ^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/shr_frozen_violation1.stack.stderr
+++ b/tests/fail/both_borrows/shr_frozen_violation1.stack.stderr
@@ -26,6 +26,7 @@ note: inside `main`
    |
 LL |     println!("{}", foo(&mut 0));
    |                    ^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/shr_frozen_violation1.tree.stderr
+++ b/tests/fail/both_borrows/shr_frozen_violation1.tree.stderr
@@ -29,6 +29,7 @@ note: inside `main`
    |
 LL |     println!("{}", foo(&mut 0));
    |                    ^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/shr_frozen_violation2.stack.stderr
+++ b/tests/fail/both_borrows/shr_frozen_violation2.stack.stderr
@@ -21,6 +21,7 @@ LL |         x = 1;
    |         ^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/shr_frozen_violation2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/shr_frozen_violation2.tree.stderr
+++ b/tests/fail/both_borrows/shr_frozen_violation2.tree.stderr
@@ -19,6 +19,7 @@ LL |         x = 1;
    = help: this transition corresponds to a loss of read permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/shr_frozen_violation2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/box-cell-alias.stderr
+++ b/tests/fail/box-cell-alias.stderr
@@ -26,6 +26,7 @@ note: inside `main`
    |
 LL |     let res = helper(val, ptr);
    |               ^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/branchless-select-i128-pointer.stderr
+++ b/tests/fail/branchless-select-i128-pointer.stderr
@@ -12,6 +12,7 @@ LL | |             )
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/branchless-select-i128-pointer.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/concurrency/read_only_atomic_cmpxchg.stderr
+++ b/tests/fail/concurrency/read_only_atomic_cmpxchg.stderr
@@ -10,6 +10,7 @@ see <https://doc.rust-lang.org/nightly/std/sync/atomic/index.html#atomic-accesse
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/read_only_atomic_cmpxchg.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/concurrency/read_only_atomic_load_acquire.stderr
+++ b/tests/fail/concurrency/read_only_atomic_load_acquire.stderr
@@ -12,6 +12,7 @@ see <https://doc.rust-lang.org/nightly/std/sync/atomic/index.html#atomic-accesse
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/read_only_atomic_load_acquire.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/concurrency/read_only_atomic_load_large.stderr
+++ b/tests/fail/concurrency/read_only_atomic_load_large.stderr
@@ -12,6 +12,7 @@ see <https://doc.rust-lang.org/nightly/std/sync/atomic/index.html#atomic-accesse
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/read_only_atomic_load_large.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/coroutine-pinned-moved.stderr
+++ b/tests/fail/coroutine-pinned-moved.stderr
@@ -29,6 +29,7 @@ note: inside `main`
    |
 LL |     coroutine_iterator_2.next(); // and use moved value
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/dangling_pointers/dangling_pointer_deref.stderr
+++ b/tests/fail/dangling_pointers/dangling_pointer_deref.stderr
@@ -18,6 +18,7 @@ LL |     };
    |     ^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/dangling_pointer_deref.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/dangling_pointers/dangling_pointer_deref_match_never.stderr
+++ b/tests/fail/dangling_pointers/dangling_pointer_deref_match_never.stderr
@@ -8,6 +8,7 @@ LL |         match *p {}
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/dangling_pointer_deref_match_never.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/dangling_pointers/dangling_pointer_offset.stderr
+++ b/tests/fail/dangling_pointers/dangling_pointer_offset.stderr
@@ -18,6 +18,7 @@ LL |     };
    |     ^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/dangling_pointer_offset.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/dangling_pointers/dangling_pointer_project_underscore_let.stderr
+++ b/tests/fail/dangling_pointers/dangling_pointer_project_underscore_let.stderr
@@ -18,6 +18,7 @@ LL |     };
    |     ^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/dangling_pointer_project_underscore_let.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/dangling_pointers/dangling_pointer_project_underscore_let_type_annotation.stderr
+++ b/tests/fail/dangling_pointers/dangling_pointer_project_underscore_let_type_annotation.stderr
@@ -18,6 +18,7 @@ LL |     };
    |     ^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/dangling_pointer_project_underscore_let_type_annotation.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/dangling_pointers/dangling_pointer_project_underscore_match.stderr
+++ b/tests/fail/dangling_pointers/dangling_pointer_project_underscore_match.stderr
@@ -18,6 +18,7 @@ LL |     };
    |     ^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/dangling_pointer_project_underscore_match.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/dangling_pointers/dangling_primitive.stderr
+++ b/tests/fail/dangling_pointers/dangling_primitive.stderr
@@ -18,6 +18,7 @@ LL |     };
    |     ^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at RUSTLIB/std/src/macros.rs:LL:CC
+   = note: This occured with miri seed: 0
    = note: this error originates in the macro `dbg` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/dangling_pointers/dangling_zst_deref.stderr
+++ b/tests/fail/dangling_pointers/dangling_zst_deref.stderr
@@ -18,6 +18,7 @@ LL |     };
    |     ^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/dangling_zst_deref.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/dangling_pointers/deref-invalid-ptr.stderr
+++ b/tests/fail/dangling_pointers/deref-invalid-ptr.stderr
@@ -8,6 +8,7 @@ LL |     let _y = unsafe { &*x as *const u32 };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/deref-invalid-ptr.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/dangling_pointers/deref_dangling_box.stderr
+++ b/tests/fail/dangling_pointers/deref_dangling_box.stderr
@@ -8,6 +8,7 @@ LL |     let _val = unsafe { addr_of_mut!(**outer) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at RUSTLIB/core/src/ptr/mod.rs:LL:CC
+   = note: This occured with miri seed: 0
    = note: this error originates in the macro `addr_of_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/dangling_pointers/deref_dangling_ref.stderr
+++ b/tests/fail/dangling_pointers/deref_dangling_ref.stderr
@@ -8,6 +8,7 @@ LL |     let _val = unsafe { addr_of_mut!(**outer) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at RUSTLIB/core/src/ptr/mod.rs:LL:CC
+   = note: This occured with miri seed: 0
    = note: this error originates in the macro `addr_of_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/dangling_pointers/dyn_size.stderr
+++ b/tests/fail/dangling_pointers/dyn_size.stderr
@@ -8,6 +8,7 @@ LL |     let _ptr = unsafe { &*ptr };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/dyn_size.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/dangling_pointers/maybe_null_pointer_deref_zst.stderr
+++ b/tests/fail/dangling_pointers/maybe_null_pointer_deref_zst.stderr
@@ -8,6 +8,7 @@ LL |     let _x: () = unsafe { *ptr };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/maybe_null_pointer_deref_zst.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/dangling_pointers/maybe_null_pointer_write_zst.stderr
+++ b/tests/fail/dangling_pointers/maybe_null_pointer_write_zst.stderr
@@ -8,6 +8,7 @@ LL |     unsafe { *ptr = zst_val };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/maybe_null_pointer_write_zst.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/dangling_pointers/null_pointer_deref.stderr
+++ b/tests/fail/dangling_pointers/null_pointer_deref.stderr
@@ -8,6 +8,7 @@ LL |     let x: i32 = unsafe { *std::ptr::null() };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/null_pointer_deref.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/dangling_pointers/null_pointer_deref_zst.stderr
+++ b/tests/fail/dangling_pointers/null_pointer_deref_zst.stderr
@@ -8,6 +8,7 @@ LL |     let x: () = unsafe { *std::ptr::null() };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/null_pointer_deref_zst.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/dangling_pointers/null_pointer_write.stderr
+++ b/tests/fail/dangling_pointers/null_pointer_write.stderr
@@ -8,6 +8,7 @@ LL |     unsafe { *std::ptr::null_mut() = 0i32 };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/null_pointer_write.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/dangling_pointers/null_pointer_write_zst.stderr
+++ b/tests/fail/dangling_pointers/null_pointer_write_zst.stderr
@@ -8,6 +8,7 @@ LL |     unsafe { std::ptr::null_mut::<[u8; 0]>().write(zst_val) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/null_pointer_write_zst.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/dangling_pointers/out_of_bounds_project.stderr
+++ b/tests/fail/dangling_pointers/out_of_bounds_project.stderr
@@ -13,6 +13,7 @@ LL |     let v = 0u32;
    |         ^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at RUSTLIB/core/src/ptr/mod.rs:LL:CC
+   = note: This occured with miri seed: 0
    = note: this error originates in the macro `addr_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/dangling_pointers/out_of_bounds_read.stderr
+++ b/tests/fail/dangling_pointers/out_of_bounds_read.stderr
@@ -13,6 +13,7 @@ LL |     let v: Vec<u16> = vec![1, 2];
    |                       ^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/out_of_bounds_read.rs:LL:CC
+   = note: This occured with miri seed: 0
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/dangling_pointers/out_of_bounds_write.stderr
+++ b/tests/fail/dangling_pointers/out_of_bounds_write.stderr
@@ -13,6 +13,7 @@ LL |     let mut v: Vec<u16> = vec![1, 2];
    |                           ^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/out_of_bounds_write.rs:LL:CC
+   = note: This occured with miri seed: 0
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/dangling_pointers/stack_temporary.stderr
+++ b/tests/fail/dangling_pointers/stack_temporary.stderr
@@ -18,6 +18,7 @@ LL |         let x = make_ref(&mut 0); // The temporary storing "0" is deallocat
    |                                 ^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/stack_temporary.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/dangling_pointers/storage_dead_dangling.stderr
+++ b/tests/fail/dangling_pointers/storage_dead_dangling.stderr
@@ -13,6 +13,7 @@ note: inside `main`
    |
 LL |     evil();
    |     ^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/dangling_pointers/wild_pointer_deref.stderr
+++ b/tests/fail/dangling_pointers/wild_pointer_deref.stderr
@@ -8,6 +8,7 @@ LL |     let x = unsafe { *p };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/wild_pointer_deref.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/alloc_read_race.stderr
+++ b/tests/fail/data_race/alloc_read_race.stderr
@@ -13,6 +13,7 @@ LL |             pointer.store(Box::into_raw(Box::new_uninit()), Ordering::Relax
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/alloc_read_race.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/alloc_write_race.stderr
+++ b/tests/fail/data_race/alloc_write_race.stderr
@@ -13,6 +13,7 @@ LL |                 .store(Box::into_raw(Box::<usize>::new_uninit()) as *mut us
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/alloc_write_race.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/atomic_read_na_write_race1.stderr
+++ b/tests/fail/data_race/atomic_read_na_write_race1.stderr
@@ -13,6 +13,7 @@ LL |             *(c.0 as *mut usize) = 32;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/atomic_read_na_write_race1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/atomic_read_na_write_race2.stderr
+++ b/tests/fail/data_race/atomic_read_na_write_race2.stderr
@@ -13,6 +13,7 @@ LL |             atomic_ref.load(Ordering::SeqCst)
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/atomic_read_na_write_race2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/atomic_write_na_read_race1.stderr
+++ b/tests/fail/data_race/atomic_write_na_read_race1.stderr
@@ -13,6 +13,7 @@ LL |             atomic_ref.store(32, Ordering::SeqCst)
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/atomic_write_na_read_race1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/atomic_write_na_read_race2.stderr
+++ b/tests/fail/data_race/atomic_write_na_read_race2.stderr
@@ -13,6 +13,7 @@ LL |             let _val = *(c.0 as *mut usize);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/atomic_write_na_read_race2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/atomic_write_na_write_race1.stderr
+++ b/tests/fail/data_race/atomic_write_na_write_race1.stderr
@@ -13,6 +13,7 @@ LL |             *(c.0 as *mut usize) = 32;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/atomic_write_na_write_race1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/atomic_write_na_write_race2.stderr
+++ b/tests/fail/data_race/atomic_write_na_write_race2.stderr
@@ -13,6 +13,7 @@ LL |             atomic_ref.store(64, Ordering::SeqCst);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/atomic_write_na_write_race2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/dangling_thread_async_race.stderr
+++ b/tests/fail/data_race/dangling_thread_async_race.stderr
@@ -13,6 +13,7 @@ LL |             *c.0 = 32;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/dangling_thread_async_race.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/dangling_thread_race.stderr
+++ b/tests/fail/data_race/dangling_thread_race.stderr
@@ -13,6 +13,7 @@ LL |             *c.0 = 32;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/dangling_thread_race.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/dealloc_read_race1.stderr
+++ b/tests/fail/data_race/dealloc_read_race1.stderr
@@ -18,6 +18,7 @@ LL |             let _val = *ptr.0;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/dealloc_read_race1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/dealloc_read_race2.stderr
+++ b/tests/fail/data_race/dealloc_read_race2.stderr
@@ -22,6 +22,7 @@ LL | |             )
    | |_____________^
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/dealloc_read_race2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/dealloc_read_race_stack.stderr
+++ b/tests/fail/data_race/dealloc_read_race_stack.stderr
@@ -13,6 +13,7 @@ LL |             *pointer.load(Ordering::Acquire)
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/dealloc_read_race_stack.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/dealloc_write_race1.stderr
+++ b/tests/fail/data_race/dealloc_write_race1.stderr
@@ -18,6 +18,7 @@ LL |             *ptr.0 = 2;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/dealloc_write_race1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/dealloc_write_race2.stderr
+++ b/tests/fail/data_race/dealloc_write_race2.stderr
@@ -22,6 +22,7 @@ LL | |             );
    | |_____________^
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/dealloc_write_race2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/dealloc_write_race_stack.stderr
+++ b/tests/fail/data_race/dealloc_write_race_stack.stderr
@@ -13,6 +13,7 @@ LL |             *pointer.load(Ordering::Acquire) = 3;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/dealloc_write_race_stack.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/enable_after_join_to_main.stderr
+++ b/tests/fail/data_race/enable_after_join_to_main.stderr
@@ -13,6 +13,7 @@ LL |             *c.0 = 32;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/enable_after_join_to_main.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/fence_after_load.stderr
+++ b/tests/fail/data_race/fence_after_load.stderr
@@ -13,6 +13,7 @@ LL |         unsafe { V = 1 }
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/fence_after_load.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/mixed_size_read.stderr
+++ b/tests/fail/data_race/mixed_size_read.stderr
@@ -15,6 +15,7 @@ LL |             a16.load(Ordering::SeqCst);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/mixed_size_read.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/mixed_size_write.stderr
+++ b/tests/fail/data_race/mixed_size_write.stderr
@@ -15,6 +15,7 @@ LL |             a16.store(1, Ordering::SeqCst);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/mixed_size_write.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/read_read_race1.stderr
+++ b/tests/fail/data_race/read_read_race1.stderr
@@ -15,6 +15,7 @@ LL |             unsafe { ptr.read() };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/read_read_race1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/read_read_race2.stderr
+++ b/tests/fail/data_race/read_read_race2.stderr
@@ -15,6 +15,7 @@ LL |             a.load(Ordering::SeqCst);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/read_read_race2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/read_write_race.stderr
+++ b/tests/fail/data_race/read_write_race.stderr
@@ -13,6 +13,7 @@ LL |             let _val = *c.0;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/read_write_race.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/read_write_race_stack.stderr
+++ b/tests/fail/data_race/read_write_race_stack.stderr
@@ -13,6 +13,7 @@ LL |             *pointer.load(Ordering::Acquire) = 3;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/read_write_race_stack.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/relax_acquire_race.stderr
+++ b/tests/fail/data_race/relax_acquire_race.stderr
@@ -13,6 +13,7 @@ LL |             *c.0 = 1;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/relax_acquire_race.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/release_seq_race.stderr
+++ b/tests/fail/data_race/release_seq_race.stderr
@@ -13,6 +13,7 @@ LL |             *c.0 = 1;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/release_seq_race.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/release_seq_race_same_thread.stderr
+++ b/tests/fail/data_race/release_seq_race_same_thread.stderr
@@ -13,6 +13,7 @@ LL |             *c.0 = 1;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/release_seq_race_same_thread.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/rmw_race.stderr
+++ b/tests/fail/data_race/rmw_race.stderr
@@ -13,6 +13,7 @@ LL |             *c.0 = 1;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/rmw_race.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/stack_pop_race.stderr
+++ b/tests/fail/data_race/stack_pop_race.stderr
@@ -18,6 +18,7 @@ note: inside `main`
    |
 LL |     race(0);
    |     ^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/write_write_race.stderr
+++ b/tests/fail/data_race/write_write_race.stderr
@@ -13,6 +13,7 @@ LL |             *c.0 = 32;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/write_write_race.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/write_write_race_stack.stderr
+++ b/tests/fail/data_race/write_write_race_stack.stderr
@@ -13,6 +13,7 @@ LL |             *pointer.load(Ordering::Acquire) = 3;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/write_write_race_stack.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/dyn-call-trait-mismatch.stderr
+++ b/tests/fail/dyn-call-trait-mismatch.stderr
@@ -8,6 +8,7 @@ LL |     r2.method2();
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/dyn-call-trait-mismatch.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/dyn-upcast-nop-wrong-trait.stderr
+++ b/tests/fail/dyn-upcast-nop-wrong-trait.stderr
@@ -8,6 +8,7 @@ LL |     let ptr: *const (dyn fmt::Debug + Send + Sync) = unsafe { std::mem::tra
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/dyn-upcast-nop-wrong-trait.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/dyn-upcast-trait-mismatch.stderr
+++ b/tests/fail/dyn-upcast-trait-mismatch.stderr
@@ -8,6 +8,7 @@ LL |     let _err = baz_fake as *const dyn Foo;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/dyn-upcast-trait-mismatch.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/enum-set-discriminant-niche-variant-wrong.stderr
+++ b/tests/fail/enum-set-discriminant-niche-variant-wrong.stderr
@@ -13,6 +13,7 @@ note: inside `main`
    |
 LL |     set_discriminant(&mut v);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/extern-type-field-offset.stderr
+++ b/tests/fail/extern-type-field-offset.stderr
@@ -7,6 +7,7 @@ LL |     let _field = &x.a;
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
    = note: BACKTRACE:
    = note: inside `main` at $DIR/extern-type-field-offset.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/extern_static.stderr
+++ b/tests/fail/extern_static.stderr
@@ -7,6 +7,7 @@ LL |     let _val = unsafe { std::ptr::addr_of!(FOO) };
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
    = note: BACKTRACE:
    = note: inside `main` at $DIR/extern_static.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/extern_static_in_const.stderr
+++ b/tests/fail/extern_static_in_const.stderr
@@ -7,6 +7,7 @@ LL |     let _val = X;
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
    = note: BACKTRACE:
    = note: inside `main` at $DIR/extern_static_in_const.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_calls/arg_inplace_mutate.stack.stderr
+++ b/tests/fail/function_calls/arg_inplace_mutate.stack.stderr
@@ -29,6 +29,7 @@ note: inside `main`
    |
 LL |             Call(_unit = callee(Move(*ptr), ptr), ReturnTo(after_call), UnwindContinue())
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
    = note: this error originates in the macro `::core::intrinsics::mir::__internal_remove_let` which comes from the expansion of the macro `mir` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_calls/arg_inplace_mutate.tree.stderr
+++ b/tests/fail/function_calls/arg_inplace_mutate.tree.stderr
@@ -37,6 +37,7 @@ note: inside `main`
    |
 LL |             Call(_unit = callee(Move(*ptr), ptr), ReturnTo(after_call), UnwindContinue())
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
    = note: this error originates in the macro `::core::intrinsics::mir::__internal_remove_let` which comes from the expansion of the macro `mir` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_calls/arg_inplace_observe_after.stderr
+++ b/tests/fail/function_calls/arg_inplace_observe_after.stderr
@@ -8,6 +8,7 @@ LL |             _observe = non_copy.0;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/arg_inplace_observe_after.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_calls/arg_inplace_observe_during.none.stderr
+++ b/tests/fail/function_calls/arg_inplace_observe_during.none.stderr
@@ -13,6 +13,7 @@ note: inside `main`
    |
 LL |             Call(_unit = change_arg(Move(*ptr), ptr), ReturnTo(after_call), UnwindContinue())
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_calls/arg_inplace_observe_during.stack.stderr
+++ b/tests/fail/function_calls/arg_inplace_observe_during.stack.stderr
@@ -29,6 +29,7 @@ note: inside `main`
    |
 LL |             Call(_unit = change_arg(Move(*ptr), ptr), ReturnTo(after_call), UnwindContinue())
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
    = note: this error originates in the macro `::core::intrinsics::mir::__internal_remove_let` which comes from the expansion of the macro `mir` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_calls/arg_inplace_observe_during.tree.stderr
+++ b/tests/fail/function_calls/arg_inplace_observe_during.tree.stderr
@@ -37,6 +37,7 @@ note: inside `main`
    |
 LL |             Call(_unit = change_arg(Move(*ptr), ptr), ReturnTo(after_call), UnwindContinue())
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
    = note: this error originates in the macro `::core::intrinsics::mir::__internal_remove_let` which comes from the expansion of the macro `mir` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_calls/check_arg_abi.stderr
+++ b/tests/fail/function_calls/check_arg_abi.stderr
@@ -8,6 +8,7 @@ LL |         let _ = malloc(0);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/check_arg_abi.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_calls/check_arg_count_abort.stderr
+++ b/tests/fail/function_calls/check_arg_count_abort.stderr
@@ -8,6 +8,7 @@ LL |         abort(1);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/check_arg_count_abort.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_calls/check_arg_count_too_few_args.stderr
+++ b/tests/fail/function_calls/check_arg_count_too_few_args.stderr
@@ -8,6 +8,7 @@ LL |         let _ = malloc();
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/check_arg_count_too_few_args.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_calls/check_arg_count_too_many_args.stderr
+++ b/tests/fail/function_calls/check_arg_count_too_many_args.stderr
@@ -8,6 +8,7 @@ LL |         let _ = malloc(1, 2);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/check_arg_count_too_many_args.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_calls/check_callback_abi.stderr
+++ b/tests/fail/function_calls/check_callback_abi.stderr
@@ -13,6 +13,7 @@ LL | |         );
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/check_callback_abi.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_calls/exported_symbol_abi_mismatch.cache.stderr
+++ b/tests/fail/function_calls/exported_symbol_abi_mismatch.cache.stderr
@@ -8,6 +8,7 @@ LL |             foo();
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/exported_symbol_abi_mismatch.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_calls/exported_symbol_abi_mismatch.fn_ptr.stderr
+++ b/tests/fail/function_calls/exported_symbol_abi_mismatch.fn_ptr.stderr
@@ -8,6 +8,7 @@ LL |         std::mem::transmute::<unsafe fn(), unsafe extern "C" fn()>(foo)();
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/exported_symbol_abi_mismatch.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_calls/exported_symbol_abi_mismatch.no_cache.stderr
+++ b/tests/fail/function_calls/exported_symbol_abi_mismatch.no_cache.stderr
@@ -8,6 +8,7 @@ LL |             foo();
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/exported_symbol_abi_mismatch.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_calls/exported_symbol_bad_unwind1.stderr
+++ b/tests/fail/function_calls/exported_symbol_bad_unwind1.stderr
@@ -12,6 +12,7 @@ LL |     unsafe { unwind() }
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/exported_symbol_bad_unwind1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_calls/exported_symbol_bad_unwind2.both.stderr
+++ b/tests/fail/function_calls/exported_symbol_bad_unwind2.both.stderr
@@ -32,6 +32,7 @@ note: inside `main`
    |
 LL |     unsafe { nounwind() }
    | ^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_calls/exported_symbol_bad_unwind2.definition.stderr
+++ b/tests/fail/function_calls/exported_symbol_bad_unwind2.definition.stderr
@@ -32,6 +32,7 @@ note: inside `main`
    |
 LL |     unsafe { nounwind() }
    | ^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_calls/exported_symbol_bad_unwind2.extern_block.stderr
+++ b/tests/fail/function_calls/exported_symbol_bad_unwind2.extern_block.stderr
@@ -12,6 +12,7 @@ LL |     unsafe { nounwind() }
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/exported_symbol_bad_unwind2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_calls/exported_symbol_clashing.stderr
+++ b/tests/fail/function_calls/exported_symbol_clashing.stderr
@@ -16,6 +16,7 @@ LL | fn bar() {}
    | ^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/exported_symbol_clashing.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_calls/exported_symbol_shim_clashing.stderr
+++ b/tests/fail/function_calls/exported_symbol_shim_clashing.stderr
@@ -14,6 +14,7 @@ LL | | }
    | |_^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/exported_symbol_shim_clashing.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_calls/exported_symbol_wrong_arguments.stderr
+++ b/tests/fail/function_calls/exported_symbol_wrong_arguments.stderr
@@ -8,6 +8,7 @@ LL |     unsafe { foo(1) }
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/exported_symbol_wrong_arguments.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_calls/exported_symbol_wrong_type.stderr
+++ b/tests/fail/function_calls/exported_symbol_wrong_type.stderr
@@ -8,6 +8,7 @@ LL |     unsafe { FOO() }
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/exported_symbol_wrong_type.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_calls/return_pointer_aliasing.none.stderr
+++ b/tests/fail/function_calls/return_pointer_aliasing.none.stderr
@@ -13,6 +13,7 @@ note: inside `main`
    |
 LL |             Call(*ptr = myfun(ptr), ReturnTo(after_call), UnwindContinue())
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_calls/return_pointer_aliasing.stack.stderr
+++ b/tests/fail/function_calls/return_pointer_aliasing.stack.stderr
@@ -29,6 +29,7 @@ note: inside `main`
    |
 LL |             Call(*ptr = myfun(ptr), ReturnTo(after_call), UnwindContinue())
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
    = note: this error originates in the macro `::core::intrinsics::mir::__internal_remove_let` which comes from the expansion of the macro `mir` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_calls/return_pointer_aliasing.tree.stderr
+++ b/tests/fail/function_calls/return_pointer_aliasing.tree.stderr
@@ -37,6 +37,7 @@ note: inside `main`
    |
 LL |             Call(*ptr = myfun(ptr), ReturnTo(after_call), UnwindContinue())
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
    = note: this error originates in the macro `::core::intrinsics::mir::__internal_remove_let` which comes from the expansion of the macro `mir` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_calls/return_pointer_aliasing2.stack.stderr
+++ b/tests/fail/function_calls/return_pointer_aliasing2.stack.stderr
@@ -32,6 +32,7 @@ note: inside `main`
    |
 LL |             Call(_x = myfun(ptr), ReturnTo(after_call), UnwindContinue())
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
    = note: this error originates in the macro `::core::intrinsics::mir::__internal_remove_let` which comes from the expansion of the macro `mir` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_calls/return_pointer_aliasing2.tree.stderr
+++ b/tests/fail/function_calls/return_pointer_aliasing2.tree.stderr
@@ -37,6 +37,7 @@ note: inside `main`
    |
 LL |             Call(_x = myfun(ptr), ReturnTo(after_call), UnwindContinue())
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
    = note: this error originates in the macro `::core::intrinsics::mir::__internal_remove_let` which comes from the expansion of the macro `mir` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_calls/return_pointer_on_unwind.stderr
+++ b/tests/fail/function_calls/return_pointer_on_unwind.stderr
@@ -12,6 +12,7 @@ LL |     dbg!(x.0);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at RUSTLIB/std/src/macros.rs:LL:CC
+   = note: This occured with miri seed: 0
    = note: this error originates in the macro `dbg` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/function_calls/simd_feature_flag_difference.stderr
+++ b/tests/fail/function_calls/simd_feature_flag_difference.stderr
@@ -13,6 +13,7 @@ note: inside `main`
    |
 LL |     let copy = bar(input);
    |                ^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_calls/target_feature.stderr
+++ b/tests/fail/function_calls/target_feature.stderr
@@ -8,6 +8,7 @@ LL |         ssse3_fn();
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/target_feature.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_pointers/abi_mismatch_array_vs_struct.stderr
+++ b/tests/fail/function_pointers/abi_mismatch_array_vs_struct.stderr
@@ -10,6 +10,7 @@ LL |     g(Default::default())
    = help: if you think this code should be accepted anyway, please report an issue with Miri
    = note: BACKTRACE:
    = note: inside `main` at $DIR/abi_mismatch_array_vs_struct.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_pointers/abi_mismatch_int_vs_float.stderr
+++ b/tests/fail/function_pointers/abi_mismatch_int_vs_float.stderr
@@ -10,6 +10,7 @@ LL |     g(42)
    = help: if you think this code should be accepted anyway, please report an issue with Miri
    = note: BACKTRACE:
    = note: inside `main` at $DIR/abi_mismatch_int_vs_float.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_pointers/abi_mismatch_raw_pointer.stderr
+++ b/tests/fail/function_pointers/abi_mismatch_raw_pointer.stderr
@@ -10,6 +10,7 @@ LL |     g(&42 as *const i32)
    = help: if you think this code should be accepted anyway, please report an issue with Miri
    = note: BACKTRACE:
    = note: inside `main` at $DIR/abi_mismatch_raw_pointer.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_pointers/abi_mismatch_repr_C.stderr
+++ b/tests/fail/function_pointers/abi_mismatch_repr_C.stderr
@@ -10,6 +10,7 @@ LL |     fnptr(S1(NonZeroI32::new(1).unwrap()));
    = help: if you think this code should be accepted anyway, please report an issue with Miri
    = note: BACKTRACE:
    = note: inside `main` at $DIR/abi_mismatch_repr_C.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_pointers/abi_mismatch_return_type.stderr
+++ b/tests/fail/function_pointers/abi_mismatch_return_type.stderr
@@ -10,6 +10,7 @@ LL |     g()
    = help: if you think this code should be accepted anyway, please report an issue with Miri
    = note: BACKTRACE:
    = note: inside `main` at $DIR/abi_mismatch_return_type.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_pointers/abi_mismatch_simple.stderr
+++ b/tests/fail/function_pointers/abi_mismatch_simple.stderr
@@ -10,6 +10,7 @@ LL |     g(42)
    = help: if you think this code should be accepted anyway, please report an issue with Miri
    = note: BACKTRACE:
    = note: inside `main` at $DIR/abi_mismatch_simple.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_pointers/abi_mismatch_too_few_args.stderr
+++ b/tests/fail/function_pointers/abi_mismatch_too_few_args.stderr
@@ -8,6 +8,7 @@ LL |     g()
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/abi_mismatch_too_few_args.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_pointers/abi_mismatch_too_many_args.stderr
+++ b/tests/fail/function_pointers/abi_mismatch_too_many_args.stderr
@@ -8,6 +8,7 @@ LL |     g(42)
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/abi_mismatch_too_many_args.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_pointers/abi_mismatch_vector.stderr
+++ b/tests/fail/function_pointers/abi_mismatch_vector.stderr
@@ -10,6 +10,7 @@ LL |     g(Default::default())
    = help: if you think this code should be accepted anyway, please report an issue with Miri
    = note: BACKTRACE:
    = note: inside `main` at $DIR/abi_mismatch_vector.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_pointers/cast_box_int_to_fn_ptr.stderr
+++ b/tests/fail/function_pointers/cast_box_int_to_fn_ptr.stderr
@@ -8,6 +8,7 @@ LL |     (*g)(42)
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/cast_box_int_to_fn_ptr.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_pointers/cast_int_to_fn_ptr.stderr
+++ b/tests/fail/function_pointers/cast_int_to_fn_ptr.stderr
@@ -8,6 +8,7 @@ LL |     g(42)
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/cast_int_to_fn_ptr.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_pointers/deref_fn_ptr.stderr
+++ b/tests/fail/function_pointers/deref_fn_ptr.stderr
@@ -8,6 +8,7 @@ LL |         *std::mem::transmute::<fn(), *const u8>(f)
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/deref_fn_ptr.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_pointers/execute_memory.stderr
+++ b/tests/fail/function_pointers/execute_memory.stderr
@@ -8,6 +8,7 @@ LL |         f()
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/execute_memory.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/function_pointers/fn_ptr_offset.stderr
+++ b/tests/fail/function_pointers/fn_ptr_offset.stderr
@@ -8,6 +8,7 @@ LL |     x();
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/fn_ptr_offset.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsic_fallback_checks_ub.stderr
+++ b/tests/fail/intrinsic_fallback_checks_ub.stderr
@@ -7,6 +7,7 @@ LL |     ptr_guaranteed_cmp::<()>(std::ptr::null(), std::ptr::null());
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
    = note: BACKTRACE:
    = note: inside `main` at $DIR/intrinsic_fallback_checks_ub.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/assume.stderr
+++ b/tests/fail/intrinsics/assume.stderr
@@ -8,6 +8,7 @@ LL |         std::intrinsics::assume(x > 42);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/assume.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/copy_null.stderr
+++ b/tests/fail/intrinsics/copy_null.stderr
@@ -8,6 +8,7 @@ LL |         copy_nonoverlapping(std::ptr::null(), ptr, 0);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/copy_null.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/copy_overflow.stderr
+++ b/tests/fail/intrinsics/copy_overflow.stderr
@@ -8,6 +8,7 @@ LL |         (&mut y as *mut i32).copy_from(&x, 1usize << (mem::size_of::<usize>
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/copy_overflow.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/copy_overlapping.stderr
+++ b/tests/fail/intrinsics/copy_overlapping.stderr
@@ -8,6 +8,7 @@ LL |         copy_nonoverlapping(a, b, 2);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/copy_overlapping.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/copy_unaligned.stderr
+++ b/tests/fail/intrinsics/copy_unaligned.stderr
@@ -8,6 +8,7 @@ LL |         copy_nonoverlapping(&data[5], ptr, 0);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/copy_unaligned.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/ctlz_nonzero.stderr
+++ b/tests/fail/intrinsics/ctlz_nonzero.stderr
@@ -8,6 +8,7 @@ LL |         ctlz_nonzero(0u8);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/ctlz_nonzero.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/cttz_nonzero.stderr
+++ b/tests/fail/intrinsics/cttz_nonzero.stderr
@@ -8,6 +8,7 @@ LL |         cttz_nonzero(0u8);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/cttz_nonzero.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/div-by-zero.stderr
+++ b/tests/fail/intrinsics/div-by-zero.stderr
@@ -8,6 +8,7 @@ LL |         let _n = unchecked_div(1i64, 0);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/div-by-zero.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/exact_div1.stderr
+++ b/tests/fail/intrinsics/exact_div1.stderr
@@ -8,6 +8,7 @@ LL |     unsafe { std::intrinsics::exact_div(2, 0) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/exact_div1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/exact_div2.stderr
+++ b/tests/fail/intrinsics/exact_div2.stderr
@@ -8,6 +8,7 @@ LL |     unsafe { std::intrinsics::exact_div(2u16, 3) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/exact_div2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/exact_div3.stderr
+++ b/tests/fail/intrinsics/exact_div3.stderr
@@ -8,6 +8,7 @@ LL |     unsafe { std::intrinsics::exact_div(-19i8, 2) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/exact_div3.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/exact_div4.stderr
+++ b/tests/fail/intrinsics/exact_div4.stderr
@@ -8,6 +8,7 @@ LL |     unsafe { std::intrinsics::exact_div(i64::MIN, -1) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/exact_div4.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/fast_math_both.stderr
+++ b/tests/fail/intrinsics/fast_math_both.stderr
@@ -8,6 +8,7 @@ LL | ...: f32 = core::intrinsics::fsub_fast(f32::NAN, f32::NAN);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/fast_math_both.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/fast_math_first.stderr
+++ b/tests/fail/intrinsics/fast_math_first.stderr
@@ -8,6 +8,7 @@ LL | ...   let _x: f32 = core::intrinsics::frem_fast(f32::NAN, 3.2);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/fast_math_first.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/fast_math_result.stderr
+++ b/tests/fail/intrinsics/fast_math_result.stderr
@@ -8,6 +8,7 @@ LL |         let _x: f32 = core::intrinsics::fdiv_fast(1.0, 0.0);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/fast_math_result.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/fast_math_second.stderr
+++ b/tests/fail/intrinsics/fast_math_second.stderr
@@ -8,6 +8,7 @@ LL | ...f32 = core::intrinsics::fmul_fast(3.4f32, f32::INFINITY);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/fast_math_second.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/float_to_int_32_inf1.stderr
+++ b/tests/fail/intrinsics/float_to_int_32_inf1.stderr
@@ -8,6 +8,7 @@ LL |         float_to_int_unchecked::<f32, i32>(f32::INFINITY);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/float_to_int_32_inf1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/float_to_int_32_infneg1.stderr
+++ b/tests/fail/intrinsics/float_to_int_32_infneg1.stderr
@@ -8,6 +8,7 @@ LL |         float_to_int_unchecked::<f32, i32>(f32::NEG_INFINITY);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/float_to_int_32_infneg1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/float_to_int_32_nan.stderr
+++ b/tests/fail/intrinsics/float_to_int_32_nan.stderr
@@ -8,6 +8,7 @@ LL |         float_to_int_unchecked::<f32, u32>(f32::NAN);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/float_to_int_32_nan.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/float_to_int_32_nanneg.stderr
+++ b/tests/fail/intrinsics/float_to_int_32_nanneg.stderr
@@ -8,6 +8,7 @@ LL |         float_to_int_unchecked::<f32, u32>(-f32::NAN);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/float_to_int_32_nanneg.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/float_to_int_32_neg.stderr
+++ b/tests/fail/intrinsics/float_to_int_32_neg.stderr
@@ -8,6 +8,7 @@ LL |         float_to_int_unchecked::<f32, u32>(-1.000000001f32);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/float_to_int_32_neg.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/float_to_int_32_too_big1.stderr
+++ b/tests/fail/intrinsics/float_to_int_32_too_big1.stderr
@@ -8,6 +8,7 @@ LL |         float_to_int_unchecked::<f32, i32>(2147483648.0f32);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/float_to_int_32_too_big1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/float_to_int_32_too_big2.stderr
+++ b/tests/fail/intrinsics/float_to_int_32_too_big2.stderr
@@ -8,6 +8,7 @@ LL |         float_to_int_unchecked::<f32, u32>((u32::MAX - 127) as f32);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/float_to_int_32_too_big2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/float_to_int_32_too_small1.stderr
+++ b/tests/fail/intrinsics/float_to_int_32_too_small1.stderr
@@ -8,6 +8,7 @@ LL |         float_to_int_unchecked::<f32, i32>(-2147483904.0f32);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/float_to_int_32_too_small1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/float_to_int_64_inf1.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_inf1.stderr
@@ -8,6 +8,7 @@ LL |         float_to_int_unchecked::<f64, u128>(f64::INFINITY);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/float_to_int_64_inf1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/float_to_int_64_infneg1.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_infneg1.stderr
@@ -8,6 +8,7 @@ LL |         float_to_int_unchecked::<f64, u128>(f64::NEG_INFINITY);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/float_to_int_64_infneg1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/float_to_int_64_infneg2.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_infneg2.stderr
@@ -8,6 +8,7 @@ LL |         float_to_int_unchecked::<f64, i128>(f64::NEG_INFINITY);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/float_to_int_64_infneg2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/float_to_int_64_nan.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_nan.stderr
@@ -8,6 +8,7 @@ LL |         float_to_int_unchecked::<f64, u32>(f64::NAN);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/float_to_int_64_nan.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/float_to_int_64_neg.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_neg.stderr
@@ -8,6 +8,7 @@ LL |         float_to_int_unchecked::<f64, u128>(-1.0000000000001f64);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/float_to_int_64_neg.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/float_to_int_64_too_big1.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_big1.stderr
@@ -8,6 +8,7 @@ LL |         float_to_int_unchecked::<f64, i32>(2147483648.0f64);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/float_to_int_64_too_big1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/float_to_int_64_too_big2.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_big2.stderr
@@ -8,6 +8,7 @@ LL |         float_to_int_unchecked::<f64, i64>(9223372036854775808.0f64);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/float_to_int_64_too_big2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/float_to_int_64_too_big3.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_big3.stderr
@@ -8,6 +8,7 @@ LL |         float_to_int_unchecked::<f64, u64>(18446744073709551616.0f64);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/float_to_int_64_too_big3.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/float_to_int_64_too_big4.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_big4.stderr
@@ -8,6 +8,7 @@ LL |         float_to_int_unchecked::<f64, u128>(u128::MAX as f64);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/float_to_int_64_too_big4.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/float_to_int_64_too_big5.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_big5.stderr
@@ -8,6 +8,7 @@ LL |         float_to_int_unchecked::<f64, i128>(2402823669209384634633746074317
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/float_to_int_64_too_big5.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/float_to_int_64_too_big6.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_big6.stderr
@@ -8,6 +8,7 @@ LL |         float_to_int_unchecked::<f64, u128>(f64::MAX);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/float_to_int_64_too_big6.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/float_to_int_64_too_big7.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_big7.stderr
@@ -8,6 +8,7 @@ LL |         float_to_int_unchecked::<f64, i128>(f64::MIN);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/float_to_int_64_too_big7.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/float_to_int_64_too_small1.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_small1.stderr
@@ -8,6 +8,7 @@ LL |         float_to_int_unchecked::<f64, i32>(-2147483649.0f64);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/float_to_int_64_too_small1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/float_to_int_64_too_small2.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_small2.stderr
@@ -8,6 +8,7 @@ LL |         float_to_int_unchecked::<f64, i64>(-9223372036854777856.0f64);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/float_to_int_64_too_small2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/float_to_int_64_too_small3.stderr
+++ b/tests/fail/intrinsics/float_to_int_64_too_small3.stderr
@@ -8,6 +8,7 @@ LL |         float_to_int_unchecked::<f64, i128>(-240282366920938463463374607431
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/float_to_int_64_too_small3.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/intrinsic_target_feature.stderr
+++ b/tests/fail/intrinsics/intrinsic_target_feature.stderr
@@ -8,6 +8,7 @@ LL |         dpps(_mm_setzero_ps(), _mm_setzero_ps(), 0);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/intrinsic_target_feature.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/out_of_bounds_ptr_1.stderr
+++ b/tests/fail/intrinsics/out_of_bounds_ptr_1.stderr
@@ -13,6 +13,7 @@ LL |     let v = [0i8; 4];
    |         ^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/out_of_bounds_ptr_1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/out_of_bounds_ptr_2.stderr
+++ b/tests/fail/intrinsics/out_of_bounds_ptr_2.stderr
@@ -8,6 +8,7 @@ LL |     let x = unsafe { x.offset(isize::MIN) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/out_of_bounds_ptr_2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/out_of_bounds_ptr_3.stderr
+++ b/tests/fail/intrinsics/out_of_bounds_ptr_3.stderr
@@ -13,6 +13,7 @@ LL |     let v = [0i8; 4];
    |         ^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/out_of_bounds_ptr_3.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/ptr_offset_0_plus_0.stderr
+++ b/tests/fail/intrinsics/ptr_offset_0_plus_0.stderr
@@ -8,6 +8,7 @@ LL |     let _x = unsafe { x.offset(0) }; // UB despite offset 0, NULL is never 
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/ptr_offset_0_plus_0.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/ptr_offset_from_oob.stderr
+++ b/tests/fail/intrinsics/ptr_offset_from_oob.stderr
@@ -8,6 +8,7 @@ LL |     unsafe { end_ptr.offset_from(end_ptr) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/ptr_offset_from_oob.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/ptr_offset_from_unsigned_neg.stderr
+++ b/tests/fail/intrinsics/ptr_offset_from_unsigned_neg.stderr
@@ -8,6 +8,7 @@ LL |     let _val = unsafe { ptr1.sub_ptr(ptr2) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/ptr_offset_from_unsigned_neg.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/ptr_offset_int_plus_int.stderr
+++ b/tests/fail/intrinsics/ptr_offset_int_plus_int.stderr
@@ -8,6 +8,7 @@ LL |         let _val = (1 as *mut u8).offset(1);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/ptr_offset_int_plus_int.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/ptr_offset_int_plus_ptr.stderr
+++ b/tests/fail/intrinsics/ptr_offset_int_plus_ptr.stderr
@@ -8,6 +8,7 @@ LL |         let _val = (1 as *mut u8).offset(ptr as isize);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/ptr_offset_int_plus_ptr.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/ptr_offset_overflow.stderr
+++ b/tests/fail/intrinsics/ptr_offset_overflow.stderr
@@ -8,6 +8,7 @@ LL |     let _val = unsafe { x.offset(isize::MIN) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/ptr_offset_overflow.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/ptr_offset_ptr_plus_0.stderr
+++ b/tests/fail/intrinsics/ptr_offset_ptr_plus_0.stderr
@@ -13,6 +13,7 @@ LL |     let x = Box::into_raw(Box::new(0u32));
    |                           ^^^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/ptr_offset_ptr_plus_0.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/raw_eq_on_ptr.stderr
+++ b/tests/fail/intrinsics/raw_eq_on_ptr.stderr
@@ -8,6 +8,7 @@ LL |     unsafe { raw_eq(&x, &x) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/raw_eq_on_ptr.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/rem-by-zero.stderr
+++ b/tests/fail/intrinsics/rem-by-zero.stderr
@@ -8,6 +8,7 @@ LL |         let _n = unchecked_rem(3u32, 0);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/rem-by-zero.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/simd-div-by-zero.stderr
+++ b/tests/fail/intrinsics/simd-div-by-zero.stderr
@@ -8,6 +8,7 @@ LL |         simd_div(x, y);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/simd-div-by-zero.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/simd-div-overflow.stderr
+++ b/tests/fail/intrinsics/simd-div-overflow.stderr
@@ -8,6 +8,7 @@ LL |         simd_div(x, y);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/simd-div-overflow.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/simd-extract.stderr
+++ b/tests/fail/intrinsics/simd-extract.stderr
@@ -8,6 +8,7 @@ LL |     let _x: i32 = unsafe { std::intrinsics::simd::simd_extract(v, 4) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/simd-extract.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/simd-float-to-int.stderr
+++ b/tests/fail/intrinsics/simd-float-to-int.stderr
@@ -8,6 +8,7 @@ LL |         let _x: i32x2 = f32x2::from_array([f32::MAX, f32::MIN]).to_int_unch
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/simd-float-to-int.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/simd-gather.stderr
+++ b/tests/fail/intrinsics/simd-gather.stderr
@@ -8,6 +8,7 @@ LL |         let _result = Simd::gather_select_unchecked(&vec, Mask::splat(true)
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/simd-gather.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/simd-reduce-invalid-bool.stderr
+++ b/tests/fail/intrinsics/simd-reduce-invalid-bool.stderr
@@ -8,6 +8,7 @@ LL |         simd_reduce_any(x);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/simd-reduce-invalid-bool.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/simd-rem-by-zero.stderr
+++ b/tests/fail/intrinsics/simd-rem-by-zero.stderr
@@ -8,6 +8,7 @@ LL |         simd_rem(x, y);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/simd-rem-by-zero.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/simd-scatter.stderr
+++ b/tests/fail/intrinsics/simd-scatter.stderr
@@ -18,6 +18,7 @@ LL |         let mut vec: Vec<i8> = vec![10, 11, 12, 13, 14, 15, 16, 17, 18];
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/simd-scatter.rs:LL:CC
+   = note: This occured with miri seed: 0
    = note: this error originates in the macro `vec` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/intrinsics/simd-select-bitmask-invalid.stderr
+++ b/tests/fail/intrinsics/simd-select-bitmask-invalid.stderr
@@ -8,6 +8,7 @@ LL |         simd_select_bitmask(0b11111111u8, x, x);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/simd-select-bitmask-invalid.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/simd-select-invalid-bool.stderr
+++ b/tests/fail/intrinsics/simd-select-invalid-bool.stderr
@@ -8,6 +8,7 @@ LL |         simd_select(x, x, x);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/simd-select-invalid-bool.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/simd-shl-too-far.stderr
+++ b/tests/fail/intrinsics/simd-shl-too-far.stderr
@@ -8,6 +8,7 @@ LL |         simd_shl(x, y);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/simd-shl-too-far.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/simd-shr-too-far.stderr
+++ b/tests/fail/intrinsics/simd-shr-too-far.stderr
@@ -8,6 +8,7 @@ LL |         simd_shr(x, y);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/simd-shr-too-far.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/typed-swap-invalid-array.stderr
+++ b/tests/fail/intrinsics/typed-swap-invalid-array.stderr
@@ -13,6 +13,7 @@ note: inside `main`
    |
 LL |     invalid_array();
    |     ^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/typed-swap-invalid-scalar.stderr
+++ b/tests/fail/intrinsics/typed-swap-invalid-scalar.stderr
@@ -13,6 +13,7 @@ note: inside `main`
    |
 LL |     invalid_scalar();
    |     ^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/unchecked_add1.stderr
+++ b/tests/fail/intrinsics/unchecked_add1.stderr
@@ -8,6 +8,7 @@ LL |     let _val = unsafe { 40000u16.unchecked_add(30000) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/unchecked_add1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/unchecked_add2.stderr
+++ b/tests/fail/intrinsics/unchecked_add2.stderr
@@ -8,6 +8,7 @@ LL |     let _val = unsafe { (-30000i16).unchecked_add(-8000) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/unchecked_add2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/unchecked_div1.stderr
+++ b/tests/fail/intrinsics/unchecked_div1.stderr
@@ -8,6 +8,7 @@ LL |         std::intrinsics::unchecked_div(i16::MIN, -1);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/unchecked_div1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/unchecked_mul1.stderr
+++ b/tests/fail/intrinsics/unchecked_mul1.stderr
@@ -8,6 +8,7 @@ LL |     let _val = unsafe { 300u16.unchecked_mul(250u16) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/unchecked_mul1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/unchecked_mul2.stderr
+++ b/tests/fail/intrinsics/unchecked_mul2.stderr
@@ -8,6 +8,7 @@ LL |     let _val = unsafe { 1_000_000_000i32.unchecked_mul(-4) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/unchecked_mul2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/unchecked_shl.stderr
+++ b/tests/fail/intrinsics/unchecked_shl.stderr
@@ -8,6 +8,7 @@ LL |         let _n = 1i8.unchecked_shl(8);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/unchecked_shl.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/unchecked_shl2.stderr
+++ b/tests/fail/intrinsics/unchecked_shl2.stderr
@@ -8,6 +8,7 @@ LL |         let _n = intrinsics::unchecked_shl(1i8, -1);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/unchecked_shl2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/unchecked_shr.stderr
+++ b/tests/fail/intrinsics/unchecked_shr.stderr
@@ -8,6 +8,7 @@ LL |         let _n = 1i64.unchecked_shr(64);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/unchecked_shr.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/unchecked_sub1.stderr
+++ b/tests/fail/intrinsics/unchecked_sub1.stderr
@@ -8,6 +8,7 @@ LL |     let _val = unsafe { 14u32.unchecked_sub(22) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/unchecked_sub1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/unchecked_sub2.stderr
+++ b/tests/fail/intrinsics/unchecked_sub2.stderr
@@ -8,6 +8,7 @@ LL |     let _val = unsafe { 30000i16.unchecked_sub(-7000) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/unchecked_sub2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/uninit_uninhabited_type.stderr
+++ b/tests/fail/intrinsics/uninit_uninhabited_type.stderr
@@ -21,6 +21,7 @@ note: inside `main`
    |
 LL |     let _ = unsafe { std::mem::uninitialized::<!>() };
    | ^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/write_bytes_null.stderr
+++ b/tests/fail/intrinsics/write_bytes_null.stderr
@@ -8,6 +8,7 @@ LL |     unsafe { write_bytes::<u8>(std::ptr::null_mut(), 0, 0) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/write_bytes_null.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/write_bytes_overflow.stderr
+++ b/tests/fail/intrinsics/write_bytes_overflow.stderr
@@ -8,6 +8,7 @@ LL |         (&mut y as *mut i32).write_bytes(0u8, 1usize << (mem::size_of::<usi
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/write_bytes_overflow.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/intrinsics/zero_fn_ptr.stderr
+++ b/tests/fail/intrinsics/zero_fn_ptr.stderr
@@ -21,6 +21,7 @@ note: inside `main`
    |
 LL |     let _ = unsafe { std::mem::zeroed::<fn()>() };
    | ^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/issue-miri-1112.stderr
+++ b/tests/fail/issue-miri-1112.stderr
@@ -13,6 +13,7 @@ note: inside `main`
    |
 LL |         let _raw: &FunnyPointer = FunnyPointer::from_data_ptr(&hello, &meta as *const _);
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/issue-miri-2432.stderr
+++ b/tests/fail/issue-miri-2432.stderr
@@ -8,6 +8,7 @@ LL |     <dyn X as X>::foo(&());
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/issue-miri-2432.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/issue-miri-3288-ice-symbolic-alignment-extern-static.stderr
+++ b/tests/fail/issue-miri-3288-ice-symbolic-alignment-extern-static.stderr
@@ -7,6 +7,7 @@ LL |     let _val = *DISPATCH_QUEUE_CONCURRENT;
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
    = note: BACKTRACE:
    = note: inside `main` at $DIR/issue-miri-3288-ice-symbolic-alignment-extern-static.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/layout_cycle.stderr
+++ b/tests/fail/layout_cycle.stderr
@@ -22,6 +22,7 @@ note: inside `main`
    |
 LL |     println!("{}", foo::<S<()>>());
    |                    ^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/memleak.stderr
+++ b/tests/fail/memleak.stderr
@@ -15,6 +15,7 @@ note: inside `main`
    |
 LL |     std::mem::forget(Box::new(42));
    |                      ^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/memleak_rc.32bit.stderr
+++ b/tests/fail/memleak_rc.32bit.stderr
@@ -16,6 +16,7 @@ note: inside `main`
    |
 LL |     let x = Dummy(Rc::new(RefCell::new(None)));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/memleak_rc.64bit.stderr
+++ b/tests/fail/memleak_rc.64bit.stderr
@@ -16,6 +16,7 @@ note: inside `main`
    |
 LL |     let x = Dummy(Rc::new(RefCell::new(None)));
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/miri-seed.rs
+++ b/tests/fail/miri-seed.rs
@@ -1,0 +1,8 @@
+//@compile-flags: -Zmiri-seed=9223372036854775807
+#![feature(core_intrinsics)]
+
+fn main() {
+    unsafe {
+        core::intrinsics::breakpoint() //~ ERROR: trace/breakpoint trap
+    };
+}

--- a/tests/fail/miri-seed.stderr
+++ b/tests/fail/miri-seed.stderr
@@ -1,12 +1,12 @@
 error: abnormal termination: trace/breakpoint trap
-  --> $DIR/breakpoint.rs:LL:CC
+  --> $DIR/miri-seed.rs:LL:CC
    |
 LL |         core::intrinsics::breakpoint()
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ trace/breakpoint trap
    |
    = note: BACKTRACE:
-   = note: inside `main` at $DIR/breakpoint.rs:LL:CC
-   = note: This occured with miri seed: 0
+   = note: inside `main` at $DIR/miri-seed.rs:LL:CC
+   = note: This occured with miri seed: 9223372036854775807
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/modifying_constants.stderr
+++ b/tests/fail/modifying_constants.stderr
@@ -8,6 +8,7 @@ LL |     *y = 42;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/modifying_constants.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/never_match_never.stderr
+++ b/tests/fail/never_match_never.stderr
@@ -8,6 +8,7 @@ LL |     unsafe { match (*ptr).1 {} }
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/never_match_never.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/never_say_never.stderr
+++ b/tests/fail/never_say_never.stderr
@@ -8,6 +8,7 @@ LL |     f(x)
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/never_say_never.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/never_transmute_humans.stderr
+++ b/tests/fail/never_transmute_humans.stderr
@@ -8,6 +8,7 @@ LL |         std::mem::transmute::<Human, !>(Human)
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/never_transmute_humans.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/never_transmute_void.stderr
+++ b/tests/fail/never_transmute_void.stderr
@@ -13,6 +13,7 @@ note: inside `main`
    |
 LL |     m::f(v);
    |     ^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/overlapping_assignment.stderr
+++ b/tests/fail/overlapping_assignment.stderr
@@ -13,6 +13,7 @@ note: inside `main`
    |
 LL |     self_copy(ptr, ptr);
    |     ^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/panic/bad_unwind.stderr
+++ b/tests/fail/panic/bad_unwind.stderr
@@ -20,6 +20,7 @@ note: inside `main`
    |
 LL |     std::panic::catch_unwind(|| unwind()).unwrap_err();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/panic/double_panic.stderr
+++ b/tests/fail/panic/double_panic.stderr
@@ -30,6 +30,7 @@ LL | |     let _foo = Foo;
 LL | |     panic!("first");
 LL | | }
    | |_^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/panic/no_std.stderr
+++ b/tests/fail/panic/no_std.stderr
@@ -13,6 +13,7 @@ note: inside `start`
    |
 LL |     panic!("blarg I am dead")
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/panic/panic_abort1.stderr
+++ b/tests/fail/panic/panic_abort1.stderr
@@ -21,6 +21,7 @@ note: inside `main`
    |
 LL |     std::panic!("panicking from libstd");
    | ^
+   = note: This occured with miri seed: 0
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/panic/panic_abort2.stderr
+++ b/tests/fail/panic/panic_abort2.stderr
@@ -21,6 +21,7 @@ note: inside `main`
    |
 LL |     std::panic!("{}-panicking from libstd", 42);
    | ^
+   = note: This occured with miri seed: 0
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `std::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/panic/panic_abort3.stderr
+++ b/tests/fail/panic/panic_abort3.stderr
@@ -21,6 +21,7 @@ note: inside `main`
    |
 LL |     core::panic!("panicking from libcore");
    | ^
+   = note: This occured with miri seed: 0
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/panic/panic_abort4.stderr
+++ b/tests/fail/panic/panic_abort4.stderr
@@ -21,6 +21,7 @@ note: inside `main`
    |
 LL |     core::panic!("{}-panicking from libcore", 42);
    | ^
+   = note: This occured with miri seed: 0
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `core::panic` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/panic/unwind_panic_abort.stderr
+++ b/tests/fail/panic/unwind_panic_abort.stderr
@@ -8,6 +8,7 @@ LL |         miri_start_unwind(&mut 0);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/unwind_panic_abort.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/provenance/pointer_partial_overwrite.stderr
+++ b/tests/fail/provenance/pointer_partial_overwrite.stderr
@@ -8,6 +8,7 @@ LL |     let x = *p;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/pointer_partial_overwrite.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/provenance/provenance_transmute.stderr
+++ b/tests/fail/provenance/provenance_transmute.stderr
@@ -13,6 +13,7 @@ note: inside `main`
    |
 LL |         deref(ptr1, ptr2.with_addr(ptr1.addr()));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/provenance/ptr_int_unexposed.stderr
+++ b/tests/fail/provenance/ptr_int_unexposed.stderr
@@ -8,6 +8,7 @@ LL |     assert_eq!(unsafe { *ptr }, 3);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/ptr_int_unexposed.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/provenance/ptr_invalid.stderr
+++ b/tests/fail/provenance/ptr_invalid.stderr
@@ -8,6 +8,7 @@ LL |     let _val = unsafe { *xptr_invalid };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/ptr_invalid.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/provenance/ptr_invalid_offset.stderr
+++ b/tests/fail/provenance/ptr_invalid_offset.stderr
@@ -8,6 +8,7 @@ LL |     let _ = unsafe { roundtrip.offset(1) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/ptr_invalid_offset.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/provenance/strict_provenance_cast.stderr
+++ b/tests/fail/provenance/strict_provenance_cast.stderr
@@ -7,6 +7,7 @@ LL |     let _ptr = std::ptr::with_exposed_provenance::<i32>(addr);
    = help: use Strict Provenance APIs (https://doc.rust-lang.org/nightly/std/ptr/index.html#strict-provenance, https://crates.io/crates/sptr) instead
    = note: BACKTRACE:
    = note: inside `main` at $DIR/strict_provenance_cast.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/rc_as_ptr.stderr
+++ b/tests/fail/rc_as_ptr.stderr
@@ -18,6 +18,7 @@ LL |     drop(strong);
    |     ^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at RUSTLIB/core/src/macros/mod.rs:LL:CC
+   = note: This occured with miri seed: 0
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/reading_half_a_pointer.stderr
+++ b/tests/fail/reading_half_a_pointer.stderr
@@ -8,6 +8,7 @@ LL |         let _val = *x;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/reading_half_a_pointer.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/shims/backtrace/bad-backtrace-decl.stderr
+++ b/tests/fail/shims/backtrace/bad-backtrace-decl.stderr
@@ -8,6 +8,7 @@ LL | ...   miri_resolve_frame(*frame, 0);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/bad-backtrace-decl.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/shims/backtrace/bad-backtrace-flags.stderr
+++ b/tests/fail/shims/backtrace/bad-backtrace-flags.stderr
@@ -7,6 +7,7 @@ LL |         miri_get_backtrace(2, std::ptr::null_mut());
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
    = note: BACKTRACE:
    = note: inside `main` at $DIR/bad-backtrace-flags.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/shims/backtrace/bad-backtrace-ptr.stderr
+++ b/tests/fail/shims/backtrace/bad-backtrace-ptr.stderr
@@ -8,6 +8,7 @@ LL |         miri_resolve_frame(std::ptr::null_mut(), 0);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/bad-backtrace-ptr.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/shims/backtrace/bad-backtrace-resolve-flags.stderr
+++ b/tests/fail/shims/backtrace/bad-backtrace-resolve-flags.stderr
@@ -7,6 +7,7 @@ LL |         miri_resolve_frame(buf[0], 2);
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
    = note: BACKTRACE:
    = note: inside `main` at $DIR/bad-backtrace-resolve-flags.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/shims/backtrace/bad-backtrace-resolve-names-flags.stderr
+++ b/tests/fail/shims/backtrace/bad-backtrace-resolve-names-flags.stderr
@@ -7,6 +7,7 @@ LL | ...   miri_resolve_frame_names(buf[0], 2, std::ptr::null_mut(), std::ptr::n
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
    = note: BACKTRACE:
    = note: inside `main` at $DIR/bad-backtrace-resolve-names-flags.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/shims/backtrace/bad-backtrace-size-flags.stderr
+++ b/tests/fail/shims/backtrace/bad-backtrace-size-flags.stderr
@@ -7,6 +7,7 @@ LL |         miri_backtrace_size(2);
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
    = note: BACKTRACE:
    = note: inside `main` at $DIR/bad-backtrace-size-flags.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/shims/shim_arg_size.stderr
+++ b/tests/fail/shims/shim_arg_size.stderr
@@ -8,6 +8,7 @@ LL |         memchr(std::ptr::null(), 0, 0);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/shim_arg_size.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/should-pass/cpp20_rwc_syncs.stderr
+++ b/tests/fail/should-pass/cpp20_rwc_syncs.stderr
@@ -13,6 +13,7 @@ note: inside `main`
    |
 LL |         test_cpp20_rwc_syncs();
    |         ^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/deallocate_against_protector1.stderr
+++ b/tests/fail/stacked_borrows/deallocate_against_protector1.stderr
@@ -31,6 +31,7 @@ LL | |         let raw = x as *mut _;
 LL | |         drop(unsafe { Box::from_raw(raw) });
 LL | |     });
    | |______^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/disable_mut_does_not_merge_srw.stderr
+++ b/tests/fail/stacked_borrows/disable_mut_does_not_merge_srw.stderr
@@ -21,6 +21,7 @@ LL |         *base = 1;
    |         ^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/disable_mut_does_not_merge_srw.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/drop_in_place_protector.stderr
+++ b/tests/fail/stacked_borrows/drop_in_place_protector.stderr
@@ -25,6 +25,7 @@ note: inside `main`
    |
 LL |         core::ptr::drop_in_place(x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
    = note: this error originates in the macro `core::ptr::addr_of_mut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/drop_in_place_retag.stderr
+++ b/tests/fail/stacked_borrows/drop_in_place_retag.stderr
@@ -21,6 +21,7 @@ note: inside `main`
    |
 LL |         core::ptr::drop_in_place(x.cast_mut());
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
    = note: this error originates in the macro `core::ptr::addr_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/stacked_borrows/exposed_only_ro.stderr
+++ b/tests/fail/stacked_borrows/exposed_only_ro.stderr
@@ -11,6 +11,7 @@ LL |     unsafe { *ptr = 0 };
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/exposed_only_ro.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/fnentry_invalidation.stderr
+++ b/tests/fail/stacked_borrows/fnentry_invalidation.stderr
@@ -21,6 +21,7 @@ LL |     x.do_bad();
    |     ^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/fnentry_invalidation.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/fnentry_invalidation2.stderr
+++ b/tests/fail/stacked_borrows/fnentry_invalidation2.stderr
@@ -21,6 +21,7 @@ LL |     let _ = t.sli.as_mut_ptr();
    |             ^^^^^^^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/fnentry_invalidation2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/illegal_dealloc1.stderr
+++ b/tests/fail/stacked_borrows/illegal_dealloc1.stderr
@@ -23,6 +23,7 @@ note: inside `main`
    |
 LL |         dealloc(ptr2, Layout::from_size_align_unchecked(1, 1));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/illegal_read1.stderr
+++ b/tests/fail/stacked_borrows/illegal_read1.stderr
@@ -21,6 +21,7 @@ LL |     let _val = unsafe { *xraw };
    |                         ^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_read1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/illegal_read2.stderr
+++ b/tests/fail/stacked_borrows/illegal_read2.stderr
@@ -21,6 +21,7 @@ LL |     let shr = unsafe { &*xraw };
    |                        ^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_read2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/illegal_read3.stderr
+++ b/tests/fail/stacked_borrows/illegal_read3.stderr
@@ -21,6 +21,7 @@ LL |     let _val = unsafe { *xref1.r };
    |                         ^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_read3.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/illegal_read4.stderr
+++ b/tests/fail/stacked_borrows/illegal_read4.stderr
@@ -21,6 +21,7 @@ LL |     let _val = unsafe { *xraw }; // use the raw again, this invalidates xre
    |                         ^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_read4.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/illegal_read5.stderr
+++ b/tests/fail/stacked_borrows/illegal_read5.stderr
@@ -21,6 +21,7 @@ LL |     mem::forget(unsafe { ptr::read(xshr) }); // but after reading through t
    |                          ^^^^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_read5.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/illegal_read6.stderr
+++ b/tests/fail/stacked_borrows/illegal_read6.stderr
@@ -21,6 +21,7 @@ LL |         let x = &mut *x; // kill `raw`
    |                 ^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_read6.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/illegal_read7.stderr
+++ b/tests/fail/stacked_borrows/illegal_read7.stderr
@@ -21,6 +21,7 @@ LL |         let _val = ptr::read(raw);
    |                    ^^^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_read7.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/illegal_read8.stderr
+++ b/tests/fail/stacked_borrows/illegal_read8.stderr
@@ -21,6 +21,7 @@ LL |         *y2 += 1;
    |         ^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_read8.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/illegal_read_despite_exposed1.stderr
+++ b/tests/fail/stacked_borrows/illegal_read_despite_exposed1.stderr
@@ -21,6 +21,7 @@ LL |         *exposed_ptr = 0;
    |         ^^^^^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_read_despite_exposed1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/illegal_read_despite_exposed2.stderr
+++ b/tests/fail/stacked_borrows/illegal_read_despite_exposed2.stderr
@@ -21,6 +21,7 @@ LL |         let _val = *exposed_ptr;
    |                    ^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_read_despite_exposed2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/illegal_write2.stderr
+++ b/tests/fail/stacked_borrows/illegal_write2.stderr
@@ -21,6 +21,7 @@ LL |     drop(&mut *target); // reborrow
    |          ^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_write2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/illegal_write3.stderr
+++ b/tests/fail/stacked_borrows/illegal_write3.stderr
@@ -16,6 +16,7 @@ LL |     let ptr = r#ref as *const _ as *mut _; // raw ptr, with raw tag
    |               ^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_write3.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/illegal_write4.stderr
+++ b/tests/fail/stacked_borrows/illegal_write4.stderr
@@ -21,6 +21,7 @@ LL |     let _mut_ref: &mut i32 = unsafe { mem::transmute(raw) }; // &mut, with 
    |                                       ^^^^^^^^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_write4.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/illegal_write_despite_exposed1.stderr
+++ b/tests/fail/stacked_borrows/illegal_write_despite_exposed1.stderr
@@ -21,6 +21,7 @@ LL |         *exposed_ptr = 0;
    |         ^^^^^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/illegal_write_despite_exposed1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/interior_mut1.stderr
+++ b/tests/fail/stacked_borrows/interior_mut1.stderr
@@ -21,6 +21,7 @@ LL |         *c.get() = UnsafeCell::new(1); // invalidates inner_shr
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/interior_mut1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/interior_mut2.stderr
+++ b/tests/fail/stacked_borrows/interior_mut2.stderr
@@ -21,6 +21,7 @@ LL |         *c.get() = UnsafeCell::new(0); // now inner_shr gets invalidated
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/interior_mut2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/invalidate_against_protector1.stderr
+++ b/tests/fail/stacked_borrows/invalidate_against_protector1.stderr
@@ -23,6 +23,7 @@ note: inside `main`
    |
 LL |     inner(xraw, xref);
    |     ^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/load_invalid_mut.stderr
+++ b/tests/fail/stacked_borrows/load_invalid_mut.stderr
@@ -21,6 +21,7 @@ LL |     let _val = unsafe { *xraw }; // invalidate xref
    |                         ^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/load_invalid_mut.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/pass_invalid_mut.stderr
+++ b/tests/fail/stacked_borrows/pass_invalid_mut.stderr
@@ -21,6 +21,7 @@ LL |     let _val = unsafe { *xraw }; // invalidate xref
    |                         ^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/pass_invalid_mut.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/pointer_smuggling.stderr
+++ b/tests/fail/stacked_borrows/pointer_smuggling.stderr
@@ -26,6 +26,7 @@ note: inside `main`
    |
 LL |     fun2(); // if they now use a raw ptr they break our reference
    |     ^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/raw_tracking.stderr
+++ b/tests/fail/stacked_borrows/raw_tracking.stderr
@@ -21,6 +21,7 @@ LL |     let raw2 = &mut l as *mut _; // invalidates raw1
    |                ^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/raw_tracking.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/retag_data_race_protected_read.stderr
+++ b/tests/fail/stacked_borrows/retag_data_race_protected_read.stderr
@@ -16,6 +16,7 @@ LL |     unsafe { ptr.0.read() };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/retag_data_race_protected_read.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/retag_data_race_read.stderr
+++ b/tests/fail/stacked_borrows/retag_data_race_read.stderr
@@ -21,6 +21,7 @@ note: inside closure
    |
 LL |     let t2 = std::thread::spawn(move || thread_2(p));
    |                                         ^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/return_invalid_mut.stderr
+++ b/tests/fail/stacked_borrows/return_invalid_mut.stderr
@@ -26,6 +26,7 @@ note: inside `main`
    |
 LL |     foo(&mut (1, 2));
    |     ^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/return_invalid_mut_option.stderr
+++ b/tests/fail/stacked_borrows/return_invalid_mut_option.stderr
@@ -27,6 +27,7 @@ note: inside `main`
    |
 LL |     match foo(&mut (1, 2)) {
    |           ^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/return_invalid_mut_tuple.stderr
+++ b/tests/fail/stacked_borrows/return_invalid_mut_tuple.stderr
@@ -27,6 +27,7 @@ note: inside `main`
    |
 LL |     foo(&mut (1, 2)).0;
    |     ^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/shared_rw_borrows_are_weak1.stderr
+++ b/tests/fail/stacked_borrows/shared_rw_borrows_are_weak1.stderr
@@ -21,6 +21,7 @@ LL |         shr_rw.set(1);
    |         ^^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/shared_rw_borrows_are_weak1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/shared_rw_borrows_are_weak2.stderr
+++ b/tests/fail/stacked_borrows/shared_rw_borrows_are_weak2.stderr
@@ -21,6 +21,7 @@ LL |         shr_rw.replace(1);
    |         ^^^^^^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/shared_rw_borrows_are_weak2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/static_memory_modification.stderr
+++ b/tests/fail/stacked_borrows/static_memory_modification.stderr
@@ -8,6 +8,7 @@ LL |         std::mem::transmute::<&usize, &mut usize>(&X)
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/static_memory_modification.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/track_caller.stderr
+++ b/tests/fail/stacked_borrows/track_caller.stderr
@@ -21,6 +21,7 @@ LL |     callee(xraw);
    |     ^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/track_caller.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/transmute-is-no-escape.stderr
+++ b/tests/fail/stacked_borrows/transmute-is-no-escape.stderr
@@ -16,6 +16,7 @@ LL |     let raw = (&mut x[1] as *mut i32).wrapping_offset(-1);
    |                ^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/transmute-is-no-escape.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/unescaped_local.stderr
+++ b/tests/fail/stacked_borrows/unescaped_local.stderr
@@ -11,6 +11,7 @@ LL |         *raw = 13;
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/unescaped_local.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/unescaped_static.stderr
+++ b/tests/fail/stacked_borrows/unescaped_static.stderr
@@ -16,6 +16,7 @@ LL |     let ptr_to_first = &ARRAY[0] as *const u8;
    |                        ^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/unescaped_static.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/zst_slice.stderr
+++ b/tests/fail/stacked_borrows/zst_slice.stderr
@@ -16,6 +16,7 @@ LL |         assert_eq!(*s.as_ptr().add(1), 2);
    |                     ^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at RUSTLIB/core/src/macros/mod.rs:LL:CC
+   = note: This occured with miri seed: 0
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/static_memory_modification1.stderr
+++ b/tests/fail/static_memory_modification1.stderr
@@ -8,6 +8,7 @@ LL |         *std::mem::transmute::<&usize, &mut usize>(&X) = 6;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/static_memory_modification1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/static_memory_modification2.stderr
+++ b/tests/fail/static_memory_modification2.stderr
@@ -8,6 +8,7 @@ LL |         transmute::<&[u8], &mut [u8]>(s.as_bytes())[4] = 42;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/static_memory_modification2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/static_memory_modification3.stderr
+++ b/tests/fail/static_memory_modification3.stderr
@@ -8,6 +8,7 @@ LL |         transmute::<&[u8], &mut [u8]>(bs)[4] = 42;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/static_memory_modification3.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/terminate-terminator.stderr
+++ b/tests/fail/terminate-terminator.stderr
@@ -40,6 +40,7 @@ note: inside `main`
    |
 LL |     panic_abort();
    | ^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/tls/tls_static_dealloc.stderr
+++ b/tests/fail/tls/tls_static_dealloc.stderr
@@ -8,6 +8,7 @@ LL |         let _val = *dangling_ptr.0;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/tls_static_dealloc.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/tls_macro_leak.stderr
+++ b/tests/fail/tls_macro_leak.stderr
@@ -24,6 +24,7 @@ LL | /         TLS.with(|cell| {
 LL | |             cell.set(Some(Box::leak(Box::new(123))));
 LL | |         });
    | |__________^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/tls_static_leak.stderr
+++ b/tests/fail/tls_static_leak.stderr
@@ -15,6 +15,7 @@ note: inside closure
    |
 LL |         TLS.set(Some(Box::leak(Box::new(123))));
    |                                ^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/transmute-pair-uninit.stderr
+++ b/tests/fail/transmute-pair-uninit.stderr
@@ -8,6 +8,7 @@ LL |     let v = unsafe { *z.offset(first_undef) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/transmute-pair-uninit.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/tree_borrows/alternate-read-write.stderr
+++ b/tests/fail/tree_borrows/alternate-read-write.stderr
@@ -31,6 +31,7 @@ LL |     let _val = *x;
    = help: this transition corresponds to a loss of write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/alternate-read-write.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/tree_borrows/children-can-alias.default.stderr
+++ b/tests/fail/tree_borrows/children-can-alias.default.stderr
@@ -8,6 +8,7 @@ LL |         std::hint::unreachable_unchecked();
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/children-can-alias.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/tree_borrows/children-can-alias.uniq.stderr
+++ b/tests/fail/tree_borrows/children-can-alias.uniq.stderr
@@ -30,6 +30,7 @@ note: inside `main`
    |
 LL |         raw_children_of_unique_can_alias(Unique::new_unchecked(raw));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/tree_borrows/error-range.stderr
+++ b/tests/fail/tree_borrows/error-range.stderr
@@ -25,6 +25,7 @@ LL |         data[5] = 1;
    = help: this transition corresponds to a loss of read permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/error-range.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/tree_borrows/fnentry_invalidation.stderr
+++ b/tests/fail/tree_borrows/fnentry_invalidation.stderr
@@ -25,6 +25,7 @@ LL |     x.do_bad();
    = help: this transition corresponds to a loss of write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/fnentry_invalidation.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/tree_borrows/outside-range.stderr
+++ b/tests/fail/tree_borrows/outside-range.stderr
@@ -25,6 +25,7 @@ note: inside `main`
    |
 LL |         stuff(&mut *raw, raw);
    |         ^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/tree_borrows/parent_read_freezes_raw_mut.stderr
+++ b/tests/fail/tree_borrows/parent_read_freezes_raw_mut.stderr
@@ -25,6 +25,7 @@ LL |         assert_eq!(root, 0); // Parent Read
    = help: this transition corresponds to a loss of write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/parent_read_freezes_raw_mut.rs:LL:CC
+   = note: This occured with miri seed: 0
    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

--- a/tests/fail/tree_borrows/pass_invalid_mut.stderr
+++ b/tests/fail/tree_borrows/pass_invalid_mut.stderr
@@ -36,6 +36,7 @@ note: inside `main`
    |
 LL |     foo(xref);
    |     ^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/tree_borrows/reserved/cell-protected-write.stderr
+++ b/tests/fail/tree_borrows/reserved/cell-protected-write.stderr
@@ -35,6 +35,7 @@ note: inside `main`
    |
 LL |         write_second(x, y);
    |         ^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/tree_borrows/reserved/int-protected-write.stderr
+++ b/tests/fail/tree_borrows/reserved/int-protected-write.stderr
@@ -35,6 +35,7 @@ note: inside `main`
    |
 LL |         write_second(x, y);
    |         ^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/tree_borrows/return_invalid_mut.stderr
+++ b/tests/fail/tree_borrows/return_invalid_mut.stderr
@@ -31,6 +31,7 @@ LL |     let _val = unsafe { *xraw }; // invalidate xref for writing
    = help: this transition corresponds to a loss of write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/return_invalid_mut.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/tree_borrows/spurious_read.stderr
+++ b/tests/fail/tree_borrows/spurious_read.stderr
@@ -37,6 +37,7 @@ note: inside closure
    |
 LL |         let _y = as_mut(unsafe { &mut *ptr.0 }, b.clone());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/tree_borrows/strongly-protected.stderr
+++ b/tests/fail/tree_borrows/strongly-protected.stderr
@@ -42,6 +42,7 @@ LL | |         let raw = x as *mut _;
 LL | |         drop(unsafe { Box::from_raw(raw) });
 LL | |     });
    | |______^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/tree_borrows/unique.default.stderr
+++ b/tests/fail/tree_borrows/unique.default.stderr
@@ -25,6 +25,7 @@ LL |         let _definitely_parent = data; // definitely Frozen by now
    = help: this transition corresponds to a loss of write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/unique.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/tree_borrows/unique.uniq.stderr
+++ b/tests/fail/tree_borrows/unique.uniq.stderr
@@ -31,6 +31,7 @@ LL |         let _maybe_parent = *rawptr; // maybe becomes Frozen
    = help: this transition corresponds to a loss of write permissions
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/unique.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/tree_borrows/write-during-2phase.stderr
+++ b/tests/fail/tree_borrows/write-during-2phase.stderr
@@ -31,6 +31,7 @@ LL | |         *inner = 42;
 LL | |         n
 LL | |     });
    | |______^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/type-too-large.stderr
+++ b/tests/fail/type-too-large.stderr
@@ -6,6 +6,7 @@ LL |     _fat = [0; (1u64 << 61) as usize + (1u64 << 31) as usize];
    |
    = note: BACKTRACE:
    = note: inside `main` at $DIR/type-too-large.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/unaligned_pointers/alignment.stderr
+++ b/tests/fail/unaligned_pointers/alignment.stderr
@@ -8,6 +8,7 @@ LL |         *(x_ptr as *mut u32) = 42; *(x_ptr.add(1) as *mut u32) = 42;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/alignment.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/unaligned_pointers/atomic_unaligned.stderr
+++ b/tests/fail/unaligned_pointers/atomic_unaligned.stderr
@@ -8,6 +8,7 @@ LL |         ::std::intrinsics::atomic_load_seqcst(zptr);
    = help: but due to `-Zmiri-symbolic-alignment-check`, alignment errors can also be false positives
    = note: BACKTRACE:
    = note: inside `main` at $DIR/atomic_unaligned.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/unaligned_pointers/drop_in_place.stderr
+++ b/tests/fail/unaligned_pointers/drop_in_place.stderr
@@ -13,6 +13,7 @@ note: inside `main`
    |
 LL |         core::ptr::drop_in_place(p);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/unaligned_pointers/dyn_alignment.stderr
+++ b/tests/fail/unaligned_pointers/dyn_alignment.stderr
@@ -8,6 +8,7 @@ LL |         let _ptr = &*ptr;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/dyn_alignment.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/unaligned_pointers/field_requires_parent_struct_alignment.stderr
+++ b/tests/fail/unaligned_pointers/field_requires_parent_struct_alignment.stderr
@@ -13,6 +13,7 @@ note: inside `main`
    |
 LL |         foo(odd_ptr.cast());
    |         ^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/unaligned_pointers/field_requires_parent_struct_alignment2.stderr
+++ b/tests/fail/unaligned_pointers/field_requires_parent_struct_alignment2.stderr
@@ -13,6 +13,7 @@ note: inside `main`
    |
 LL |         foo(odd_ptr.cast());
    |         ^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/unaligned_pointers/intptrcast_alignment_check.stderr
+++ b/tests/fail/unaligned_pointers/intptrcast_alignment_check.stderr
@@ -8,6 +8,7 @@ LL |     unsafe { *u16_ptr = 2 };
    = help: but due to `-Zmiri-symbolic-alignment-check`, alignment errors can also be false positives
    = note: BACKTRACE:
    = note: inside `main` at $DIR/intptrcast_alignment_check.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/unaligned_pointers/promise_alignment.call_unaligned_ptr.stderr
+++ b/tests/fail/unaligned_pointers/promise_alignment.call_unaligned_ptr.stderr
@@ -7,6 +7,7 @@ LL |         unsafe { utils::miri_promise_symbolic_alignment(align8.add(1).cast(
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
    = note: BACKTRACE:
    = note: inside `main` at $DIR/promise_alignment.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/unaligned_pointers/promise_alignment.read_unaligned_ptr.stderr
+++ b/tests/fail/unaligned_pointers/promise_alignment.read_unaligned_ptr.stderr
@@ -8,6 +8,7 @@ LL |         let _val = unsafe { align8.cast::<Align16>().read() };
    = help: but due to `-Zmiri-symbolic-alignment-check`, alignment errors can also be false positives
    = note: BACKTRACE:
    = note: inside `main` at $DIR/promise_alignment.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/unaligned_pointers/promise_alignment_zero.stderr
+++ b/tests/fail/unaligned_pointers/promise_alignment_zero.stderr
@@ -7,6 +7,7 @@ LL |     unsafe { utils::miri_promise_symbolic_alignment(buffer.as_ptr().cast(),
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
    = note: BACKTRACE:
    = note: inside `main` at $DIR/promise_alignment_zero.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/unaligned_pointers/reference_to_packed.stderr
+++ b/tests/fail/unaligned_pointers/reference_to_packed.stderr
@@ -13,6 +13,7 @@ note: inside `main`
    |
 LL |         let p: &i32 = unsafe { raw_to_ref(ptr::addr_of!(foo.x)) };
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/unaligned_pointers/unaligned_ptr1.stderr
+++ b/tests/fail/unaligned_pointers/unaligned_ptr1.stderr
@@ -8,6 +8,7 @@ LL |         let _x = unsafe { *x };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/unaligned_ptr1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/unaligned_pointers/unaligned_ptr2.stderr
+++ b/tests/fail/unaligned_pointers/unaligned_ptr2.stderr
@@ -8,6 +8,7 @@ LL |     let _x = unsafe { *x };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/unaligned_ptr2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/unaligned_pointers/unaligned_ptr3.stderr
+++ b/tests/fail/unaligned_pointers/unaligned_ptr3.stderr
@@ -8,6 +8,7 @@ LL |         let _x = unsafe { *x };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/unaligned_ptr3.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/unaligned_pointers/unaligned_ptr4.stderr
+++ b/tests/fail/unaligned_pointers/unaligned_ptr4.stderr
@@ -8,6 +8,7 @@ LL |         let _val = unsafe { *ptr };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/unaligned_ptr4.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/unaligned_pointers/unaligned_ptr_zst.stderr
+++ b/tests/fail/unaligned_pointers/unaligned_ptr_zst.stderr
@@ -8,6 +8,7 @@ LL |         let _x = unsafe { *x };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/unaligned_ptr_zst.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/unaligned_pointers/unaligned_ref_addr_of.stderr
+++ b/tests/fail/unaligned_pointers/unaligned_ref_addr_of.stderr
@@ -8,6 +8,7 @@ LL |         let _x = unsafe { &*x };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/unaligned_ref_addr_of.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/uninit/uninit-after-aggregate-assign.stderr
+++ b/tests/fail/uninit/uninit-after-aggregate-assign.stderr
@@ -8,6 +8,7 @@ LL |             _val = *sptr2; // should hence be UB
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/uninit-after-aggregate-assign.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/uninit/uninit_alloc_diagnostic.stderr
+++ b/tests/fail/uninit/uninit_alloc_diagnostic.stderr
@@ -14,6 +14,7 @@ note: inside `main`
    |
 LL |         drop(slice1.cmp(slice2));
    |              ^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 Uninitialized memory occurred at ALLOC[0x4..0x10], in this allocation:
 ALLOC (Rust heap, size: 32, align: 8) {

--- a/tests/fail/uninit/uninit_alloc_diagnostic_with_provenance.stderr
+++ b/tests/fail/uninit/uninit_alloc_diagnostic_with_provenance.stderr
@@ -14,6 +14,7 @@ note: inside `main`
    |
 LL |         drop(slice1.cmp(slice2));
    |              ^^^^^^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 Uninitialized memory occurred at ALLOC[0x4..0x8], in this allocation:
 ALLOC (Rust heap, size: 16, align: 8) {

--- a/tests/fail/uninit/uninit_byte_read.stderr
+++ b/tests/fail/uninit/uninit_byte_read.stderr
@@ -8,6 +8,7 @@ LL |     let undef = unsafe { *v.as_ptr().add(5) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/uninit_byte_read.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/unreachable.stderr
+++ b/tests/fail/unreachable.stderr
@@ -8,6 +8,7 @@ LL |     unsafe { std::hint::unreachable_unchecked() }
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/unreachable.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/unsized-local.stderr
+++ b/tests/fail/unsized-local.stderr
@@ -7,6 +7,7 @@ LL |     let x = *(Box::new(A) as Box<dyn Foo>);
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
    = note: BACKTRACE:
    = note: inside `main` at $DIR/unsized-local.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/unsupported_foreign_function.stderr
+++ b/tests/fail/unsupported_foreign_function.stderr
@@ -8,6 +8,7 @@ LL |         foo();
    = help: however, note that Miri does not aim to support every FFI function out there; for instance, we will not support APIs for things such as GUIs, scripting languages, or databases
    = note: BACKTRACE:
    = note: inside `main` at $DIR/unsupported_foreign_function.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/unwind-action-terminate.stderr
+++ b/tests/fail/unwind-action-terminate.stderr
@@ -32,6 +32,7 @@ note: inside `main`
    |
 LL |     panic_abort();
    | ^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/cast_fn_ptr_invalid_callee_arg.stderr
+++ b/tests/fail/validity/cast_fn_ptr_invalid_callee_arg.stderr
@@ -8,6 +8,7 @@ LL |     g(0usize as *const i32)
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/cast_fn_ptr_invalid_callee_arg.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/cast_fn_ptr_invalid_callee_ret.stderr
+++ b/tests/fail/validity/cast_fn_ptr_invalid_callee_ret.stderr
@@ -8,6 +8,7 @@ LL |     f();
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/cast_fn_ptr_invalid_callee_ret.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/cast_fn_ptr_invalid_caller_arg.stderr
+++ b/tests/fail/validity/cast_fn_ptr_invalid_caller_arg.stderr
@@ -13,6 +13,7 @@ note: inside `main`
    |
 LL |     call(f);
    |     ^^^^^^^
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/cast_fn_ptr_invalid_caller_ret.stderr
+++ b/tests/fail/validity/cast_fn_ptr_invalid_caller_ret.stderr
@@ -8,6 +8,7 @@ LL |     let _x = g();
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/cast_fn_ptr_invalid_caller_ret.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/dangling_ref1.stderr
+++ b/tests/fail/validity/dangling_ref1.stderr
@@ -8,6 +8,7 @@ LL |     let _x: &i32 = unsafe { mem::transmute(16usize) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/dangling_ref1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/dangling_ref2.stderr
+++ b/tests/fail/validity/dangling_ref2.stderr
@@ -8,6 +8,7 @@ LL |     let _x: &i32 = unsafe { mem::transmute(ptr) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/dangling_ref2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/dangling_ref3.stderr
+++ b/tests/fail/validity/dangling_ref3.stderr
@@ -8,6 +8,7 @@ LL |     let _x: &i32 = unsafe { mem::transmute(dangling()) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/dangling_ref3.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/invalid_bool.stderr
+++ b/tests/fail/validity/invalid_bool.stderr
@@ -8,6 +8,7 @@ LL |     let _b = unsafe { std::mem::transmute::<u8, bool>(2) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/invalid_bool.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/invalid_bool_op.stderr
+++ b/tests/fail/validity/invalid_bool_op.stderr
@@ -8,6 +8,7 @@ LL |     let _x = b == std::hint::black_box(true);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/invalid_bool_op.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/invalid_bool_uninit.stderr
+++ b/tests/fail/validity/invalid_bool_uninit.stderr
@@ -8,6 +8,7 @@ LL |     let _b = unsafe { MyUninit { init: () }.uninit };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/invalid_bool_uninit.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/invalid_char.stderr
+++ b/tests/fail/validity/invalid_char.stderr
@@ -8,6 +8,7 @@ LL |     let _val = match unsafe { std::mem::transmute::<i32, char>(-1) } {
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/invalid_char.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/invalid_char_op.stderr
+++ b/tests/fail/validity/invalid_char_op.stderr
@@ -8,6 +8,7 @@ LL |     let _x = c == 'x';
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/invalid_char_op.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/invalid_char_uninit.stderr
+++ b/tests/fail/validity/invalid_char_uninit.stderr
@@ -8,6 +8,7 @@ LL |     let _b = unsafe { MyUninit { init: () }.uninit };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/invalid_char_uninit.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/invalid_enum_op.stderr
+++ b/tests/fail/validity/invalid_enum_op.stderr
@@ -8,6 +8,7 @@ LL |     let _val = mem::discriminant(&f);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/invalid_enum_op.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/invalid_enum_tag.stderr
+++ b/tests/fail/validity/invalid_enum_tag.stderr
@@ -8,6 +8,7 @@ LL |     let _f = unsafe { std::mem::transmute::<i32, Foo>(42) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/invalid_enum_tag.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/invalid_fnptr_null.stderr
+++ b/tests/fail/validity/invalid_fnptr_null.stderr
@@ -8,6 +8,7 @@ LL |     let _b: fn() = unsafe { std::mem::transmute(0usize) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/invalid_fnptr_null.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/invalid_fnptr_uninit.stderr
+++ b/tests/fail/validity/invalid_fnptr_uninit.stderr
@@ -8,6 +8,7 @@ LL |     let _b = unsafe { MyUninit { init: () }.uninit };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/invalid_fnptr_uninit.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/invalid_int_op.stderr
+++ b/tests/fail/validity/invalid_int_op.stderr
@@ -8,6 +8,7 @@ LL |     let i = unsafe { std::mem::MaybeUninit::<i32>::uninit().assume_init() }
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/invalid_int_op.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/invalid_wide_raw.stderr
+++ b/tests/fail/validity/invalid_wide_raw.stderr
@@ -8,6 +8,7 @@ LL |     dbg!(S { x: unsafe { std::mem::transmute((0usize, 0usize)) } });
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/invalid_wide_raw.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/match_binder_checks_validity1.stderr
+++ b/tests/fail/validity/match_binder_checks_validity1.stderr
@@ -8,6 +8,7 @@ LL |             _x => println!("hi from the void!"),
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/match_binder_checks_validity1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/match_binder_checks_validity2.stderr
+++ b/tests/fail/validity/match_binder_checks_validity2.stderr
@@ -8,6 +8,7 @@ LL |             _x => println!("hi from the void!"),
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/match_binder_checks_validity2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/nonzero.stderr
+++ b/tests/fail/validity/nonzero.stderr
@@ -8,6 +8,7 @@ LL |     let _x = Some(unsafe { NonZero(0) });
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/nonzero.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/ref_to_uninhabited1.stderr
+++ b/tests/fail/validity/ref_to_uninhabited1.stderr
@@ -8,6 +8,7 @@ LL |         let x: Box<!> = transmute(&mut 42);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/ref_to_uninhabited1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/ref_to_uninhabited2.stderr
+++ b/tests/fail/validity/ref_to_uninhabited2.stderr
@@ -8,6 +8,7 @@ LL |         let _x: &(i32, Void) = transmute(&42);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/ref_to_uninhabited2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/too-big-slice.stderr
+++ b/tests/fail/validity/too-big-slice.stderr
@@ -8,6 +8,7 @@ LL |         let _x: &[u8] = mem::transmute((ptr, usize::MAX));
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/too-big-slice.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/too-big-unsized.stderr
+++ b/tests/fail/validity/too-big-unsized.stderr
@@ -8,6 +8,7 @@ LL |         let _x: &MySlice = mem::transmute((ptr, isize::MAX as usize));
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/too-big-unsized.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/transmute_through_ptr.stderr
+++ b/tests/fail/validity/transmute_through_ptr.stderr
@@ -8,6 +8,7 @@ LL |     let y = x; // reading this ought to be enough to trigger validation
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/transmute_through_ptr.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/uninit_float.stderr
+++ b/tests/fail/validity/uninit_float.stderr
@@ -8,6 +8,7 @@ LL |     let _val: [f32; 1] = unsafe { std::mem::uninitialized() };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/uninit_float.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/uninit_integer.stderr
+++ b/tests/fail/validity/uninit_integer.stderr
@@ -8,6 +8,7 @@ LL |     let _val = unsafe { std::mem::MaybeUninit::<[usize; 1]>::uninit().assum
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/uninit_integer.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/uninit_raw_ptr.stderr
+++ b/tests/fail/validity/uninit_raw_ptr.stderr
@@ -8,6 +8,7 @@ LL |     let _val = unsafe { std::mem::MaybeUninit::<[*const u8; 1]>::uninit().a
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/uninit_raw_ptr.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/wrong-dyn-trait-generic.stderr
+++ b/tests/fail/validity/wrong-dyn-trait-generic.stderr
@@ -8,6 +8,7 @@ LL |     let _y: *const dyn Trait<u32> = unsafe { mem::transmute(x) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/wrong-dyn-trait-generic.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/validity/wrong-dyn-trait.stderr
+++ b/tests/fail/validity/wrong-dyn-trait.stderr
@@ -8,6 +8,7 @@ LL |     let _y: *const dyn fmt::Debug = unsafe { mem::transmute(x) };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/wrong-dyn-trait.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/weak_memory/racing_mixed_size.stderr
+++ b/tests/fail/weak_memory/racing_mixed_size.stderr
@@ -15,6 +15,7 @@ LL |         x.store(1, Relaxed);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/racing_mixed_size.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/weak_memory/racing_mixed_size_read.stderr
+++ b/tests/fail/weak_memory/racing_mixed_size_read.stderr
@@ -15,6 +15,7 @@ LL |         x.load(Relaxed);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at $DIR/racing_mixed_size_read.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/zst1.stderr
+++ b/tests/fail/zst1.stderr
@@ -8,6 +8,7 @@ LL |     let _val = unsafe { *x };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
    = note: inside `main` at $DIR/zst1.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/zst2.stderr
+++ b/tests/fail/zst2.stderr
@@ -18,6 +18,7 @@ LL |     drop(x_box);
    |     ^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/zst2.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/zst3.stderr
+++ b/tests/fail/zst3.stderr
@@ -13,6 +13,7 @@ LL |     let mut x_box = Box::new(1u8);
    |                     ^^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `main` at $DIR/zst3.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/pass/alloc-access-tracking.stderr
+++ b/tests/pass/alloc-access-tracking.stderr
@@ -6,6 +6,7 @@ LL |         let ptr = miri_alloc(123, 1);
    |
    = note: BACKTRACE:
    = note: inside `start` at $DIR/alloc-access-tracking.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: tracking was triggered
   --> $DIR/alloc-access-tracking.rs:LL:CC
@@ -15,6 +16,7 @@ LL |         *ptr = 42; // Crucially, only a write is printed here, no read!
    |
    = note: BACKTRACE:
    = note: inside `start` at $DIR/alloc-access-tracking.rs:LL:CC
+   = note: This occured with miri seed: 0
 
 note: tracking was triggered
   --> $DIR/alloc-access-tracking.rs:LL:CC
@@ -24,6 +26,7 @@ LL |         assert_eq!(*ptr, 42);
    |
    = note: BACKTRACE:
    = note: inside `start` at RUSTLIB/core/src/macros/mod.rs:LL:CC
+   = note: This occured with miri seed: 0
    = note: this note originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: tracking was triggered
@@ -34,4 +37,5 @@ LL |         miri_dealloc(ptr, 123, 1);
    |
    = note: BACKTRACE:
    = note: inside `start` at $DIR/alloc-access-tracking.rs:LL:CC
+   = note: This occured with miri seed: 0
 

--- a/tests/pass/box.stack.stderr
+++ b/tests/pass/box.stack.stderr
@@ -17,6 +17,7 @@ note: inside `main`
    |
 LL |     into_raw();
    |     ^^^^^^^^^^
+   = note: This occured with miri seed: 0
 
 warning: integer-to-pointer cast
   --> $DIR/box.rs:LL:CC
@@ -31,4 +32,5 @@ note: inside `main`
    |
 LL |     into_unique();
    |     ^^^^^^^^^^^^^
+   = note: This occured with miri seed: 0
 

--- a/tests/pass/extern_types.stack.stderr
+++ b/tests/pass/extern_types.stack.stderr
@@ -12,4 +12,5 @@ LL |     let x: &Foo = unsafe { &*(16 as *const Foo) };
    = help: Alternatively, the `-Zmiri-permissive-provenance` flag disables this warning.
    = note: BACKTRACE:
    = note: inside `main` at $DIR/extern_types.rs:LL:CC
+   = note: This occured with miri seed: 0
 

--- a/tests/pass/stacked-borrows/issue-miri-2389.stderr
+++ b/tests/pass/stacked-borrows/issue-miri-2389.stderr
@@ -12,4 +12,5 @@ LL |         let wildcard = &root0 as *const Cell<i32> as usize as *const Cell<i
    = help: Alternatively, the `-Zmiri-permissive-provenance` flag disables this warning.
    = note: BACKTRACE:
    = note: inside `main` at $DIR/issue-miri-2389.rs:LL:CC
+   = note: This occured with miri seed: 0
 


### PR DESCRIPTION
I think this could be a good idea. It makes it easier to reproduce issues just by viewing the diagnostic output.

One thing that could possibly changed is if `-Zmiri-seed` is not passed, then the seed will be zero every time, so don't display it. But showing it unconditionally that makes it explicit that the seed is zero and not some magic number miri creates. 

Anyways let me know your thoughts. 