### PR TITLE
support `f*_algebraic`

### DIFF
--- a/src/intrinsics/mod.rs
+++ b/src/intrinsics/mod.rs
@@ -256,6 +256,28 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
                 let res = this.adjust_nan(res, &[f]);
                 this.write_scalar(res, dest)?;
             }
+            #[rustfmt::skip]
+            | "fadd_algebraic"
+            | "fsub_algebraic"
+            | "fmul_algebraic"
+            | "fdiv_algebraic"
+            | "frem_algebraic"
+            => {
+                let [a, b] = check_arg_count(args)?;
+                let a = this.read_immediate(a)?;
+                let b = this.read_immediate(b)?;
+                let op = match intrinsic_name {
+                    "fadd_algebraic" => mir::BinOp::Add,
+                    "fsub_algebraic" => mir::BinOp::Sub,
+                    "fmul_algebraic" => mir::BinOp::Mul,
+                    "fdiv_algebraic" => mir::BinOp::Div,
+                    "frem_algebraic" => mir::BinOp::Rem,
+                    _ => bug!(),
+                };
+                let res = this.wrapping_binary_op(op, &a, &b)?;
+                // `wrapping_binary_op` already called `generate_nan` if necessary.
+                this.write_immediate(*res, dest)?;
+            }
 
             #[rustfmt::skip]
             | "fadd_fast"

--- a/tests/pass/intrinsics/float_algebraic_math.rs
+++ b/tests/pass/intrinsics/float_algebraic_math.rs
@@ -1,0 +1,32 @@
+#![feature(core_intrinsics)]
+
+use std::intrinsics::{
+    fadd_algebraic, fdiv_algebraic, fmul_algebraic, frem_algebraic, fsub_algebraic,
+};
+
+#[inline(never)]
+pub fn test_operations_f64(a: f64, b: f64) {
+    // make sure they all map to the correct operation
+    assert_eq!(fadd_algebraic(a, b), a + b);
+    assert_eq!(fsub_algebraic(a, b), a - b);
+    assert_eq!(fmul_algebraic(a, b), a * b);
+    assert_eq!(fdiv_algebraic(a, b), a / b);
+    assert_eq!(frem_algebraic(a, b), a % b);
+}
+
+#[inline(never)]
+pub fn test_operations_f32(a: f32, b: f32) {
+    // make sure they all map to the correct operation
+    assert_eq!(fadd_algebraic(a, b), a + b);
+    assert_eq!(fsub_algebraic(a, b), a - b);
+    assert_eq!(fmul_algebraic(a, b), a * b);
+    assert_eq!(fdiv_algebraic(a, b), a / b);
+    assert_eq!(frem_algebraic(a, b), a % b);
+}
+
+fn main() {
+    test_operations_f64(1., 2.);
+    test_operations_f64(10., 5.);
+    test_operations_f32(11., 2.);
+    test_operations_f32(10., 15.);
+}


### PR DESCRIPTION
supports the [`f*_algebraic`](https://doc.rust-lang.org/std/intrinsics/fn.fadd_algebraic.html) intrinsics.