### PR TITLE
Don't print unnecessary sysroot messages

### DIFF
--- a/cargo-miri/Cargo.lock
+++ b/cargo-miri/Cargo.lock
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-build-sysroot"
-version = "0.4.7"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab1dbbd1bdf65fdac44c885f6cca147ba179108ce284b60a08ccc04b1f1dbac0"
+checksum = "de6077473f0c46779b49e4587a81f1b8919e0ec26630409ecfda0ba3259efb43"
 dependencies = [
  "anyhow",
  "rustc_version",

--- a/cargo-miri/Cargo.toml
+++ b/cargo-miri/Cargo.toml
@@ -18,7 +18,7 @@ directories = "5"
 rustc_version = "0.4"
 serde_json = "1.0.40"
 cargo_metadata = "0.18.0"
-rustc-build-sysroot = "0.4.6"
+rustc-build-sysroot = "0.5.0"
 
 # Enable some feature flags that dev-dependencies need but dependencies
 # do not.  This makes `./miri install` after `./miri build` faster.


### PR DESCRIPTION
Currently, when running `cargo miri setup`, we always print that a sysroot is being prepared, even if we just bail out of building after checking the hash. So that message is wrong; we didn't actually prepare a sysroot.

We also always print the preparing message for `cargo miri run`, even if no sysroot is prepared.

With this PR, `cargo miri run` prints no sysroot messages when an existing one is reused, and when a redundant `cargo miri setup` is requested, we print:
```
A sysroot for Miri is already available in `/home/ben/.cache/miri`.
```