### PR TITLE
Use `throw_unsup_format!` instead of returning `ENOTSUP` in the mmap shim

### DIFF
--- a/src/shims/unix/mem.rs
+++ b/src/shims/unix/mem.rs
@@ -71,24 +71,27 @@ pub trait EvalContextExt<'mir, 'tcx: 'mir>: crate::MiriInterpCxExt<'mir, 'tcx> {
             throw_unsup_format!("Miri does not support file-backed memory mappings");
         }
 
-        // POSIX says:
-        // [ENOTSUP]
-        // * MAP_FIXED or MAP_PRIVATE was specified in the flags argument and the implementation
-        // does not support this functionality.
-        // * The implementation does not support the combination of accesses requested in the
-        // prot argument.
-        //
-        // Miri doesn't support MAP_FIXED or any any protections other than PROT_READ|PROT_WRITE.
-        if flags & map_fixed != 0 || prot != prot_read | prot_write {
-            this.set_last_error(this.eval_libc("ENOTSUP"))?;
-            return Ok(this.eval_libc("MAP_FAILED"));
+        // Miri doesn't support MAP_FIXED.
+        if flags & map_fixed != 0 {
+            throw_unsup_format!(
+                "Miri does not support calls to mmap with MAP_FIXED as part of the flags argument",
+            );
+        }
+
+        // Miri doesn't support protections other than PROT_READ|PROT_WRITE.
+        if prot != prot_read | prot_write {
+            throw_unsup_format!(
+                "Miri does not support calls to mmap with protections other than \
+                 PROT_READ|PROT_WRITE",
+            );
         }
 
         // Miri does not support shared mappings, or any of the other extensions that for example
         // Linux has added to the flags arguments.
         if flags != map_private | map_anonymous {
             throw_unsup_format!(
-                "Miri only supports calls to mmap which set the flags argument to MAP_PRIVATE|MAP_ANONYMOUS"
+                "Miri only supports calls to mmap which set the flags argument to \
+                 MAP_PRIVATE|MAP_ANONYMOUS",
             );
         }
 

--- a/tests/pass-dep/libc/mmap.rs
+++ b/tests/pass-dep/libc/mmap.rs
@@ -69,36 +69,6 @@ fn test_mmap<Offset: Default>(
     assert_eq!(ptr, libc::MAP_FAILED);
     assert_eq!(Error::last_os_error().raw_os_error().unwrap(), libc::EINVAL);
 
-    let ptr = unsafe {
-        mmap(
-            ptr::without_provenance_mut(page_size * 64),
-            page_size,
-            libc::PROT_READ | libc::PROT_WRITE,
-            // We don't support MAP_FIXED
-            libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_FIXED,
-            -1,
-            Default::default(),
-        )
-    };
-    assert_eq!(ptr, libc::MAP_FAILED);
-    assert_eq!(Error::last_os_error().raw_os_error().unwrap(), libc::ENOTSUP);
-
-    // We don't support protections other than read+write
-    for prot in [libc::PROT_NONE, libc::PROT_EXEC, libc::PROT_READ, libc::PROT_WRITE] {
-        let ptr = unsafe {
-            mmap(
-                ptr::null_mut(),
-                page_size,
-                prot,
-                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
-                -1,
-                Default::default(),
-            )
-        };
-        assert_eq!(ptr, libc::MAP_FAILED);
-        assert_eq!(Error::last_os_error().raw_os_error().unwrap(), libc::ENOTSUP);
-    }
-
     // We report an error for mappings whose length cannot be rounded up to a multiple of
     // the page size.
     let ptr = unsafe {


### PR DESCRIPTION
I noticed this while trying to use `mmap` with `PROT_NONE`, which resulted in this error message:
```
Os { code: 95, kind: Uncategorized, message: "<unknown errnum in strerror_r: 95>" }
```
cc @saethlin