### PR TITLE
solaris add support for threadname.

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -148,8 +148,8 @@ case $HOST_TARGET in
     UNIX="panic/panic panic/unwind concurrency/simple atomic libc-mem libc-misc libc-random env num_cpus" # the things that are very similar across all Unixes, and hence easily supported there
     TEST_TARGET=x86_64-unknown-freebsd run_tests_minimal $BASIC $UNIX threadname libc-time fs
     TEST_TARGET=i686-unknown-freebsd   run_tests_minimal $BASIC $UNIX threadname libc-time fs
-    TEST_TARGET=x86_64-unknown-illumos run_tests_minimal $BASIC $UNIX pthread-sync libc-time
-    TEST_TARGET=x86_64-pc-solaris      run_tests_minimal $BASIC $UNIX pthread-sync libc-time
+    TEST_TARGET=x86_64-unknown-illumos run_tests_minimal $BASIC $UNIX threadname pthread-sync libc-time
+    TEST_TARGET=x86_64-pc-solaris      run_tests_minimal $BASIC $UNIX threadname pthread-sync libc-time
     TEST_TARGET=aarch64-linux-android  run_tests_minimal $BASIC $UNIX
     TEST_TARGET=wasm32-wasip2          run_tests_minimal empty_main wasm heap_alloc libc-mem
     TEST_TARGET=wasm32-unknown-unknown run_tests_minimal empty_main wasm

--- a/src/shims/extern_static.rs
+++ b/src/shims/extern_static.rs
@@ -82,6 +82,9 @@ impl<'mir, 'tcx> MiriMachine<'mir, 'tcx> {
                 let val = ImmTy::from_int(0, this.machine.layouts.u8);
                 Self::alloc_extern_static(this, "_tls_used", val)?;
             }
+            "illumos" | "solaris" => {
+                Self::weak_symbol_extern_statics(this, &["pthread_setname_np"])?;
+            }
             _ => {} // No "extern statics" supported on this target
         }
         Ok(())

--- a/tests/pass-dep/libc/pthread-threadname.rs
+++ b/tests/pass-dep/libc/pthread-threadname.rs
@@ -10,7 +10,7 @@ fn main() {
         .collect::<String>();
 
     fn set_thread_name(name: &CStr) -> i32 {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "illumos", target_os = "solaris"))]
         return unsafe { libc::pthread_setname_np(libc::pthread_self(), name.as_ptr().cast()) };
         #[cfg(target_os = "freebsd")]
         unsafe {


### PR DESCRIPTION
from std::unix::thread::set_name, pthread_setname_np is a weak symbol (not always had been available). Other than that, similar to linux only having twice of its buffer limit.