### PR TITLE
add back some tokio features

### DIFF
--- a/test_dependencies/Cargo.lock
+++ b/test_dependencies/Cargo.lock
@@ -254,6 +254,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,6 +306,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",

--- a/test_dependencies/Cargo.toml
+++ b/test_dependencies/Cargo.toml
@@ -18,7 +18,9 @@ getrandom_02 = { package = "getrandom", version = "0.2", features = ["js"] }
 [target.'cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))'.dependencies]
 tempfile = "3"
 page_size = "0.6"
-tokio = { version = "1.24", features = ["macros", "rt-multi-thread", "time", "net"] }
+# Avoid pulling in all of tokio's dependencies.
+# However, without `net` and `signal`, tokio uses fewer relevant system APIs.
+tokio = { version = "1.24", features = ["macros", "rt-multi-thread", "time", "net", "fs", "sync", "signal"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.52", features = [ "Win32_Foundation", "Win32_System_Threading" ] }


### PR DESCRIPTION
Turns out I went a bit too fer when I removed features, so `socketpair` was no longer used.