### PR TITLE
Fix "local crate" detection

### DIFF
--- a/test-cargo-miri/Cargo.lock
+++ b/test-cargo-miri/Cargo.lock
@@ -124,6 +124,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-local-crate-detection"
+version = "0.1.0"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/test-cargo-miri/Cargo.toml
+++ b/test-cargo-miri/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["subcrate", "issue-1567", "exported-symbol-dep"]
+members = ["subcrate", "issue-1567", "exported-symbol-dep", "test-local-crate-detection"]
 exclude = ["no-std-smoke"] # it wants to be panic="abort"
 
 [package]

--- a/test-cargo-miri/run-test.py
+++ b/test-cargo-miri/run-test.py
@@ -131,6 +131,10 @@ def test_cargo_miri_run():
         cargo_miri("run") + ["--target-dir=custom-run", "--", "--target-dir=target/custom-run"],
         "run.args.stdout.ref", "run.custom-target-dir.stderr.ref",
     )
+    test("`cargo miri run --package=test-local-crate-detection` (test local crate detection)",
+         cargo_miri("run") + ["--package=test-local-crate-detection"],
+         "run.local_crate.stdout.ref", "run.local_crate.stderr.ref",
+    )
 
 def test_cargo_miri_test():
     # rustdoc is not run on foreign targets

--- a/test-cargo-miri/run.local_crate.stdout.ref
+++ b/test-cargo-miri/run.local_crate.stdout.ref
@@ -1,0 +1,1 @@
+subcrate,issue_1567,exported_symbol_dep,test_local_crate_detection,cargo_miri_test,cdylib,exported_symbol,issue_1691,issue_1705,issue_rust_86261,proc_macro_crate

--- a/test-cargo-miri/test-local-crate-detection/Cargo.toml
+++ b/test-cargo-miri/test-local-crate-detection/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "test-local-crate-detection"
+version = "0.1.0"
+edition = "2021"

--- a/test-cargo-miri/test-local-crate-detection/src/main.rs
+++ b/test-cargo-miri/test-local-crate-detection/src/main.rs
@@ -1,3 +1,5 @@
 fn main() {
+    // Make sure we detect all crates from this workspace as "local".
+    // The env var is set during the "build" so we can use `env!` to access it directly.
     println!("{}", env!("MIRI_LOCAL_CRATES"));
 }

--- a/test-cargo-miri/test-local-crate-detection/src/main.rs
+++ b/test-cargo-miri/test-local-crate-detection/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("{}", env!("MIRI_LOCAL_CRATES"));
+}


### PR DESCRIPTION
`PackageId` is an opaque identifier whose internal format is subject to change, so looking up the names of local crates by ID is more robust than parsing the ID.

Resolves #3643.