### PR TITLE
Draft: Create _umtx_op shim for FreeBSD

### DIFF
--- a/src/shims/unix/freebsd/foreign_items.rs
+++ b/src/shims/unix/freebsd/foreign_items.rs
@@ -1,6 +1,7 @@
 use rustc_span::Symbol;
 use rustc_target::spec::abi::Abi;
 
+use crate::shims::unix::freebsd::sync::futex;
 use crate::shims::unix::*;
 use crate::*;
 
@@ -82,6 +83,12 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let [_thread, _attr] =
                     this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
                 this.write_null(dest)?;
+            }
+
+            "_umtx_op" => {
+                let [_obj, _op, _val, _uaddr, _uaddr2] =
+                    this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                futex(this, args, dest)?;
             }
 
             _ => return Ok(EmulateItemResult::NotSupported),

--- a/src/shims/unix/freebsd/mod.rs
+++ b/src/shims/unix/freebsd/mod.rs
@@ -1,1 +1,2 @@
 pub mod foreign_items;
+pub mod sync;

--- a/src/shims/unix/freebsd/sync.rs
+++ b/src/shims/unix/freebsd/sync.rs
@@ -1,16 +1,27 @@
 use crate::*;
+use rustc_middle::ty::Ty;
+use rustc_middle::ty::Mutability;
+use rustc_middle::ty::layout::LayoutOf;
 
 pub fn futex<'tcx>(
     this: &mut MiriInterpCx<'tcx>,
     args: &[OpTy<'tcx>],
     _dest: &MPlaceTy<'tcx>,
 ) -> InterpResult<'tcx> {
+    //Checking for the minimal amount of arguments required to proceed with
+    if args.len() < 3 {
+        throw_ub_format!(
+            "incorrect number of arguments for `futex` syscall: got {}, expected at least 3",
+            args.len()
+        );
+    }
+
     //void *obj
-    let _obj = this.read_pointer(&args[0])?;
+    let obj = this.read_pointer(&args[0])?;
     //int op
     let op = this.read_scalar(&args[1])?.to_i32()?;
     //u_long val
-    let _val = this.read_scalar(&args[2])?.to_u64()?;
+    let val = this.read_scalar(&args[2])?.to_i64()?;
     //void *uaddr
     let _uaddr = this.read_pointer(&args[3])?;
     //void *uaddr2
@@ -20,8 +31,27 @@ pub fn futex<'tcx>(
     let umtx_op_wake_private = this.eval_libc_i32("UMTX_OP_WAKE_PRIVATE");
     let umtx_op_nwake_private = this.eval_libc_i32("UMTX_OP_NWAKE_PRIVATE");
 
+    let umtx_op_wait = this.eval_libc_i32("UMTX_OP_WAIT");
+
     //FUTEX private operations are not supported by miri
     match op & !umtx_op_wait_uint_private & !umtx_op_wake_private & !umtx_op_nwake_private {
+        umtx_op_wait => {
+            let ptr_layout = this.layout_of(Ty::new_ptr(this.tcx.tcx, this.tcx.types.i32, Mutability::Not))?;
+            let obj_val = this.deref_pointer(&args[0].transmute(ptr_layout, this)?)?;
+            let obj_val = this.read_scalar(&obj_val)?.to_i32()?;
+
+            if obj_val as i64 == val {
+                //wait
+            }
+
+
+            let result = 0;
+            if result == 0 {
+                return Ok(())
+            }
+
+        }
         _ => throw_unsup_format!("Miri does not support `futex` syscall with op={}", op),
     }
+    Ok(())
 }

--- a/src/shims/unix/freebsd/sync.rs
+++ b/src/shims/unix/freebsd/sync.rs
@@ -16,5 +16,12 @@ pub fn futex<'tcx>(
     //void *uaddr2
     let _uaddr2 = this.read_pointer(&args[4])?;
 
-    throw_unsup_format!("Miri does not support `futex` syscall with op={}", op);
+    let umtx_op_wait_uint_private = this.eval_libc_i32("UMTX_OP_WAIT_UINT_PRIVATE");
+    let umtx_op_wake_private = this.eval_libc_i32("UMTX_OP_WAKE_PRIVATE");
+    let umtx_op_nwake_private = this.eval_libc_i32("UMTX_OP_NWAKE_PRIVATE");
+
+    //FUTEX private operations are not supported by miri
+    match op & !umtx_op_wait_uint_private & !umtx_op_wake_private & !umtx_op_nwake_private {
+        _ => throw_unsup_format!("Miri does not support `futex` syscall with op={}", op),
+    }
 }

--- a/src/shims/unix/freebsd/sync.rs
+++ b/src/shims/unix/freebsd/sync.rs
@@ -1,0 +1,20 @@
+use crate::*;
+
+pub fn futex<'tcx>(
+    this: &mut MiriInterpCx<'tcx>,
+    args: &[OpTy<'tcx>],
+    _dest: &MPlaceTy<'tcx>,
+) -> InterpResult<'tcx> {
+    //void *obj
+    let _obj = this.read_pointer(&args[0])?;
+    //int op
+    let op = this.read_scalar(&args[1])?.to_i32()?;
+    //u_long val
+    let _val = this.read_scalar(&args[2])?.to_u64()?;
+    //void *uaddr
+    let _uaddr = this.read_pointer(&args[3])?;
+    //void *uaddr2
+    let _uaddr2 = this.read_pointer(&args[4])?;
+
+    throw_unsup_format!("Miri does not support `futex` syscall with op={}", op);
+}


### PR DESCRIPTION
This PR lays the basic works for the _umtx_op shim for freebsd

I have implemented this by taking inspiration from the linux futex shim, so it may not be perfect and I am looking forward to criticism.

I will continue that on later commits because the tests do not currently pass