### PR TITLE
README: Mention test-tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ fn does_not_work_on_miri() {
 }
 ```
 
+If the majority of tests is not Miri-compatible and an opt-in scheme
+feels more appropriate, the [`test-tag`][test-tag] crate may be useful
+as well.
+
 There is no way to list all the infinite things Miri cannot do, but the
 interpreter will explicitly tell you when it finds something unsupported:
 
@@ -137,6 +141,8 @@ error: unsupported operation: can't call foreign function: bind
     = help: this is likely not a bug in the program; it indicates that the program \
             performed an operation that Miri does not support
 ```
+
+[test-tag]: https://crates.io/crates/test-tag
 
 ### Cross-interpretation: running for different targets
 


### PR DESCRIPTION
The usage of `#[cfg_attr(miri, ignore)]` works well if the majority of tests is Miri compatible, but can be cumbersome if that's not the case. The `test-tag` crate provides the means for having an opt-in scheme instead, which may be preferred in larger code bases.

Given that the README already mentions `nextest` as a third party crate, embed a short note about the possibility of using `test-tag` as well.