### PR TITLE
Fix futex with large timeout ICE

### DIFF
--- a/src/clock.rs
+++ b/src/clock.rs
@@ -43,7 +43,8 @@ impl Instant {
                 // `Duration` does not provide a nice constructor from a `u128` of nanoseconds,
                 // so we have to implement this ourselves.
                 // It is possible for second to overflow because u64::MAX < (u128::MAX / 1e9).
-                let seconds = u64::try_from(duration.saturating_div(1_000_000_000)).unwrap();
+                // It will be saturated to u64::MAX seconds if the value after division exceeds u64::MAX.
+                let seconds = u64::try_from(duration / 1_000_000_000).unwrap_or(u64::MAX);
                 // It is impossible for nanosecond to overflow because u32::MAX > 1e9.
                 let nanosecond = u32::try_from(duration.wrapping_rem(1_000_000_000)).unwrap();
                 Duration::new(seconds, nanosecond)

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -102,7 +102,7 @@ impl Clock {
             ClockKind::Virtual { nanoseconds } => {
                 // Just pretend that we have slept for some time.
                 let nanos: u128 = duration.as_nanos();
-                nanoseconds.update(|x| x + nanos);
+                nanoseconds.update(|x| x.checked_add(nanos).expect("Miri's virtual clock cannot represent an execution this long"));
             }
         }
     }

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -40,6 +40,8 @@ impl Instant {
                 InstantKind::Virtual { nanoseconds: earlier },
             ) => {
                 let duration = nanoseconds.saturating_sub(earlier);
+                // `Duration` does not provide a nice constructor from a `u128` of nanoseconds,
+                // so we have to implement this ourselves.
                 // It is possible for second to overflow because u64::MAX < (u128::MAX / 1e9).
                 let seconds = u64::try_from(duration.saturating_div(1_000_000_000)).unwrap();
                 // It is impossible for nanosecond to overflow because u32::MAX > 1e9.

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -39,13 +39,11 @@ impl Instant {
                 InstantKind::Virtual { nanoseconds },
                 InstantKind::Virtual { nanoseconds: earlier },
             ) => {
+                let duration = nanoseconds.saturating_sub(earlier);
                 // It is possible for second to overflow because u64::MAX < (u128::MAX / 1e9).
-                let seconds = u64::try_from(
-                    nanoseconds.saturating_sub(earlier).saturating_div(1_000_000_000),
-                )
-                .unwrap();
+                let seconds = u64::try_from(duration.saturating_div(1_000_000_000)).unwrap();
                 // It is impossible for nanosecond to overflow because u32::MAX > 1e9.
-                let nanosecond = u32::try_from(nanoseconds.wrapping_rem(1_000_000_000)).unwrap();
+                let nanosecond = u32::try_from(duration.wrapping_rem(1_000_000_000)).unwrap();
                 Duration::new(seconds, nanosecond)
             }
             _ => panic!("all `Instant` must be of the same kind"),

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -103,7 +103,10 @@ impl Clock {
             ClockKind::Virtual { nanoseconds } => {
                 // Just pretend that we have slept for some time.
                 let nanos: u128 = duration.as_nanos();
-                nanoseconds.update(|x| x.checked_add(nanos).expect("Miri's virtual clock cannot represent an execution this long"));
+                nanoseconds.update(|x| {
+                    x.checked_add(nanos)
+                        .expect("Miri's virtual clock cannot represent an execution this long")
+                });
             }
         }
     }

--- a/tests/pass-dep/concurrency/linux-futex.rs
+++ b/tests/pass-dep/concurrency/linux-futex.rs
@@ -280,7 +280,23 @@ fn concurrent_wait_wake() {
     assert!(woken > 0 && woken < rounds);
 }
 
+// Reproduce of https://github.com/rust-lang/miri/issues/3647.
+fn large_timeout() {
+    let futex: i32 = 123;
+
+    unsafe {
+        libc::syscall(
+            libc::SYS_futex,
+            addr_of!(futex),
+            libc::FUTEX_WAIT,
+            123,
+            &libc::timespec { tv_sec: 184467440839020, tv_nsec: 117558982 },
+        );
+    }
+}
+
 fn main() {
+    large_timeout();
     wake_nobody();
     wake_dangling();
     wait_wrong_val();

--- a/tests/pass-dep/concurrency/linux-futex.rs
+++ b/tests/pass-dep/concurrency/linux-futex.rs
@@ -280,21 +280,6 @@ fn concurrent_wait_wake() {
     assert!(woken > 0 && woken < rounds);
 }
 
-// Reproduce https://github.com/rust-lang/miri/issues/3647. This should not ICE.
-fn large_timeout() {
-    let futex: i32 = 123;
-
-    unsafe {
-        libc::syscall(
-            libc::SYS_futex,
-            addr_of!(futex),
-            libc::FUTEX_WAIT,
-            123,
-            &libc::timespec { tv_sec: 184467440839020, tv_nsec: 117558982 },
-        );
-    }
-}
-
 fn main() {
     wake_nobody();
     wake_dangling();
@@ -304,5 +289,4 @@ fn main() {
     wait_wake();
     wait_wake_bitset();
     concurrent_wait_wake();
-    large_timeout();
 }

--- a/tests/pass-dep/concurrency/linux-futex.rs
+++ b/tests/pass-dep/concurrency/linux-futex.rs
@@ -280,7 +280,7 @@ fn concurrent_wait_wake() {
     assert!(woken > 0 && woken < rounds);
 }
 
-// Reproduce of https://github.com/rust-lang/miri/issues/3647.
+// Reproduce https://github.com/rust-lang/miri/issues/3647. This should not ICE.
 fn large_timeout() {
     let futex: i32 = 123;
 
@@ -296,7 +296,6 @@ fn large_timeout() {
 }
 
 fn main() {
-    large_timeout();
     wake_nobody();
     wake_dangling();
     wait_wrong_val();
@@ -305,4 +304,5 @@ fn main() {
     wait_wake();
     wait_wake_bitset();
     concurrent_wait_wake();
+    large_timeout();
 }


### PR DESCRIPTION
Fixes #3647. 

This PR changed the type of ``nanoseconds`` from ``u64`` to ``u128``. In ``duration_since``, nanoseconds is manually converted to second by dividing it with 1e9. But overflow is still possible. 