### PR TITLE
Minor fix: Change wording of epoll_create1 and socketpair's throw_unsup_format

### DIFF
--- a/src/shims/unix/linux/epoll.rs
+++ b/src/shims/unix/linux/epoll.rs
@@ -57,10 +57,13 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let flags = this.read_scalar(flags)?.to_i32()?;
 
         let epoll_cloexec = this.eval_libc_i32("EPOLL_CLOEXEC");
-        if flags == epoll_cloexec {
-            // Miri does not support exec, so this flag has no effect.
-        } else if flags != 0 {
-            throw_unsup_format!("epoll_create1 flags {flags} are not implemented");
+
+        // Miri does not support exec, so EPOLL_CLOEXEC flag has no effect.
+        if flags != epoll_cloexec && flags != 0 {
+            throw_unsup_format!(
+                "epoll_create1: flag {:#x} is unsupported, only 0 or EPOLL_CLOEXEC are allowed",
+                flags
+            );
         }
 
         let fd = this.machine.fds.insert_fd(FileDescriptor::new(Epoll::default()));

--- a/src/shims/unix/socket.rs
+++ b/src/shims/unix/socket.rs
@@ -179,19 +179,19 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // their values differ.
         if domain != this.eval_libc_i32("AF_UNIX") && domain != this.eval_libc_i32("AF_LOCAL") {
             throw_unsup_format!(
-                "socketpair: Unsupported domain {:#x} is used, only AF_UNIX \
+                "socketpair: domain {:#x} is unsupported, only AF_UNIX \
                                  and AF_LOCAL are allowed",
                 domain
             );
         } else if type_ != 0 {
             throw_unsup_format!(
-                "socketpair: Unsupported type {:#x} is used, only SOCK_STREAM, \
+                "socketpair: type {:#x} is unsupported, only SOCK_STREAM, \
                                  SOCK_CLOEXEC and SOCK_NONBLOCK are allowed",
                 type_
             );
         } else if protocol != 0 {
             throw_unsup_format!(
-                "socketpair: Unsupported socket protocol {protocol} is used, \
+                "socketpair: socket protocol {protocol} is unsupported, \
                                  only 0 is allowed",
             );
         }


### PR DESCRIPTION
This PR slightly changes the wording and format of ``epoll_create1``'s ``throw_unsup_format`` to match other shims. It is just a minor detail that I couldn't help but want to change while reading it. Sorry if it is not appropriate to open a PR for such minor detail.