### PR TITLE
disable tls with Box::leak test on solaris/illumos.

### DIFF
--- a/tests/pass/tls/tls_leak_main_thread_allowed.rs
+++ b/tests/pass/tls/tls_leak_main_thread_allowed.rs
@@ -1,4 +1,6 @@
 //@ignore-target-windows: Windows uses a different mechanism for `thread_local!`
+//@revisions: default tls
+//@[tls]compile-flags: -Zmiri-ignore-leaks
 #![feature(thread_local)]
 
 use std::cell::Cell;


### PR DESCRIPTION
on these platforms, thread_local is disabled as there is no support for cleanup callback, the test is leaking here.