### PR TITLE
Fix miri.bat to not exit unconditionally

### DIFF
--- a/miri.bat
+++ b/miri.bat
@@ -6,7 +6,7 @@ set MIRI_SCRIPT_TARGET_DIR=%0\..\miri-script\target
 :: If any other steps are added, the "|| exit /b" must be appended to early
 :: return from the script. If not, it will continue execution.
 cargo +stable build %CARGO_EXTRA_FLAGS% -q --target-dir %MIRI_SCRIPT_TARGET_DIR% --manifest-path %0\..\miri-script\Cargo.toml ^
-  || echo Failed to build miri-script. Is the 'stable' toolchain installed? & exit /b
+  || echo Failed to build miri-script. Is the 'stable' toolchain installed? && exit /b
 
 :: Forwards all arguments to this file to the executable.
 :: We invoke the binary directly to avoid going through rustup, which would set some extra

--- a/miri.bat
+++ b/miri.bat
@@ -6,7 +6,7 @@ set MIRI_SCRIPT_TARGET_DIR=%0\..\miri-script\target
 :: If any other steps are added, the "|| exit /b" must be appended to early
 :: return from the script. If not, it will continue execution.
 cargo +stable build %CARGO_EXTRA_FLAGS% -q --target-dir %MIRI_SCRIPT_TARGET_DIR% --manifest-path %0\..\miri-script\Cargo.toml ^
-  || echo Failed to build miri-script. Is the 'stable' toolchain installed? && exit /b
+  || (echo Failed to build miri-script. Is the 'stable' toolchain installed? & exit /b)
 
 :: Forwards all arguments to this file to the executable.
 :: We invoke the binary directly to avoid going through rustup, which would set some extra


### PR DESCRIPTION
#3703 has a small typo causing it to regress ./miri.bat to not working at all. 

This PR fixes it. Tested on Windows 11, with stable toolchain missing as well as installed.
```test
./miri toolchain
error: toolchain 'stable-x86_64-pc-windows-msvc' is not installed
Failed to build miri-script. Is the 'stable' toolchain installed?
```

Closes #3714 