### PR TITLE
iter_exported_symbols: also walk used statics in local crate

### DIFF
--- a/tests/pass/tls/win_tls_callback.rs
+++ b/tests/pass/tls/win_tls_callback.rs
@@ -1,0 +1,16 @@
+//! Ensure that we call Windows TLS callbacks in the local crate.
+//@only-target-windows
+// Calling eprintln in the callback seems to (re-)initialize some thread-local storage
+// and then leak the memory allocated for that. Let's just ignore these leaks,
+// that's not what this test is about.
+//@compile-flags: -Zmiri-ignore-leaks
+
+#[link_section = ".CRT$XLB"]
+#[used] // Miri only considers explicitly `#[used]` statics for `lookup_link_section`
+pub static CALLBACK: unsafe extern "system" fn(*const (), u32, *const ()) = tls_callback;
+
+unsafe extern "system" fn tls_callback(_h: *const (), _dw_reason: u32, _pv: *const ()) {
+    eprintln!("in tls_callback");
+}
+
+fn main() {}

--- a/tests/pass/tls/win_tls_callback.stderr
+++ b/tests/pass/tls/win_tls_callback.stderr
@@ -1,0 +1,1 @@
+in tls_callback


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/126938 got reverted, we need a different approach.

Fixes https://github.com/rust-lang/miri/issues/3722