### PR TITLE
remove some SSE/SSE2 intrinsics that are no longer used by stdarch

### DIFF
--- a/src/shims/x86/avx.rs
+++ b/src/shims/x86/avx.rs
@@ -73,13 +73,12 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 round_all::<rustc_apfloat::ieee::Double>(this, op, rounding, dest)?;
             }
-            // Used to implement _mm256_{sqrt,rcp,rsqrt}_ps functions.
+            // Used to implement _mm256_{rcp,rsqrt}_ps functions.
             // Performs the operations on all components of `op`.
-            "sqrt.ps.256" | "rcp.ps.256" | "rsqrt.ps.256" => {
+            "rcp.ps.256" | "rsqrt.ps.256" => {
                 let [op] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
 
                 let which = match unprefixed_name {
-                    "sqrt.ps.256" => FloatUnaryOp::Sqrt,
                     "rcp.ps.256" => FloatUnaryOp::Rcp,
                     "rsqrt.ps.256" => FloatUnaryOp::Rsqrt,
                     _ => unreachable!(),

--- a/src/shims/x86/sse.rs
+++ b/src/shims/x86/sse.rs
@@ -1,5 +1,4 @@
 use rustc_apfloat::ieee::Single;
-use rustc_middle::mir;
 use rustc_span::Symbol;
 use rustc_target::spec::abi::Abi;
 
@@ -29,18 +28,14 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // performed only on the first element, copying the remaining elements from the input
         // vector (for binary operations, from the left-hand side).
         match unprefixed_name {
-            // Used to implement _mm_{add,sub,mul,div,min,max}_ss functions.
+            // Used to implement _mm_{min,max}_ss functions.
             // Performs the operations on the first component of `left` and
             // `right` and copies the remaining components from `left`.
-            "add.ss" | "sub.ss" | "mul.ss" | "div.ss" | "min.ss" | "max.ss" => {
+            "min.ss" | "max.ss" => {
                 let [left, right] =
                     this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
 
                 let which = match unprefixed_name {
-                    "add.ss" => FloatBinOp::Arith(mir::BinOp::Add),
-                    "sub.ss" => FloatBinOp::Arith(mir::BinOp::Sub),
-                    "mul.ss" => FloatBinOp::Arith(mir::BinOp::Mul),
-                    "div.ss" => FloatBinOp::Arith(mir::BinOp::Div),
                     "min.ss" => FloatBinOp::Min,
                     "max.ss" => FloatBinOp::Max,
                     _ => unreachable!(),
@@ -65,14 +60,13 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 bin_op_simd_float_all::<Single>(this, which, left, right, dest)?;
             }
-            // Used to implement _mm_{sqrt,rcp,rsqrt}_ss functions.
+            // Used to implement _mm_{rcp,rsqrt}_ss functions.
             // Performs the operations on the first component of `op` and
             // copies the remaining components from `op`.
-            "sqrt.ss" | "rcp.ss" | "rsqrt.ss" => {
+            "rcp.ss" | "rsqrt.ss" => {
                 let [op] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
 
                 let which = match unprefixed_name {
-                    "sqrt.ss" => FloatUnaryOp::Sqrt,
                     "rcp.ss" => FloatUnaryOp::Rcp,
                     "rsqrt.ss" => FloatUnaryOp::Rsqrt,
                     _ => unreachable!(),
@@ -82,11 +76,10 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             }
             // Used to implement _mm_{sqrt,rcp,rsqrt}_ps functions.
             // Performs the operations on all components of `op`.
-            "sqrt.ps" | "rcp.ps" | "rsqrt.ps" => {
+            "rcp.ps" | "rsqrt.ps" => {
                 let [op] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
 
                 let which = match unprefixed_name {
-                    "sqrt.ps" => FloatUnaryOp::Sqrt,
                     "rcp.ps" => FloatUnaryOp::Rcp,
                     "rsqrt.ps" => FloatUnaryOp::Rsqrt,
                     _ => unreachable!(),

--- a/tests/fail/intrinsics/intrinsic_target_feature.rs
+++ b/tests/fail/intrinsics/intrinsic_target_feature.rs
@@ -24,7 +24,7 @@ fn main() {
 
     unsafe {
         // Pass, since SSE is enabled
-        addss(_mm_setzero_ps(), _mm_setzero_ps());
+        minss(_mm_setzero_ps(), _mm_setzero_ps());
 
         // Fail, since SSE4.1 is not enabled
         dpps(_mm_setzero_ps(), _mm_setzero_ps(), 0);
@@ -34,8 +34,8 @@ fn main() {
 
 #[allow(improper_ctypes)]
 extern "C" {
-    #[link_name = "llvm.x86.sse.add.ss"]
-    fn addss(a: __m128, b: __m128) -> __m128;
+    #[link_name = "llvm.x86.sse.min.ss"]
+    fn minss(a: __m128, b: __m128) -> __m128;
 
     #[link_name = "llvm.x86.sse41.dpps"]
     fn dpps(a: __m128, b: __m128, imm8: u8) -> __m128;


### PR DESCRIPTION
Fixes https://github.com/rust-lang/miri/issues/3691