### PR TITLE
Add `gettid` support

### DIFF
--- a/src/shims/env.rs
+++ b/src/shims/env.rs
@@ -108,4 +108,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             EnvVars::Windows(vars) => vars.get(name),
         }
     }
+
+    fn get_pid(&self) -> u32 {
+        let this = self.eval_context_ref();
+        if this.machine.communicate() { std::process::id() } else { 1000 }
+    }
 }

--- a/src/shims/unix/linux/foreign_items.rs
+++ b/src/shims/unix/linux/foreign_items.rs
@@ -94,6 +94,11 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 )?;
                 this.write_scalar(res, dest)?;
             }
+            "gettid" => {
+                let [] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
+                let result = this.linux_gettid()?;
+                this.write_scalar(Scalar::from_i32(result), dest)?;
+            }
 
             // Dynamically invoked syscalls
             "syscall" => {

--- a/src/shims/windows/env.rs
+++ b/src/shims/windows/env.rs
@@ -200,9 +200,8 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     fn GetCurrentProcessId(&mut self) -> InterpResult<'tcx, u32> {
         let this = self.eval_context_mut();
         this.assert_target_os("windows", "GetCurrentProcessId");
-        this.check_no_isolation("`GetCurrentProcessId`")?;
 
-        Ok(std::process::id())
+        Ok(this.get_pid())
     }
 
     #[allow(non_snake_case)]

--- a/tests/pass-dep/libc/gettid.rs
+++ b/tests/pass-dep/libc/gettid.rs
@@ -1,0 +1,22 @@
+//@only-target-linux
+//@revisions: with_isolation without_isolation
+//@[without_isolation] compile-flags: -Zmiri-disable-isolation
+
+use libc::{getpid, gettid};
+use std::thread;
+
+fn main() {
+    thread::spawn(|| {
+        // Test that in isolation mode a deterministic value will be returned.
+        // The value 1001 is not important, we only care that whatever the value
+        // is, won't change from execution to execution.
+        #[cfg(with_isolation)]
+        assert_eq!(unsafe { gettid() }, 1001);
+
+        assert_ne!(unsafe { gettid() }, unsafe { getpid() });
+    });
+
+    // Test that the thread ID of the main thread is the same as the process
+    // ID.
+    assert_eq!(unsafe { gettid() }, unsafe { getpid() });
+}

--- a/tests/pass/getpid.rs
+++ b/tests/pass/getpid.rs
@@ -1,9 +1,20 @@
-//@compile-flags: -Zmiri-disable-isolation
+//@revisions: with_isolation without_isolation
+//@[without_isolation] compile-flags: -Zmiri-disable-isolation
 
 fn getpid() -> u32 {
     std::process::id()
 }
 
 fn main() {
-    getpid();
+    let pid = getpid();
+
+    std::thread::spawn(move || {
+        assert_eq!(getpid(), pid);
+    });
+
+    // Test that in isolation mode a deterministic value will be returned.
+    // The value 1000 is not important, we only care that whatever the value
+    // is, won't change from execution to execution.
+    #[cfg(with_isolation)]
+    assert_eq!(pid, 1000);
 }


### PR DESCRIPTION
Add support for `gettid` in miri.

To ensure that the requirement that  `getpid() == gettdi()` for the main thread, we use the value returned by `getpid` and add to it the internal thread index.

Since `getpid` is only supported when isolation is disabled, and we want `gettid` to be used both in isolated and non-isolated executions, we modify `getpid` to return a hardcoded value (1000) when running in isolation mode.

Fixes #3730