### PR TITLE
Insert FileDescription instead of FileDescriptor in ``insert_fd``

### DIFF
--- a/src/machine.rs
+++ b/src/machine.rs
@@ -660,7 +660,7 @@ impl<'tcx> MiriMachine<'tcx> {
             tls: TlsData::default(),
             isolated_op: config.isolated_op,
             validate: config.validate,
-            fds: shims::FdTable::new(config.mute_stdout_stderr),
+            fds: shims::FdTable::init(config.mute_stdout_stderr),
             dirs: Default::default(),
             layouts,
             threads,

--- a/src/shims/unix/linux/epoll.rs
+++ b/src/shims/unix/linux/epoll.rs
@@ -5,8 +5,6 @@ use rustc_data_structures::fx::FxHashMap;
 use crate::shims::unix::*;
 use crate::*;
 
-use self::shims::unix::fd::FileDescriptor;
-
 /// An `Epoll` file descriptor connects file handles and epoll events
 #[derive(Clone, Debug, Default)]
 struct Epoll {
@@ -66,7 +64,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             );
         }
 
-        let fd = this.machine.fds.insert_fd(FileDescriptor::new(Epoll::default()));
+        let fd = this.machine.fds.insert_fd(Epoll::default());
         Ok(Scalar::from_i32(fd))
     }
 

--- a/src/shims/unix/linux/eventfd.rs
+++ b/src/shims/unix/linux/eventfd.rs
@@ -8,8 +8,6 @@ use rustc_target::abi::Endian;
 use crate::shims::unix::*;
 use crate::{concurrency::VClock, *};
 
-use self::shims::unix::fd::FileDescriptor;
-
 // We'll only do reads and writes in chunks of size u64.
 const U64_ARRAY_SIZE: usize = mem::size_of::<u64>();
 
@@ -180,11 +178,11 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             throw_unsup_format!("eventfd: encountered unknown unsupported flags {:#x}", flags);
         }
 
-        let fd = this.machine.fds.insert_fd(FileDescriptor::new(Event {
+        let fd = this.machine.fds.insert_fd(Event {
             counter: val.into(),
             is_nonblock,
             clock: VClock::default(),
-        }));
+        });
         Ok(Scalar::from_i32(fd))
     }
 }

--- a/src/shims/unix/socket.rs
+++ b/src/shims/unix/socket.rs
@@ -7,8 +7,6 @@ use std::rc::{Rc, Weak};
 use crate::shims::unix::*;
 use crate::{concurrency::VClock, *};
 
-use self::fd::FileDescriptor;
-
 /// The maximum capacity of the socketpair buffer in bytes.
 /// This number is arbitrary as the value can always
 /// be configured in the real system.
@@ -221,9 +219,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         };
 
         let fds = &mut this.machine.fds;
-        let sv0 = fds.insert_fd(FileDescriptor::new(socketpair_0));
+        let sv0 = fds.insert_fd(socketpair_0);
+        let sv1 = fds.insert_fd(socketpair_1);
         let sv0 = Scalar::from_int(sv0, sv.layout.size);
-        let sv1 = fds.insert_fd(FileDescriptor::new(socketpair_1));
         let sv1 = Scalar::from_int(sv1, sv.layout.size);
 
         this.write_scalar(sv0, &sv)?;


### PR DESCRIPTION
This PR moves the creation of ``FileDescriptor`` inside ``insert_fd``, and ``insert_fd`` now takes in ``FileDescription`` instead of ``FileDescriptor``.  This change is needed by #3712. 