### PR TITLE
Add hook for updating the canonical address

### DIFF
--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -423,6 +423,13 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     }
                 }
             }
+            "miri_set_canonical_address" => {
+                let [old_ptr, new_ptr] = this.check_shim(abi, Abi::Rust, link_name, args)?;
+                let old_ptr = this.read_pointer(old_ptr)?;
+                let new_ptr = this.read_pointer(new_ptr)?;
+                let (alloc_id, _, _) = this.ptr_get_alloc_id(old_ptr, 0)?;
+                this.machine.set_alloc_address(alloc_id, new_ptr.addr().bytes());
+            }
 
             // Aborting the process.
             "exit" => {

--- a/tests/utils/miri_extern.rs
+++ b/tests/utils/miri_extern.rs
@@ -147,4 +147,9 @@ extern "Rust" {
     /// "symbolic" alignment checks. Will fail if the pointer is not actually aligned or `align` is
     /// not a power of two. Has no effect when alignment checks are concrete (which is the default).
     pub fn miri_promise_symbolic_alignment(ptr: *const (), align: usize);
+
+    /// Miri-provided extern function to specify that a new address is to be considered the
+    /// canonical address, where `new` is a valid alias to the `old` allocation,
+    /// usually due to them having different values in bits that are ignored by hardware.
+    pub fn miri_set_canonical_address(old: *const (), new: *const ());
 }


### PR DESCRIPTION
Where a method modifies the address that should be considered canonical - such as via TBI or when an MTE tag has been set - Miri will need to be notified.

This adds a hook to inform Miri of the new address.

---

The implementation used here permits a single (mutable) alias, with the intent that user code will only use the alias (once set) rather than the original `base_addr`. I'm open to feedback on this approach, but ran into issues when trying to update the actual `base_addr` when popping the function off the stack (and thus deallocating anything created in the function), hence this implementation which allows that to work correctly.

In particular, this would allow https://github.com/rust-lang/stdarch/pull/1622 to work under Miri, as it could use this hook to ensure that Miri is aware that the change to the pointer address is actually fine in context.