### PR TITLE
throw_unsup_format for alignment greater than 2^29

### DIFF
--- a/tests/fail/alloc/unsupported_big_alignment.rs
+++ b/tests/fail/alloc/unsupported_big_alignment.rs
@@ -1,0 +1,14 @@
+// Previously, attempting to allocate with an alignment greater than 2^29 would cause miri to ICE
+// because rustc does not support alignments that large.
+// https://github.com/rust-lang/miri/issues/3687
+
+extern "Rust" {
+    fn __rust_alloc(size: usize, align: usize) -> *mut u8;
+}
+
+fn main() {
+    unsafe {
+        __rust_alloc(1, 1 << 30);
+        //~^ERROR: exceeding rustc's maximum supported value
+    }
+}

--- a/tests/fail/alloc/unsupported_big_alignment.stderr
+++ b/tests/fail/alloc/unsupported_big_alignment.stderr
@@ -1,0 +1,14 @@
+error: unsupported operation: creating allocation with alignment ALIGN exceeding rustc's maximum supported value
+  --> $DIR/unsupported_big_alignment.rs:LL:CC
+   |
+LL |         __rust_alloc(1, 1 << 30);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^ creating allocation with alignment ALIGN exceeding rustc's maximum supported value
+   |
+   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
+   = note: BACKTRACE:
+   = note: inside `main` at $DIR/unsupported_big_alignment.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/tests/fail/alloc/unsupported_non_power_two_alignment.rs
+++ b/tests/fail/alloc/unsupported_non_power_two_alignment.rs
@@ -1,0 +1,11 @@
+// Test non-power-of-two alignment.
+extern "Rust" {
+    fn __rust_alloc(size: usize, align: usize) -> *mut u8;
+}
+
+fn main() {
+    unsafe {
+        __rust_alloc(1, 3);
+        //~^ERROR: creating allocation with non-power-of-two alignment
+    }
+}

--- a/tests/fail/alloc/unsupported_non_power_two_alignment.stderr
+++ b/tests/fail/alloc/unsupported_non_power_two_alignment.stderr
@@ -1,0 +1,15 @@
+error: Undefined Behavior: creating allocation with non-power-of-two alignment ALIGN
+  --> $DIR/unsupported_non_power_two_alignment.rs:LL:CC
+   |
+LL |         __rust_alloc(1, 3);
+   |         ^^^^^^^^^^^^^^^^^^ creating allocation with non-power-of-two alignment ALIGN
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+   = note: BACKTRACE:
+   = note: inside `main` at $DIR/unsupported_non_power_two_alignment.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes #3687 