### PR TITLE
Don't panic on `miri_print_borrow_state()` under `-Zmiri-disable-stacked-borrows`.

### DIFF
--- a/src/borrow_tracker/mod.rs
+++ b/src/borrow_tracker/mod.rs
@@ -346,7 +346,11 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
     fn print_borrow_state(&mut self, alloc_id: AllocId, show_unnamed: bool) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
-        let method = this.machine.borrow_tracker.as_ref().unwrap().borrow().borrow_tracker_method;
+        let Some(borrow_tracker) = &this.machine.borrow_tracker else {
+            eprintln!("attempted to print borrow state, but no borrow state is being tracked");
+            return Ok(());
+        };
+        let method = borrow_tracker.borrow().borrow_tracker_method;
         match method {
             BorrowTrackerMethod::StackedBorrows => this.print_stacks(alloc_id),
             BorrowTrackerMethod::TreeBorrows => this.print_tree(alloc_id, show_unnamed),

--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -289,8 +289,12 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let [id, show_unnamed] = this.check_shim(abi, Abi::Rust, link_name, args)?;
                 let id = this.read_scalar(id)?.to_u64()?;
                 let show_unnamed = this.read_scalar(show_unnamed)?.to_bool()?;
-                if let Some(id) = std::num::NonZero::new(id) {
-                    this.print_borrow_state(AllocId(id), show_unnamed)?;
+                if let Some(id) = std::num::NonZero::new(id).map(AllocId)
+                    && this.get_alloc_info(id).2 == AllocKind::LiveData
+                {
+                    this.print_borrow_state(id, show_unnamed)?;
+                } else {
+                    eprintln!("{id} is not the ID of a live data allocation");
                 }
             }
             "miri_pointer_name" => {


### PR DESCRIPTION
Fixes #3459

Instead, just print "attempted to print borrow state, but no borrow state is being tracked" directly to ~~stdout~~ stderr and return successfully. Alternately, the diagnostic machinery could be used to print a structured error/warning.

 (Does not address the comment about nothing being printed for `miri_print_borrow_state` with `alloc_id = 0`)