### PR TITLE
miri-script: use --remap-path-prefix to print errors relative to the right root

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,9 @@
+[unstable]
+profile-rustflags = true
+
+# Add back the containing directory of the packages we have to refer to using --manifest-path.
+# Per-package profiles avoid adding this to build dependencies.
+[profile.dev.package."cargo-miri"]
+rustflags = ["--remap-path-prefix", "=cargo-miri"]
+[profile.dev.package."miri-script"]
+rustflags = ["--remap-path-prefix", "=miri-script"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: clippy (all features)
         run: ./miri clippy --all-features -- -D warnings
       - name: rustdoc
-        run: RUSTDOCFLAGS="-Dwarnings" ./miri cargo doc --document-private-items
+        run: RUSTDOCFLAGS="-Dwarnings" ./miri doc --document-private-items
 
   # These jobs doesn't actually test anything, but they're only used to tell
   # bors the build completed, as there is no practical way to detect when a

--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -35,6 +35,10 @@ runs:
         run: cargo install -f rustup-toolchain-install-master hyperfine
         shell: bash
 
+      - name: Install nightly toolchain
+        run: rustup toolchain install nightly --profile minimal
+        shell: bash
+
       - name: Install "master" toolchain
         run: |
           if [[ ${{ github.event_name }} == 'schedule' ]]; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -309,6 +309,7 @@ anyone but Miri itself. They are used to communicate between different Miri
 binaries, and as such worth documenting:
 
 * `CARGO_EXTRA_FLAGS` is understood by `./miri` and passed to all host cargo invocations.
+  It is reserved for CI usage; setting the wrong flags this way can easily confuse the script.
 * `MIRI_BE_RUSTC` can be set to `host` or `target`. It tells the Miri driver to
   actually not interpret the code but compile it like rustc would. With `target`, Miri sets
   some compiler flags to prepare the code for interpretation; with `host`, this is not done.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,24 +173,24 @@ to `.vscode/settings.json` in your local Miri clone:
         "cargo-miri/Cargo.toml",
         "miri-script/Cargo.toml",
     ],
+    "rust-analyzer.check.invocationLocation": "root",
+    "rust-analyzer.check.invocationStrategy": "once",
     "rust-analyzer.check.overrideCommand": [
         "env",
         "MIRI_AUTO_OPS=no",
         "./miri",
-        "cargo",
         "clippy", // make this `check` when working with a locally built rustc
         "--message-format=json",
-        "--all-targets",
     ],
     // Contrary to what the name suggests, this also affects proc macros.
+    "rust-analyzer.cargo.buildScripts.invocationLocation": "root",
+    "rust-analyzer.cargo.buildScripts.invocationStrategy": "once",
     "rust-analyzer.cargo.buildScripts.overrideCommand": [
         "env",
         "MIRI_AUTO_OPS=no",
         "./miri",
-        "cargo",
         "check",
         "--message-format=json",
-        "--all-targets",
     ],
 }
 ```

--- a/cargo-miri/miri
+++ b/cargo-miri/miri
@@ -1,4 +1,0 @@
-#!/bin/sh
-# RA invokes `./miri cargo ...` for each workspace, so we need to forward that to the main `miri`
-# script. See <https://github.com/rust-analyzer/rust-analyzer/issues/10793>.
-exec "$(dirname "$0")"/../miri "$@"

--- a/cargo-miri/src/util.rs
+++ b/cargo-miri/src/util.rs
@@ -93,12 +93,9 @@ pub fn find_miri() -> PathBuf {
     if let Some(path) = env::var_os("MIRI") {
         return path.into();
     }
+    // Assume it is in the same directory as ourselves.
     let mut path = std::env::current_exe().expect("current executable path invalid");
-    if cfg!(windows) {
-        path.set_file_name("miri.exe");
-    } else {
-        path.set_file_name("miri");
-    }
+    path.set_file_name(format!("miri{}", env::consts::EXE_SUFFIX));
     path
 }
 

--- a/miri
+++ b/miri
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 set -e
+# We want to call the binary directly, so we need to know where it ends up.
+MIRI_SCRIPT_TARGET_DIR="$(dirname "$0")"/miri-script/target
+# If stdout is not a terminal and we are not on CI, assume that we are being invoked by RA, and use JSON output.
+if ! [ -t 1 ] && [ -z "$CI" ]; then
+  MESSAGE_FORMAT="--message-format=json"
+fi
+# We need a nightly toolchain, for the `profile-rustflags` cargo feature.
+cargo +nightly build $CARGO_EXTRA_FLAGS --manifest-path "$(dirname "$0")"/miri-script/Cargo.toml \
+  -q --target-dir "$MIRI_SCRIPT_TARGET_DIR" $MESSAGE_FORMAT || \
+  ( echo "Failed to build miri-script. Is the 'nightly' toolchain installed?"; exit 1 )
 # Instead of doing just `cargo run --manifest-path .. $@`, we invoke miri-script binary directly. Invoking `cargo run` goes through
 # rustup (that sets it's own environmental variables), which is undesirable.
-MIRI_SCRIPT_TARGET_DIR="$(dirname "$0")"/miri-script/target
-cargo +stable build $CARGO_EXTRA_FLAGS -q --target-dir "$MIRI_SCRIPT_TARGET_DIR" --manifest-path "$(dirname "$0")"/miri-script/Cargo.toml || \
-  ( echo "Failed to build miri-script. Is the 'stable' toolchain installed?"; exit 1 )
 "$MIRI_SCRIPT_TARGET_DIR"/debug/miri-script "$@"

--- a/miri-script/miri
+++ b/miri-script/miri
@@ -1,4 +1,0 @@
-#!/bin/sh
-# RA invokes `./miri cargo ...` for each workspace, so we need to forward that to the main `miri`
-# script. See <https://github.com/rust-analyzer/rust-analyzer/issues/10793>.
-exec "$(dirname "$0")"/../miri "$@"

--- a/miri-script/src/commands.rs
+++ b/miri-script/src/commands.rs
@@ -153,8 +153,7 @@ impl Command {
             | Command::Test { .. }
             | Command::Run { .. }
             | Command::Fmt { .. }
-            | Command::Clippy { .. }
-            | Command::Cargo { .. } => Self::auto_actions()?,
+            | Command::Clippy { .. } => Self::auto_actions()?,
             | Command::Toolchain { .. }
             | Command::Bench { .. }
             | Command::RustcPull { .. }
@@ -170,7 +169,6 @@ impl Command {
                 Self::run(dep, verbose, many_seeds, target, edition, flags),
             Command::Fmt { flags } => Self::fmt(flags),
             Command::Clippy { flags } => Self::clippy(flags),
-            Command::Cargo { flags } => Self::cargo(flags),
             Command::Bench { target, benches } => Self::bench(target, benches),
             Command::Toolchain { flags } => Self::toolchain(flags),
             Command::RustcPull { commit } => Self::rustc_pull(commit.clone()),
@@ -446,15 +444,6 @@ impl Command {
         e.clippy(path!(e.miri_dir / "Cargo.toml"), &flags)?;
         e.clippy(path!(e.miri_dir / "cargo-miri" / "Cargo.toml"), &flags)?;
         e.clippy(path!(e.miri_dir / "miri-script" / "Cargo.toml"), &flags)?;
-        Ok(())
-    }
-
-    fn cargo(flags: Vec<String>) -> Result<()> {
-        let e = MiriEnv::new()?;
-        let toolchain = &e.toolchain;
-        // We carefully kept the working dir intact, so this will run cargo *on the workspace in the
-        // current working dir*, not on the main Miri workspace. That is exactly what RA needs.
-        cmd!(e.sh, "cargo +{toolchain} {flags...}").run()?;
         Ok(())
     }
 

--- a/miri-script/src/commands.rs
+++ b/miri-script/src/commands.rs
@@ -153,6 +153,7 @@ impl Command {
             | Command::Test { .. }
             | Command::Run { .. }
             | Command::Fmt { .. }
+            | Command::Doc { .. }
             | Command::Clippy { .. } => Self::auto_actions()?,
             | Command::Toolchain { .. }
             | Command::Bench { .. }
@@ -167,6 +168,7 @@ impl Command {
             Command::Test { bless, flags, target } => Self::test(bless, flags, target),
             Command::Run { dep, verbose, many_seeds, target, edition, flags } =>
                 Self::run(dep, verbose, many_seeds, target, edition, flags),
+            Command::Doc { flags } => Self::doc(flags),
             Command::Fmt { flags } => Self::fmt(flags),
             Command::Clippy { flags } => Self::clippy(flags),
             Command::Bench { target, benches } => Self::bench(target, benches),
@@ -436,6 +438,13 @@ impl Command {
         let e = MiriEnv::new()?;
         e.check(path!(e.miri_dir / "Cargo.toml"), &flags)?;
         e.check(path!(e.miri_dir / "cargo-miri" / "Cargo.toml"), &flags)?;
+        Ok(())
+    }
+
+    fn doc(flags: Vec<String>) -> Result<()> {
+        let e = MiriEnv::new()?;
+        e.doc(path!(e.miri_dir / "Cargo.toml"), &flags)?;
+        e.doc(path!(e.miri_dir / "cargo-miri" / "Cargo.toml"), &flags)?;
         Ok(())
     }
 

--- a/miri-script/src/main.rs
+++ b/miri-script/src/main.rs
@@ -48,6 +48,11 @@ pub enum Command {
         /// Flags that are passed through to `miri`.
         flags: Vec<String>,
     },
+    /// Build documentation
+    Doc {
+        /// Flags that are passed through to `cargo doc`.
+        flags: Vec<String>,
+    },
     /// Format all sources and tests.
     Fmt {
         /// Flags that are passed through to `rustfmt`.
@@ -148,6 +153,7 @@ fn main() -> Result<()> {
     let command = match args.next_raw().as_deref() {
         Some("build") => Command::Build { flags: args.remainder() },
         Some("check") => Command::Check { flags: args.remainder() },
+        Some("doc") => Command::Doc { flags: args.remainder() },
         Some("test") => {
             let mut target = None;
             let mut bless = false;

--- a/miri-script/src/main.rs
+++ b/miri-script/src/main.rs
@@ -58,9 +58,6 @@ pub enum Command {
         /// Flags that are passed through to `cargo clippy`.
         flags: Vec<String>,
     },
-    /// Runs just `cargo <flags>` with the Miri-specific environment variables.
-    /// Mainly meant to be invoked by rust-analyzer.
-    Cargo { flags: Vec<String> },
     /// Runs the benchmarks from bench-cargo-miri in hyperfine. hyperfine needs to be installed.
     Bench {
         target: Option<String>,
@@ -205,7 +202,6 @@ fn main() -> Result<()> {
         }
         Some("fmt") => Command::Fmt { flags: args.remainder() },
         Some("clippy") => Command::Clippy { flags: args.remainder() },
-        Some("cargo") => Command::Cargo { flags: args.remainder() },
         Some("install") => Command::Install { flags: args.remainder() },
         Some("bench") => {
             let mut target = None;

--- a/miri-script/src/util.rs
+++ b/miri-script/src/util.rs
@@ -7,7 +7,7 @@ use std::thread;
 use anyhow::{anyhow, Context, Result};
 use dunce::canonicalize;
 use path_macro::path;
-use xshell::{cmd, Shell};
+use xshell::{cmd, Cmd, Shell};
 
 pub fn miri_dir() -> std::io::Result<PathBuf> {
     const MIRI_SCRIPT_ROOT_DIR: &str = env!("CARGO_MANIFEST_DIR");
@@ -28,13 +28,14 @@ pub fn flagsplit(flags: &str) -> Vec<String> {
 }
 
 /// Some extra state we track for building Miri, such as the right RUSTFLAGS.
+#[derive(Clone)]
 pub struct MiriEnv {
     /// miri_dir is the root of the miri repository checkout we are working in.
     pub miri_dir: PathBuf,
     /// active_toolchain is passed as `+toolchain` argument to cargo/rustc invocations.
     pub toolchain: String,
     /// Extra flags to pass to cargo.
-    pub cargo_extra_flags: Vec<String>,
+    cargo_extra_flags: Vec<String>,
     /// The rustc sysroot
     pub sysroot: PathBuf,
     /// The shell we use.
@@ -54,15 +55,14 @@ impl MiriEnv {
 
         // Determine some toolchain properties
         if !libdir.exists() {
-            println!("Something went wrong determining the library dir.");
-            println!("I got {} but that does not exist.", libdir.display());
-            println!("Please report a bug at https://github.com/rust-lang/miri/issues.");
+            eprintln!("Something went wrong determining the library dir.");
+            eprintln!("I got {} but that does not exist.", libdir.display());
+            eprintln!("Please report a bug at https://github.com/rust-lang/miri/issues.");
             std::process::exit(2);
         }
-        // Share target dir between `miri` and `cargo-miri`.
-        let target_dir = std::env::var_os("CARGO_TARGET_DIR")
-            .unwrap_or_else(|| path!(miri_dir / "target").into());
-        sh.set_var("CARGO_TARGET_DIR", target_dir);
+
+        // Hard-code the target dir, since we rely on all binaries ending up in the same spot.
+        sh.set_var("CARGO_TARGET_DIR", path!(miri_dir / "target"));
 
         // We configure dev builds to not be unusably slow.
         let devel_opt_level =
@@ -91,8 +91,24 @@ impl MiriEnv {
         // Get extra flags for cargo.
         let cargo_extra_flags = std::env::var("CARGO_EXTRA_FLAGS").unwrap_or_default();
         let cargo_extra_flags = flagsplit(&cargo_extra_flags);
+        if cargo_extra_flags.iter().any(|a| a == "--release" || a.starts_with("--profile")) {
+            // This makes binaries end up in different paths, let's not do that.
+            eprintln!(
+                "Passing `--release` or `--profile` in `CARGO_EXTRA_FLAGS` will totally confuse miri-script, please don't do that."
+            );
+            std::process::exit(1);
+        }
 
         Ok(MiriEnv { miri_dir, toolchain, sh, sysroot, cargo_extra_flags })
+    }
+
+    pub fn cargo_cmd(&self, manifest_path: impl AsRef<OsStr>, cmd: &str) -> Cmd<'_> {
+        let MiriEnv { toolchain, cargo_extra_flags, .. } = self;
+        let manifest_path = Path::new(manifest_path.as_ref());
+        cmd!(
+            self.sh,
+            "cargo +{toolchain} {cmd} {cargo_extra_flags...} --manifest-path {manifest_path}"
+        )
     }
 
     pub fn install_to_sysroot(
@@ -102,6 +118,7 @@ impl MiriEnv {
     ) -> Result<()> {
         let MiriEnv { sysroot, toolchain, cargo_extra_flags, .. } = self;
         // Install binaries to the miri toolchain's `sysroot` so they do not interact with other toolchains.
+        // (Not using `cargo_cmd` as `install` is special and doesn't use `--manifest-path`.)
         cmd!(self.sh, "cargo +{toolchain} install {cargo_extra_flags...} --path {path} --force --root {sysroot} {args...}").run()?;
         Ok(())
     }
@@ -112,40 +129,34 @@ impl MiriEnv {
         args: &[String],
         quiet: bool,
     ) -> Result<()> {
-        let MiriEnv { toolchain, cargo_extra_flags, .. } = self;
         let quiet_flag = if quiet { Some("--quiet") } else { None };
         // We build the tests as well, (a) to avoid having rebuilds when building the tests later
         // and (b) to have more parallelism during the build of Miri and its tests.
-        let mut cmd = cmd!(
-            self.sh,
-            "cargo +{toolchain} build --bins --tests {cargo_extra_flags...} --manifest-path {manifest_path} {quiet_flag...} {args...}"
-        );
+        // This means `./miri run` without `--dep` will build Miri twice (for the sysroot with
+        // dev-dependencies, and then for running without dev-dependencies), but the way more common
+        // `./miri test` will avoid building Miri twice.
+        let mut cmd = self
+            .cargo_cmd(manifest_path, "build")
+            .args(&["--bins", "--tests"])
+            .args(quiet_flag)
+            .args(args);
         cmd.set_quiet(quiet);
         cmd.run()?;
         Ok(())
     }
 
     pub fn check(&self, manifest_path: impl AsRef<OsStr>, args: &[String]) -> Result<()> {
-        let MiriEnv { toolchain, cargo_extra_flags, .. } = self;
-        cmd!(self.sh, "cargo +{toolchain} check {cargo_extra_flags...} --manifest-path {manifest_path} --all-targets {args...}")
-            .run()?;
+        self.cargo_cmd(manifest_path, "check").arg("--all-targets").args(args).run()?;
         Ok(())
     }
 
     pub fn clippy(&self, manifest_path: impl AsRef<OsStr>, args: &[String]) -> Result<()> {
-        let MiriEnv { toolchain, cargo_extra_flags, .. } = self;
-        cmd!(self.sh, "cargo +{toolchain} clippy {cargo_extra_flags...} --manifest-path {manifest_path} --all-targets {args...}")
-            .run()?;
+        self.cargo_cmd(manifest_path, "clippy").arg("--all-targets").args(args).run()?;
         Ok(())
     }
 
     pub fn test(&self, manifest_path: impl AsRef<OsStr>, args: &[String]) -> Result<()> {
-        let MiriEnv { toolchain, cargo_extra_flags, .. } = self;
-        cmd!(
-            self.sh,
-            "cargo +{toolchain} test {cargo_extra_flags...} --manifest-path {manifest_path} {args...}"
-        )
-        .run()?;
+        self.cargo_cmd(manifest_path, "test").args(args).run()?;
         Ok(())
     }
 
@@ -155,7 +166,6 @@ impl MiriEnv {
     pub fn format_files(
         &self,
         files: impl Iterator<Item = Result<PathBuf, walkdir::Error>>,
-        toolchain: &str,
         config_path: &Path,
         flags: &[String],
     ) -> anyhow::Result<()> {
@@ -166,6 +176,7 @@ impl MiriEnv {
         // Format in batches as not all our files fit into Windows' command argument limit.
         for batch in &files.chunks(256) {
             // Build base command.
+            let toolchain = &self.toolchain;
             let mut cmd = cmd!(
                 self.sh,
                 "rustfmt +{toolchain} --edition=2021 --config-path {config_path} --unstable-features --skip-children {flags...}"
@@ -197,7 +208,7 @@ impl MiriEnv {
     pub fn run_many_times(
         &self,
         range: Range<u32>,
-        run: impl Fn(&Shell, u32) -> Result<()> + Sync,
+        run: impl Fn(&Self, u32) -> Result<()> + Sync,
     ) -> Result<()> {
         // `next` is atomic so threads can concurrently fetch their next value to run.
         let next = AtomicU32::new(range.start);
@@ -207,10 +218,10 @@ impl MiriEnv {
             let mut handles = Vec::new();
             // Spawn one worker per core.
             for _ in 0..thread::available_parallelism()?.get() {
-                // Create a copy of the shell for this thread.
-                let local_shell = self.sh.clone();
+                // Create a copy of the environment for this thread.
+                let local_miri = self.clone();
                 let handle = s.spawn(|| -> Result<()> {
-                    let local_shell = local_shell; // move the copy into this thread.
+                    let local_miri = local_miri; // move the copy into this thread.
                     // Each worker thread keeps asking for numbers until we're all done.
                     loop {
                         let cur = next.fetch_add(1, Ordering::Relaxed);
@@ -219,7 +230,7 @@ impl MiriEnv {
                             break;
                         }
                         // Run the command with this seed.
-                        run(&local_shell, cur).inspect_err(|_| {
+                        run(&local_miri, cur).inspect_err(|_| {
                             // If we failed, tell everyone about this.
                             failed.store(true, Ordering::Relaxed);
                         })?;

--- a/miri-script/src/util.rs
+++ b/miri-script/src/util.rs
@@ -150,6 +150,11 @@ impl MiriEnv {
         Ok(())
     }
 
+    pub fn doc(&self, manifest_path: impl AsRef<OsStr>, args: &[String]) -> Result<()> {
+        self.cargo_cmd(manifest_path, "doc").args(args).run()?;
+        Ok(())
+    }
+
     pub fn clippy(&self, manifest_path: impl AsRef<OsStr>, args: &[String]) -> Result<()> {
         self.cargo_cmd(manifest_path, "clippy").arg("--all-targets").args(args).run()?;
         Ok(())

--- a/miri-script/src/util.rs
+++ b/miri-script/src/util.rs
@@ -33,7 +33,7 @@ pub struct MiriEnv {
     /// miri_dir is the root of the miri repository checkout we are working in.
     pub miri_dir: PathBuf,
     /// active_toolchain is passed as `+toolchain` argument to cargo/rustc invocations.
-    pub toolchain: String,
+    toolchain: String,
     /// Extra flags to pass to cargo.
     cargo_extra_flags: Vec<String>,
     /// The rustc sysroot


### PR DESCRIPTION
Inspired by https://github.com/rust-lang/rust-clippy/pull/13232, this makes it so that when cargo-miri fails to build, `./miri check` will print errors with paths like `cargo-miri/src/setup.rs`. That means we can get rid of the miri-symlink-hacks and instead tell RA to just always invoke the `./miri clippy` script just once, in the root.

This means that we can no longer share a target dir between cargo-miri and miri as the RUSTFLAGS are different to crates that are shared in the dependency tree need to be built twice with two different flags. `miri-script` hence now has to set the MIRI environment variable to tell the `cargo miri setup` invocation where to find Miri.

I also made it so that errors in miri-script itself are properly shown in RA, for which the `./miri` shell wrapper needs to set the right flags.