### PR TITLE
FD: remove big surrounding RefCell, simplify socketpair

### DIFF
--- a/src/shims/unix/fd.rs
+++ b/src/shims/unix/fd.rs
@@ -2,9 +2,9 @@
 //! standard file descriptors (stdin/stdout/stderr).
 
 use std::any::Any;
-use std::cell::{Ref, RefCell, RefMut};
 use std::collections::BTreeMap;
 use std::io::{self, ErrorKind, IsTerminal, Read, SeekFrom, Write};
+use std::ops::Deref;
 use std::rc::Rc;
 use std::rc::Weak;
 
@@ -27,7 +27,7 @@ pub trait FileDescription: std::fmt::Debug + Any {
 
     /// Reads as much as possible into the given buffer, and returns the number of bytes read.
     fn read<'tcx>(
-        &mut self,
+        &self,
         _communicate_allowed: bool,
         _fd_id: FdId,
         _bytes: &mut [u8],
@@ -38,7 +38,7 @@ pub trait FileDescription: std::fmt::Debug + Any {
 
     /// Writes as much as possible from the given buffer, and returns the number of bytes written.
     fn write<'tcx>(
-        &mut self,
+        &self,
         _communicate_allowed: bool,
         _fd_id: FdId,
         _bytes: &[u8],
@@ -50,7 +50,7 @@ pub trait FileDescription: std::fmt::Debug + Any {
     /// Reads as much as possible into the given buffer from a given offset,
     /// and returns the number of bytes read.
     fn pread<'tcx>(
-        &mut self,
+        &self,
         _communicate_allowed: bool,
         _bytes: &mut [u8],
         _offset: u64,
@@ -62,7 +62,7 @@ pub trait FileDescription: std::fmt::Debug + Any {
     /// Writes as much as possible from the given buffer starting at a given offset,
     /// and returns the number of bytes written.
     fn pwrite<'tcx>(
-        &mut self,
+        &self,
         _communicate_allowed: bool,
         _bytes: &[u8],
         _offset: u64,
@@ -74,7 +74,7 @@ pub trait FileDescription: std::fmt::Debug + Any {
     /// Seeks to the given offset (which can be relative to the beginning, end, or current position).
     /// Returns the new position from the start of the stream.
     fn seek<'tcx>(
-        &mut self,
+        &self,
         _communicate_allowed: bool,
         _offset: SeekFrom,
     ) -> InterpResult<'tcx, io::Result<u64>> {
@@ -111,13 +111,8 @@ pub trait FileDescription: std::fmt::Debug + Any {
 
 impl dyn FileDescription {
     #[inline(always)]
-    pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
+    pub fn downcast<T: Any>(&self) -> Option<&T> {
         (self as &dyn Any).downcast_ref()
-    }
-
-    #[inline(always)]
-    pub fn downcast_mut<T: Any>(&mut self) -> Option<&mut T> {
-        (self as &mut dyn Any).downcast_mut()
     }
 }
 
@@ -127,7 +122,7 @@ impl FileDescription for io::Stdin {
     }
 
     fn read<'tcx>(
-        &mut self,
+        &self,
         communicate_allowed: bool,
         _fd_id: FdId,
         bytes: &mut [u8],
@@ -137,7 +132,7 @@ impl FileDescription for io::Stdin {
             // We want isolation mode to be deterministic, so we have to disallow all reads, even stdin.
             helpers::isolation_abort_error("`read` from stdin")?;
         }
-        Ok(Read::read(self, bytes))
+        Ok(Read::read(&mut { self }, bytes))
     }
 
     fn is_tty(&self, communicate_allowed: bool) -> bool {
@@ -151,14 +146,14 @@ impl FileDescription for io::Stdout {
     }
 
     fn write<'tcx>(
-        &mut self,
+        &self,
         _communicate_allowed: bool,
         _fd_id: FdId,
         bytes: &[u8],
         _ecx: &mut MiriInterpCx<'tcx>,
     ) -> InterpResult<'tcx, io::Result<usize>> {
         // We allow writing to stderr even with isolation enabled.
-        let result = Write::write(self, bytes);
+        let result = Write::write(&mut { self }, bytes);
         // Stdout is buffered, flush to make sure it appears on the
         // screen.  This is the write() syscall of the interpreted
         // program, we want it to correspond to a write() syscall on
@@ -180,7 +175,7 @@ impl FileDescription for io::Stderr {
     }
 
     fn write<'tcx>(
-        &mut self,
+        &self,
         _communicate_allowed: bool,
         _fd_id: FdId,
         bytes: &[u8],
@@ -206,7 +201,7 @@ impl FileDescription for NullOutput {
     }
 
     fn write<'tcx>(
-        &mut self,
+        &self,
         _communicate_allowed: bool,
         _fd_id: FdId,
         bytes: &[u8],
@@ -221,26 +216,23 @@ impl FileDescription for NullOutput {
 #[derive(Clone, Debug)]
 pub struct FileDescWithId<T: FileDescription + ?Sized> {
     id: FdId,
-    file_description: RefCell<Box<T>>,
+    file_description: Box<T>,
 }
 
 #[derive(Clone, Debug)]
 pub struct FileDescriptionRef(Rc<FileDescWithId<dyn FileDescription>>);
 
+impl Deref for FileDescriptionRef {
+    type Target = dyn FileDescription;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.0.file_description
+    }
+}
+
 impl FileDescriptionRef {
     fn new(fd: impl FileDescription, id: FdId) -> Self {
-        FileDescriptionRef(Rc::new(FileDescWithId {
-            id,
-            file_description: RefCell::new(Box::new(fd)),
-        }))
-    }
-
-    pub fn borrow(&self) -> Ref<'_, dyn FileDescription> {
-        Ref::map(self.0.file_description.borrow(), |fd| fd.as_ref())
-    }
-
-    pub fn borrow_mut(&self) -> RefMut<'_, dyn FileDescription> {
-        RefMut::map(self.0.file_description.borrow_mut(), |fd| fd.as_mut())
+        FileDescriptionRef(Rc::new(FileDescWithId { id, file_description: Box::new(fd) }))
     }
 
     pub fn close<'tcx>(
@@ -256,7 +248,7 @@ impl FileDescriptionRef {
                 // Remove entry from the global epoll_event_interest table.
                 ecx.machine.epoll_interests.remove(id);
 
-                RefCell::into_inner(fd.file_description).close(communicate_allowed, ecx)
+                fd.file_description.close(communicate_allowed, ecx)
             }
             None => Ok(Ok(())),
         }
@@ -277,7 +269,7 @@ impl FileDescriptionRef {
         ecx: &mut InterpCx<'tcx, MiriMachine<'tcx>>,
     ) -> InterpResult<'tcx, ()> {
         use crate::shims::unix::linux::epoll::EvalContextExt;
-        ecx.check_and_update_readiness(self.get_id(), || self.borrow_mut().get_epoll_ready_events())
+        ecx.check_and_update_readiness(self.get_id(), || self.get_epoll_ready_events())
     }
 }
 
@@ -334,11 +326,20 @@ impl FdTable {
         fds
     }
 
-    /// Insert a new file description to the FdTable.
-    pub fn insert_new(&mut self, fd: impl FileDescription) -> i32 {
+    pub fn new_ref(&mut self, fd: impl FileDescription) -> FileDescriptionRef {
         let file_handle = FileDescriptionRef::new(fd, self.next_file_description_id);
         self.next_file_description_id = FdId(self.next_file_description_id.0.strict_add(1));
-        self.insert_ref_with_min_fd(file_handle, 0)
+        file_handle
+    }
+
+    /// Insert a new file description to the FdTable.
+    pub fn insert_new(&mut self, fd: impl FileDescription) -> i32 {
+        let fd_ref = self.new_ref(fd);
+        self.insert(fd_ref)
+    }
+
+    pub fn insert(&mut self, fd_ref: FileDescriptionRef) -> i32 {
+        self.insert_ref_with_min_fd(fd_ref, 0)
     }
 
     /// Insert a file description, giving it a file descriptor that is at least `min_fd`.
@@ -368,17 +369,7 @@ impl FdTable {
         new_fd
     }
 
-    pub fn get(&self, fd: i32) -> Option<Ref<'_, dyn FileDescription>> {
-        let fd = self.fds.get(&fd)?;
-        Some(fd.borrow())
-    }
-
-    pub fn get_mut(&self, fd: i32) -> Option<RefMut<'_, dyn FileDescription>> {
-        let fd = self.fds.get(&fd)?;
-        Some(fd.borrow_mut())
-    }
-
-    pub fn get_ref(&self, fd: i32) -> Option<FileDescriptionRef> {
+    pub fn get(&self, fd: i32) -> Option<FileDescriptionRef> {
         let fd = self.fds.get(&fd)?;
         Some(fd.clone())
     }
@@ -397,7 +388,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     fn dup(&mut self, old_fd: i32) -> InterpResult<'tcx, Scalar> {
         let this = self.eval_context_mut();
 
-        let Some(dup_fd) = this.machine.fds.get_ref(old_fd) else {
+        let Some(dup_fd) = this.machine.fds.get(old_fd) else {
             return Ok(Scalar::from_i32(this.fd_not_found()?));
         };
         Ok(Scalar::from_i32(this.machine.fds.insert_ref_with_min_fd(dup_fd, 0)))
@@ -406,7 +397,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     fn dup2(&mut self, old_fd: i32, new_fd: i32) -> InterpResult<'tcx, Scalar> {
         let this = self.eval_context_mut();
 
-        let Some(dup_fd) = this.machine.fds.get_ref(old_fd) else {
+        let Some(dup_fd) = this.machine.fds.get(old_fd) else {
             return Ok(Scalar::from_i32(this.fd_not_found()?));
         };
         if new_fd != old_fd {
@@ -492,7 +483,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             }
             let start = this.read_scalar(&args[2])?.to_i32()?;
 
-            match this.machine.fds.get_ref(fd) {
+            match this.machine.fds.get(fd) {
                 Some(dup_fd) =>
                     Ok(Scalar::from_i32(this.machine.fds.insert_ref_with_min_fd(dup_fd, start))),
                 None => Ok(Scalar::from_i32(this.fd_not_found()?)),
@@ -565,7 +556,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let communicate = this.machine.communicate();
 
         // We temporarily dup the FD to be able to retain mutable access to `this`.
-        let Some(fd) = this.machine.fds.get_ref(fd) else {
+        let Some(fd) = this.machine.fds.get(fd) else {
             trace!("read: FD not found");
             return Ok(Scalar::from_target_isize(this.fd_not_found()?, this));
         };
@@ -576,14 +567,14 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // `usize::MAX` because it is bounded by the host's `isize`.
         let mut bytes = vec![0; usize::try_from(count).unwrap()];
         let result = match offset {
-            None => fd.borrow_mut().read(communicate, fd.get_id(), &mut bytes, this),
+            None => fd.read(communicate, fd.get_id(), &mut bytes, this),
             Some(offset) => {
                 let Ok(offset) = u64::try_from(offset) else {
                     let einval = this.eval_libc("EINVAL");
                     this.set_last_error(einval)?;
                     return Ok(Scalar::from_target_isize(-1, this));
                 };
-                fd.borrow_mut().pread(communicate, &mut bytes, offset, this)
+                fd.pread(communicate, &mut bytes, offset, this)
             }
         };
 
@@ -629,19 +620,19 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
         let bytes = this.read_bytes_ptr_strip_provenance(buf, Size::from_bytes(count))?.to_owned();
         // We temporarily dup the FD to be able to retain mutable access to `this`.
-        let Some(fd) = this.machine.fds.get_ref(fd) else {
+        let Some(fd) = this.machine.fds.get(fd) else {
             return Ok(Scalar::from_target_isize(this.fd_not_found()?, this));
         };
 
         let result = match offset {
-            None => fd.borrow_mut().write(communicate, fd.get_id(), &bytes, this),
+            None => fd.write(communicate, fd.get_id(), &bytes, this),
             Some(offset) => {
                 let Ok(offset) = u64::try_from(offset) else {
                     let einval = this.eval_libc("EINVAL");
                     this.set_last_error(einval)?;
                     return Ok(Scalar::from_target_isize(-1, this));
                 };
-                fd.borrow_mut().pwrite(communicate, &bytes, offset, this)
+                fd.pwrite(communicate, &bytes, offset, this)
             }
         };
 

--- a/src/shims/unix/fs.rs
+++ b/src/shims/unix/fs.rs
@@ -12,7 +12,7 @@ use rustc_data_structures::fx::FxHashMap;
 use rustc_target::abi::Size;
 
 use crate::shims::os_str::bytes_to_os_str;
-use crate::shims::unix::fd::FdId;
+use crate::shims::unix::fd::FileDescriptionRef;
 use crate::shims::unix::*;
 use crate::*;
 use shims::time::system_time_to_duration;
@@ -32,8 +32,8 @@ impl FileDescription for FileHandle {
 
     fn read<'tcx>(
         &self,
+        _self_ref: &FileDescriptionRef,
         communicate_allowed: bool,
-        _fd_id: FdId,
         bytes: &mut [u8],
         _ecx: &mut MiriInterpCx<'tcx>,
     ) -> InterpResult<'tcx, io::Result<usize>> {
@@ -43,8 +43,8 @@ impl FileDescription for FileHandle {
 
     fn write<'tcx>(
         &self,
+        _self_ref: &FileDescriptionRef,
         communicate_allowed: bool,
-        _fd_id: FdId,
         bytes: &[u8],
         _ecx: &mut MiriInterpCx<'tcx>,
     ) -> InterpResult<'tcx, io::Result<usize>> {

--- a/src/shims/unix/fs.rs
+++ b/src/shims/unix/fs.rs
@@ -31,29 +31,29 @@ impl FileDescription for FileHandle {
     }
 
     fn read<'tcx>(
-        &mut self,
+        &self,
         communicate_allowed: bool,
         _fd_id: FdId,
         bytes: &mut [u8],
         _ecx: &mut MiriInterpCx<'tcx>,
     ) -> InterpResult<'tcx, io::Result<usize>> {
         assert!(communicate_allowed, "isolation should have prevented even opening a file");
-        Ok(self.file.read(bytes))
+        Ok((&mut &self.file).read(bytes))
     }
 
     fn write<'tcx>(
-        &mut self,
+        &self,
         communicate_allowed: bool,
         _fd_id: FdId,
         bytes: &[u8],
         _ecx: &mut MiriInterpCx<'tcx>,
     ) -> InterpResult<'tcx, io::Result<usize>> {
         assert!(communicate_allowed, "isolation should have prevented even opening a file");
-        Ok(self.file.write(bytes))
+        Ok((&mut &self.file).write(bytes))
     }
 
     fn pread<'tcx>(
-        &mut self,
+        &self,
         communicate_allowed: bool,
         bytes: &mut [u8],
         offset: u64,
@@ -63,13 +63,13 @@ impl FileDescription for FileHandle {
         // Emulates pread using seek + read + seek to restore cursor position.
         // Correctness of this emulation relies on sequential nature of Miri execution.
         // The closure is used to emulate `try` block, since we "bubble" `io::Error` using `?`.
+        let file = &mut &self.file;
         let mut f = || {
-            let cursor_pos = self.file.stream_position()?;
-            self.file.seek(SeekFrom::Start(offset))?;
-            let res = self.file.read(bytes);
+            let cursor_pos = file.stream_position()?;
+            file.seek(SeekFrom::Start(offset))?;
+            let res = file.read(bytes);
             // Attempt to restore cursor position even if the read has failed
-            self.file
-                .seek(SeekFrom::Start(cursor_pos))
+            file.seek(SeekFrom::Start(cursor_pos))
                 .expect("failed to restore file position, this shouldn't be possible");
             res
         };
@@ -77,7 +77,7 @@ impl FileDescription for FileHandle {
     }
 
     fn pwrite<'tcx>(
-        &mut self,
+        &self,
         communicate_allowed: bool,
         bytes: &[u8],
         offset: u64,
@@ -87,13 +87,13 @@ impl FileDescription for FileHandle {
         // Emulates pwrite using seek + write + seek to restore cursor position.
         // Correctness of this emulation relies on sequential nature of Miri execution.
         // The closure is used to emulate `try` block, since we "bubble" `io::Error` using `?`.
+        let file = &mut &self.file;
         let mut f = || {
-            let cursor_pos = self.file.stream_position()?;
-            self.file.seek(SeekFrom::Start(offset))?;
-            let res = self.file.write(bytes);
+            let cursor_pos = file.stream_position()?;
+            file.seek(SeekFrom::Start(offset))?;
+            let res = file.write(bytes);
             // Attempt to restore cursor position even if the write has failed
-            self.file
-                .seek(SeekFrom::Start(cursor_pos))
+            file.seek(SeekFrom::Start(cursor_pos))
                 .expect("failed to restore file position, this shouldn't be possible");
             res
         };
@@ -101,12 +101,12 @@ impl FileDescription for FileHandle {
     }
 
     fn seek<'tcx>(
-        &mut self,
+        &self,
         communicate_allowed: bool,
         offset: SeekFrom,
     ) -> InterpResult<'tcx, io::Result<u64>> {
         assert!(communicate_allowed, "isolation should have prevented even opening a file");
-        Ok(self.file.seek(offset))
+        Ok((&mut &self.file).seek(offset))
     }
 
     fn close<'tcx>(
@@ -580,7 +580,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
         let communicate = this.machine.communicate();
 
-        let Some(mut file_description) = this.machine.fds.get_mut(fd) else {
+        let Some(file_description) = this.machine.fds.get(fd) else {
             return Ok(Scalar::from_i64(this.fd_not_found()?));
         };
         let result = file_description
@@ -1276,7 +1276,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
         // FIXME: Support ftruncate64 for all FDs
         let FileHandle { file, writable } =
-            file_description.downcast_ref::<FileHandle>().ok_or_else(|| {
+            file_description.downcast::<FileHandle>().ok_or_else(|| {
                 err_unsup_format!("`ftruncate64` is only supported on file-backed file descriptors")
             })?;
 
@@ -1328,7 +1328,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         };
         // Only regular files support synchronization.
         let FileHandle { file, writable } =
-            file_description.downcast_ref::<FileHandle>().ok_or_else(|| {
+            file_description.downcast::<FileHandle>().ok_or_else(|| {
                 err_unsup_format!("`fsync` is only supported on file-backed file descriptors")
             })?;
         let io_result = maybe_sync_file(file, *writable, File::sync_all);
@@ -1353,7 +1353,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         };
         // Only regular files support synchronization.
         let FileHandle { file, writable } =
-            file_description.downcast_ref::<FileHandle>().ok_or_else(|| {
+            file_description.downcast::<FileHandle>().ok_or_else(|| {
                 err_unsup_format!("`fdatasync` is only supported on file-backed file descriptors")
             })?;
         let io_result = maybe_sync_file(file, *writable, File::sync_data);
@@ -1401,7 +1401,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         };
         // Only regular files support synchronization.
         let FileHandle { file, writable } =
-            file_description.downcast_ref::<FileHandle>().ok_or_else(|| {
+            file_description.downcast::<FileHandle>().ok_or_else(|| {
                 err_unsup_format!(
                     "`sync_data_range` is only supported on file-backed file descriptors"
                 )
@@ -1708,7 +1708,7 @@ impl FileMetadata {
         };
 
         let file = &file_description
-            .downcast_ref::<FileHandle>()
+            .downcast::<FileHandle>()
             .ok_or_else(|| {
                 err_unsup_format!(
                     "obtaining metadata is only supported on file-backed file descriptors"

--- a/src/shims/unix/linux/epoll.rs
+++ b/src/shims/unix/linux/epoll.rs
@@ -35,6 +35,7 @@ impl EpollEventInstance {
         EpollEventInstance { events, data }
     }
 }
+
 /// EpollEventInterest registers the file description information to an epoll
 /// instance during a successful `epoll_ctl` call. It also stores additional
 /// information needed to check and update readiness state for `epoll_wait`.
@@ -434,7 +435,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
     /// For a specific file description, get its ready events and update
     /// the corresponding ready list. This function is called whenever a file description
-    /// is registered with epoll, or when its readiness *might* have changed.
+    /// is registered with epoll, or the buffer it reads from / writes to changed.
+    /// This *will* report an event if anyone is subscribed to it, without any further
+    /// filtering, so do not call this function when an FD didn't have anything happen to it!
     fn check_and_update_readiness(&self, fd_ref: &FileDescriptionRef) -> InterpResult<'tcx, ()> {
         let this = self.eval_context_ref();
         let id = fd_ref.get_id();

--- a/src/shims/unix/linux/epoll.rs
+++ b/src/shims/unix/linux/epoll.rs
@@ -433,11 +433,13 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         Ok(Scalar::from_i32(num_of_events))
     }
 
-    /// For a specific file description, get its ready events and update
-    /// the corresponding ready list. This function is called whenever a file description
-    /// is registered with epoll, or the buffer it reads from / writes to changed.
-    /// This *will* report an event if anyone is subscribed to it, without any further
-    /// filtering, so do not call this function when an FD didn't have anything happen to it!
+    /// For a specific file description, get its ready events and update the corresponding ready
+    /// list. This function should be called whenever an event causes more bytes or an EOF to become
+    /// newly readable from an FD, and whenever more bytes can be written to an FD or no more future
+    /// writes are possible.
+    ///
+    /// This *will* report an event if anyone is subscribed to it, without any further filtering, so
+    /// do not call this function when an FD didn't have anything happen to it!
     fn check_and_update_readiness(&self, fd_ref: &FileDescriptionRef) -> InterpResult<'tcx, ()> {
         let this = self.eval_context_ref();
         let id = fd_ref.get_id();

--- a/src/shims/unix/linux/eventfd.rs
+++ b/src/shims/unix/linux/eventfd.rs
@@ -1,4 +1,5 @@
 //! Linux `eventfd` implementation.
+use std::cell::{Cell, RefCell};
 use std::io;
 use std::io::{Error, ErrorKind};
 use std::mem;
@@ -27,9 +28,9 @@ const MAX_COUNTER: u64 = u64::MAX - 1;
 struct Event {
     /// The object contains an unsigned 64-bit integer (uint64_t) counter that is maintained by the
     /// kernel. This counter is initialized with the value specified in the argument initval.
-    counter: u64,
+    counter: Cell<u64>,
     is_nonblock: bool,
-    clock: VClock,
+    clock: RefCell<VClock>,
 }
 
 impl FileDescription for Event {
@@ -42,8 +43,8 @@ impl FileDescription for Event {
         // need to be supported in the future, the check should be added here.
 
         Ok(EpollReadyEvents {
-            epollin: self.counter != 0,
-            epollout: self.counter != MAX_COUNTER,
+            epollin: self.counter.get() != 0,
+            epollout: self.counter.get() != MAX_COUNTER,
             ..EpollReadyEvents::new()
         })
     }
@@ -58,7 +59,7 @@ impl FileDescription for Event {
 
     /// Read the counter in the buffer and return the counter if succeeded.
     fn read<'tcx>(
-        &mut self,
+        &self,
         _communicate_allowed: bool,
         fd_id: FdId,
         bytes: &mut [u8],
@@ -69,7 +70,8 @@ impl FileDescription for Event {
             return Ok(Err(Error::from(ErrorKind::InvalidInput)));
         };
         // Block when counter == 0.
-        if self.counter == 0 {
+        let counter = self.counter.get();
+        if counter == 0 {
             if self.is_nonblock {
                 return Ok(Err(Error::from(ErrorKind::WouldBlock)));
             } else {
@@ -78,13 +80,13 @@ impl FileDescription for Event {
             }
         } else {
             // Synchronize with all prior `write` calls to this FD.
-            ecx.acquire_clock(&self.clock);
+            ecx.acquire_clock(&self.clock.borrow());
             // Return the counter in the host endianness using the buffer provided by caller.
             *bytes = match ecx.tcx.sess.target.endian {
-                Endian::Little => self.counter.to_le_bytes(),
-                Endian::Big => self.counter.to_be_bytes(),
+                Endian::Little => counter.to_le_bytes(),
+                Endian::Big => counter.to_be_bytes(),
             };
-            self.counter = 0;
+            self.counter.set(0);
             // When any of the event happened, we check and update the status of all supported event
             // types for current file description.
 
@@ -114,7 +116,7 @@ impl FileDescription for Event {
     /// supplied buffer is less than 8 bytes, or if an attempt is
     /// made to write the value 0xffffffffffffffff.
     fn write<'tcx>(
-        &mut self,
+        &self,
         _communicate_allowed: bool,
         fd_id: FdId,
         bytes: &[u8],
@@ -135,13 +137,13 @@ impl FileDescription for Event {
         }
         // If the addition does not let the counter to exceed the maximum value, update the counter.
         // Else, block.
-        match self.counter.checked_add(num) {
+        match self.counter.get().checked_add(num) {
             Some(new_count @ 0..=MAX_COUNTER) => {
                 // Future `read` calls will synchronize with this write, so update the FD clock.
                 if let Some(clock) = &ecx.release_clock() {
-                    self.clock.join(clock);
+                    self.clock.borrow_mut().join(clock);
                 }
-                self.counter = new_count;
+                self.counter.set(new_count);
             }
             None | Some(u64::MAX) => {
                 if self.is_nonblock {
@@ -219,8 +221,11 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
         let fds = &mut this.machine.fds;
 
-        let fd_value =
-            fds.insert_new(Event { counter: val.into(), is_nonblock, clock: VClock::default() });
+        let fd_value = fds.insert_new(Event {
+            counter: Cell::new(val.into()),
+            is_nonblock,
+            clock: RefCell::new(VClock::default()),
+        });
 
         Ok(Scalar::from_i32(fd_value))
     }

--- a/src/shims/unix/socket.rs
+++ b/src/shims/unix/socket.rs
@@ -200,6 +200,7 @@ impl FileDescription for SocketPair {
         drop(writebuf);
 
         // Notification should be provided for peer fd as it became readable.
+        // The kernel does this even if the fd was already readable before, so we follow suit.
         ecx.check_and_update_readiness(&peer_fd)?;
 
         return Ok(Ok(actual_write_size));

--- a/tests/pass-dep/libc/libc-epoll.rs
+++ b/tests/pass-dep/libc/libc-epoll.rs
@@ -96,6 +96,7 @@ fn test_epoll_socketpair() {
     assert_eq!(res, 0);
 
     // Check result from epoll_wait.
+    // We expect to get a read, write, HUP notification from the close since closing an FD always unblocks reads and writes on its peer.
     let expected_event = u32::try_from(libc::EPOLLRDHUP | libc::EPOLLIN | libc::EPOLLOUT).unwrap();
     let expected_value = u64::try_from(fds[1]).unwrap();
     assert!(check_epoll_wait::<8>(epfd, &[(expected_event, expected_value)]));


### PR DESCRIPTION
A while ago, I added the big implicit RefCell for all file descriptions since it avoided interior mutability in `eventfd`. However, this requires us to hold the RefCell "lock" around the entire invocation of the `read`/`write` methods on an FD, which is not great. For instance, if an FD wants to update epoll notifications from inside its `read`/`write`, it is very crucial that the notification check does not end up accessing the FD itself. Such cycles, however, occur naturally:
- eventfd wants to update notifications for itself
- socketfd wants to update notifications on its "peer", which will in turn check *its* peer to see whether that buffer is empty -- and my peer's peer is myself.

This then also lets us simplify socketpair, which currently holds a weak reference to its peer *and* a weak reference to the peer's buffer -- that was previously needed precisely to avoid this issue.