### PR TITLE
epoll: handle edge case for epoll_ctl

### DIFF
--- a/tests/fail-dep/libc/libc_epoll_unsupported_fd.rs
+++ b/tests/fail-dep/libc/libc_epoll_unsupported_fd.rs
@@ -1,0 +1,18 @@
+//@only-target-linux
+
+// This is a test for registering unsupported fd with epoll.
+// Register epoll fd with epoll is allowed in real system, but we do not support this.
+fn main() {
+    // Create two epoll instance.
+    let epfd0 = unsafe { libc::epoll_create1(0) };
+    assert_ne!(epfd0, -1);
+    let epfd1 = unsafe { libc::epoll_create1(0) };
+    assert_ne!(epfd1, -1);
+
+    // Register epoll with epoll.
+    let mut ev =
+        libc::epoll_event { events: (libc::EPOLLIN | libc::EPOLLET) as _, u64: epfd1 as u64 };
+    let res = unsafe { libc::epoll_ctl(epfd0, libc::EPOLL_CTL_ADD, epfd1, &mut ev) };
+    //~^ERROR: epoll does not support this file description
+    assert_eq!(res, 0);
+}

--- a/tests/fail-dep/libc/libc_epoll_unsupported_fd.stderr
+++ b/tests/fail-dep/libc/libc_epoll_unsupported_fd.stderr
@@ -1,0 +1,14 @@
+error: unsupported operation: epoll: epoll does not support this file description
+  --> $DIR/libc_epoll_unsupported_fd.rs:LL:CC
+   |
+LL |     let res = unsafe { libc::epoll_ctl(epfd0, libc::EPOLL_CTL_ADD, epfd1, &mut ev) };
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ epoll: epoll does not support this file description
+   |
+   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
+   = note: BACKTRACE:
+   = note: inside `main` at $DIR/libc_epoll_unsupported_fd.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
There is a test case that revealed that our implementation differs from the real system:
 - Set up an epoll watching the FD
- Call epoll_wait
- Set up another epoll watching the same FD
- Call epoll_wait on the first epoll. Nothing should be reported!


This happened because, in ``epoll_ctl``, we used ``check_and_update_readiness``, which is a function that would return notification for all epoll file description that registered a particular file description. But we shouldn't do that because no notification should be returned if there is no I/O activity between two ``epoll_wait`` (every first ``epoll_wait`` that happens after ``epoll_ctl`` is an exception, we should return notification that reflects the readiness of file description). 

r? @oli-obk 