### PR TITLE
Fix a misleading comment in `tests/pass/tree_borrows/tree-borrows.rs`

### DIFF
--- a/tests/pass/tree_borrows/tree-borrows.rs
+++ b/tests/pass/tree_borrows/tree-borrows.rs
@@ -321,7 +321,7 @@ fn not_unpin_not_protected() {
     pub struct NotUnpin(#[allow(dead_code)] i32, PhantomPinned);
 
     fn inner(x: &mut NotUnpin, f: fn(&mut NotUnpin)) {
-        // `f` may mutate, but it may not deallocate!
+        // `f` is allowed to deallocate `x`.
         f(x)
     }
 


### PR DESCRIPTION
The original comment is somewhat misleading.

Since we don't add a protector for `x` here, `f` should be allowed to deallocate `x`.