### PR TITLE
epoll: Add a EINVAL case

### DIFF
--- a/src/shims/unix/linux/epoll.rs
+++ b/src/shims/unix/linux/epoll.rs
@@ -251,6 +251,13 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             throw_unsup_format!("epoll_ctl: encountered unknown unsupported operation {:#x}", op);
         }
 
+        // Throw EINVAL if epfd and fd have the same value.
+        if epfd_value == fd {
+            let einval = this.eval_libc("EINVAL");
+            this.set_last_error(einval)?;
+            return Ok(Scalar::from_i32(-1));
+        }
+
         // Check if epfd is a valid epoll file descriptor.
         let Some(epfd) = this.machine.fds.get(epfd_value) else {
             return Ok(Scalar::from_i32(this.fd_not_found()?));


### PR DESCRIPTION
In ``epoll_ctl`` documentation, it is mentioned that: 
> EINVAL epfd is not an epoll file descriptor, or fd is the same as epfd, or the requested operation op is not supported by this interface.

So I added this EINVAL case for ``epfd == fd`` in ``epoll_ctl``