### PR TITLE
fix calling pipe, pipe2, socketpair with a pointer-to-array

### DIFF
--- a/src/shims/unix/unnamed_socket.rs
+++ b/src/shims/unix/unnamed_socket.rs
@@ -339,7 +339,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     ) -> InterpResult<'tcx, Scalar> {
         let this = self.eval_context_mut();
 
-        let pipefd = this.deref_pointer(pipefd)?;
+        let pipefd = this.deref_pointer_as(pipefd, this.machine.layouts.i32)?;
         let flags = match flags {
             Some(flags) => this.read_scalar(flags)?.to_i32()?,
             None => 0,

--- a/tests/pass-dep/libc/libc-pipe.rs
+++ b/tests/pass-dep/libc/libc-pipe.rs
@@ -6,6 +6,7 @@ fn main() {
     test_pipe();
     test_pipe_threaded();
     test_race();
+    test_pipe_array();
 }
 
 fn test_pipe() {
@@ -96,4 +97,14 @@ fn test_race() {
     assert_eq!(res, 1);
     thread::yield_now();
     thread1.join().unwrap();
+}
+
+fn test_pipe_array() {
+    // Declare `pipe` to take an array rather than a `*mut i32`.
+    extern "C" {
+        fn pipe(pipefd: &mut [i32; 2]) -> i32;
+    }
+
+    let mut fds: [i32; 2] = [0; 2];
+    assert_eq!(unsafe { pipe(&mut fds) }, 0);
 }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/miri/issues/3839