### PR TITLE
Disable tree traversal optimization that is wrong due to lazy nodes.

### DIFF
--- a/tests/fail/tree_borrows/repeated_foreign_read_lazy_conflicted.rs
+++ b/tests/fail/tree_borrows/repeated_foreign_read_lazy_conflicted.rs
@@ -1,0 +1,23 @@
+//@compile-flags: -Zmiri-tree-borrows
+
+use std::ptr::addr_of_mut;
+
+fn do_something(_: u8) {}
+
+unsafe fn access_after_sub_1(x: &mut u8, orig_ptr: *mut u8) {
+    // causes a second access, which should make the lazy part of `x` be `Reserved {conflicted: true}`
+    do_something(*orig_ptr);
+    // read from the conflicted pointer
+    *(x as *mut u8).byte_sub(1) = 42; //~ ERROR: /write access through .* is forbidden/
+}
+
+pub fn main() {
+    unsafe {
+        let mut alloc = [0u8, 0u8];
+        let orig_ptr = addr_of_mut!(alloc) as *mut u8;
+        let foo = &mut *orig_ptr;
+        // cause a foreign read access to foo
+        do_something(alloc[0]);
+        access_after_sub_1(&mut *(foo as *mut u8).byte_add(1), orig_ptr);
+    }
+}

--- a/tests/fail/tree_borrows/repeated_foreign_read_lazy_conflicted.stderr
+++ b/tests/fail/tree_borrows/repeated_foreign_read_lazy_conflicted.stderr
@@ -1,0 +1,31 @@
+error: Undefined Behavior: write access through <TAG> at ALLOC[0x0] is forbidden
+  --> $DIR/repeated_foreign_read_lazy_conflicted.rs:LL:CC
+   |
+LL |     *(x as *mut u8).byte_sub(1) = 42;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ write access through <TAG> at ALLOC[0x0] is forbidden
+   |
+   = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
+   = help: the accessed tag <TAG> has state Reserved (conflicted) which forbids this child write access
+help: the accessed tag <TAG> was created here, in the initial state Reserved
+  --> $DIR/repeated_foreign_read_lazy_conflicted.rs:LL:CC
+   |
+LL | unsafe fn access_after_sub_1(x: &mut u8, orig_ptr: *mut u8) {
+   |                              ^
+help: the accessed tag <TAG> later transitioned to Reserved (conflicted) due to a foreign read access at offsets [0x0..0x1]
+  --> $DIR/repeated_foreign_read_lazy_conflicted.rs:LL:CC
+   |
+LL |     do_something(*orig_ptr);
+   |                  ^^^^^^^^^
+   = help: this transition corresponds to a temporary loss of write permissions until function exit
+   = note: BACKTRACE (of the first span):
+   = note: inside `access_after_sub_1` at $DIR/repeated_foreign_read_lazy_conflicted.rs:LL:CC
+note: inside `main`
+  --> $DIR/repeated_foreign_read_lazy_conflicted.rs:LL:CC
+   |
+LL |         access_after_sub_1(&mut *(foo as *mut u8).byte_add(1), orig_ptr);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
See #3846 for more information.

For now, the optimization is disabled in a very "hotfix" way, while we think about potential fixes. Nonetheless, this fixes #3846 