### PR TITLE
Refactor fd read/write

### DIFF
--- a/src/shims/unix/fd.rs
+++ b/src/shims/unix/fd.rs
@@ -25,10 +25,9 @@ pub(crate) enum FlockOp {
 pub trait FileDescription: std::fmt::Debug + Any {
     fn name(&self) -> &'static str;
 
-    /// Reads as much as possible into the given buffer, and returns the number of bytes read.
-    /// `ptr` is the pointer to the user supplied read buffer.
-    /// `len` indicates how many bytes the user requested.
-    /// `dest` is where the return value should be stored.
+    /// Reads as much as possible into the given buffer `ptr`.
+    /// `len` indicates how many bytes we should try to read.
+    /// `dest` is where the return value should be stored: number of bytes read, or `-1` in case of error.
     fn read<'tcx>(
         &self,
         _self_ref: &FileDescriptionRef,
@@ -41,10 +40,9 @@ pub trait FileDescription: std::fmt::Debug + Any {
         throw_unsup_format!("cannot read from {}", self.name());
     }
 
-    /// Writes as much as possible from the given buffer, and returns the number of bytes written.
-    /// `ptr` is the pointer to the user supplied read buffer.
-    /// `len` indicates how many bytes the user requested.
-    /// `dest` is where the return value should be stored.
+    /// Writes as much as possible from the given buffer `ptr`.
+    /// `len` indicates how many bytes we should try to write.
+    /// `dest` is where the return value should be stored: number of bytes written, or `-1` in case of error.
     fn write<'tcx>(
         &self,
         _self_ref: &FileDescriptionRef,
@@ -57,11 +55,9 @@ pub trait FileDescription: std::fmt::Debug + Any {
         throw_unsup_format!("cannot write to {}", self.name());
     }
 
-    /// Reads as much as possible into the given buffer from a given offset,
-    /// and returns the number of bytes read.
-    /// `ptr` is the pointer to the user supplied read buffer.
-    /// `len` indicates how many bytes the user requested.
-    /// `dest` is where the return value should be stored.
+    /// Reads as much as possible into the given buffer `ptr` from a given offset.
+    /// `len` indicates how many bytes we should try to read.
+    /// `dest` is where the return value should be stored: number of bytes read, or `-1` in case of error.
     fn pread<'tcx>(
         &self,
         _communicate_allowed: bool,
@@ -74,11 +70,10 @@ pub trait FileDescription: std::fmt::Debug + Any {
         throw_unsup_format!("cannot pread from {}", self.name());
     }
 
-    /// Writes as much as possible from the given buffer starting at a given offset,
-    /// and returns the number of bytes written.
+    /// Writes as much as possible from the given buffer `ptr` starting at a given offset.
     /// `ptr` is the pointer to the user supplied read buffer.
-    /// `len` indicates how many bytes the user requested.
-    /// `dest` is where the return value should be stored.
+    /// `len` indicates how many bytes we should try to write.
+    /// `dest` is where the return value should be stored: number of bytes written, or `-1` in case of error.
     fn pwrite<'tcx>(
         &self,
         _communicate_allowed: bool,

--- a/src/shims/unix/fd.rs
+++ b/src/shims/unix/fd.rs
@@ -26,13 +26,16 @@ pub trait FileDescription: std::fmt::Debug + Any {
     fn name(&self) -> &'static str;
 
     /// Reads as much as possible into the given buffer, and returns the number of bytes read.
+    /// `ptr` is the pointer to user supplied read buffer.
     fn read<'tcx>(
         &self,
         _self_ref: &FileDescriptionRef,
         _communicate_allowed: bool,
-        _bytes: &mut [u8],
+        _ptr: Pointer,
+        _len: u64,
+        _dest: &MPlaceTy<'tcx>,
         _ecx: &mut MiriInterpCx<'tcx>,
-    ) -> InterpResult<'tcx, io::Result<usize>> {
+    ) -> InterpResult<'tcx> {
         throw_unsup_format!("cannot read from {}", self.name());
     }
 
@@ -42,8 +45,9 @@ pub trait FileDescription: std::fmt::Debug + Any {
         _self_ref: &FileDescriptionRef,
         _communicate_allowed: bool,
         _bytes: &[u8],
+        _dest: &MPlaceTy<'tcx>,
         _ecx: &mut MiriInterpCx<'tcx>,
-    ) -> InterpResult<'tcx, io::Result<usize>> {
+    ) -> InterpResult<'tcx> {
         throw_unsup_format!("cannot write to {}", self.name());
     }
 
@@ -52,10 +56,12 @@ pub trait FileDescription: std::fmt::Debug + Any {
     fn pread<'tcx>(
         &self,
         _communicate_allowed: bool,
-        _bytes: &mut [u8],
         _offset: u64,
+        _ptr: Pointer,
+        _len: u64,
+        _dest: &MPlaceTy<'tcx>,
         _ecx: &mut MiriInterpCx<'tcx>,
-    ) -> InterpResult<'tcx, io::Result<usize>> {
+    ) -> InterpResult<'tcx> {
         throw_unsup_format!("cannot pread from {}", self.name());
     }
 
@@ -66,8 +72,9 @@ pub trait FileDescription: std::fmt::Debug + Any {
         _communicate_allowed: bool,
         _bytes: &[u8],
         _offset: u64,
+        _dest: &MPlaceTy<'tcx>,
         _ecx: &mut MiriInterpCx<'tcx>,
-    ) -> InterpResult<'tcx, io::Result<usize>> {
+    ) -> InterpResult<'tcx> {
         throw_unsup_format!("cannot pwrite to {}", self.name());
     }
 
@@ -125,14 +132,18 @@ impl FileDescription for io::Stdin {
         &self,
         _self_ref: &FileDescriptionRef,
         communicate_allowed: bool,
-        bytes: &mut [u8],
-        _ecx: &mut MiriInterpCx<'tcx>,
-    ) -> InterpResult<'tcx, io::Result<usize>> {
+        ptr: Pointer,
+        len: u64,
+        dest: &MPlaceTy<'tcx>,
+        ecx: &mut MiriInterpCx<'tcx>,
+    ) -> InterpResult<'tcx> {
+        let mut bytes = vec![0; usize::try_from(len).unwrap()];
         if !communicate_allowed {
             // We want isolation mode to be deterministic, so we have to disallow all reads, even stdin.
             helpers::isolation_abort_error("`read` from stdin")?;
         }
-        Ok(Read::read(&mut { self }, bytes))
+        let result = Read::read(&mut { self }, &mut bytes);
+        ecx.return_read_bytes_and_count(ptr, bytes, result, dest)
     }
 
     fn is_tty(&self, communicate_allowed: bool) -> bool {
@@ -150,8 +161,9 @@ impl FileDescription for io::Stdout {
         _self_ref: &FileDescriptionRef,
         _communicate_allowed: bool,
         bytes: &[u8],
-        _ecx: &mut MiriInterpCx<'tcx>,
-    ) -> InterpResult<'tcx, io::Result<usize>> {
+        dest: &MPlaceTy<'tcx>,
+        ecx: &mut MiriInterpCx<'tcx>,
+    ) -> InterpResult<'tcx> {
         // We allow writing to stderr even with isolation enabled.
         let result = Write::write(&mut { self }, bytes);
         // Stdout is buffered, flush to make sure it appears on the
@@ -160,8 +172,7 @@ impl FileDescription for io::Stdout {
         // the host -- there is no good in adding extra buffering
         // here.
         io::stdout().flush().unwrap();
-
-        Ok(result)
+        ecx.return_written_byte_count_or_error(result, dest)
     }
 
     fn is_tty(&self, communicate_allowed: bool) -> bool {
@@ -179,11 +190,13 @@ impl FileDescription for io::Stderr {
         _self_ref: &FileDescriptionRef,
         _communicate_allowed: bool,
         bytes: &[u8],
-        _ecx: &mut MiriInterpCx<'tcx>,
-    ) -> InterpResult<'tcx, io::Result<usize>> {
+        dest: &MPlaceTy<'tcx>,
+        ecx: &mut MiriInterpCx<'tcx>,
+    ) -> InterpResult<'tcx> {
         // We allow writing to stderr even with isolation enabled.
         // No need to flush, stderr is not buffered.
-        Ok(Write::write(&mut { self }, bytes))
+        let result = Write::write(&mut { self }, bytes);
+        ecx.return_written_byte_count_or_error(result, dest)
     }
 
     fn is_tty(&self, communicate_allowed: bool) -> bool {
@@ -205,10 +218,12 @@ impl FileDescription for NullOutput {
         _self_ref: &FileDescriptionRef,
         _communicate_allowed: bool,
         bytes: &[u8],
-        _ecx: &mut MiriInterpCx<'tcx>,
-    ) -> InterpResult<'tcx, io::Result<usize>> {
+        dest: &MPlaceTy<'tcx>,
+        ecx: &mut MiriInterpCx<'tcx>,
+    ) -> InterpResult<'tcx> {
         // We just don't write anything, but report to the user that we did.
-        Ok(Ok(bytes.len()))
+        let result = Ok(bytes.len());
+        ecx.return_written_byte_count_or_error(result, dest)
     }
 }
 
@@ -535,7 +550,8 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         buf: Pointer,
         count: u64,
         offset: Option<i128>,
-    ) -> InterpResult<'tcx, Scalar> {
+        dest: &MPlaceTy<'tcx>,
+    ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
 
         // Isolation check is done via `FileDescription` trait.
@@ -555,43 +571,29 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // We temporarily dup the FD to be able to retain mutable access to `this`.
         let Some(fd) = this.machine.fds.get(fd_num) else {
             trace!("read: FD not found");
-            return Ok(Scalar::from_target_isize(this.fd_not_found()?, this));
+            let res: i32 = this.fd_not_found()?;
+            this.write_int(res, dest)?;
+            return Ok(());
         };
 
         trace!("read: FD mapped to {fd:?}");
         // We want to read at most `count` bytes. We are sure that `count` is not negative
         // because it was a target's `usize`. Also we are sure that its smaller than
         // `usize::MAX` because it is bounded by the host's `isize`.
-        let mut bytes = vec![0; usize::try_from(count).unwrap()];
-        let result = match offset {
-            None => fd.read(&fd, communicate, &mut bytes, this),
+
+        match offset {
+            None => fd.read(&fd, communicate, buf, count, dest, this)?,
             Some(offset) => {
                 let Ok(offset) = u64::try_from(offset) else {
                     let einval = this.eval_libc("EINVAL");
                     this.set_last_error(einval)?;
-                    return Ok(Scalar::from_target_isize(-1, this));
+                    this.write_int(-1, dest)?;
+                    return Ok(());
                 };
-                fd.pread(communicate, &mut bytes, offset, this)
+                fd.pread(communicate, offset, buf, count, dest, this)?
             }
         };
-
-        // `File::read` never returns a value larger than `count`, so this cannot fail.
-        match result?.map(|c| i64::try_from(c).unwrap()) {
-            Ok(read_bytes) => {
-                // If reading to `bytes` did not fail, we write those bytes to the buffer.
-                // Crucially, if fewer than `bytes.len()` bytes were read, only write
-                // that much into the output buffer!
-                this.write_bytes_ptr(
-                    buf,
-                    bytes[..usize::try_from(read_bytes).unwrap()].iter().copied(),
-                )?;
-                Ok(Scalar::from_target_isize(read_bytes, this))
-            }
-            Err(e) => {
-                this.set_last_error_from_io_error(e)?;
-                Ok(Scalar::from_target_isize(-1, this))
-            }
-        }
+        Ok(())
     }
 
     fn write(
@@ -600,7 +602,8 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         buf: Pointer,
         count: u64,
         offset: Option<i128>,
-    ) -> InterpResult<'tcx, Scalar> {
+        dest: &MPlaceTy<'tcx>,
+    ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
 
         // Isolation check is done via `FileDescription` trait.
@@ -618,22 +621,64 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let bytes = this.read_bytes_ptr_strip_provenance(buf, Size::from_bytes(count))?.to_owned();
         // We temporarily dup the FD to be able to retain mutable access to `this`.
         let Some(fd) = this.machine.fds.get(fd_num) else {
-            return Ok(Scalar::from_target_isize(this.fd_not_found()?, this));
+            let res: i32 = this.fd_not_found()?;
+            this.write_int(res, dest)?;
+            return Ok(());
         };
 
-        let result = match offset {
-            None => fd.write(&fd, communicate, &bytes, this),
+        match offset {
+            None => fd.write(&fd, communicate, &bytes, dest, this)?,
             Some(offset) => {
                 let Ok(offset) = u64::try_from(offset) else {
                     let einval = this.eval_libc("EINVAL");
                     this.set_last_error(einval)?;
-                    return Ok(Scalar::from_target_isize(-1, this));
+                    this.write_int(-1, dest)?;
+                    return Ok(());
                 };
-                fd.pwrite(communicate, &bytes, offset, this)
+                fd.pwrite(communicate, &bytes, offset, dest, this)?
             }
         };
+        Ok(())
+    }
 
-        let result = result?.map(|c| i64::try_from(c).unwrap());
-        Ok(Scalar::from_target_isize(this.try_unwrap_io_result(result)?, this))
+    /// This function either writes to the user supplied buffer and to dest place, or sets the
+    /// last libc error and writes -1 to dest.
+    fn return_read_bytes_and_count(
+        &mut self,
+        buf: Pointer,
+        bytes: Vec<u8>,
+        result: io::Result<usize>,
+        dest: &MPlaceTy<'tcx>,
+    ) -> InterpResult<'tcx> {
+        let this = self.eval_context_mut();
+        match result {
+            Ok(read_bytes) => {
+                // If reading to `bytes` did not fail, we write those bytes to the buffer.
+                // Crucially, if fewer than `bytes.len()` bytes were read, only write
+                // that much into the output buffer!
+                this.write_bytes_ptr(buf, bytes[..read_bytes].iter().copied())?;
+                // The actual read size is always lesser than `count` so this cannot fail.
+                this.write_int(u64::try_from(read_bytes).unwrap(), dest)?;
+                return Ok(());
+            }
+            Err(e) => {
+                this.set_last_error_from_io_error(e)?;
+                this.write_int(-1, dest)?;
+                return Ok(());
+            }
+        }
+    }
+
+    /// This function writes the number of written bytes to dest place, or sets the
+    /// last libc error and writes -1 to dest.
+    fn return_written_byte_count_or_error(
+        &mut self,
+        result: io::Result<usize>,
+        dest: &MPlaceTy<'tcx>,
+    ) -> InterpResult<'tcx> {
+        let this = self.eval_context_mut();
+        let result = this.try_unwrap_io_result(result.map(|c| i64::try_from(c).unwrap()))?;
+        this.write_int(result, dest)?;
+        Ok(())
     }
 }

--- a/src/shims/unix/fd.rs
+++ b/src/shims/unix/fd.rs
@@ -579,6 +579,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let count = count
             .min(u64::try_from(this.target_isize_max()).unwrap())
             .min(u64::try_from(isize::MAX).unwrap());
+        let count = usize::try_from(count).unwrap(); // now it fits in a `usize`
         let communicate = this.machine.communicate();
 
         // We temporarily dup the FD to be able to retain mutable access to `this`.
@@ -595,7 +596,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // `usize::MAX` because it is bounded by the host's `isize`.
 
         match offset {
-            None => fd.read(&fd, communicate, buf, usize::try_from(count).unwrap(), dest, this)?,
+            None => fd.read(&fd, communicate, buf, count, dest, this)?,
             Some(offset) => {
                 let Ok(offset) = u64::try_from(offset) else {
                     let einval = this.eval_libc("EINVAL");
@@ -603,7 +604,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     this.write_int(-1, dest)?;
                     return Ok(());
                 };
-                fd.pread(communicate, offset, buf, usize::try_from(count).unwrap(), dest, this)?
+                fd.pread(communicate, offset, buf, count, dest, this)?
             }
         };
         Ok(())
@@ -629,6 +630,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let count = count
             .min(u64::try_from(this.target_isize_max()).unwrap())
             .min(u64::try_from(isize::MAX).unwrap());
+        let count = usize::try_from(count).unwrap(); // now it fits in a `usize`
         let communicate = this.machine.communicate();
 
         // We temporarily dup the FD to be able to retain mutable access to `this`.
@@ -639,7 +641,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         };
 
         match offset {
-            None => fd.write(&fd, communicate, buf, usize::try_from(count).unwrap(), dest, this)?,
+            None => fd.write(&fd, communicate, buf, count, dest, this)?,
             Some(offset) => {
                 let Ok(offset) = u64::try_from(offset) else {
                     let einval = this.eval_libc("EINVAL");
@@ -647,7 +649,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     this.write_int(-1, dest)?;
                     return Ok(());
                 };
-                fd.pwrite(communicate, buf, usize::try_from(count).unwrap(), offset, dest, this)?
+                fd.pwrite(communicate, buf, count, offset, dest, this)?
             }
         };
         Ok(())

--- a/src/shims/unix/fd.rs
+++ b/src/shims/unix/fd.rs
@@ -173,9 +173,9 @@ impl FileDescription for io::Stdout {
         dest: &MPlaceTy<'tcx>,
         ecx: &mut MiriInterpCx<'tcx>,
     ) -> InterpResult<'tcx> {
-        let bytes = ecx.read_bytes_ptr_strip_provenance(ptr, Size::from_bytes(len))?.to_owned();
+        let bytes = ecx.read_bytes_ptr_strip_provenance(ptr, Size::from_bytes(len))?;
         // We allow writing to stderr even with isolation enabled.
-        let result = Write::write(&mut { self }, &bytes);
+        let result = Write::write(&mut { self }, bytes);
         // Stdout is buffered, flush to make sure it appears on the
         // screen.  This is the write() syscall of the interpreted
         // program, we want it to correspond to a write() syscall on
@@ -204,10 +204,10 @@ impl FileDescription for io::Stderr {
         dest: &MPlaceTy<'tcx>,
         ecx: &mut MiriInterpCx<'tcx>,
     ) -> InterpResult<'tcx> {
-        let bytes = ecx.read_bytes_ptr_strip_provenance(ptr, Size::from_bytes(len))?.to_owned();
+        let bytes = ecx.read_bytes_ptr_strip_provenance(ptr, Size::from_bytes(len))?;
         // We allow writing to stderr even with isolation enabled.
         // No need to flush, stderr is not buffered.
-        let result = Write::write(&mut { self }, &bytes);
+        let result = Write::write(&mut { self }, bytes);
         ecx.return_written_byte_count_or_error(result, dest)
     }
 

--- a/src/shims/unix/foreign_items.rs
+++ b/src/shims/unix/foreign_items.rs
@@ -92,8 +92,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let fd = this.read_scalar(fd)?.to_i32()?;
                 let buf = this.read_pointer(buf)?;
                 let count = this.read_target_usize(count)?;
-                let result = this.read(fd, buf, count, None)?;
-                this.write_scalar(result, dest)?;
+                this.read(fd, buf, count, None, dest)?;
             }
             "write" => {
                 let [fd, buf, n] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
@@ -101,9 +100,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let buf = this.read_pointer(buf)?;
                 let count = this.read_target_usize(n)?;
                 trace!("Called write({:?}, {:?}, {:?})", fd, buf, count);
-                let result = this.write(fd, buf, count, None)?;
-                // Now, `result` is the value we return back to the program.
-                this.write_scalar(result, dest)?;
+                this.write(fd, buf, count, None, dest)?;
             }
             "pread" => {
                 let [fd, buf, count, offset] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
@@ -111,8 +108,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let buf = this.read_pointer(buf)?;
                 let count = this.read_target_usize(count)?;
                 let offset = this.read_scalar(offset)?.to_int(this.libc_ty_layout("off_t").size)?;
-                let result = this.read(fd, buf, count, Some(offset))?;
-                this.write_scalar(result, dest)?;
+                this.read(fd, buf, count, Some(offset), dest)?;
             }
             "pwrite" => {
                 let [fd, buf, n, offset] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
@@ -121,9 +117,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let count = this.read_target_usize(n)?;
                 let offset = this.read_scalar(offset)?.to_int(this.libc_ty_layout("off_t").size)?;
                 trace!("Called pwrite({:?}, {:?}, {:?}, {:?})", fd, buf, count, offset);
-                let result = this.write(fd, buf, count, Some(offset))?;
-                // Now, `result` is the value we return back to the program.
-                this.write_scalar(result, dest)?;
+                this.write(fd, buf, count, Some(offset), dest)?;
             }
             "pread64" => {
                 let [fd, buf, count, offset] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
@@ -131,8 +125,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let buf = this.read_pointer(buf)?;
                 let count = this.read_target_usize(count)?;
                 let offset = this.read_scalar(offset)?.to_int(this.libc_ty_layout("off64_t").size)?;
-                let result = this.read(fd, buf, count, Some(offset))?;
-                this.write_scalar(result, dest)?;
+                this.read(fd, buf, count, Some(offset), dest)?;
             }
             "pwrite64" => {
                 let [fd, buf, n, offset] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;
@@ -141,9 +134,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let count = this.read_target_usize(n)?;
                 let offset = this.read_scalar(offset)?.to_int(this.libc_ty_layout("off64_t").size)?;
                 trace!("Called pwrite64({:?}, {:?}, {:?}, {:?})", fd, buf, count, offset);
-                let result = this.write(fd, buf, count, Some(offset))?;
-                // Now, `result` is the value we return back to the program.
-                this.write_scalar(result, dest)?;
+                this.write(fd, buf, count, Some(offset), dest)?;
             }
             "close" => {
                 let [fd] = this.check_shim(abi, Abi::C { unwind: false }, link_name, args)?;

--- a/src/shims/unix/fs.rs
+++ b/src/shims/unix/fs.rs
@@ -55,8 +55,8 @@ impl FileDescription for FileHandle {
         ecx: &mut MiriInterpCx<'tcx>,
     ) -> InterpResult<'tcx> {
         assert!(communicate_allowed, "isolation should have prevented even opening a file");
-        let bytes = ecx.read_bytes_ptr_strip_provenance(ptr, Size::from_bytes(len))?.to_owned();
-        let result = (&mut &self.file).write(&bytes);
+        let bytes = ecx.read_bytes_ptr_strip_provenance(ptr, Size::from_bytes(len))?;
+        let result = (&mut &self.file).write(bytes);
         ecx.return_written_byte_count_or_error(result, dest)
     }
 
@@ -102,11 +102,11 @@ impl FileDescription for FileHandle {
         // Correctness of this emulation relies on sequential nature of Miri execution.
         // The closure is used to emulate `try` block, since we "bubble" `io::Error` using `?`.
         let file = &mut &self.file;
-        let bytes = ecx.read_bytes_ptr_strip_provenance(ptr, Size::from_bytes(len))?.to_owned();
+        let bytes = ecx.read_bytes_ptr_strip_provenance(ptr, Size::from_bytes(len))?;
         let mut f = || {
             let cursor_pos = file.stream_position()?;
             file.seek(SeekFrom::Start(offset))?;
-            let res = file.write(&bytes);
+            let res = file.write(bytes);
             // Attempt to restore cursor position even if the write has failed
             file.seek(SeekFrom::Start(cursor_pos))
                 .expect("failed to restore file position, this shouldn't be possible");

--- a/src/shims/unix/fs.rs
+++ b/src/shims/unix/fs.rs
@@ -42,7 +42,7 @@ impl FileDescription for FileHandle {
         assert!(communicate_allowed, "isolation should have prevented even opening a file");
         let mut bytes = vec![0; usize::try_from(len).unwrap()];
         let result = (&mut &self.file).read(&mut bytes);
-        ecx.return_read_bytes_and_count(ptr, bytes.to_vec(), result, dest)
+        ecx.return_read_bytes_and_count(ptr, &bytes, result, dest)
     }
 
     fn write<'tcx>(
@@ -83,7 +83,7 @@ impl FileDescription for FileHandle {
             res
         };
         let result = f();
-        ecx.return_read_bytes_and_count(ptr, bytes.to_vec(), result, dest)
+        ecx.return_read_bytes_and_count(ptr, &bytes, result, dest)
     }
 
     fn pwrite<'tcx>(

--- a/src/shims/unix/unnamed_socket.rs
+++ b/src/shims/unix/unnamed_socket.rs
@@ -137,7 +137,7 @@ impl FileDescription for AnonSocket {
         // Always succeed on read size 0.
         if request_byte_size == 0 {
             let result = Ok(0);
-            return ecx.return_read_bytes_and_count(ptr, bytes.to_vec(), result, dest);
+            return ecx.return_read_bytes_and_count(ptr, &bytes, result, dest);
         }
 
         let Some(readbuf) = &self.readbuf else {
@@ -151,7 +151,7 @@ impl FileDescription for AnonSocket {
                 // Socketpair with no peer and empty buffer.
                 // 0 bytes successfully read indicates end-of-file.
                 let result = Ok(0);
-                return ecx.return_read_bytes_and_count(ptr, bytes.to_vec(), result, dest);
+                return ecx.return_read_bytes_and_count(ptr, &bytes, result, dest);
             } else {
                 if self.is_nonblock {
                     // Non-blocking socketpair with writer and empty buffer.
@@ -160,7 +160,7 @@ impl FileDescription for AnonSocket {
                     // POSIX.1-2001 allows either error to be returned for this case.
                     // Since there is no ErrorKind for EAGAIN, WouldBlock is used.
                     let result = Err(Error::from(ErrorKind::WouldBlock));
-                    return ecx.return_read_bytes_and_count(ptr, bytes.to_vec(), result, dest);
+                    return ecx.return_read_bytes_and_count(ptr, &bytes, result, dest);
                 } else {
                     // Blocking socketpair with writer and empty buffer.
                     // FIXME: blocking is currently not supported
@@ -193,7 +193,7 @@ impl FileDescription for AnonSocket {
         }
 
         let result = Ok(actual_read_size);
-        ecx.return_read_bytes_and_count(ptr, bytes.to_vec(), result, dest)
+        ecx.return_read_bytes_and_count(ptr, &bytes, result, dest)
     }
 
     fn write<'tcx>(

--- a/src/shims/unix/unnamed_socket.rs
+++ b/src/shims/unix/unnamed_socket.rs
@@ -245,7 +245,7 @@ impl FileDescription for AnonSocket {
         }
         // Do full write / partial write based on the space available.
         let actual_write_size = len.min(available_space);
-        let bytes = ecx.read_bytes_ptr_strip_provenance(ptr, Size::from_bytes(len))?.to_owned();
+        let bytes = ecx.read_bytes_ptr_strip_provenance(ptr, Size::from_bytes(len))?;
         writebuf.buf.extend(&bytes[..actual_write_size]);
 
         // Need to stop accessing peer_fd so that it can be notified.


### PR DESCRIPTION


This PR passed the responsibility of reading to user supplied buffer and dest place to each implementation of ``FileDescription::read/write/pread/pwrite``. 

This is part of #3665.