### PR TITLE
Fix comment in mutex_id_offset

### DIFF
--- a/src/shims/unix/sync.rs
+++ b/src/shims/unix/sync.rs
@@ -62,7 +62,6 @@ fn is_mutex_kind_normal<'tcx>(ecx: &MiriInterpCx<'tcx>, kind: i32) -> InterpResu
 // pthread_mutex_t is between 24 and 48 bytes, depending on the platform.
 // We ignore the platform layout and store our own fields:
 // - id: u32
-// - kind: i32
 
 fn mutex_id_offset<'tcx>(ecx: &MiriInterpCx<'tcx>) -> InterpResult<'tcx, u64> {
     let offset = match &*ecx.tcx.sess.target.os {


### PR DESCRIPTION
We no longer store the kind inside the pthread_mutex_t, so this comment is outdated.
Sorry I didn't catch this in the original PR.