### PR TITLE
detect when pthread_rwlock_t is moved

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,8 +134,8 @@ pub use crate::concurrency::{
     data_race::{AtomicFenceOrd, AtomicReadOrd, AtomicRwOrd, AtomicWriteOrd, EvalContextExt as _},
     init_once::{EvalContextExt as _, InitOnceId},
     sync::{
-        AdditionalMutexData, CondvarId, EvalContextExt as _, MutexId, MutexKind, RwLockId,
-        SynchronizationObjects,
+        AdditionalMutexData, AdditionalRwLockData, CondvarId, EvalContextExt as _, MutexId,
+        MutexKind, RwLockId, SynchronizationObjects,
     },
     thread::{
         BlockReason, EvalContextExt as _, StackEmptyCallback, ThreadId, ThreadManager,

--- a/tests/fail-dep/concurrency/libx_pthread_rwlock_moved.rs
+++ b/tests/fail-dep/concurrency/libx_pthread_rwlock_moved.rs
@@ -1,0 +1,14 @@
+//@ignore-target-windows: No pthreads on Windows
+
+fn main() {
+    unsafe {
+        let mut rw = libc::PTHREAD_RWLOCK_INITIALIZER;
+
+        libc::pthread_rwlock_rdlock(&mut rw as *mut _);
+
+        // Move rwlock
+        let mut rw2 = rw;
+
+        libc::pthread_rwlock_unlock(&mut rw2 as *mut _); //~ ERROR: pthread_rwlock_t can't be moved after first use
+    }
+}

--- a/tests/fail-dep/concurrency/libx_pthread_rwlock_moved.stderr
+++ b/tests/fail-dep/concurrency/libx_pthread_rwlock_moved.stderr
@@ -1,0 +1,15 @@
+error: Undefined Behavior: pthread_rwlock_t can't be moved after first use
+  --> $DIR/libx_pthread_rwlock_moved.rs:LL:CC
+   |
+LL |         libc::pthread_rwlock_unlock(&mut rw2 as *mut _);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pthread_rwlock_t can't be moved after first use
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+   = note: BACKTRACE:
+   = note: inside `main` at $DIR/libx_pthread_rwlock_moved.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
For some implementations of pthreads, the address of pthread_rwlock_t (or its fields) is used to identify the lock. That means that if the contents of a pthread_rwlock_t are moved in memory, effectively a new lock object is created, which is completely independted from the original. Thus we want to detect when when such objects are moved and show an error.

see also #3749 for more context