### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/sysroots.yml
+++ b/.github/workflows/sysroots.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build the sysroots
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build the sysroots
         run: |
           cargo install -f rustup-toolchain-install-master

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Here is an example job for GitHub Actions:
     name: "Miri"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Miri
         run: |
           rustup toolchain install nightly --component miri


### PR DESCRIPTION
Required for using Node.js 20.x in CI
* Changelog for actions/checkout@v4 https://github.com/actions/checkout/blob/main/CHANGELOG.md?rgh-link-date=2024-09-04T18%3A38%3A10Z#v400
* GitHub Blog post https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

Refs: https://github.com/rust-lang/rust/pull/130124#issuecomment-2336871149