### PR TITLE
ptr_offset_unsigned_overflow: extend test

### DIFF
--- a/tests/fail/intrinsics/ptr_offset_unsigned_overflow.rs
+++ b/tests/fail/intrinsics/ptr_offset_unsigned_overflow.rs
@@ -1,7 +1,8 @@
 fn main() {
     let x = &[0i32; 2];
     let x = x.as_ptr().wrapping_add(1);
-    // If the `!0` is interpreted as `isize`, it is just `-1` and hence harmless.
-    // However, this is unsigned arithmetic, so really this is `usize::MAX` and hence UB.
-    unsafe { x.byte_add(!0).read() }; //~ERROR: does not fit in an `isize`
+    // If `usize::MAX` is interpreted as `isize`, it is just `-1` and hence harmless.
+    let _ = unsafe { x.byte_offset(usize::MAX as isize) };
+    // However, `byte_add` uses unsigned arithmetic, so really this is `usize::MAX` and hence UB.
+    let _ = unsafe { x.byte_add(usize::MAX) }; //~ERROR: does not fit in an `isize`
 }

--- a/tests/fail/intrinsics/ptr_offset_unsigned_overflow.stderr
+++ b/tests/fail/intrinsics/ptr_offset_unsigned_overflow.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: overflowing pointer arithmetic: the total offset in bytes does not fit in an `isize`
   --> tests/fail/intrinsics/ptr_offset_unsigned_overflow.rs:LL:CC
    |
-LL |     unsafe { x.byte_add(!0).read() };
-   |              ^^^^^^^^^^^^^^ overflowing pointer arithmetic: the total offset in bytes does not fit in an `isize`
+LL |     let _ = unsafe { x.byte_add(usize::MAX) };
+   |                      ^^^^^^^^^^^^^^^^^^^^^^ overflowing pointer arithmetic: the total offset in bytes does not fit in an `isize`
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information


### PR DESCRIPTION
Test that indeed, the signed version works before the unsigned version is UB.