### PR TITLE
try to give the CI job permission to create PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ on:
   schedule:
     - cron: '44 4 * * *' # At 4:44 UTC every day.
 
+permissions:
+  contents: write
+
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
See the discussion [here](https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/did.20github.20token.20permissions.20change.3F).

@rust-lang/infra just a heads-up that we are doing this -- I have no idea if this could cause any issues elsewhere, or if it is important that we limit the permissions here somehow, or so.