### PR TITLE
looks like we need more permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,9 @@ on:
     - cron: '44 4 * * *' # At 4:44 UTC every day.
 
 permissions:
-  contents: read
+  # The cronjob needs to be able to push to the repo...
+  contents: write
+  # ... and create a PR.
   pull-requests: write
 
 defaults:


### PR DESCRIPTION
The cron job [failed](https://github.com/rust-lang/miri/actions/runs/11007186322/job/30563264024) last night, so let's see if this helps.