### PR TITLE
Scope CI permissions to the job that needs it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,6 @@ on:
   schedule:
     - cron: '44 4 * * *' # At 4:44 UTC every day.
 
-permissions:
-  # The cronjob needs to be able to push to the repo...
-  contents: write
-  # ... and create a PR.
-  pull-requests: write
-
 defaults:
   run:
     shell: bash
@@ -93,6 +87,11 @@ jobs:
   cron-fail-notify:
     name: cronjob failure notification
     runs-on: ubuntu-latest
+    permissions:
+        # The cronjob needs to be able to push to the repo...
+        contents: write
+        # ... and create a PR.
+        pull-requests: write
     needs: [build, style]
     if: github.event_name == 'schedule' && failure()
     steps:


### PR DESCRIPTION
I scoped the permissions only to the job that requires them.