### PR TITLE
Android: Fixed tests for libc time API

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -154,7 +154,7 @@ case $HOST_TARGET in
     TEST_TARGET=i686-unknown-freebsd   run_tests_minimal $BASIC $UNIX threadname pthread time fs
     TEST_TARGET=x86_64-unknown-illumos run_tests_minimal $BASIC $UNIX thread sync available-parallelism time tls
     TEST_TARGET=x86_64-pc-solaris      run_tests_minimal $BASIC $UNIX thread sync available-parallelism time tls
-    TEST_TARGET=aarch64-linux-android  run_tests_minimal $BASIC $UNIX hashmap pthread time --skip threadname --skip pthread_cond_timedwait
+    TEST_TARGET=aarch64-linux-android  run_tests_minimal $BASIC $UNIX hashmap pthread time --skip threadname
     TEST_TARGET=wasm32-wasip2          run_tests_minimal $BASIC wasm
     TEST_TARGET=wasm32-unknown-unknown run_tests_minimal no_std empty_main wasm # this target doesn't really have std
     TEST_TARGET=thumbv7em-none-eabihf  run_tests_minimal no_std

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -154,7 +154,7 @@ case $HOST_TARGET in
     TEST_TARGET=i686-unknown-freebsd   run_tests_minimal $BASIC $UNIX threadname pthread time fs
     TEST_TARGET=x86_64-unknown-illumos run_tests_minimal $BASIC $UNIX thread sync available-parallelism time tls
     TEST_TARGET=x86_64-pc-solaris      run_tests_minimal $BASIC $UNIX thread sync available-parallelism time tls
-    TEST_TARGET=aarch64-linux-android  run_tests_minimal $BASIC $UNIX hashmap pthread --skip threadname --skip pthread_cond_timedwait
+    TEST_TARGET=aarch64-linux-android  run_tests_minimal $BASIC $UNIX hashmap pthread time --skip threadname --skip pthread_cond_timedwait
     TEST_TARGET=wasm32-wasip2          run_tests_minimal $BASIC wasm
     TEST_TARGET=wasm32-unknown-unknown run_tests_minimal no_std empty_main wasm # this target doesn't really have std
     TEST_TARGET=thumbv7em-none-eabihf  run_tests_minimal no_std

--- a/src/shims/time.rs
+++ b/src/shims/time.rs
@@ -36,8 +36,8 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let mut relative_clocks;
 
         match this.tcx.sess.target.os.as_ref() {
-            "linux" | "freebsd" => {
-                // Linux and FreeBSD have two main kinds of clocks. REALTIME clocks return the actual time since the
+            "linux" | "freebsd" | "android" => {
+                // Linux, Android, and FreeBSD have two main kinds of clocks. REALTIME clocks return the actual time since the
                 // Unix epoch, including effects which may cause time to move backwards such as NTP.
                 // Linux further distinguishes regular and "coarse" clocks, but the "coarse" version
                 // is just specified to be "faster and less precise", so we implement both the same way.

--- a/tests/pass-dep/libc/libc-time.rs
+++ b/tests/pass-dep/libc/libc-time.rs
@@ -15,7 +15,7 @@ fn test_clocks() {
     assert_eq!(is_error, 0);
     let is_error = unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, tp.as_mut_ptr()) };
     assert_eq!(is_error, 0);
-    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "android"))]
     {
         let is_error = unsafe { libc::clock_gettime(libc::CLOCK_REALTIME_COARSE, tp.as_mut_ptr()) };
         assert_eq!(is_error, 0);
@@ -63,9 +63,19 @@ fn test_localtime_r() {
         tm_wday: 0,
         tm_yday: 0,
         tm_isdst: 0,
-        #[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "macos",
+            target_os = "freebsd",
+            target_os = "android"
+        ))]
         tm_gmtoff: 0,
-        #[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "macos",
+            target_os = "freebsd",
+            target_os = "android"
+        ))]
         tm_zone: std::ptr::null_mut::<libc::c_char>(),
     };
     let res = unsafe { libc::localtime_r(custom_time_ptr, &mut tm) };
@@ -79,9 +89,19 @@ fn test_localtime_r() {
     assert_eq!(tm.tm_wday, 0);
     assert_eq!(tm.tm_yday, 97);
     assert_eq!(tm.tm_isdst, -1);
-    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "android"
+    ))]
     assert_eq!(tm.tm_gmtoff, 0);
-    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd"))]
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "android"
+    ))]
     unsafe {
         assert_eq!(std::ffi::CStr::from_ptr(tm.tm_zone).to_str().unwrap(), "+00")
     };


### PR DESCRIPTION
Closes #3888.

There's nothing to do, really. All of the API is already supported by `miri`, but I just tweaked tests a bit to match the data structures and functions from `bionic`.