### PR TITLE
add tests for validity of Box with custom allocator

### DIFF
--- a/tests/fail/validity/box-custom-alloc-dangling-ptr.rs
+++ b/tests/fail/validity/box-custom-alloc-dangling-ptr.rs
@@ -1,0 +1,32 @@
+//! Ensure that a box with a custom allocator detects when the pointer is dangling.
+#![feature(allocator_api)]
+// This should not need the aliasing model.
+//@compile-flags: -Zmiri-disable-stacked-borrows
+use std::alloc::Layout;
+use std::ptr::NonNull;
+
+#[allow(unused)]
+struct MyAlloc(usize, usize); // make sure `Box<T, MyAlloc>` is an `Aggregate`
+
+unsafe impl std::alloc::Allocator for MyAlloc {
+    fn allocate(&self, _layout: Layout) -> Result<NonNull<[u8]>, std::alloc::AllocError> {
+        unimplemented!()
+    }
+
+    unsafe fn deallocate(&self, _ptr: NonNull<u8>, _layout: Layout) {
+        unimplemented!()
+    }
+}
+
+#[repr(C)]
+struct MyBox<T> {
+    ptr: NonNull<T>,
+    alloc: MyAlloc,
+}
+
+fn main() {
+    let b = MyBox { ptr: NonNull::<i32>::dangling(), alloc: MyAlloc(0, 0) };
+    let _b: Box<i32, MyAlloc> = unsafe {
+        std::mem::transmute(b) //~ERROR: dangling box
+    };
+}

--- a/tests/fail/validity/box-custom-alloc-dangling-ptr.stderr
+++ b/tests/fail/validity/box-custom-alloc-dangling-ptr.stderr
@@ -1,0 +1,15 @@
+error: Undefined Behavior: constructing invalid value: encountered a dangling box (0x4[noalloc] has no provenance)
+  --> tests/fail/validity/box-custom-alloc-dangling-ptr.rs:LL:CC
+   |
+LL |         std::mem::transmute(b)
+   |         ^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value: encountered a dangling box (0x4[noalloc] has no provenance)
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+   = note: BACKTRACE:
+   = note: inside `main` at tests/fail/validity/box-custom-alloc-dangling-ptr.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/tests/fail/validity/box-custom-alloc-invalid-alloc.rs
+++ b/tests/fail/validity/box-custom-alloc-invalid-alloc.rs
@@ -1,0 +1,37 @@
+//! Ensure that a box with a custom allocator detects when the allocator itself is invalid.
+#![feature(allocator_api)]
+// This should not need the aliasing model.
+//@compile-flags: -Zmiri-disable-stacked-borrows
+use std::alloc::Layout;
+use std::mem::MaybeUninit;
+use std::ptr::NonNull;
+
+// make sure `Box<T, MyAlloc>` is an `Aggregate`
+#[allow(unused)]
+struct MyAlloc {
+    my_alloc_field1: usize,
+    my_alloc_field2: usize,
+}
+
+unsafe impl std::alloc::Allocator for MyAlloc {
+    fn allocate(&self, _layout: Layout) -> Result<NonNull<[u8]>, std::alloc::AllocError> {
+        unimplemented!()
+    }
+
+    unsafe fn deallocate(&self, _ptr: NonNull<u8>, _layout: Layout) {
+        unimplemented!()
+    }
+}
+
+#[repr(C)]
+struct MyBox<T> {
+    ptr: NonNull<T>,
+    alloc: MaybeUninit<MyAlloc>,
+}
+
+fn main() {
+    let b = MyBox { ptr: NonNull::from(&42), alloc: MaybeUninit::uninit() };
+    let _b: Box<i32, MyAlloc> = unsafe {
+        std::mem::transmute(b) //~ERROR: uninitialized memory
+    };
+}

--- a/tests/fail/validity/box-custom-alloc-invalid-alloc.stderr
+++ b/tests/fail/validity/box-custom-alloc-invalid-alloc.stderr
@@ -1,0 +1,15 @@
+error: Undefined Behavior: constructing invalid value at .1.my_alloc_field1: encountered uninitialized memory, but expected an integer
+  --> tests/fail/validity/box-custom-alloc-invalid-alloc.rs:LL:CC
+   |
+LL |         std::mem::transmute(b)
+   |         ^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .1.my_alloc_field1: encountered uninitialized memory, but expected an integer
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+   = note: BACKTRACE:
+   = note: inside `main` at tests/fail/validity/box-custom-alloc-invalid-alloc.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Ensure that the validity visitor visits both parts of a box with custom allocator using the right types.