### PR TITLE
skip old getrandom crate on Solaris

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -150,11 +150,11 @@ case $HOST_TARGET in
     # Partially supported targets (tier 2)
     BASIC="empty_main integer heap_alloc libc-mem vec string btreemap" # ensures we have the basics: pre-main code, system allocator
     UNIX="hello panic/panic panic/unwind concurrency/simple atomic libc-mem libc-misc libc-random env num_cpus" # the things that are very similar across all Unixes, and hence easily supported there
-    TEST_TARGET=x86_64-unknown-freebsd run_tests_minimal $BASIC $UNIX hashmap random threadname pthread time fs
-    TEST_TARGET=i686-unknown-freebsd   run_tests_minimal $BASIC $UNIX hashmap random threadname pthread time fs
-    TEST_TARGET=x86_64-unknown-illumos run_tests_minimal $BASIC $UNIX hashmap thread sync available-parallelism time tls
-    TEST_TARGET=x86_64-pc-solaris      run_tests_minimal $BASIC $UNIX hashmap thread sync available-parallelism time tls
-    TEST_TARGET=aarch64-linux-android  run_tests_minimal $BASIC $UNIX hashmap pthread time --skip threadname
+    TEST_TARGET=x86_64-unknown-freebsd run_tests_minimal $BASIC $UNIX time hashmap random threadname pthread fs
+    TEST_TARGET=i686-unknown-freebsd   run_tests_minimal $BASIC $UNIX time hashmap random threadname pthread fs
+    TEST_TARGET=x86_64-unknown-illumos run_tests_minimal $BASIC $UNIX time hashmap random thread sync available-parallelism tls
+    TEST_TARGET=x86_64-pc-solaris      run_tests_minimal $BASIC $UNIX time hashmap random thread sync available-parallelism tls
+    TEST_TARGET=aarch64-linux-android  run_tests_minimal $BASIC $UNIX time hashmap pthread --skip threadname
     TEST_TARGET=wasm32-wasip2          run_tests_minimal $BASIC wasm
     TEST_TARGET=wasm32-unknown-unknown run_tests_minimal no_std empty_main wasm # this target doesn't really have std
     TEST_TARGET=thumbv7em-none-eabihf  run_tests_minimal no_std

--- a/tests/pass-dep/getrandom.rs
+++ b/tests/pass-dep/getrandom.rs
@@ -6,6 +6,11 @@
 /// Test direct calls of getrandom 0.1 and 0.2.
 fn main() {
     let mut data = vec![0; 16];
+
+    // Old Solaris had a different return type for `getrandom`, and old versions of the getrandom crate
+    // used that signature, which Miri is not happy about.
+    #[cfg(not(target_os = "solaris"))]
     getrandom_01::getrandom(&mut data).unwrap();
+
     getrandom_02::getrandom(&mut data).unwrap();
 }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/miri/issues/3924

Now we should be able to enable randomness tests on Solarish (and Android, while we are at it).