### PR TITLE
Added rust-analyzer instructions for Helix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,48 +195,42 @@ installed (`cargo install hyperfine`).
 
 ## Configuring `rust-analyzer`
 
-To configure `rust-analyzer` and VS Code for working on Miri, save the following
-to `.vscode/settings.json` in your local Miri clone:
+To configure `rust-analyzer` and the IDE for working on Miri, use one of the provided
+configuration files according to the instructions below.
 
-```json
-{
-    "rust-analyzer.rustc.source": "discover",
-    "rust-analyzer.linkedProjects": [
-        "Cargo.toml",
-        "cargo-miri/Cargo.toml",
-        "miri-script/Cargo.toml",
-    ],
-    "rust-analyzer.check.invocationLocation": "root",
-    "rust-analyzer.check.invocationStrategy": "once",
-    "rust-analyzer.check.overrideCommand": [
-        "env",
-        "MIRI_AUTO_OPS=no",
-        "./miri",
-        "clippy", // make this `check` when working with a locally built rustc
-        "--message-format=json",
-    ],
-    // Contrary to what the name suggests, this also affects proc macros.
-    "rust-analyzer.cargo.buildScripts.invocationLocation": "root",
-    "rust-analyzer.cargo.buildScripts.invocationStrategy": "once",
-    "rust-analyzer.cargo.buildScripts.overrideCommand": [
-        "env",
-        "MIRI_AUTO_OPS=no",
-        "./miri",
-        "check",
-        "--message-format=json",
-    ],
-}
-```
 
-> #### Note
+### Visual Studio Code
+
+Copy [`etc/rust_analyzer_vscode.json`] to `.vscode/settings.json` in the project root directory.
+
+> #### Hint
 >
-> If you are [building Miri with a locally built rustc][], set
-> `rust-analyzer.rustcSource` to the relative path from your Miri clone to the
-> root `Cargo.toml` of the locally built rustc. For example, the path might look
-> like `../rust/Cargo.toml`.
+> To keep the `rust-analyzer` configuration up-to-date, make a symbolic link to one 
+> of the provided files depending on the IDE you use.
+
+[`etc/rust_analyzer_vscode.json`]: https://github.com/rust-lang/miri/blob/master/etc/rust_analyzer_vscode.json
+
+### Helix
+
+Copy [`etc/rust_analyzer_helix.toml`] to `.helix/languages.toml` in the project root directory.
+
+Since working on Miri requires a custom toolchain, and Helix requires the language server
+to be installed with the toolchain, you have to run `./miri toolchain -c rust-analyzer`
+when installing the Miri toolchain. Alternatively, set the `RUSTUP_TOOLCHAIN` environment variable according to
+[the documentation](https://rust-analyzer.github.io/manual.html#toolchain).
+
+[`etc/rust_analyzer_helix.toml`]: https://github.com/rust-lang/miri/blob/master/etc/rust_analyzer_helix.toml
+
+### Advanced configuration
+
+If you are building Miri with a locally built rustc, set
+`rust-analyzer.rustcSource` to the relative path from your Miri clone to the
+root `Cargo.toml` of the locally built rustc. For example, the path might look
+like `../rust/Cargo.toml`. In addition to that, replace `clippy` by `check`
+in the `rust-analyzer.check.overrideCommand` setting.
 
 See the rustc-dev-guide's docs on ["Configuring `rust-analyzer` for `rustc`"][rdg-r-a]
-for more information about configuring VS Code and `rust-analyzer`.
+for more information about configuring the IDE and `rust-analyzer`.
 
 [rdg-r-a]: https://rustc-dev-guide.rust-lang.org/building/suggested.html#configuring-rust-analyzer-for-rustc
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,18 +195,13 @@ installed (`cargo install hyperfine`).
 
 ## Configuring `rust-analyzer`
 
-To configure `rust-analyzer` and the IDE for working on Miri, use one of the provided
-configuration files according to the instructions below.
-
+To configure `rust-analyzer` and the IDE for working on Miri, copy one of the provided
+configuration files according to the instructions below. You can also set up a symbolic
+link to keep the configuration in sync with our recommendations.
 
 ### Visual Studio Code
 
 Copy [`etc/rust_analyzer_vscode.json`] to `.vscode/settings.json` in the project root directory.
-
-> #### Hint
->
-> To keep the `rust-analyzer` configuration up-to-date, make a symbolic link to one 
-> of the provided files depending on the IDE you use.
 
 [`etc/rust_analyzer_vscode.json`]: https://github.com/rust-lang/miri/blob/master/etc/rust_analyzer_vscode.json
 

--- a/etc/rust_analyzer_helix.toml
+++ b/etc/rust_analyzer_helix.toml
@@ -1,0 +1,32 @@
+[language-server.rust-analyzer.config.rustc]
+source = "discover"
+
+[language-server.rust-analyzer.config]
+linkedProjects = [
+    "Cargo.toml",
+    "cargo-miri/Cargo.toml",
+    "miri-script/Cargo.toml",
+]
+
+[language-server.rust-analyzer.config.check]
+invocationLocation = "root"
+invocationStrategy = "once"
+overrideCommand = [
+    "env",
+    "MIRI_AUTO_OPS=no",
+    "./miri",
+    "clippy", # make this `check` when working with a locally built rustc
+    "--message-format=json",
+]
+
+# Contrary to what the name suggests, this also affects proc macros.
+[language-server.rust-analyzer.config.buildScripts]
+invocationLocation = "root"
+invocationStrategy = "once"
+overrideCommand = [
+    "env",
+    "MIRI_AUTO_OPS=no",
+    "./miri",
+    "check",
+    "--message-format=json",
+]

--- a/etc/rust_analyzer_vscode.json
+++ b/etc/rust_analyzer_vscode.json
@@ -1,0 +1,27 @@
+{
+    "rust-analyzer.rustc.source": "discover",
+    "rust-analyzer.linkedProjects": [
+        "Cargo.toml",
+        "cargo-miri/Cargo.toml",
+        "miri-script/Cargo.toml",
+    ],
+    "rust-analyzer.check.invocationLocation": "root",
+    "rust-analyzer.check.invocationStrategy": "once",
+    "rust-analyzer.check.overrideCommand": [
+        "env",
+        "MIRI_AUTO_OPS=no",
+        "./miri",
+        "clippy", // make this `check` when working with a locally built rustc
+        "--message-format=json",
+    ],
+    // Contrary to what the name suggests, this also affects proc macros.
+    "rust-analyzer.cargo.buildScripts.invocationLocation": "root",
+    "rust-analyzer.cargo.buildScripts.invocationStrategy": "once",
+    "rust-analyzer.cargo.buildScripts.overrideCommand": [
+        "env",
+        "MIRI_AUTO_OPS=no",
+        "./miri",
+        "check",
+        "--message-format=json",
+    ],
+}


### PR DESCRIPTION
That pull request adds information on how to configure Helix to use `rust-analyzer`, and moves the existing configuration to the `src/etc` directory as it's in the `rust` repository. Not adding instructions for other IDE because there's a link leading to the how-to for `rustc`.