### PR TITLE
avoid pthread_attr_t in tests

### DIFF
--- a/tests/fail-dep/concurrency/libc_pthread_create_main_terminate.rs
+++ b/tests/fail-dep/concurrency/libc_pthread_create_main_terminate.rs
@@ -12,8 +12,9 @@ extern "C" fn thread_start(_null: *mut libc::c_void) -> *mut libc::c_void {
 fn main() {
     unsafe {
         let mut native: libc::pthread_t = mem::zeroed();
-        let attr: libc::pthread_attr_t = mem::zeroed();
-        // assert_eq!(libc::pthread_attr_init(&mut attr), 0); FIXME: this function is not yet implemented.
-        assert_eq!(libc::pthread_create(&mut native, &attr, thread_start, ptr::null_mut()), 0);
+        assert_eq!(
+            libc::pthread_create(&mut native, ptr::null(), thread_start, ptr::null_mut()),
+            0
+        );
     }
 }

--- a/tests/fail-dep/concurrency/libc_pthread_create_too_few_args.rs
+++ b/tests/fail-dep/concurrency/libc_pthread_create_too_few_args.rs
@@ -12,12 +12,13 @@ extern "C" fn thread_start() -> *mut libc::c_void {
 fn main() {
     unsafe {
         let mut native: libc::pthread_t = mem::zeroed();
-        let attr: libc::pthread_attr_t = mem::zeroed();
-        // assert_eq!(libc::pthread_attr_init(&mut attr), 0); FIXME: this function is not yet implemented.
         let thread_start: extern "C" fn() -> *mut libc::c_void = thread_start;
         let thread_start: extern "C" fn(*mut libc::c_void) -> *mut libc::c_void =
             mem::transmute(thread_start);
-        assert_eq!(libc::pthread_create(&mut native, &attr, thread_start, ptr::null_mut()), 0);
+        assert_eq!(
+            libc::pthread_create(&mut native, ptr::null(), thread_start, ptr::null_mut()),
+            0
+        );
         assert_eq!(libc::pthread_join(native, ptr::null_mut()), 0);
     }
 }

--- a/tests/fail-dep/concurrency/libc_pthread_create_too_many_args.rs
+++ b/tests/fail-dep/concurrency/libc_pthread_create_too_many_args.rs
@@ -12,12 +12,13 @@ extern "C" fn thread_start(_null: *mut libc::c_void, _x: i32) -> *mut libc::c_vo
 fn main() {
     unsafe {
         let mut native: libc::pthread_t = mem::zeroed();
-        let attr: libc::pthread_attr_t = mem::zeroed();
-        // assert_eq!(libc::pthread_attr_init(&mut attr), 0); FIXME: this function is not yet implemented.
         let thread_start: extern "C" fn(*mut libc::c_void, i32) -> *mut libc::c_void = thread_start;
         let thread_start: extern "C" fn(*mut libc::c_void) -> *mut libc::c_void =
             mem::transmute(thread_start);
-        assert_eq!(libc::pthread_create(&mut native, &attr, thread_start, ptr::null_mut()), 0);
+        assert_eq!(
+            libc::pthread_create(&mut native, ptr::null(), thread_start, ptr::null_mut()),
+            0
+        );
         assert_eq!(libc::pthread_join(native, ptr::null_mut()), 0);
     }
 }

--- a/tests/fail-dep/concurrency/libc_pthread_join_detached.rs
+++ b/tests/fail-dep/concurrency/libc_pthread_join_detached.rs
@@ -11,9 +11,10 @@ extern "C" fn thread_start(_null: *mut libc::c_void) -> *mut libc::c_void {
 fn main() {
     unsafe {
         let mut native: libc::pthread_t = mem::zeroed();
-        let attr: libc::pthread_attr_t = mem::zeroed();
-        // assert_eq!(libc::pthread_attr_init(&mut attr), 0); FIXME: this function is not yet implemented.
-        assert_eq!(libc::pthread_create(&mut native, &attr, thread_start, ptr::null_mut()), 0);
+        assert_eq!(
+            libc::pthread_create(&mut native, ptr::null(), thread_start, ptr::null_mut()),
+            0
+        );
         assert_eq!(libc::pthread_detach(native), 0);
         assert_eq!(libc::pthread_join(native, ptr::null_mut()), 0); //~ ERROR: Undefined Behavior: trying to join a detached thread
     }

--- a/tests/fail-dep/concurrency/libc_pthread_join_joined.rs
+++ b/tests/fail-dep/concurrency/libc_pthread_join_joined.rs
@@ -11,9 +11,10 @@ extern "C" fn thread_start(_null: *mut libc::c_void) -> *mut libc::c_void {
 fn main() {
     unsafe {
         let mut native: libc::pthread_t = mem::zeroed();
-        let attr: libc::pthread_attr_t = mem::zeroed();
-        // assert_eq!(libc::pthread_attr_init(&mut attr), 0); FIXME: this function is not yet implemented.
-        assert_eq!(libc::pthread_create(&mut native, &attr, thread_start, ptr::null_mut()), 0);
+        assert_eq!(
+            libc::pthread_create(&mut native, ptr::null(), thread_start, ptr::null_mut()),
+            0
+        );
         assert_eq!(libc::pthread_join(native, ptr::null_mut()), 0);
         assert_eq!(libc::pthread_join(native, ptr::null_mut()), 0); //~ ERROR: Undefined Behavior: trying to join an already joined thread
     }

--- a/tests/fail-dep/concurrency/libc_pthread_join_multiple.rs
+++ b/tests/fail-dep/concurrency/libc_pthread_join_multiple.rs
@@ -14,9 +14,10 @@ extern "C" fn thread_start(_null: *mut libc::c_void) -> *mut libc::c_void {
 fn main() {
     unsafe {
         let mut native: libc::pthread_t = mem::zeroed();
-        let attr: libc::pthread_attr_t = mem::zeroed();
-        // assert_eq!(libc::pthread_attr_init(&mut attr), 0); FIXME: this function is not yet implemented.
-        assert_eq!(libc::pthread_create(&mut native, &attr, thread_start, ptr::null_mut()), 0);
+        assert_eq!(
+            libc::pthread_create(&mut native, ptr::null(), thread_start, ptr::null_mut()),
+            0
+        );
         let mut native_copy: libc::pthread_t = mem::zeroed();
         ptr::copy_nonoverlapping(&native, &mut native_copy, 1);
         let handle = thread::spawn(move || {


### PR DESCRIPTION
We don't support `pthread_attr_init` so the code here is actually technically wrong (passing attributes to `pthread_create` that were not initialized properly). It's also unnecessary, we can just pass a null pointer for the attributes to indicate "default attributes please".