### PR TITLE
Do not store synchronization primitive IDs in adressable memory

### DIFF
--- a/src/concurrency/init_once.rs
+++ b/src/concurrency/init_once.rs
@@ -2,7 +2,6 @@ use std::collections::VecDeque;
 
 use rustc_index::Idx;
 
-use super::sync::EvalContextExtPriv as _;
 use super::vector_clock::VClock;
 use crate::*;
 
@@ -27,22 +26,6 @@ pub(super) struct InitOnce {
 
 impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
 pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
-    fn init_once_get_or_create_id(
-        &mut self,
-        lock: &MPlaceTy<'tcx>,
-        offset: u64,
-    ) -> InterpResult<'tcx, InitOnceId> {
-        let this = self.eval_context_mut();
-        this.get_or_create_id(
-            lock,
-            offset,
-            |ecx| &mut ecx.machine.sync.init_onces,
-            |_| interp_ok(Default::default()),
-        )?
-        .ok_or_else(|| err_ub_format!("init_once has invalid ID"))
-        .into()
-    }
-
     #[inline]
     fn init_once_status(&mut self, id: InitOnceId) -> InitOnceStatus {
         let this = self.eval_context_ref();

--- a/src/concurrency/sync.rs
+++ b/src/concurrency/sync.rs
@@ -234,8 +234,8 @@ pub fn lazy_sync_get_data<'tcx, T: 'static + Copy>(
             &init_field,
             &ImmTy::from_scalar(init_cookie, ecx.machine.layouts.u32),
             init_cookie,
-            AtomicRwOrd::Acquire,
-            AtomicReadOrd::Acquire,
+            AtomicRwOrd::Relaxed,
+            AtomicReadOrd::Relaxed,
             /* can_fail_spuriously */ false,
         )?
         .to_scalar_pair();

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -223,14 +223,13 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     }
 
     /// Evaluates the scalar at the specified path.
-    fn eval_path(&self, path: &[&str]) -> OpTy<'tcx> {
+    fn eval_path(&self, path: &[&str]) -> MPlaceTy<'tcx> {
         let this = self.eval_context_ref();
         let instance = resolve_path(*this.tcx, path, Namespace::ValueNS);
         // We don't give a span -- this isn't actually used directly by the program anyway.
-        let const_val = this.eval_global(instance).unwrap_or_else(|err| {
+        this.eval_global(instance).unwrap_or_else(|err| {
             panic!("failed to evaluate required Rust item: {path:?}\n{err:?}")
-        });
-        const_val.into()
+        })
     }
     fn eval_path_scalar(&self, path: &[&str]) -> Scalar {
         let this = self.eval_context_ref();

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -362,6 +362,12 @@ impl VisitProvenance for AllocExtra<'_> {
     }
 }
 
+impl<'tcx> AllocExtra<'tcx> {
+    pub fn get_sync<T: 'static>(&self, offset: Size) -> Option<&T> {
+        self.sync.get(&offset).and_then(|s| s.downcast_ref::<T>())
+    }
+}
+
 /// Precomputed layouts of primitive types
 pub struct PrimitiveLayouts<'tcx> {
     pub unit: TyAndLayout<'tcx>,

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -362,12 +362,6 @@ impl VisitProvenance for AllocExtra<'_> {
     }
 }
 
-impl<'tcx> AllocExtra<'tcx> {
-    pub fn get_sync<T: 'static>(&self, offset: Size) -> Option<&T> {
-        self.sync.get(&offset).and_then(|s| s.downcast_ref::<T>())
-    }
-}
-
 /// Precomputed layouts of primitive types
 pub struct PrimitiveLayouts<'tcx> {
     pub unit: TyAndLayout<'tcx>,

--- a/src/shims/unix/macos/sync.rs
+++ b/src/shims/unix/macos/sync.rs
@@ -12,7 +12,7 @@
 
 use crate::*;
 
-struct LockData {
+struct MacOsUnfairLock {
     id: MutexId,
 }
 
@@ -25,11 +25,11 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // that's just implicitly creating a new lock at the new location.
         let (alloc, offset, _) = this.ptr_get_alloc_id(lock.ptr(), 0)?;
         let (alloc_extra, machine) = this.get_alloc_extra_mut(alloc)?;
-        if let Some(data) = alloc_extra.get_sync::<LockData>(offset) {
+        if let Some(data) = alloc_extra.get_sync::<MacOsUnfairLock>(offset) {
             interp_ok(data.id)
         } else {
             let id = machine.sync.mutex_create();
-            alloc_extra.sync.insert(offset, Box::new(LockData { id }));
+            alloc_extra.sync.insert(offset, Box::new(MacOsUnfairLock { id }));
             interp_ok(id)
         }
     }

--- a/src/shims/unix/macos/sync.rs
+++ b/src/shims/unix/macos/sync.rs
@@ -20,7 +20,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // os_unfair_lock holds a 32-bit value, is initialized with zero and
         // must be assumed to be opaque. Therefore, we can just store our
         // internal mutex ID in the structure without anyone noticing.
-        this.mutex_get_or_create_id(&lock, 0, |_| interp_ok(None))
+        this.mutex_get_or_create_id(&lock, /* offset */ 0)
     }
 }
 

--- a/src/shims/windows/sync.rs
+++ b/src/shims/windows/sync.rs
@@ -7,7 +7,7 @@ use crate::concurrency::sync::lazy_sync_get_data;
 use crate::*;
 
 #[derive(Copy, Clone)]
-struct InitOnceData {
+struct WindowsInitOnce {
     id: InitOnceId,
 }
 
@@ -19,7 +19,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
     fn init_once_get_data(
         &mut self,
         init_once_ptr: &OpTy<'tcx>,
-    ) -> InterpResult<'tcx, InitOnceData> {
+    ) -> InterpResult<'tcx, WindowsInitOnce> {
         let this = self.eval_context_mut();
 
         let init_once = this.deref_pointer(init_once_ptr)?;
@@ -28,7 +28,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
         lazy_sync_get_data(this, &init_once, init_offset, "INIT_ONCE", |this| {
             // TODO: check that this is still all-zero.
             let id = this.machine.sync.init_once_create();
-            interp_ok(InitOnceData { id })
+            interp_ok(WindowsInitOnce { id })
         })
     }
 

--- a/tests/fail-dep/concurrency/libc_pthread_cond_move.init.stderr
+++ b/tests/fail-dep/concurrency/libc_pthread_cond_move.init.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: pthread_cond_t can't be moved after first use
+error: Undefined Behavior: `pthread_cond_t` can't be moved after first use
   --> tests/fail-dep/concurrency/libc_pthread_cond_move.rs:LL:CC
    |
 LL |         libc::pthread_cond_destroy(cond2.as_mut_ptr());
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pthread_cond_t can't be moved after first use
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `pthread_cond_t` can't be moved after first use
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail-dep/concurrency/libc_pthread_cond_move.rs
+++ b/tests/fail-dep/concurrency/libc_pthread_cond_move.rs
@@ -18,7 +18,7 @@ fn check() {
         // move pthread_cond_t
         let mut cond2 = cond;
 
-        libc::pthread_cond_destroy(cond2.as_mut_ptr()); //~[init] ERROR: pthread_cond_t can't be moved after first use
+        libc::pthread_cond_destroy(cond2.as_mut_ptr()); //~[init] ERROR: can't be moved after first use
     }
 }
 
@@ -32,6 +32,6 @@ fn check() {
         // move pthread_cond_t
         let mut cond2 = cond;
 
-        libc::pthread_cond_destroy(&mut cond2 as *mut _); //~[static_initializer] ERROR: pthread_cond_t can't be moved after first use
+        libc::pthread_cond_destroy(&mut cond2 as *mut _); //~[static_initializer] ERROR: can't be moved after first use
     }
 }

--- a/tests/fail-dep/concurrency/libc_pthread_cond_move.static_initializer.stderr
+++ b/tests/fail-dep/concurrency/libc_pthread_cond_move.static_initializer.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: pthread_cond_t can't be moved after first use
+error: Undefined Behavior: `pthread_cond_t` can't be moved after first use
   --> tests/fail-dep/concurrency/libc_pthread_cond_move.rs:LL:CC
    |
 LL |         libc::pthread_cond_destroy(&mut cond2 as *mut _);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pthread_cond_t can't be moved after first use
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `pthread_cond_t` can't be moved after first use
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail-dep/concurrency/libc_pthread_mutex_move.init.stderr
+++ b/tests/fail-dep/concurrency/libc_pthread_mutex_move.init.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: pthread_mutex_t can't be moved after first use
+error: Undefined Behavior: `pthread_mutex_t` can't be moved after first use
   --> tests/fail-dep/concurrency/libc_pthread_mutex_move.rs:LL:CC
    |
 LL |         libc::pthread_mutex_lock(&mut m2 as *mut _);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pthread_mutex_t can't be moved after first use
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `pthread_mutex_t` can't be moved after first use
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail-dep/concurrency/libc_pthread_mutex_move.rs
+++ b/tests/fail-dep/concurrency/libc_pthread_mutex_move.rs
@@ -12,7 +12,7 @@ fn check() {
         assert_eq!(libc::pthread_mutex_init(&mut m as *mut _, std::ptr::null()), 0);
 
         let mut m2 = m; // move the mutex
-        libc::pthread_mutex_lock(&mut m2 as *mut _); //~[init] ERROR: pthread_mutex_t can't be moved after first use
+        libc::pthread_mutex_lock(&mut m2 as *mut _); //~[init] ERROR: can't be moved after first use
     }
 }
 
@@ -23,6 +23,6 @@ fn check() {
         libc::pthread_mutex_lock(&mut m as *mut _);
 
         let mut m2 = m; // move the mutex
-        libc::pthread_mutex_unlock(&mut m2 as *mut _); //~[static_initializer] ERROR: pthread_mutex_t can't be moved after first use
+        libc::pthread_mutex_unlock(&mut m2 as *mut _); //~[static_initializer] ERROR: can't be moved after first use
     }
 }

--- a/tests/fail-dep/concurrency/libc_pthread_mutex_move.static_initializer.stderr
+++ b/tests/fail-dep/concurrency/libc_pthread_mutex_move.static_initializer.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: pthread_mutex_t can't be moved after first use
+error: Undefined Behavior: `pthread_mutex_t` can't be moved after first use
   --> tests/fail-dep/concurrency/libc_pthread_mutex_move.rs:LL:CC
    |
 LL |         libc::pthread_mutex_unlock(&mut m2 as *mut _);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pthread_mutex_t can't be moved after first use
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `pthread_mutex_t` can't be moved after first use
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail-dep/concurrency/libx_pthread_rwlock_moved.rs
+++ b/tests/fail-dep/concurrency/libx_pthread_rwlock_moved.rs
@@ -9,6 +9,6 @@ fn main() {
         // Move rwlock
         let mut rw2 = rw;
 
-        libc::pthread_rwlock_unlock(&mut rw2 as *mut _); //~ ERROR: pthread_rwlock_t can't be moved after first use
+        libc::pthread_rwlock_unlock(&mut rw2 as *mut _); //~ ERROR: can't be moved after first use
     }
 }

--- a/tests/fail-dep/concurrency/libx_pthread_rwlock_moved.stderr
+++ b/tests/fail-dep/concurrency/libx_pthread_rwlock_moved.stderr
@@ -1,8 +1,8 @@
-error: Undefined Behavior: pthread_rwlock_t can't be moved after first use
+error: Undefined Behavior: `pthread_rwlock_t` can't be moved after first use
   --> tests/fail-dep/concurrency/libx_pthread_rwlock_moved.rs:LL:CC
    |
 LL |         libc::pthread_rwlock_unlock(&mut rw2 as *mut _);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ pthread_rwlock_t can't be moved after first use
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `pthread_rwlock_t` can't be moved after first use
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information


### PR DESCRIPTION
We shouldn't store this in a place where the program can mess with it.

Fixes https://github.com/rust-lang/miri/issues/1649

Blocked by https://github.com/rust-lang/rust/pull/131593