### PR TITLE
Avoid some needless monomorphizations

### DIFF
--- a/src/concurrency/init_once.rs
+++ b/src/concurrency/init_once.rs
@@ -2,6 +2,7 @@ use std::collections::VecDeque;
 
 use rustc_index::Idx;
 
+use super::thread::DynUnblockCallback;
 use super::vector_clock::VClock;
 use crate::*;
 
@@ -34,11 +35,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
     /// Put the thread into the queue waiting for the initialization.
     #[inline]
-    fn init_once_enqueue_and_block(
-        &mut self,
-        id: InitOnceId,
-        callback: impl UnblockCallback<'tcx> + 'tcx,
-    ) {
+    fn init_once_enqueue_and_block(&mut self, id: InitOnceId, callback: DynUnblockCallback<'tcx>) {
         let this = self.eval_context_mut();
         let thread = this.active_thread();
         let init_once = &mut this.machine.sync.init_onces[id];

--- a/src/concurrency/thread.rs
+++ b/src/concurrency/thread.rs
@@ -50,7 +50,7 @@ pub trait UnblockCallback<'tcx>: VisitProvenance {
     fn timeout(self: Box<Self>, _ecx: &mut InterpCx<'tcx, MiriMachine<'tcx>>)
     -> InterpResult<'tcx>;
 }
-type DynUnblockCallback<'tcx> = Box<dyn UnblockCallback<'tcx> + 'tcx>;
+pub type DynUnblockCallback<'tcx> = Box<dyn UnblockCallback<'tcx> + 'tcx>;
 
 #[macro_export]
 macro_rules! callback {
@@ -101,7 +101,7 @@ macro_rules! callback {
             }
         }
 
-        Callback { $($name,)* _phantom: std::marker::PhantomData }
+        Box::new(Callback { $($name,)* _phantom: std::marker::PhantomData })
     }}
 }
 
@@ -715,11 +715,11 @@ impl<'tcx> ThreadManager<'tcx> {
         &mut self,
         reason: BlockReason,
         timeout: Option<Timeout>,
-        callback: impl UnblockCallback<'tcx> + 'tcx,
+        callback: DynUnblockCallback<'tcx>,
     ) {
         let state = &mut self.threads[self.active_thread].state;
         assert!(state.is_enabled());
-        *state = ThreadState::Blocked { reason, timeout, callback: Box::new(callback) }
+        *state = ThreadState::Blocked { reason, timeout, callback }
     }
 
     /// Change the active thread to some enabled thread.
@@ -1032,7 +1032,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         &mut self,
         reason: BlockReason,
         timeout: Option<(TimeoutClock, TimeoutAnchor, Duration)>,
-        callback: impl UnblockCallback<'tcx> + 'tcx,
+        callback: DynUnblockCallback<'tcx>,
     ) {
         let this = self.eval_context_mut();
         let timeout = timeout.map(|(clock, anchor, duration)| {


### PR DESCRIPTION
All code paths always end up boxing the type, so let's do it eagerly in the `callback!` macro instead