### PR TITLE
fix error returned from readdir_r when isolation is enabled, and uses of raw_os_error

### DIFF
--- a/src/shims/unix/fs.rs
+++ b/src/shims/unix/fs.rs
@@ -339,7 +339,10 @@ trait EvalContextExtPrivate<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     _ => interp_ok(this.eval_libc("DT_UNKNOWN").to_u8()?.into()),
                 }
             }
-            Err(e) => this.io_error_to_errnum(e)?.to_i32(),
+            Err(_) => {
+                // Fallback on error
+                interp_ok(this.eval_libc("DT_UNKNOWN").to_u8()?.into())
+            }
         }
     }
 }

--- a/src/shims/unix/fs.rs
+++ b/src/shims/unix/fs.rs
@@ -1130,8 +1130,8 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // Reject if isolation is enabled.
         if let IsolatedOp::Reject(reject_with) = this.machine.isolated_op {
             this.reject_in_isolation("`readdir_r`", reject_with)?;
-            // Set error code as "EBADF" (bad fd)
-            return this.set_last_error_and_return_i32(LibcError("EBADF"));
+            // Return error code, do *not* set `errno`.
+            return interp_ok(this.eval_libc("EBADF"));
         }
 
         let open_dir = this.machine.dirs.streams.get_mut(&dirp).ok_or_else(|| {


### PR DESCRIPTION
In https://github.com/rust-lang/miri/pull/3779 @oli-obk noticed that our `readdir_r` is buggy -- it shouldn't ever set errno, but the "isolation enabled" path used the shared helper that sets errno.

So this PR fixes that. I think that is the only part of https://github.com/rust-lang/miri/pull/3779 that intentionally changes behavior.

I also noticed some uses of raw_os_error, which is buggy since it returns host error codes that we can't just use for the target.