### PR TITLE
Add GC heuristic

### DIFF
--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -33,8 +33,8 @@ use std::sync::atomic::{AtomicI32, AtomicU32, Ordering};
 use std::sync::{Arc, Once};
 
 use miri::{
-    BacktraceStyle, BorrowTrackerMethod, MiriConfig, MiriEntryFnType, ProvenanceMode, RetagFields,
-    ValidationMode,
+    BacktraceStyle, BorrowTrackerMethod, MiriConfig, MiriEntryFnType, ProvenanceGcSettings,
+    ProvenanceMode, RetagFields, ValidationMode,
 };
 use rustc_abi::ExternAbi;
 use rustc_data_structures::sync;
@@ -646,7 +646,10 @@ fn main() {
             let interval = param.parse::<u32>().unwrap_or_else(|err| {
                 show_error!("-Zmiri-provenance-gc requires a `u32`: {}", err)
             });
-            miri_config.gc_interval = interval;
+            miri_config.gc_settings = match interval {
+                0 => ProvenanceGcSettings::Disabled,
+                interval => ProvenanceGcSettings::Regularly { interval },
+            };
         } else if let Some(param) = arg.strip_prefix("-Zmiri-measureme=") {
             miri_config.measureme_out = Some(param.to_string());
         } else if let Some(param) = arg.strip_prefix("-Zmiri-backtrace=") {

--- a/src/borrow_tracker/tree_borrows/tree.rs
+++ b/src/borrow_tracker/tree_borrows/tree.rs
@@ -897,11 +897,11 @@ impl Tree {
     pub fn tree_grew_significantly_since_last_gc(&self) -> bool {
         let current = self.nodes_count();
         // do not trigger the GC for small nodes
-        let last = self.nodes_at_last_gc.max(50);
+        let last = self.nodes_at_last_gc.max(100);
         // trigger the GC if the tree doubled since the last run,
         // or otherwise got "significantly" larger.
         // Note that for trees < 100 nodes, nothing happens.
-        current > 2 * last || current > last + 1500
+        current > 2 * last || current > last + 2500
     }
 
     pub fn remove_unreachable_tags(&mut self, live_tags: &FxHashSet<BorTag>) {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -89,6 +89,18 @@ pub enum ValidationMode {
     Deep,
 }
 
+/// Settings for the provenance GC
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum ProvenanceGcSettings {
+    /// The GC is disabled
+    Disabled,
+    /// The GC is to run regularly, every `inverval` basic blocks
+    Regularly { interval: u32 },
+    /// The GC runs as needed, determined by heuristics.
+    /// See `should_run_provenance_gc`
+    Heuristically,
+}
+
 /// Configuration needed to spawn a Miri instance.
 #[derive(Clone)]
 pub struct MiriConfig {
@@ -151,8 +163,8 @@ pub struct MiriConfig {
     /// The location of a shared object file to load when calling external functions
     /// FIXME! consider allowing users to specify paths to multiple files, or to a directory
     pub native_lib: Option<PathBuf>,
-    /// Run a garbage collector for BorTags every N basic blocks.
-    pub gc_interval: u32,
+    /// Settings for the provenance GC (e.g. how often it runs)
+    pub gc_settings: ProvenanceGcSettings,
     /// The number of CPUs to be reported by miri.
     pub num_cpus: u32,
     /// Requires Miri to emulate pages of a certain size
@@ -194,7 +206,7 @@ impl Default for MiriConfig {
             report_progress: None,
             retag_fields: RetagFields::Yes,
             native_lib: None,
-            gc_interval: 10_000,
+            gc_settings: ProvenanceGcSettings::Heuristically,
             num_cpus: 1,
             page_size: None,
             collect_leak_backtraces: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,8 +140,8 @@ pub use crate::diagnostics::{
     EvalContextExt as _, NonHaltingDiagnostic, TerminationInfo, report_error,
 };
 pub use crate::eval::{
-    AlignmentCheck, BacktraceStyle, IsolatedOp, MiriConfig, MiriEntryFnType, RejectOpWith,
-    ValidationMode, create_ecx, eval_entry,
+    AlignmentCheck, BacktraceStyle, IsolatedOp, MiriConfig, MiriEntryFnType, ProvenanceGcSettings,
+    RejectOpWith, ValidationMode, create_ecx, eval_entry,
 };
 pub use crate::helpers::{AccessKind, EvalContextExt as _};
 pub use crate::intrinsics::EvalContextExt as _;


### PR DESCRIPTION
Miri's GC runs every 10000 basic block, by default. It turns out that sometimes, it is better if the GC runs more often. This is especially true for some Tree Borrows programs, since in Tree Borrow, memory accesses take time linear in the size of a certain tree, and this tree can grow quite large, but is usually compacted significantly at every GC run. For some programs, it can be advantageous to run the GC every 200 blocks, or even more often.

Unfortunately, such a GC frequency would slow down other programs. To achieve a balance, this PR proposes a "heuristics" that allows running the GC more often based on how large the Tree Borrows tree grows. It is quite likely that other parts of Miri want to plug into this mechanisms as well, eventually. However, such concrete other cases are further work, as long as the system is designed to be general enough. This PR only contributes integration with Tree Borrows. It is also possible that the actual heuristics need more tweaks, but for now, the performance improvements look promising.

It is further likely that the overall design needs some change, since it currently relies on `Cell`s. Also, I was not too sure where to put the new `enum`s. So this PR is WIP for now, although it is functionally complete.