### PR TITLE
[TB Optimization] Skip subtrees based on the subtree's root node's permissions

### DIFF
--- a/src/borrow_tracker/tree_borrows/perms.rs
+++ b/src/borrow_tracker/tree_borrows/perms.rs
@@ -237,6 +237,10 @@ impl Permission {
     pub fn is_active(&self) -> bool {
         self.inner == Active
     }
+    /// Check if `self` is the never-allow-writes-again state of a pointer (is `Frozen`).
+    pub fn is_frozen(&self) -> bool {
+        self.inner == Frozen
+    }
 
     /// Default initial permission of the root of a new tree at inbounds positions.
     /// Must *only* be used for the root, this is not in general an "initial" permission!

--- a/tests/fail/tree_borrows/subtree_traversal_skipping_diagnostics.rs
+++ b/tests/fail/tree_borrows/subtree_traversal_skipping_diagnostics.rs
@@ -1,0 +1,29 @@
+//@compile-flags: -Zmiri-tree-borrows -Zmiri-provenance-gc=0
+
+// Shows the effect of the optimization of #4008.
+// The diagnostics change, but not the error itself.
+
+// When this method is called, the tree will be a single line and look like this,
+// with other_ptr being the root at the top
+// other_ptr = root : Active
+// intermediary     : Frozen // an intermediary node
+// m                : Reserved
+fn write_to_mut(m: &mut u8, other_ptr: *const u8) {
+    unsafe {
+        std::hint::black_box(*other_ptr);
+    }
+    // In line 17 above, m should have become Reserved (protected) so that this write is impossible.
+    // However, that does not happen because the read above is not forwarded to the subtree below
+    // the Frozen intermediary node. This does not affect UB, however, because the Frozen that blocked
+    // the read already prevents any child writes.
+    *m = 42; //~ERROR: /write access through .* is forbidden/
+}
+
+fn main() {
+    let root = 42u8;
+    unsafe {
+        let intermediary = &root;
+        let data = &mut *(core::ptr::addr_of!(*intermediary) as *mut u8);
+        write_to_mut(data, core::ptr::addr_of!(root));
+    }
+}

--- a/tests/fail/tree_borrows/subtree_traversal_skipping_diagnostics.stderr
+++ b/tests/fail/tree_borrows/subtree_traversal_skipping_diagnostics.stderr
@@ -5,18 +5,18 @@ LL |     *m = 42;
    |     ^^^^^^^ write access through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
-   = help: the accessed tag <TAG> has state Reserved (conflicted) which forbids this child write access
-help: the accessed tag <TAG> was created here, in the initial state Reserved
+   = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>
+   = help: the conflicting tag <TAG> has state Frozen which forbids this child write access
+help: the accessed tag <TAG> was created here
   --> tests/fail/tree_borrows/subtree_traversal_skipping_diagnostics.rs:LL:CC
    |
 LL | fn write_to_mut(m: &mut u8, other_ptr: *const u8) {
    |                 ^
-help: the accessed tag <TAG> later transitioned to Reserved (conflicted) due to a foreign read access at offsets [0x0..0x1]
+help: the conflicting tag <TAG> was created here, in the initial state Frozen
   --> tests/fail/tree_borrows/subtree_traversal_skipping_diagnostics.rs:LL:CC
    |
-LL |         std::hint::black_box(*other_ptr);
-   |                              ^^^^^^^^^^
-   = help: this transition corresponds to a temporary loss of write permissions until function exit
+LL |         let intermediary = &root;
+   |                            ^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `write_to_mut` at tests/fail/tree_borrows/subtree_traversal_skipping_diagnostics.rs:LL:CC
 note: inside `main`

--- a/tests/fail/tree_borrows/subtree_traversal_skipping_diagnostics.stderr
+++ b/tests/fail/tree_borrows/subtree_traversal_skipping_diagnostics.stderr
@@ -1,0 +1,31 @@
+error: Undefined Behavior: write access through <TAG> at ALLOC[0x0] is forbidden
+  --> tests/fail/tree_borrows/subtree_traversal_skipping_diagnostics.rs:LL:CC
+   |
+LL |     *m = 42;
+   |     ^^^^^^^ write access through <TAG> at ALLOC[0x0] is forbidden
+   |
+   = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
+   = help: the accessed tag <TAG> has state Reserved (conflicted) which forbids this child write access
+help: the accessed tag <TAG> was created here, in the initial state Reserved
+  --> tests/fail/tree_borrows/subtree_traversal_skipping_diagnostics.rs:LL:CC
+   |
+LL | fn write_to_mut(m: &mut u8, other_ptr: *const u8) {
+   |                 ^
+help: the accessed tag <TAG> later transitioned to Reserved (conflicted) due to a foreign read access at offsets [0x0..0x1]
+  --> tests/fail/tree_borrows/subtree_traversal_skipping_diagnostics.rs:LL:CC
+   |
+LL |         std::hint::black_box(*other_ptr);
+   |                              ^^^^^^^^^^
+   = help: this transition corresponds to a temporary loss of write permissions until function exit
+   = note: BACKTRACE (of the first span):
+   = note: inside `write_to_mut` at tests/fail/tree_borrows/subtree_traversal_skipping_diagnostics.rs:LL:CC
+note: inside `main`
+  --> tests/fail/tree_borrows/subtree_traversal_skipping_diagnostics.rs:LL:CC
+   |
+LL |         write_to_mut(data, core::ptr::addr_of!(root));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
In #4006, we re-added the functionality for skipping subtrees. It turns out that just skipping subtrees based on their last recorded access is imprecise. In certain cases, we know we can skip subtrees purely based on the root's current permission, without having to track the last access. Specifically:
* Disabled nodes can always be skipped, since the whole subtree must necessarily be invariant under all foreign accesses
* Frozen nodes an be skipped for foreign reads, since the whole subtree must necessarily be invariant under all foreign reads.

Note that this PR loosens the notion of "invariant" a bit. For example, it is possible that there is a `Reserved` protected node that is a child of a `Frozen` node. When that undergoes a foreign read, it becomes conflicted. If we skip accessing that subtree, it no longer does become conflicted.
The reason this is still OK is that the only effect of this conflictedness is blocking child write accesses. But such accesses are already blocked by the `Frozen` node further up the tree. So no UB is missed, all that happens is that diagnostics are triggered at a different node. 

For more detailed analysis of why this is correct, see the in-code comments.

Here is a performance analysis, comparing this PR's improvements with that of #4006:

![performance comparison](https://github.com/user-attachments/assets/a77aaac9-20e8-43e5-9e01-89a928b09683)

As in #4006, this is a log graph. The blue line shows performance without #4006, red is with the re-added optimization of #4006, yellow is this PR (which is stacked on top of #4006), and green is just the changes proposed here, but with the "latest foreign access tracking" machinery of #4006 removed. As can be seen, having both combined gives the greatest performance.