### PR TITLE
Renamed `this` to `ecx` in `extern_static`

### DIFF
--- a/src/shims/extern_static.rs
+++ b/src/shims/extern_static.rs
@@ -4,13 +4,13 @@ use crate::*;
 
 impl<'tcx> MiriMachine<'tcx> {
     fn alloc_extern_static(
-        this: &mut MiriInterpCx<'tcx>,
+        ecx: &mut MiriInterpCx<'tcx>,
         name: &str,
         val: ImmTy<'tcx>,
     ) -> InterpResult<'tcx> {
-        let place = this.allocate(val.layout, MiriMemoryKind::ExternStatic.into())?;
-        this.write_immediate(*val, &place)?;
-        Self::add_extern_static(this, name, place.ptr());
+        let place = ecx.allocate(val.layout, MiriMemoryKind::ExternStatic.into())?;
+        ecx.write_immediate(*val, &place)?;
+        Self::add_extern_static(ecx, name, place.ptr());
         interp_ok(())
     }
 
@@ -18,72 +18,69 @@ impl<'tcx> MiriMachine<'tcx> {
     /// Most of them are for weak symbols, which we all set to null (indicating that the
     /// symbol is not supported, and triggering fallback code which ends up calling
     /// some other shim that we do support).
-    fn null_ptr_extern_statics(
-        this: &mut MiriInterpCx<'tcx>,
-        names: &[&str],
-    ) -> InterpResult<'tcx> {
+    fn null_ptr_extern_statics(ecx: &mut MiriInterpCx<'tcx>, names: &[&str]) -> InterpResult<'tcx> {
         for name in names {
-            let val = ImmTy::from_int(0, this.machine.layouts.usize);
-            Self::alloc_extern_static(this, name, val)?;
+            let val = ImmTy::from_int(0, ecx.machine.layouts.usize);
+            Self::alloc_extern_static(ecx, name, val)?;
         }
         interp_ok(())
     }
 
     /// Extern statics that are initialized with function pointers to the symbols of the same name.
     fn weak_symbol_extern_statics(
-        this: &mut MiriInterpCx<'tcx>,
+        ecx: &mut MiriInterpCx<'tcx>,
         names: &[&str],
     ) -> InterpResult<'tcx> {
         for name in names {
-            assert!(this.is_dyn_sym(name), "{name} is not a dynamic symbol");
-            let layout = this.machine.layouts.const_raw_ptr;
-            let ptr = this.fn_ptr(FnVal::Other(DynSym::from_str(name)));
-            let val = ImmTy::from_scalar(Scalar::from_pointer(ptr, this), layout);
-            Self::alloc_extern_static(this, name, val)?;
+            assert!(ecx.is_dyn_sym(name), "{name} is not a dynamic symbol");
+            let layout = ecx.machine.layouts.const_raw_ptr;
+            let ptr = ecx.fn_ptr(FnVal::Other(DynSym::from_str(name)));
+            let val = ImmTy::from_scalar(Scalar::from_pointer(ptr, ecx), layout);
+            Self::alloc_extern_static(ecx, name, val)?;
         }
         interp_ok(())
     }
 
     /// Sets up the "extern statics" for this machine.
-    pub fn init_extern_statics(this: &mut MiriInterpCx<'tcx>) -> InterpResult<'tcx> {
+    pub fn init_extern_statics(ecx: &mut MiriInterpCx<'tcx>) -> InterpResult<'tcx> {
         // "__rust_no_alloc_shim_is_unstable"
-        let val = ImmTy::from_int(0, this.machine.layouts.u8); // always 0, value does not matter
-        Self::alloc_extern_static(this, "__rust_no_alloc_shim_is_unstable", val)?;
+        let val = ImmTy::from_int(0, ecx.machine.layouts.u8); // always 0, value does not matter
+        Self::alloc_extern_static(ecx, "__rust_no_alloc_shim_is_unstable", val)?;
 
         // "__rust_alloc_error_handler_should_panic"
-        let val = this.tcx.sess.opts.unstable_opts.oom.should_panic();
-        let val = ImmTy::from_int(val, this.machine.layouts.u8);
-        Self::alloc_extern_static(this, "__rust_alloc_error_handler_should_panic", val)?;
+        let val = ecx.tcx.sess.opts.unstable_opts.oom.should_panic();
+        let val = ImmTy::from_int(val, ecx.machine.layouts.u8);
+        Self::alloc_extern_static(ecx, "__rust_alloc_error_handler_should_panic", val)?;
 
-        if this.target_os_is_unix() {
+        if ecx.target_os_is_unix() {
             // "environ" is mandated by POSIX.
-            let environ = this.machine.env_vars.unix().environ();
-            Self::add_extern_static(this, "environ", environ);
+            let environ = ecx.machine.env_vars.unix().environ();
+            Self::add_extern_static(ecx, "environ", environ);
         }
 
-        match this.tcx.sess.target.os.as_ref() {
+        match ecx.tcx.sess.target.os.as_ref() {
             "linux" => {
-                Self::null_ptr_extern_statics(this, &[
+                Self::null_ptr_extern_statics(ecx, &[
                     "__cxa_thread_atexit_impl",
                     "__clock_gettime64",
                 ])?;
-                Self::weak_symbol_extern_statics(this, &["getrandom", "statx"])?;
+                Self::weak_symbol_extern_statics(ecx, &["getrandom", "statx"])?;
             }
             "freebsd" => {
-                Self::null_ptr_extern_statics(this, &["__cxa_thread_atexit_impl"])?;
+                Self::null_ptr_extern_statics(ecx, &["__cxa_thread_atexit_impl"])?;
             }
             "android" => {
-                Self::null_ptr_extern_statics(this, &["bsd_signal"])?;
-                Self::weak_symbol_extern_statics(this, &["signal", "getrandom"])?;
+                Self::null_ptr_extern_statics(ecx, &["bsd_signal"])?;
+                Self::weak_symbol_extern_statics(ecx, &["signal", "getrandom"])?;
             }
             "windows" => {
                 // "_tls_used"
                 // This is some obscure hack that is part of the Windows TLS story. It's a `u8`.
-                let val = ImmTy::from_int(0, this.machine.layouts.u8);
-                Self::alloc_extern_static(this, "_tls_used", val)?;
+                let val = ImmTy::from_int(0, ecx.machine.layouts.u8);
+                Self::alloc_extern_static(ecx, "_tls_used", val)?;
             }
             "illumos" | "solaris" => {
-                Self::weak_symbol_extern_statics(this, &["pthread_setname_np"])?;
+                Self::weak_symbol_extern_statics(ecx, &["pthread_setname_np"])?;
             }
             _ => {} // No "extern statics" supported on this target
         }


### PR DESCRIPTION
A small addition to #4029. There's no conflict with `self` and it's not an extension, so should be `ecx` too, I guess.