### PR TITLE
refactor: refine thread variant for windows

### DIFF
--- a/src/concurrency/thread.rs
+++ b/src/concurrency/thread.rs
@@ -113,6 +113,11 @@ impl ThreadId {
         self.0
     }
 
+    /// Create a new thread id from a `u32` without checking if this thread exists.
+    pub fn new_unchecked(id: u32) -> Self {
+        Self(id)
+    }
+
     pub const MAIN_THREAD: ThreadId = ThreadId(0);
 }
 


### PR DESCRIPTION
close #4014, check thread id before making it into `handle` on Windows.