### PR TITLE
use -Zroot-dir instead of --remap-path-prefix for diagnostic dir handling

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,9 +1,0 @@
-[unstable]
-profile-rustflags = true
-
-# Add back the containing directory of the packages we have to refer to using --manifest-path.
-# Per-package profiles avoid adding this to build dependencies.
-[profile.dev.package."cargo-miri"]
-rustflags = ["--remap-path-prefix", "=cargo-miri"]
-[profile.dev.package."miri-script"]
-rustflags = ["--remap-path-prefix", "=miri-script"]

--- a/miri
+++ b/miri
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 set -e
 # We want to call the binary directly, so we need to know where it ends up.
-MIRI_SCRIPT_TARGET_DIR="$(dirname "$0")"/miri-script/target
+ROOT_DIR="$(dirname "$0")"
+MIRI_SCRIPT_TARGET_DIR="$ROOT_DIR"/miri-script/target
 # If stdout is not a terminal and we are not on CI, assume that we are being invoked by RA, and use JSON output.
 if ! [ -t 1 ] && [ -z "$CI" ]; then
   MESSAGE_FORMAT="--message-format=json"
 fi
-# We need a nightly toolchain, for the `profile-rustflags` cargo feature.
-cargo +nightly build $CARGO_EXTRA_FLAGS --manifest-path "$(dirname "$0")"/miri-script/Cargo.toml \
+# We need a nightly toolchain, for `-Zroot-dir`.
+cargo +nightly build $CARGO_EXTRA_FLAGS --manifest-path "$ROOT_DIR"/miri-script/Cargo.toml \
+  -Zroot-dir="$ROOT_DIR" \
   -q --target-dir "$MIRI_SCRIPT_TARGET_DIR" $MESSAGE_FORMAT || \
   ( echo "Failed to build miri-script. Is the 'nightly' toolchain installed?"; exit 1 )
 # Instead of doing just `cargo run --manifest-path .. $@`, we invoke miri-script binary directly. Invoking `cargo run` goes through

--- a/miri-script/src/util.rs
+++ b/miri-script/src/util.rs
@@ -105,7 +105,7 @@ impl MiriEnv {
 
         // Get extra flags for cargo.
         let cargo_extra_flags = std::env::var("CARGO_EXTRA_FLAGS").unwrap_or_default();
-        let cargo_extra_flags = flagsplit(&cargo_extra_flags);
+        let mut cargo_extra_flags = flagsplit(&cargo_extra_flags);
         if cargo_extra_flags.iter().any(|a| a == "--release" || a.starts_with("--profile")) {
             // This makes binaries end up in different paths, let's not do that.
             eprintln!(
@@ -113,6 +113,8 @@ impl MiriEnv {
             );
             std::process::exit(1);
         }
+        // Also set `-Zroot-dir` for cargo, to print diagnostics relative to the miri dir.
+        cargo_extra_flags.push(format!("-Zroot-dir={}", miri_dir.display()));
 
         Ok(MiriEnv { miri_dir, toolchain, sh, sysroot, cargo_extra_flags, libdir })
     }


### PR DESCRIPTION
A while ago we started setting `--remap-path-prefix` so that `./miri check` would show all error messages relative to the Miri dir, rather than relative to the folder of the respective crate. Now cargo has `-Zroot-dir` which is more directly targeting this usecase, and which will hopefully [soon](https://github.com/rust-lang/rust/pull/132390) be used by rustc for the same purpose. So let's use it in Miri as well. I checked locally that this works for both miri-script and cargo-miri.