### PR TITLE
Enable `[bot-pull-requests]` triagebot feature

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -29,3 +29,6 @@ review_labels = ["S-waiting-on-review"]
 remove_labels = ["S-waiting-on-author"]
 # Those labels are added when PR author requests a review from an assignee
 add_labels = ["S-waiting-on-review"]
+
+# Automatically close and reopen PRs made by bots to run CI on them
+[bot-pull-requests]


### PR DESCRIPTION
Enables a triagebot feature to automatically close and reopen bot PRs to enable CI on them. The feature was implemented in https://github.com/rust-lang/triagebot/pull/1866.

More context: https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/No.20PR.20CI.20for.20bot.20PRs.20.28in.20Miri.20repo.29.3F