### PR TITLE
Allow backtraces to cross thread boundaries

### DIFF
--- a/tests/fail-dep/concurrency/libc_pthread_create_too_few_args.stderr
+++ b/tests/fail-dep/concurrency/libc_pthread_create_too_few_args.stderr
@@ -5,6 +5,8 @@ error: Undefined Behavior: calling a function with more arguments than it expect
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE on thread `unnamed-ID`:
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `main` at tests/fail-dep/concurrency/libc_pthread_create_too_few_args.rs:LL:CC
 
 error: aborting due to 1 previous error
 

--- a/tests/fail-dep/concurrency/libc_pthread_create_too_many_args.stderr
+++ b/tests/fail-dep/concurrency/libc_pthread_create_too_many_args.stderr
@@ -5,6 +5,8 @@ error: Undefined Behavior: calling a function with fewer arguments than it requi
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE on thread `unnamed-ID`:
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `main` at tests/fail-dep/concurrency/libc_pthread_create_too_many_args.rs:LL:CC
 
 error: aborting due to 1 previous error
 

--- a/tests/fail-dep/concurrency/libc_pthread_join_main.stderr
+++ b/tests/fail-dep/concurrency/libc_pthread_join_main.stderr
@@ -8,6 +8,22 @@ LL |             assert_eq!(libc::pthread_join(thread_id, ptr::null_mut()), 0);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE on thread `unnamed-ID`:
    = note: inside closure at tests/fail-dep/concurrency/libc_pthread_join_main.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail-dep/concurrency/libc_pthread_join_main.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail-dep/concurrency/libc_pthread_join_main.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail-dep/concurrency/libc_pthread_join_main.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail-dep/concurrency/libc_pthread_join_main.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail-dep/concurrency/libc_pthread_join_main.rs:LL:CC
+   |
+LL |       let handle = thread::spawn(move || {
+   |  __________________^
+LL | |         unsafe {
+LL | |             assert_eq!(libc::pthread_join(thread_id, ptr::null_mut()), 0);
+LL | |         }
+LL | |     });
+   | |______^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail-dep/concurrency/libc_pthread_join_multiple.stderr
+++ b/tests/fail-dep/concurrency/libc_pthread_join_multiple.stderr
@@ -8,6 +8,20 @@ LL | ...   assert_eq!(libc::pthread_join(native_copy, ptr::null_mut()), 0);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE on thread `unnamed-ID`:
    = note: inside closure at tests/fail-dep/concurrency/libc_pthread_join_multiple.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail-dep/concurrency/libc_pthread_join_multiple.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail-dep/concurrency/libc_pthread_join_multiple.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail-dep/concurrency/libc_pthread_join_multiple.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail-dep/concurrency/libc_pthread_join_multiple.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail-dep/concurrency/libc_pthread_join_multiple.rs:LL:CC
+   |
+LL |   ...   let handle = thread::spawn(move || {
+   |  ____________________^
+LL | | ...       assert_eq!(libc::pthread_join(native_copy, ptr::null_mut()), 0);
+LL | | ...   });
+   | |________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail-dep/concurrency/libc_pthread_join_self.stderr
+++ b/tests/fail-dep/concurrency/libc_pthread_join_self.stderr
@@ -8,6 +8,23 @@ LL |             assert_eq!(libc::pthread_join(native, ptr::null_mut()), 0);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE on thread `unnamed-ID`:
    = note: inside closure at tests/fail-dep/concurrency/libc_pthread_join_self.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail-dep/concurrency/libc_pthread_join_self.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail-dep/concurrency/libc_pthread_join_self.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail-dep/concurrency/libc_pthread_join_self.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail-dep/concurrency/libc_pthread_join_self.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail-dep/concurrency/libc_pthread_join_self.rs:LL:CC
+   |
+LL |       let handle = thread::spawn(|| {
+   |  __________________^
+LL | |         unsafe {
+LL | |             let native: libc::pthread_t = libc::pthread_self();
+LL | |             assert_eq!(libc::pthread_join(native, ptr::null_mut()), 0);
+LL | |         }
+LL | |     });
+   | |______^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail-dep/concurrency/libc_pthread_mutex_deadlock.stderr
+++ b/tests/fail-dep/concurrency/libc_pthread_mutex_deadlock.stderr
@@ -6,6 +6,19 @@ LL |             assert_eq!(libc::pthread_mutex_lock(lock_copy.0.get() as *mut _
    |
    = note: BACKTRACE on thread `unnamed-ID`:
    = note: inside closure at tests/fail-dep/concurrency/libc_pthread_mutex_deadlock.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail-dep/concurrency/libc_pthread_mutex_deadlock.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail-dep/concurrency/libc_pthread_mutex_deadlock.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail-dep/concurrency/libc_pthread_mutex_deadlock.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail-dep/concurrency/libc_pthread_mutex_deadlock.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail-dep/concurrency/libc_pthread_mutex_deadlock.rs:LL:CC
+   |
+LL | /         thread::spawn(move || {
+LL | |             assert_eq!(libc::pthread_mutex_lock(lock_copy.0.get() as *mut _), 0);
+LL | |         })
+   | |__________^
 
 error: deadlock: the evaluated program deadlocked
   --> RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC

--- a/tests/fail-dep/concurrency/libc_pthread_mutex_wrong_owner.stderr
+++ b/tests/fail-dep/concurrency/libc_pthread_mutex_wrong_owner.stderr
@@ -8,6 +8,19 @@ LL | ...t_eq!(libc::pthread_mutex_unlock(lock_copy.0.get() as *mut _), 0);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE on thread `unnamed-ID`:
    = note: inside closure at tests/fail-dep/concurrency/libc_pthread_mutex_wrong_owner.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail-dep/concurrency/libc_pthread_mutex_wrong_owner.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail-dep/concurrency/libc_pthread_mutex_wrong_owner.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail-dep/concurrency/libc_pthread_mutex_wrong_owner.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail-dep/concurrency/libc_pthread_mutex_wrong_owner.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail-dep/concurrency/libc_pthread_mutex_wrong_owner.rs:LL:CC
+   |
+LL | / ...   thread::spawn(move || {
+LL | | ...       assert_eq!(libc::pthread_mutex_unlock(lock_copy.0.get() as *mut _), 0);
+LL | | ...   })
+   | |________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail-dep/concurrency/libc_pthread_rwlock_read_wrong_owner.stderr
+++ b/tests/fail-dep/concurrency/libc_pthread_rwlock_read_wrong_owner.stderr
@@ -8,6 +8,19 @@ LL | ...   assert_eq!(libc::pthread_rwlock_unlock(lock_copy.0.get() as *mut _), 
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE on thread `unnamed-ID`:
    = note: inside closure at tests/fail-dep/concurrency/libc_pthread_rwlock_read_wrong_owner.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail-dep/concurrency/libc_pthread_rwlock_read_wrong_owner.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail-dep/concurrency/libc_pthread_rwlock_read_wrong_owner.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail-dep/concurrency/libc_pthread_rwlock_read_wrong_owner.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail-dep/concurrency/libc_pthread_rwlock_read_wrong_owner.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail-dep/concurrency/libc_pthread_rwlock_read_wrong_owner.rs:LL:CC
+   |
+LL | / ...   thread::spawn(move || {
+LL | | ...       assert_eq!(libc::pthread_rwlock_unlock(lock_copy.0.get() as *mut _), 0);
+LL | | ...   })
+   | |________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail-dep/concurrency/libc_pthread_rwlock_write_read_deadlock.stderr
+++ b/tests/fail-dep/concurrency/libc_pthread_rwlock_write_read_deadlock.stderr
@@ -6,6 +6,19 @@ LL |             assert_eq!(libc::pthread_rwlock_wrlock(lock_copy.0.get() as *mu
    |
    = note: BACKTRACE on thread `unnamed-ID`:
    = note: inside closure at tests/fail-dep/concurrency/libc_pthread_rwlock_write_read_deadlock.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail-dep/concurrency/libc_pthread_rwlock_write_read_deadlock.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail-dep/concurrency/libc_pthread_rwlock_write_read_deadlock.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail-dep/concurrency/libc_pthread_rwlock_write_read_deadlock.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail-dep/concurrency/libc_pthread_rwlock_write_read_deadlock.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail-dep/concurrency/libc_pthread_rwlock_write_read_deadlock.rs:LL:CC
+   |
+LL | /         thread::spawn(move || {
+LL | |             assert_eq!(libc::pthread_rwlock_wrlock(lock_copy.0.get() as *mut _), 0);
+LL | |         })
+   | |__________^
 
 error: deadlock: the evaluated program deadlocked
   --> RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC

--- a/tests/fail-dep/concurrency/libc_pthread_rwlock_write_write_deadlock.stderr
+++ b/tests/fail-dep/concurrency/libc_pthread_rwlock_write_write_deadlock.stderr
@@ -6,6 +6,19 @@ LL |             assert_eq!(libc::pthread_rwlock_wrlock(lock_copy.0.get() as *mu
    |
    = note: BACKTRACE on thread `unnamed-ID`:
    = note: inside closure at tests/fail-dep/concurrency/libc_pthread_rwlock_write_write_deadlock.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail-dep/concurrency/libc_pthread_rwlock_write_write_deadlock.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail-dep/concurrency/libc_pthread_rwlock_write_write_deadlock.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail-dep/concurrency/libc_pthread_rwlock_write_write_deadlock.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail-dep/concurrency/libc_pthread_rwlock_write_write_deadlock.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail-dep/concurrency/libc_pthread_rwlock_write_write_deadlock.rs:LL:CC
+   |
+LL | /         thread::spawn(move || {
+LL | |             assert_eq!(libc::pthread_rwlock_wrlock(lock_copy.0.get() as *mut _), 0);
+LL | |         })
+   | |__________^
 
 error: deadlock: the evaluated program deadlocked
   --> RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC

--- a/tests/fail-dep/concurrency/libc_pthread_rwlock_write_wrong_owner.stderr
+++ b/tests/fail-dep/concurrency/libc_pthread_rwlock_write_wrong_owner.stderr
@@ -8,6 +8,19 @@ LL | ...   assert_eq!(libc::pthread_rwlock_unlock(lock_copy.0.get() as *mut _), 
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE on thread `unnamed-ID`:
    = note: inside closure at tests/fail-dep/concurrency/libc_pthread_rwlock_write_wrong_owner.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail-dep/concurrency/libc_pthread_rwlock_write_wrong_owner.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail-dep/concurrency/libc_pthread_rwlock_write_wrong_owner.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail-dep/concurrency/libc_pthread_rwlock_write_wrong_owner.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail-dep/concurrency/libc_pthread_rwlock_write_wrong_owner.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail-dep/concurrency/libc_pthread_rwlock_write_wrong_owner.rs:LL:CC
+   |
+LL | / ...   thread::spawn(move || {
+LL | | ...       assert_eq!(libc::pthread_rwlock_unlock(lock_copy.0.get() as *mut _), 0);
+LL | | ...   })
+   | |________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail-dep/libc/env-set_var-data-race.stderr
+++ b/tests/fail-dep/libc/env-set_var-data-race.stderr
@@ -13,6 +13,22 @@ LL |     env::set_var("MY_RUST_VAR", "Ferris");
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail-dep/libc/env-set_var-data-race.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail-dep/libc/env-set_var-data-race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail-dep/libc/env-set_var-data-race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail-dep/libc/env-set_var-data-race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail-dep/libc/env-set_var-data-race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail-dep/libc/env-set_var-data-race.rs:LL:CC
+   |
+LL |       let t = thread::spawn(|| unsafe {
+   |  _____________^
+LL | |         // Access the environment in another thread without taking the env lock.
+LL | |         // This represents some C code that queries the environment.
+LL | |         libc::getenv(b"TZ/0".as_ptr().cast());
+LL | |     });
+   | |______^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail-dep/libc/eventfd_block_read_twice.stderr
+++ b/tests/fail-dep/libc/eventfd_block_read_twice.stderr
@@ -19,6 +19,24 @@ error: deadlock: the evaluated program deadlocked
    = note: the evaluated program deadlocked
    = note: (no span available)
    = note: BACKTRACE on thread `unnamed-ID`:
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail-dep/libc/eventfd_block_read_twice.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail-dep/libc/eventfd_block_read_twice.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail-dep/libc/eventfd_block_read_twice.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail-dep/libc/eventfd_block_read_twice.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail-dep/libc/eventfd_block_read_twice.rs:LL:CC
+   |
+LL |       let thread1 = thread::spawn(move || {
+   |  ___________________^
+LL | |         let mut buf: [u8; 8] = [0; 8];
+LL | |         // This read will block initially.
+LL | |         let res: i64 = unsafe { libc::read(fd, buf.as_mut_ptr().cast(), 8).try_into().unwrap() };
+...  |
+LL | |         assert_eq!(counter, 1_u64);
+LL | |     });
+   | |______^
 
 error: deadlock: the evaluated program deadlocked
   --> tests/fail-dep/libc/eventfd_block_read_twice.rs:LL:CC
@@ -28,12 +46,48 @@ LL |         let res: i64 = unsafe { libc::read(fd, buf.as_mut_ptr().cast(), 8).
    |
    = note: BACKTRACE on thread `unnamed-ID`:
    = note: inside closure at tests/fail-dep/libc/eventfd_block_read_twice.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail-dep/libc/eventfd_block_read_twice.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail-dep/libc/eventfd_block_read_twice.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail-dep/libc/eventfd_block_read_twice.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail-dep/libc/eventfd_block_read_twice.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail-dep/libc/eventfd_block_read_twice.rs:LL:CC
+   |
+LL |       let thread2 = thread::spawn(move || {
+   |  ___________________^
+LL | |         let mut buf: [u8; 8] = [0; 8];
+LL | |         // This read will block initially, then get unblocked by thread3, then get blocked again
+LL | |         // because the `read` in thread1 executes first and set the counter to 0 again.
+...  |
+LL | |         assert_eq!(counter, 1_u64);
+LL | |     });
+   | |______^
 
 error: deadlock: the evaluated program deadlocked
    |
    = note: the evaluated program deadlocked
    = note: (no span available)
    = note: BACKTRACE on thread `unnamed-ID`:
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail-dep/libc/eventfd_block_read_twice.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail-dep/libc/eventfd_block_read_twice.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail-dep/libc/eventfd_block_read_twice.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail-dep/libc/eventfd_block_read_twice.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail-dep/libc/eventfd_block_read_twice.rs:LL:CC
+   |
+LL |       let thread3 = thread::spawn(move || {
+   |  ___________________^
+LL | |         let sized_8_data = 1_u64.to_ne_bytes();
+LL | |         // Write 1 to the counter, so both thread1 and thread2 will unblock.
+LL | |         let res: i64 = unsafe {
+...  |
+LL | |         assert_eq!(res, 8);
+LL | |     });
+   | |______^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail-dep/libc/eventfd_block_write_twice.stderr
+++ b/tests/fail-dep/libc/eventfd_block_write_twice.stderr
@@ -19,6 +19,24 @@ error: deadlock: the evaluated program deadlocked
    = note: the evaluated program deadlocked
    = note: (no span available)
    = note: BACKTRACE on thread `unnamed-ID`:
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail-dep/libc/eventfd_block_write_twice.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail-dep/libc/eventfd_block_write_twice.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail-dep/libc/eventfd_block_write_twice.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail-dep/libc/eventfd_block_write_twice.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail-dep/libc/eventfd_block_write_twice.rs:LL:CC
+   |
+LL |       let thread1 = thread::spawn(move || {
+   |  ___________________^
+LL | |         let sized_8_data = (u64::MAX - 1).to_ne_bytes();
+LL | |         let res: i64 = unsafe {
+LL | |             libc::write(fd, sized_8_data.as_ptr() as *const libc::c_void, 8).try_into().unwrap()
+...  |
+LL | |         assert_eq!(res, 8);
+LL | |     });
+   | |______^
 
 error: deadlock: the evaluated program deadlocked
   --> tests/fail-dep/libc/eventfd_block_write_twice.rs:LL:CC
@@ -28,12 +46,48 @@ LL |             libc::write(fd, sized_8_data.as_ptr() as *const libc::c_void, 8
    |
    = note: BACKTRACE on thread `unnamed-ID`:
    = note: inside closure at tests/fail-dep/libc/eventfd_block_write_twice.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail-dep/libc/eventfd_block_write_twice.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail-dep/libc/eventfd_block_write_twice.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail-dep/libc/eventfd_block_write_twice.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail-dep/libc/eventfd_block_write_twice.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail-dep/libc/eventfd_block_write_twice.rs:LL:CC
+   |
+LL |       let thread2 = thread::spawn(move || {
+   |  ___________________^
+LL | |         let sized_8_data = (u64::MAX - 1).to_ne_bytes();
+LL | |         // Write u64::MAX - 1, so the all subsequent write will block.
+LL | |         let res: i64 = unsafe {
+...  |
+LL | |         assert_eq!(res, 8);
+LL | |     });
+   | |______^
 
 error: deadlock: the evaluated program deadlocked
    |
    = note: the evaluated program deadlocked
    = note: (no span available)
    = note: BACKTRACE on thread `unnamed-ID`:
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail-dep/libc/eventfd_block_write_twice.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail-dep/libc/eventfd_block_write_twice.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail-dep/libc/eventfd_block_write_twice.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail-dep/libc/eventfd_block_write_twice.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail-dep/libc/eventfd_block_write_twice.rs:LL:CC
+   |
+LL |       let thread3 = thread::spawn(move || {
+   |  ___________________^
+LL | |         let mut buf: [u8; 8] = [0; 8];
+LL | |         // This will unblock both `write` in thread1 and thread2.
+LL | |         let res: i64 = unsafe { libc::read(fd, buf.as_mut_ptr().cast(), 8).try_into().unwrap() };
+...  |
+LL | |         assert_eq!(counter, (u64::MAX - 1));
+LL | |     });
+   | |______^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail-dep/libc/libc_epoll_block_two_thread.stderr
+++ b/tests/fail-dep/libc/libc_epoll_block_two_thread.stderr
@@ -3,6 +3,20 @@ error: deadlock: the evaluated program deadlocked
    = note: the evaluated program deadlocked
    = note: (no span available)
    = note: BACKTRACE on thread `unnamed-ID`:
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail-dep/libc/libc_epoll_block_two_thread.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail-dep/libc/libc_epoll_block_two_thread.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail-dep/libc/libc_epoll_block_two_thread.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail-dep/libc/libc_epoll_block_two_thread.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail-dep/libc/libc_epoll_block_two_thread.rs:LL:CC
+   |
+LL |       let thread2 = spawn(move || {
+   |  ___________________^
+LL | |         check_epoll_wait::<TAG>(epfd, &[(expected_event, expected_value)], -1);
+LL | |     });
+   | |______^
 
 error: deadlock: the evaluated program deadlocked
   --> RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
@@ -28,12 +42,43 @@ LL |         check_epoll_wait::<TAG>(epfd, &[(expected_event, expected_value)], 
    |
    = note: BACKTRACE on thread `unnamed-ID`:
    = note: inside closure at tests/fail-dep/libc/libc_epoll_block_two_thread.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail-dep/libc/libc_epoll_block_two_thread.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail-dep/libc/libc_epoll_block_two_thread.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail-dep/libc/libc_epoll_block_two_thread.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail-dep/libc/libc_epoll_block_two_thread.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail-dep/libc/libc_epoll_block_two_thread.rs:LL:CC
+   |
+LL |       let thread1 = spawn(move || {
+   |  ___________________^
+LL | |         check_epoll_wait::<TAG>(epfd, &[(expected_event, expected_value)], -1);
+LL | |
+LL | |     });
+   | |______^
 
 error: deadlock: the evaluated program deadlocked
    |
    = note: the evaluated program deadlocked
    = note: (no span available)
    = note: BACKTRACE on thread `unnamed-ID`:
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail-dep/libc/libc_epoll_block_two_thread.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail-dep/libc/libc_epoll_block_two_thread.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail-dep/libc/libc_epoll_block_two_thread.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail-dep/libc/libc_epoll_block_two_thread.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail-dep/libc/libc_epoll_block_two_thread.rs:LL:CC
+   |
+LL |       let thread3 = spawn(move || {
+   |  ___________________^
+LL | |         let data = "abcde".as_bytes().as_ptr();
+LL | |         let res = unsafe { libc::write(fds[1], data as *const libc::c_void, 5) };
+LL | |         assert_eq!(res, 5);
+LL | |     });
+   | |______^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/retag_data_race_write.stack.stderr
+++ b/tests/fail/both_borrows/retag_data_race_write.stack.stderr
@@ -21,6 +21,17 @@ note: inside closure
    |
 LL |     let t2 = std::thread::spawn(move || thread_2(p));
    |                                         ^^^^^^^^^^^
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/both_borrows/retag_data_race_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/both_borrows/retag_data_race_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/both_borrows/retag_data_race_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/both_borrows/retag_data_race_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/both_borrows/retag_data_race_write.rs:LL:CC
+   |
+LL |     let t2 = std::thread::spawn(move || thread_2(p));
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/both_borrows/retag_data_race_write.tree.stderr
+++ b/tests/fail/both_borrows/retag_data_race_write.tree.stderr
@@ -21,6 +21,17 @@ note: inside closure
    |
 LL |     let t2 = std::thread::spawn(move || thread_2(p));
    |                                         ^^^^^^^^^^^
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/both_borrows/retag_data_race_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/both_borrows/retag_data_race_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/both_borrows/retag_data_race_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/both_borrows/retag_data_race_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/both_borrows/retag_data_race_write.rs:LL:CC
+   |
+LL |     let t2 = std::thread::spawn(move || thread_2(p));
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/alloc_read_race.stderr
+++ b/tests/fail/data_race/alloc_read_race.stderr
@@ -13,6 +13,23 @@ LL |             pointer.store(Box::into_raw(Box::new_uninit()), Ordering::Relax
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/alloc_read_race.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/alloc_read_race.rs:LL:CC}, std::mem::MaybeUninit<usize>>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/data_race/alloc_read_race.rs:LL:CC}, std::mem::MaybeUninit<usize>>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/data_race/alloc_read_race.rs:LL:CC}, std::mem::MaybeUninit<usize>>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/data_race/alloc_read_race.rs:LL:CC}, std::mem::MaybeUninit<usize>>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/alloc_read_race.rs:LL:CC
+   |
+LL |   ...   let j2 = spawn(move || {
+   |  ________________^
+LL | | ...       let ptr = ptr; // avoid field capturing
+LL | | ...       let pointer = &*ptr.0;
+...  |
+LL | | ...       *pointer.load(Ordering::Relaxed)
+LL | | ...   });
+   | |________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/alloc_write_race.stderr
+++ b/tests/fail/data_race/alloc_write_race.stderr
@@ -13,6 +13,22 @@ LL |                 .store(Box::into_raw(Box::<usize>::new_uninit()) as *mut us
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/alloc_write_race.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/alloc_write_race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/data_race/alloc_write_race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/data_race/alloc_write_race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/data_race/alloc_write_race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/alloc_write_race.rs:LL:CC
+   |
+LL |   ...   let j2 = spawn(move || {
+   |  ________________^
+LL | | ...       let ptr = ptr; // avoid field capturing
+LL | | ...       let pointer = &*ptr.0;
+LL | | ...       *pointer.load(Ordering::Relaxed) = 2;
+LL | | ...   });
+   | |________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/atomic_read_na_write_race1.stderr
+++ b/tests/fail/data_race/atomic_read_na_write_race1.stderr
@@ -13,6 +13,21 @@ LL |             *(c.0 as *mut usize) = 32;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/atomic_read_na_write_race1.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/atomic_read_na_write_race1.rs:LL:CC}, usize>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/data_race/atomic_read_na_write_race1.rs:LL:CC}, usize>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/data_race/atomic_read_na_write_race1.rs:LL:CC}, usize>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/data_race/atomic_read_na_write_race1.rs:LL:CC}, usize>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/atomic_read_na_write_race1.rs:LL:CC
+   |
+LL |   ...   let j2 = spawn(move || {
+   |  ________________^
+LL | | ...       let c = c; // avoid field capturing
+LL | | ...       (&*c.0).load(Ordering::SeqCst)
+LL | | ...   });
+   | |________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/atomic_read_na_write_race2.stderr
+++ b/tests/fail/data_race/atomic_read_na_write_race2.stderr
@@ -13,6 +13,22 @@ LL |             atomic_ref.load(Ordering::SeqCst)
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/atomic_read_na_write_race2.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/atomic_read_na_write_race2.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/data_race/atomic_read_na_write_race2.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/data_race/atomic_read_na_write_race2.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/data_race/atomic_read_na_write_race2.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/atomic_read_na_write_race2.rs:LL:CC
+   |
+LL |   ...   let j2 = spawn(move || {
+   |  ________________^
+LL | | ...       let c = c; // avoid field capturing
+LL | | ...       let atomic_ref = &mut *c.0;
+LL | | ...       *atomic_ref.get_mut() = 32;
+LL | | ...   });
+   | |________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/atomic_write_na_read_race1.stderr
+++ b/tests/fail/data_race/atomic_write_na_read_race1.stderr
@@ -13,6 +13,22 @@ LL |             atomic_ref.store(32, Ordering::SeqCst)
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/atomic_write_na_read_race1.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/atomic_write_na_read_race1.rs:LL:CC}, usize>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/data_race/atomic_write_na_read_race1.rs:LL:CC}, usize>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/data_race/atomic_write_na_read_race1.rs:LL:CC}, usize>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/data_race/atomic_write_na_read_race1.rs:LL:CC}, usize>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/atomic_write_na_read_race1.rs:LL:CC
+   |
+LL |   ...   let j2 = spawn(move || {
+   |  ________________^
+LL | | ...       let c = c; // avoid field capturing
+LL | | ...       let atomic_ref = &mut *c.0;
+LL | | ...       *atomic_ref.get_mut()
+LL | | ...   });
+   | |________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/atomic_write_na_read_race2.stderr
+++ b/tests/fail/data_race/atomic_write_na_read_race2.stderr
@@ -13,6 +13,21 @@ LL |             let _val = *(c.0 as *mut usize);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/atomic_write_na_read_race2.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/atomic_write_na_read_race2.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/data_race/atomic_write_na_read_race2.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/data_race/atomic_write_na_read_race2.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/data_race/atomic_write_na_read_race2.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/atomic_write_na_read_race2.rs:LL:CC
+   |
+LL |   ...   let j2 = spawn(move || {
+   |  ________________^
+LL | | ...       let c = c; // avoid field capturing
+LL | | ...       (&*c.0).store(32, Ordering::SeqCst);
+LL | | ...   });
+   | |________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/atomic_write_na_write_race1.stderr
+++ b/tests/fail/data_race/atomic_write_na_write_race1.stderr
@@ -13,6 +13,21 @@ LL |             *(c.0 as *mut usize) = 32;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/atomic_write_na_write_race1.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/atomic_write_na_write_race1.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/data_race/atomic_write_na_write_race1.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/data_race/atomic_write_na_write_race1.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/data_race/atomic_write_na_write_race1.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/atomic_write_na_write_race1.rs:LL:CC
+   |
+LL |   ...   let j2 = spawn(move || {
+   |  ________________^
+LL | | ...       let c = c; // avoid field capturing
+LL | | ...       (&*c.0).store(64, Ordering::SeqCst);
+LL | | ...   });
+   | |________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/atomic_write_na_write_race2.stderr
+++ b/tests/fail/data_race/atomic_write_na_write_race2.stderr
@@ -13,6 +13,22 @@ LL |             atomic_ref.store(64, Ordering::SeqCst);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/atomic_write_na_write_race2.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/atomic_write_na_write_race2.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/data_race/atomic_write_na_write_race2.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/data_race/atomic_write_na_write_race2.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/data_race/atomic_write_na_write_race2.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/atomic_write_na_write_race2.rs:LL:CC
+   |
+LL |   ...   let j2 = spawn(move || {
+   |  ________________^
+LL | | ...       let c = c; // avoid field capturing
+LL | | ...       let atomic_ref = &mut *c.0;
+LL | | ...       *atomic_ref.get_mut() = 32;
+LL | | ...   });
+   | |________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/dangling_thread_async_race.stderr
+++ b/tests/fail/data_race/dangling_thread_async_race.stderr
@@ -13,6 +13,20 @@ LL |             *c.0 = 32;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/dangling_thread_async_race.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/dangling_thread_async_race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/data_race/dangling_thread_async_race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/data_race/dangling_thread_async_race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/data_race/dangling_thread_async_race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/dangling_thread_async_race.rs:LL:CC
+   |
+LL | / ...   spawn(move || {
+LL | | ...       let c = c; // capture `c`, not just its field.
+LL | | ...       *c.0 = 64;
+LL | | ...   })
+   | |________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/dealloc_read_race1.stderr
+++ b/tests/fail/data_race/dealloc_read_race1.stderr
@@ -18,6 +18,24 @@ LL |             let _val = *ptr.0;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/dealloc_read_race1.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/dealloc_read_race1.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/data_race/dealloc_read_race1.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/data_race/dealloc_read_race1.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/data_race/dealloc_read_race1.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/dealloc_read_race1.rs:LL:CC
+   |
+LL |           let j2 = spawn(move || {
+   |  __________________^
+LL | |             let ptr = ptr; // avoid field capturing
+LL | |             __rust_dealloc(
+LL | |
+...  |
+LL | |             );
+LL | |         });
+   | |__________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/dealloc_read_race2.stderr
+++ b/tests/fail/data_race/dealloc_read_race2.stderr
@@ -22,6 +22,23 @@ LL | |             )
    | |_____________^
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/dealloc_read_race2.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/dealloc_read_race2.rs:LL:CC}, usize>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/data_race/dealloc_read_race2.rs:LL:CC}, usize>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/data_race/dealloc_read_race2.rs:LL:CC}, usize>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/data_race/dealloc_read_race2.rs:LL:CC}, usize>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/dealloc_read_race2.rs:LL:CC
+   |
+LL |   ...   let j2 = spawn(move || {
+   |  ________________^
+LL | | ...       let ptr = ptr; // avoid field capturing
+LL | | ...       // Also an error of the form: Data race detected between (1) deallocation on thread `unnamed-ID` and (2) non-atomic read on thr...
+LL | | ...       // but the invalid allocation is detected first.
+LL | | ...       *ptr.0
+LL | | ...   });
+   | |________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/dealloc_read_race_stack.stderr
+++ b/tests/fail/data_race/dealloc_read_race_stack.stderr
@@ -13,6 +13,24 @@ LL |             *pointer.load(Ordering::Acquire)
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/dealloc_read_race_stack.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/dealloc_read_race_stack.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/data_race/dealloc_read_race_stack.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/data_race/dealloc_read_race_stack.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/data_race/dealloc_read_race_stack.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/dealloc_read_race_stack.rs:LL:CC
+   |
+LL |           let j1 = spawn(move || {
+   |  __________________^
+LL | |             let ptr = ptr; // avoid field capturing
+LL | |             let pointer = &*ptr.0;
+LL | |             {
+...  |
+LL | |             }
+LL | |         });
+   | |__________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/dealloc_write_race1.stderr
+++ b/tests/fail/data_race/dealloc_write_race1.stderr
@@ -18,6 +18,24 @@ LL |             *ptr.0 = 2;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/dealloc_write_race1.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/dealloc_write_race1.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/data_race/dealloc_write_race1.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/data_race/dealloc_write_race1.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/data_race/dealloc_write_race1.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/dealloc_write_race1.rs:LL:CC
+   |
+LL |           let j2 = spawn(move || {
+   |  __________________^
+LL | |             let ptr = ptr; // avoid field capturing
+LL | |             __rust_dealloc(
+LL | |
+...  |
+LL | |             );
+LL | |         });
+   | |__________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/dealloc_write_race2.stderr
+++ b/tests/fail/data_race/dealloc_write_race2.stderr
@@ -22,6 +22,23 @@ LL | |             );
    | |_____________^
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/dealloc_write_race2.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/dealloc_write_race2.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/data_race/dealloc_write_race2.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/data_race/dealloc_write_race2.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/data_race/dealloc_write_race2.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/dealloc_write_race2.rs:LL:CC
+   |
+LL |   ...   let j2 = spawn(move || {
+   |  ________________^
+LL | | ...       let ptr = ptr; // avoid field capturing
+LL | | ...       // Also an error of the form: Data race detected between (1) deallocation on thread `unnamed-ID` and (2) non-atomic write on th...
+LL | | ...       // but the invalid allocation is detected first.
+LL | | ...       *ptr.0 = 2;
+LL | | ...   });
+   | |________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/dealloc_write_race_stack.stderr
+++ b/tests/fail/data_race/dealloc_write_race_stack.stderr
@@ -13,6 +13,24 @@ LL |             *pointer.load(Ordering::Acquire) = 3;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/dealloc_write_race_stack.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/dealloc_write_race_stack.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/data_race/dealloc_write_race_stack.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/data_race/dealloc_write_race_stack.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/data_race/dealloc_write_race_stack.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/dealloc_write_race_stack.rs:LL:CC
+   |
+LL |           let j1 = spawn(move || {
+   |  __________________^
+LL | |             let ptr = ptr; // avoid field capturing
+LL | |             let pointer = &*ptr.0;
+LL | |             {
+...  |
+LL | |             }
+LL | |         });
+   | |__________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/enable_after_join_to_main.stderr
+++ b/tests/fail/data_race/enable_after_join_to_main.stderr
@@ -13,6 +13,21 @@ LL |             *c.0 = 32;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/enable_after_join_to_main.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/enable_after_join_to_main.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/data_race/enable_after_join_to_main.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/data_race/enable_after_join_to_main.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/data_race/enable_after_join_to_main.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/enable_after_join_to_main.rs:LL:CC
+   |
+LL |   ...   let j2 = spawn(move || {
+   |  ________________^
+LL | | ...       let c = c; // avoid field capturing
+LL | | ...       *c.0 = 64;
+LL | | ...   });
+   | |________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/local_variable_alloc_race.stderr
+++ b/tests/fail/data_race/local_variable_alloc_race.stderr
@@ -13,6 +13,28 @@ LL |             StorageLive(val);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/local_variable_alloc_race.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/local_variable_alloc_race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/data_race/local_variable_alloc_race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/data_race/local_variable_alloc_race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/data_race/local_variable_alloc_race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `spawn_thread`
+  --> tests/fail/data_race/local_variable_alloc_race.rs:LL:CC
+   |
+LL | /     std::thread::spawn(|| {
+LL | |         while P.load(Relaxed).is_null() {
+LL | |             std::hint::spin_loop();
+LL | |         }
+...  |
+LL | |         }
+LL | |     })
+   | |______^
+note: inside `main`
+  --> tests/fail/data_race/local_variable_alloc_race.rs:LL:CC
+   |
+LL |             Call(t = spawn_thread(), ReturnTo(after_spawn), UnwindContinue())
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/local_variable_read_race.stderr
+++ b/tests/fail/data_race/local_variable_read_race.stderr
@@ -13,6 +13,24 @@ LL |     let _val = val;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/local_variable_read_race.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/local_variable_read_race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/data_race/local_variable_read_race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/data_race/local_variable_read_race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/data_race/local_variable_read_race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/local_variable_read_race.rs:LL:CC
+   |
+LL |       let t1 = std::thread::spawn(|| {
+   |  ______________^
+LL | |         while P.load(Relaxed).is_null() {
+LL | |             std::hint::spin_loop();
+LL | |         }
+...  |
+LL | |         }
+LL | |     });
+   | |______^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/local_variable_write_race.stderr
+++ b/tests/fail/data_race/local_variable_write_race.stderr
@@ -13,6 +13,24 @@ LL |     let mut val: u8 = 0;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/local_variable_write_race.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/local_variable_write_race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/data_race/local_variable_write_race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/data_race/local_variable_write_race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/data_race/local_variable_write_race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/local_variable_write_race.rs:LL:CC
+   |
+LL |       let t1 = std::thread::spawn(|| {
+   |  ______________^
+LL | |         while P.load(Relaxed).is_null() {
+LL | |             std::hint::spin_loop();
+LL | |         }
+...  |
+LL | |         }
+LL | |     });
+   | |______^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/mixed_size_read_read_write.match_first_load.stderr
+++ b/tests/fail/data_race/mixed_size_read_read_write.match_first_load.stderr
@@ -15,6 +15,38 @@ LL |             a16.load(Ordering::SeqCst);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/mixed_size_read_read_write.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/mixed_size_read_read_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::scoped::<impl std::thread::Builder>::spawn_scoped::<'_, {closure@tests/fail/data_race/mixed_size_read_read_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/scoped.rs:LL:CC
+   = note: inside `std::thread::Scope::<'_, '_>::spawn::<{closure@tests/fail/data_race/mixed_size_read_read_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/scoped.rs:LL:CC
+note: inside closure
+  --> tests/fail/data_race/mixed_size_read_read_write.rs:LL:CC
+   |
+LL | /         s.spawn(|| {
+LL | |             thread::yield_now(); // make sure this happens last
+LL | |             if cfg!(match_first_load) {
+LL | |                 a16.store(0, Ordering::SeqCst);
+...  |
+LL | |             }
+LL | |         });
+   | |__________^
+   = note: inside closure at RUSTLIB/std/src/thread/scoped.rs:LL:CC
+   = note: inside `<std::panic::AssertUnwindSafe<{closure@std::thread::scope<'_, {closure@tests/fail/data_race/mixed_size_read_read_write.rs:LL:CC}, ()>::{closure#0}}> as std::ops::FnOnce<()>>::call_once` at RUSTLIB/core/src/panic/unwind_safe.rs:LL:CC
+   = note: inside `std::panicking::r#try::do_call::<std::panic::AssertUnwindSafe<{closure@std::thread::scope<'_, {closure@tests/fail/data_race/mixed_size_read_read_write.rs:LL:CC}, ()>::{closure#0}}>, ()>` at RUSTLIB/std/src/panicking.rs:LL:CC
+   = note: inside `std::panicking::r#try::<(), std::panic::AssertUnwindSafe<{closure@std::thread::scope<'_, {closure@tests/fail/data_race/mixed_size_read_read_write.rs:LL:CC}, ()>::{closure#0}}>>` at RUSTLIB/std/src/panicking.rs:LL:CC
+   = note: inside `std::panic::catch_unwind::<std::panic::AssertUnwindSafe<{closure@std::thread::scope<'_, {closure@tests/fail/data_race/mixed_size_read_read_write.rs:LL:CC}, ()>::{closure#0}}>, ()>` at RUSTLIB/std/src/panic.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/mixed_size_read_read_write.rs:LL:CC
+   |
+LL | /     thread::scope(|s| {
+LL | |         s.spawn(|| {
+LL | |             a16.load(Ordering::SeqCst);
+LL | |         });
+...  |
+LL | |         });
+LL | |     });
+   | |______^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/mixed_size_read_read_write.match_second_load.stderr
+++ b/tests/fail/data_race/mixed_size_read_read_write.match_second_load.stderr
@@ -15,6 +15,38 @@ LL |             a16.load(Ordering::SeqCst);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/mixed_size_read_read_write.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/mixed_size_read_read_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::scoped::<impl std::thread::Builder>::spawn_scoped::<'_, {closure@tests/fail/data_race/mixed_size_read_read_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/scoped.rs:LL:CC
+   = note: inside `std::thread::Scope::<'_, '_>::spawn::<{closure@tests/fail/data_race/mixed_size_read_read_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/scoped.rs:LL:CC
+note: inside closure
+  --> tests/fail/data_race/mixed_size_read_read_write.rs:LL:CC
+   |
+LL | /         s.spawn(|| {
+LL | |             thread::yield_now(); // make sure this happens last
+LL | |             if cfg!(match_first_load) {
+LL | |                 a16.store(0, Ordering::SeqCst);
+...  |
+LL | |             }
+LL | |         });
+   | |__________^
+   = note: inside closure at RUSTLIB/std/src/thread/scoped.rs:LL:CC
+   = note: inside `<std::panic::AssertUnwindSafe<{closure@std::thread::scope<'_, {closure@tests/fail/data_race/mixed_size_read_read_write.rs:LL:CC}, ()>::{closure#0}}> as std::ops::FnOnce<()>>::call_once` at RUSTLIB/core/src/panic/unwind_safe.rs:LL:CC
+   = note: inside `std::panicking::r#try::do_call::<std::panic::AssertUnwindSafe<{closure@std::thread::scope<'_, {closure@tests/fail/data_race/mixed_size_read_read_write.rs:LL:CC}, ()>::{closure#0}}>, ()>` at RUSTLIB/std/src/panicking.rs:LL:CC
+   = note: inside `std::panicking::r#try::<(), std::panic::AssertUnwindSafe<{closure@std::thread::scope<'_, {closure@tests/fail/data_race/mixed_size_read_read_write.rs:LL:CC}, ()>::{closure#0}}>>` at RUSTLIB/std/src/panicking.rs:LL:CC
+   = note: inside `std::panic::catch_unwind::<std::panic::AssertUnwindSafe<{closure@std::thread::scope<'_, {closure@tests/fail/data_race/mixed_size_read_read_write.rs:LL:CC}, ()>::{closure#0}}>, ()>` at RUSTLIB/std/src/panic.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/mixed_size_read_read_write.rs:LL:CC
+   |
+LL | /     thread::scope(|s| {
+LL | |         s.spawn(|| {
+LL | |             a16.load(Ordering::SeqCst);
+LL | |         });
+...  |
+LL | |         });
+LL | |     });
+   | |______^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/mixed_size_read_write.read_write.stderr
+++ b/tests/fail/data_race/mixed_size_read_write.read_write.stderr
@@ -15,6 +15,38 @@ LL |             a8[0].load(Ordering::SeqCst);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/mixed_size_read_write.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/mixed_size_read_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::scoped::<impl std::thread::Builder>::spawn_scoped::<'_, {closure@tests/fail/data_race/mixed_size_read_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/scoped.rs:LL:CC
+   = note: inside `std::thread::Scope::<'_, '_>::spawn::<{closure@tests/fail/data_race/mixed_size_read_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/scoped.rs:LL:CC
+note: inside closure
+  --> tests/fail/data_race/mixed_size_read_write.rs:LL:CC
+   |
+LL | / ...   s.spawn(|| {
+LL | | ...       if cfg!(read_write) {
+LL | | ...           // Let the other one go first.
+LL | | ...           thread::yield_now();
+...  |
+LL | | ...
+LL | | ...   });
+   | |________^
+   = note: inside closure at RUSTLIB/std/src/thread/scoped.rs:LL:CC
+   = note: inside `<std::panic::AssertUnwindSafe<{closure@std::thread::scope<'_, {closure@tests/fail/data_race/mixed_size_read_write.rs:LL:CC}, ()>::{closure#0}}> as std::ops::FnOnce<()>>::call_once` at RUSTLIB/core/src/panic/unwind_safe.rs:LL:CC
+   = note: inside `std::panicking::r#try::do_call::<std::panic::AssertUnwindSafe<{closure@std::thread::scope<'_, {closure@tests/fail/data_race/mixed_size_read_write.rs:LL:CC}, ()>::{closure#0}}>, ()>` at RUSTLIB/std/src/panicking.rs:LL:CC
+   = note: inside `std::panicking::r#try::<(), std::panic::AssertUnwindSafe<{closure@std::thread::scope<'_, {closure@tests/fail/data_race/mixed_size_read_write.rs:LL:CC}, ()>::{closure#0}}>>` at RUSTLIB/std/src/panicking.rs:LL:CC
+   = note: inside `std::panic::catch_unwind::<std::panic::AssertUnwindSafe<{closure@std::thread::scope<'_, {closure@tests/fail/data_race/mixed_size_read_write.rs:LL:CC}, ()>::{closure#0}}>, ()>` at RUSTLIB/std/src/panic.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/mixed_size_read_write.rs:LL:CC
+   |
+LL | /     thread::scope(|s| {
+LL | |         s.spawn(|| {
+LL | |             if cfg!(read_write) {
+LL | |                 // Let the other one go first.
+...  |
+LL | |         });
+LL | |     });
+   | |______^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/mixed_size_read_write.write_read.stderr
+++ b/tests/fail/data_race/mixed_size_read_write.write_read.stderr
@@ -15,6 +15,38 @@ LL |             a16.store(1, Ordering::SeqCst);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/mixed_size_read_write.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/mixed_size_read_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::scoped::<impl std::thread::Builder>::spawn_scoped::<'_, {closure@tests/fail/data_race/mixed_size_read_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/scoped.rs:LL:CC
+   = note: inside `std::thread::Scope::<'_, '_>::spawn::<{closure@tests/fail/data_race/mixed_size_read_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/scoped.rs:LL:CC
+note: inside closure
+  --> tests/fail/data_race/mixed_size_read_write.rs:LL:CC
+   |
+LL | / ...   s.spawn(|| {
+LL | | ...       if cfg!(write_read) {
+LL | | ...           // Let the other one go first.
+LL | | ...           thread::yield_now();
+...  |
+LL | | ...
+LL | | ...   });
+   | |________^
+   = note: inside closure at RUSTLIB/std/src/thread/scoped.rs:LL:CC
+   = note: inside `<std::panic::AssertUnwindSafe<{closure@std::thread::scope<'_, {closure@tests/fail/data_race/mixed_size_read_write.rs:LL:CC}, ()>::{closure#0}}> as std::ops::FnOnce<()>>::call_once` at RUSTLIB/core/src/panic/unwind_safe.rs:LL:CC
+   = note: inside `std::panicking::r#try::do_call::<std::panic::AssertUnwindSafe<{closure@std::thread::scope<'_, {closure@tests/fail/data_race/mixed_size_read_write.rs:LL:CC}, ()>::{closure#0}}>, ()>` at RUSTLIB/std/src/panicking.rs:LL:CC
+   = note: inside `std::panicking::r#try::<(), std::panic::AssertUnwindSafe<{closure@std::thread::scope<'_, {closure@tests/fail/data_race/mixed_size_read_write.rs:LL:CC}, ()>::{closure#0}}>>` at RUSTLIB/std/src/panicking.rs:LL:CC
+   = note: inside `std::panic::catch_unwind::<std::panic::AssertUnwindSafe<{closure@std::thread::scope<'_, {closure@tests/fail/data_race/mixed_size_read_write.rs:LL:CC}, ()>::{closure#0}}>, ()>` at RUSTLIB/std/src/panic.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/mixed_size_read_write.rs:LL:CC
+   |
+LL | /     thread::scope(|s| {
+LL | |         s.spawn(|| {
+LL | |             if cfg!(read_write) {
+LL | |                 // Let the other one go first.
+...  |
+LL | |         });
+LL | |     });
+   | |______^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/mixed_size_write_write.fst.stderr
+++ b/tests/fail/data_race/mixed_size_write_write.fst.stderr
@@ -15,6 +15,36 @@ LL |             a16.store(1, Ordering::SeqCst);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/mixed_size_write_write.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/mixed_size_write_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::scoped::<impl std::thread::Builder>::spawn_scoped::<'_, {closure@tests/fail/data_race/mixed_size_write_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/scoped.rs:LL:CC
+   = note: inside `std::thread::Scope::<'_, '_>::spawn::<{closure@tests/fail/data_race/mixed_size_write_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/scoped.rs:LL:CC
+note: inside closure
+  --> tests/fail/data_race/mixed_size_write_write.rs:LL:CC
+   |
+LL | / ...   s.spawn(|| {
+LL | | ...       let idx = if cfg!(fst) { 0 } else { 1 };
+LL | | ...       a8[idx].store(1, Ordering::SeqCst);
+LL | | ...
+LL | | ...   });
+   | |________^
+   = note: inside closure at RUSTLIB/std/src/thread/scoped.rs:LL:CC
+   = note: inside `<std::panic::AssertUnwindSafe<{closure@std::thread::scope<'_, {closure@tests/fail/data_race/mixed_size_write_write.rs:LL:CC}, ()>::{closure#0}}> as std::ops::FnOnce<()>>::call_once` at RUSTLIB/core/src/panic/unwind_safe.rs:LL:CC
+   = note: inside `std::panicking::r#try::do_call::<std::panic::AssertUnwindSafe<{closure@std::thread::scope<'_, {closure@tests/fail/data_race/mixed_size_write_write.rs:LL:CC}, ()>::{closure#0}}>, ()>` at RUSTLIB/std/src/panicking.rs:LL:CC
+   = note: inside `std::panicking::r#try::<(), std::panic::AssertUnwindSafe<{closure@std::thread::scope<'_, {closure@tests/fail/data_race/mixed_size_write_write.rs:LL:CC}, ()>::{closure#0}}>>` at RUSTLIB/std/src/panicking.rs:LL:CC
+   = note: inside `std::panic::catch_unwind::<std::panic::AssertUnwindSafe<{closure@std::thread::scope<'_, {closure@tests/fail/data_race/mixed_size_write_write.rs:LL:CC}, ()>::{closure#0}}>, ()>` at RUSTLIB/std/src/panic.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/mixed_size_write_write.rs:LL:CC
+   |
+LL | /     thread::scope(|s| {
+LL | |         s.spawn(|| {
+LL | |             a16.store(1, Ordering::SeqCst);
+LL | |         });
+...  |
+LL | |         });
+LL | |     });
+   | |______^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/mixed_size_write_write.snd.stderr
+++ b/tests/fail/data_race/mixed_size_write_write.snd.stderr
@@ -15,6 +15,36 @@ LL |             a16.store(1, Ordering::SeqCst);
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/mixed_size_write_write.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/mixed_size_write_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::scoped::<impl std::thread::Builder>::spawn_scoped::<'_, {closure@tests/fail/data_race/mixed_size_write_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/scoped.rs:LL:CC
+   = note: inside `std::thread::Scope::<'_, '_>::spawn::<{closure@tests/fail/data_race/mixed_size_write_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/scoped.rs:LL:CC
+note: inside closure
+  --> tests/fail/data_race/mixed_size_write_write.rs:LL:CC
+   |
+LL | / ...   s.spawn(|| {
+LL | | ...       let idx = if cfg!(fst) { 0 } else { 1 };
+LL | | ...       a8[idx].store(1, Ordering::SeqCst);
+LL | | ...
+LL | | ...   });
+   | |________^
+   = note: inside closure at RUSTLIB/std/src/thread/scoped.rs:LL:CC
+   = note: inside `<std::panic::AssertUnwindSafe<{closure@std::thread::scope<'_, {closure@tests/fail/data_race/mixed_size_write_write.rs:LL:CC}, ()>::{closure#0}}> as std::ops::FnOnce<()>>::call_once` at RUSTLIB/core/src/panic/unwind_safe.rs:LL:CC
+   = note: inside `std::panicking::r#try::do_call::<std::panic::AssertUnwindSafe<{closure@std::thread::scope<'_, {closure@tests/fail/data_race/mixed_size_write_write.rs:LL:CC}, ()>::{closure#0}}>, ()>` at RUSTLIB/std/src/panicking.rs:LL:CC
+   = note: inside `std::panicking::r#try::<(), std::panic::AssertUnwindSafe<{closure@std::thread::scope<'_, {closure@tests/fail/data_race/mixed_size_write_write.rs:LL:CC}, ()>::{closure#0}}>>` at RUSTLIB/std/src/panicking.rs:LL:CC
+   = note: inside `std::panic::catch_unwind::<std::panic::AssertUnwindSafe<{closure@std::thread::scope<'_, {closure@tests/fail/data_race/mixed_size_write_write.rs:LL:CC}, ()>::{closure#0}}>, ()>` at RUSTLIB/std/src/panic.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/mixed_size_write_write.rs:LL:CC
+   |
+LL | /     thread::scope(|s| {
+LL | |         s.spawn(|| {
+LL | |             a16.store(1, Ordering::SeqCst);
+LL | |         });
+...  |
+LL | |         });
+LL | |     });
+   | |______^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/read_write_race.stderr
+++ b/tests/fail/data_race/read_write_race.stderr
@@ -13,6 +13,21 @@ LL |             let _val = *c.0;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/read_write_race.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/read_write_race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/data_race/read_write_race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/data_race/read_write_race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/data_race/read_write_race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/read_write_race.rs:LL:CC
+   |
+LL |   ...   let j2 = spawn(move || {
+   |  ________________^
+LL | | ...       let c = c; // avoid field capturing
+LL | | ...       *c.0 = 64;
+LL | | ...   });
+   | |________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/read_write_race_stack.stderr
+++ b/tests/fail/data_race/read_write_race_stack.stderr
@@ -13,6 +13,24 @@ LL |             *pointer.load(Ordering::Acquire) = 3;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/read_write_race_stack.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/read_write_race_stack.rs:LL:CC}, usize>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/data_race/read_write_race_stack.rs:LL:CC}, usize>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/data_race/read_write_race_stack.rs:LL:CC}, usize>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/data_race/read_write_race_stack.rs:LL:CC}, usize>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/read_write_race_stack.rs:LL:CC
+   |
+LL |   ...   let j1 = spawn(move || {
+   |  ________________^
+LL | | ...       let ptr = ptr; // avoid field capturing
+LL | | ...       // Concurrent allocate the memory.
+LL | | ...       // Uses relaxed semantics to not generate
+...  |
+LL | | ...       stack_var
+LL | | ...   });
+   | |________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/relax_acquire_race.stderr
+++ b/tests/fail/data_race/relax_acquire_race.stderr
@@ -13,6 +13,24 @@ LL |             *c.0 = 1;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/relax_acquire_race.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/relax_acquire_race.rs:LL:CC}, u32>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/data_race/relax_acquire_race.rs:LL:CC}, u32>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/data_race/relax_acquire_race.rs:LL:CC}, u32>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/data_race/relax_acquire_race.rs:LL:CC}, u32>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/relax_acquire_race.rs:LL:CC
+   |
+LL |   ...   let j3 = spawn(move || {
+   |  ________________^
+LL | | ...       let c = c; // avoid field capturing
+LL | | ...       if SYNC.load(Ordering::Acquire) == 2 {
+LL | | ...           *c.0
+...  |
+LL | | ...       }
+LL | | ...   });
+   | |________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/release_seq_race.stderr
+++ b/tests/fail/data_race/release_seq_race.stderr
@@ -13,6 +13,24 @@ LL |             *c.0 = 1;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/release_seq_race.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/release_seq_race.rs:LL:CC}, u32>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/data_race/release_seq_race.rs:LL:CC}, u32>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/data_race/release_seq_race.rs:LL:CC}, u32>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/data_race/release_seq_race.rs:LL:CC}, u32>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/release_seq_race.rs:LL:CC
+   |
+LL |           let j3 = spawn(move || {
+   |  __________________^
+LL | |             let c = c; // avoid field capturing
+LL | |             sleep(Duration::from_millis(500));
+LL | |             if SYNC.load(Ordering::Acquire) == 3 {
+...  |
+LL | |             }
+LL | |         });
+   | |__________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/release_seq_race_same_thread.stderr
+++ b/tests/fail/data_race/release_seq_race_same_thread.stderr
@@ -13,6 +13,24 @@ LL |             *c.0 = 1;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/release_seq_race_same_thread.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/release_seq_race_same_thread.rs:LL:CC}, u32>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/data_race/release_seq_race_same_thread.rs:LL:CC}, u32>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/data_race/release_seq_race_same_thread.rs:LL:CC}, u32>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/data_race/release_seq_race_same_thread.rs:LL:CC}, u32>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/release_seq_race_same_thread.rs:LL:CC
+   |
+LL |   ...   let j2 = spawn(move || {
+   |  ________________^
+LL | | ...       let c = c; // avoid field capturing
+LL | | ...       if SYNC.load(Ordering::Acquire) == 2 {
+LL | | ...           *c.0
+...  |
+LL | | ...       }
+LL | | ...   });
+   | |________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/rmw_race.stderr
+++ b/tests/fail/data_race/rmw_race.stderr
@@ -13,6 +13,24 @@ LL |             *c.0 = 1;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/rmw_race.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/rmw_race.rs:LL:CC}, u32>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/data_race/rmw_race.rs:LL:CC}, u32>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/data_race/rmw_race.rs:LL:CC}, u32>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/data_race/rmw_race.rs:LL:CC}, u32>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/rmw_race.rs:LL:CC
+   |
+LL |   ...   let j3 = spawn(move || {
+   |  ________________^
+LL | | ...       let c = c; // capture `c`, not just its field.
+LL | | ...       if SYNC.load(Ordering::Acquire) == 3 {
+LL | | ...           *c.0
+...  |
+LL | | ...       }
+LL | | ...   });
+   | |________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/write_write_race.stderr
+++ b/tests/fail/data_race/write_write_race.stderr
@@ -13,6 +13,21 @@ LL |             *c.0 = 32;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/write_write_race.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/write_write_race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/data_race/write_write_race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/data_race/write_write_race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/data_race/write_write_race.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/write_write_race.rs:LL:CC
+   |
+LL |   ...   let j2 = spawn(move || {
+   |  ________________^
+LL | | ...       let c = c; // avoid field capturing
+LL | | ...       *c.0 = 64;
+LL | | ...   });
+   | |________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/data_race/write_write_race_stack.stderr
+++ b/tests/fail/data_race/write_write_race_stack.stderr
@@ -13,6 +13,24 @@ LL |             *pointer.load(Ordering::Acquire) = 3;
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/data_race/write_write_race_stack.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/data_race/write_write_race_stack.rs:LL:CC}, usize>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/data_race/write_write_race_stack.rs:LL:CC}, usize>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/data_race/write_write_race_stack.rs:LL:CC}, usize>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/data_race/write_write_race_stack.rs:LL:CC}, usize>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/data_race/write_write_race_stack.rs:LL:CC
+   |
+LL |           let j1 = spawn(move || {
+   |  __________________^
+LL | |             let ptr = ptr; // avoid field capturing
+LL | |             // Concurrent allocate the memory.
+LL | |             // Uses relaxed semantics to not generate
+...  |
+LL | |             stack_var
+LL | |         });
+   | |__________^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/retag_data_race_protected_read.stderr
+++ b/tests/fail/stacked_borrows/retag_data_race_protected_read.stderr
@@ -16,6 +16,23 @@ LL |     unsafe { ptr.0.read() };
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/stacked_borrows/retag_data_race_protected_read.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/stacked_borrows/retag_data_race_protected_read.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/stacked_borrows/retag_data_race_protected_read.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/stacked_borrows/retag_data_race_protected_read.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/stacked_borrows/retag_data_race_protected_read.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/stacked_borrows/retag_data_race_protected_read.rs:LL:CC
+   |
+LL |       let t = thread::spawn(move || {
+   |  _____________^
+LL | |         let ptr = ptr;
+LL | |         // We do a protected mutable retag (but no write!) in this thread.
+LL | |         fn retag(_x: &mut i32) {}
+LL | |         retag(unsafe { &mut *ptr.0 });
+LL | |     });
+   | |______^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/stacked_borrows/retag_data_race_read.stderr
+++ b/tests/fail/stacked_borrows/retag_data_race_read.stderr
@@ -21,6 +21,17 @@ note: inside closure
    |
 LL |     let t2 = std::thread::spawn(move || thread_2(p));
    |                                         ^^^^^^^^^^^
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/stacked_borrows/retag_data_race_read.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/stacked_borrows/retag_data_race_read.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/stacked_borrows/retag_data_race_read.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/stacked_borrows/retag_data_race_read.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/stacked_borrows/retag_data_race_read.rs:LL:CC
+   |
+LL |     let t2 = std::thread::spawn(move || thread_2(p));
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/tree_borrows/reservedim_spurious_write.with.stderr
+++ b/tests/fail/tree_borrows/reservedim_spurious_write.with.stderr
@@ -33,6 +33,24 @@ LL |                 *x = 64;
    = help: this transition corresponds to a loss of read and write permissions
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/tree_borrows/reservedim_spurious_write.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/tree_borrows/reservedim_spurious_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/tree_borrows/reservedim_spurious_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/tree_borrows/reservedim_spurious_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/tree_borrows/reservedim_spurious_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/tree_borrows/reservedim_spurious_write.rs:LL:CC
+   |
+LL |       let thread_2 = thread::spawn(move || {
+   |  ____________________^
+LL | |         let b = (2, by);
+LL | |         synchronized!(b, "start");
+LL | |         let ptr = ptr;
+...  |
+LL | |         synchronized!(b, "end");
+LL | |     });
+   | |______^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/tree_borrows/reservedim_spurious_write.without.stderr
+++ b/tests/fail/tree_borrows/reservedim_spurious_write.without.stderr
@@ -33,6 +33,24 @@ LL |         }
    = help: this transition corresponds to a loss of read and write permissions
    = note: BACKTRACE (of the first span) on thread `unnamed-ID`:
    = note: inside closure at tests/fail/tree_borrows/reservedim_spurious_write.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/tree_borrows/reservedim_spurious_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/tree_borrows/reservedim_spurious_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/tree_borrows/reservedim_spurious_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/tree_borrows/reservedim_spurious_write.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `main`
+  --> tests/fail/tree_borrows/reservedim_spurious_write.rs:LL:CC
+   |
+LL |       let thread_2 = thread::spawn(move || {
+   |  ____________________^
+LL | |         let b = (2, by);
+LL | |         synchronized!(b, "start");
+LL | |         let ptr = ptr;
+...  |
+LL | |         synchronized!(b, "end");
+LL | |     });
+   | |______^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/tree_borrows/spurious_read.stderr
+++ b/tests/fail/tree_borrows/spurious_read.stderr
@@ -37,6 +37,29 @@ note: inside closure
    |
 LL |         let _y = as_mut(unsafe { &mut *ptr.0 }, b.clone());
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/tree_borrows/spurious_read.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/tree_borrows/spurious_read.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/tree_borrows/spurious_read.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/tree_borrows/spurious_read.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `retagx_retagy_retx_writey_rety`
+  --> tests/fail/tree_borrows/spurious_read.rs:LL:CC
+   |
+LL |       let thread_y = thread::spawn(move || {
+   |  ____________________^
+LL | |         let b = (2, by);
+LL | |         synchronized!(b, "start");
+LL | |         let ptr = ptr;
+...  |
+LL | |         synchronized!(b, "end");
+LL | |     });
+   | |______^
+note: inside `main`
+  --> tests/fail/tree_borrows/spurious_read.rs:LL:CC
+   |
+LL |     retagx_retagy_retx_writey_rety();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/fail/weak_memory/weak_uninit.stderr
+++ b/tests/fail/weak_memory/weak_uninit.stderr
@@ -8,6 +8,22 @@ LL |     let j2 = spawn(move || x.load(Ordering::Relaxed));
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE on thread `unnamed-ID`:
    = note: inside closure at tests/fail/weak_memory/weak_uninit.rs:LL:CC
+   = note: thread `unnamed-ID` was spawned by thread `main`
+   = note: inside `std::sys::pal::PLATFORM::thread::Thread::new` at RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, {closure@tests/fail/weak_memory/weak_uninit.rs:LL:CC}, usize>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn_unchecked::<{closure@tests/fail/weak_memory/weak_uninit.rs:LL:CC}, usize>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::Builder::spawn::<{closure@tests/fail/weak_memory/weak_uninit.rs:LL:CC}, usize>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+   = note: inside `std::thread::spawn::<{closure@tests/fail/weak_memory/weak_uninit.rs:LL:CC}, usize>` at RUSTLIB/std/src/thread/mod.rs:LL:CC
+note: inside `relaxed`
+  --> tests/fail/weak_memory/weak_uninit.rs:LL:CC
+   |
+LL |     let j2 = spawn(move || x.load(Ordering::Relaxed));
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: inside `main`
+  --> tests/fail/weak_memory/weak_uninit.rs:LL:CC
+   |
+LL |         relaxed();
+   |         ^^^^^^^^^
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 


### PR DESCRIPTION
Fixes #4066

When a thread is spawned we store the ID of the spawning thread as well as a backtrace to the spawn location. When there's an error we can traverse upwards, displaying a backtrace up to the main thread.

For instance, with the following program:
```
extern "C" {
    fn unknown();
}

fn bad() {
    unsafe { unknown() }
}

fn main() {
    std::thread::spawn(bad);
}
```

Whereas previously we would see:
```
error: unsupported operation: can't call foreign function `unknown` on OS `linux`
 --> tests/temp.rs:6:14
  |
6 |     unsafe { unknown() }
  |              ^^^^^^^^^ can't call foreign function `unknown` on OS `linux`
  |
  = help: if this is a basic API commonly used on this target, please report an issue with Miri
  = help: however, note that Miri does not aim to support every FFI function out there; for instance, we will not support APIs for things such as GUIs, scripting languages, or databases
  = note: BACKTRACE on thread `unnamed-1`:
  = note: inside `bad` at tests/temp.rs:6:14: 6:23

note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

error: aborting due to 1 previous error
```

We now have:
```
error: unsupported operation: can't call foreign function `unknown` on OS `linux`
  --> tests/temp.rs:6:14
   |
6  |     unsafe { unknown() }
   |              ^^^^^^^^^ can't call foreign function `unknown` on OS `linux`
   |
   = help: if this is a basic API commonly used on this target, please report an issue with Miri
   = help: however, note that Miri does not aim to support every FFI function out there; for instance, we will not support APIs for things such as GUIs, scripting languages, or databases
   = note: BACKTRACE on thread `unnamed-1`:
   = note: inside `bad` at tests/temp.rs:6:14: 6:23
   = note: thread `unnamed-1` was spawned by thread `main`
   = note: inside `std::sys::pal::unix::thread::Thread::new` at /home/reimu/.rustup/toolchains/miri/lib/rustlib/src/rust/library/std/src/sys/pal/unix/thread.rs:84:19: 84:86
   = note: inside `std::thread::Builder::spawn_unchecked_::<'_, fn() {bad}, ()>` at /home/reimu/.rustup/toolchains/miri/lib/rustlib/src/rust/library/std/src/thread/mod.rs:600:30: 600:64
   = note: inside `std::thread::Builder::spawn_unchecked::<fn() {bad}, ()>` at /home/reimu/.rustup/toolchains/miri/lib/rustlib/src/rust/library/std/src/thread/mod.rs:467:32: 467:62
   = note: inside `std::thread::Builder::spawn::<fn() {bad}, ()>` at /home/reimu/.rustup/toolchains/miri/lib/rustlib/src/rust/library/std/src/thread/mod.rs:400:18: 400:41
   = note: inside `std::thread::spawn::<fn() {bad}, ()>` at /home/reimu/.rustup/toolchains/miri/lib/rustlib/src/rust/library/std/src/thread/mod.rs:730:5: 730:28
note: inside `main`
  --> tests/temp.rs:10:5
   |
10 |     std::thread::spawn(bad);
   |     ^^^^^^^^^^^^^^^^^^^^^^^

note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

error: aborting due to 1 previous error
```

