### PR TITLE
Implement many-seeds mode directly in the driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,14 +160,14 @@ Certain parts of the execution are picked randomly by Miri, such as the exact ba
 allocations are stored at and the interleaving of concurrently executing threads. Sometimes, it can
 be useful to explore multiple different execution, e.g. to make sure that your code does not depend
 on incidental "super-alignment" of new allocations and to test different thread interleavings.
-This can be done with the `--many-seeds` flag:
+This can be done with the `-Zmiri-many-seeds` flag:
 
 ```
-cargo miri test --many-seeds # tries the seeds in 0..64
-cargo miri test --many-seeds=0..16
+MIRIFLAGS="-Zmiri-many-seeds" cargo miri test # tries the seeds in 0..64
+MIRIFLAGS="-Zmiri-many-seeds=0..16" cargo miri test
 ```
 
-The default of 64 different seeds is quite slow, so you probably want to specify a smaller range.
+The default of 64 different seeds can be quite slow, so you often want to specify a smaller range.
 
 ### Running Miri on CI
 
@@ -317,6 +317,12 @@ environment variable. We first document the most relevant and most commonly used
   execution with a "permission denied" error being returned to the program.
   `warn` prints a full backtrace each time that happens; `warn-nobacktrace` is less
   verbose and shown at most once per operation. `hide` hides the warning entirely.
+* `-Zmiri-many-seeds=[<from>]..<to>` runs the program multiple times with different seeds for Miri's
+  RNG. With different seeds, Miri will make different choices to resolve non-determinism such as the
+  order in which concurrent threads are scheduled, or the exact addresses assigned to allocations.
+  This is useful to find bugs that only occur under particular interleavings of concurrent threads,
+  or that otherwise depend on non-determinism. If the `<from>` part is skipped, it defaults to `0`.
+  Can be used without a value; in that case the range defaults to `0..64`.
 * `-Zmiri-num-cpus` states the number of available CPUs to be reported by miri. By default, the
   number of available CPUs is `1`. Note that this flag does not affect how miri handles threads in
   any way.

--- a/README.md
+++ b/README.md
@@ -323,6 +323,8 @@ environment variable. We first document the most relevant and most commonly used
   This is useful to find bugs that only occur under particular interleavings of concurrent threads,
   or that otherwise depend on non-determinism. If the `<from>` part is skipped, it defaults to `0`.
   Can be used without a value; in that case the range defaults to `0..64`.
+* `-Zmiri-many-seeds-keep-going` tells Miri to really try all the seeds in the given range, even if
+  a failing seed has already been found. This is useful to determine which fraction of seeds fails.
 * `-Zmiri-num-cpus` states the number of available CPUs to be reported by miri. By default, the
   number of available CPUs is `1`. Note that this flag does not affect how miri handles threads in
   any way.

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -66,9 +66,9 @@ function run_tests {
     time MIRIFLAGS="${MIRIFLAGS-} -O -Zmir-opt-level=4 -Cdebug-assertions=yes" MIRI_SKIP_UI_CHECKS=1 ./miri test $TARGET_FLAG tests/{pass,panic}
   fi
   if [ -n "${MANY_SEEDS-}" ]; then
-    # Also run some many-seeds tests. (Also tests `./miri run`.)
+    # Run many-seeds tests. (Also tests `./miri run`.)
     time for FILE in tests/many-seeds/*.rs; do
-      ./miri run "--many-seeds=0..$MANY_SEEDS" $TARGET_FLAG "$FILE"
+      ./miri run "-Zmiri-many-seeds=0..$MANY_SEEDS" $TARGET_FLAG "$FILE"
     done
   fi
   if [ -n "${TEST_BENCH-}" ]; then

--- a/miri-script/src/main.rs
+++ b/miri-script/src/main.rs
@@ -4,28 +4,8 @@ mod commands;
 mod coverage;
 mod util;
 
-use std::ops::Range;
-
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Result, bail};
 use clap::{Parser, Subcommand};
-
-/// Parses a seed range
-///
-/// This function is used for the `--many-seeds` flag. It expects the range in the form
-/// `<from>..<to>`. `<from>` is inclusive, `<to>` is exclusive. `<from>` can be omitted,
-/// in which case it is assumed to be `0`.
-fn parse_range(val: &str) -> anyhow::Result<Range<u32>> {
-    let (from, to) = val
-        .split_once("..")
-        .ok_or_else(|| anyhow!("invalid format for `--many-seeds`: expected `from..to`"))?;
-    let from: u32 = if from.is_empty() {
-        0
-    } else {
-        from.parse().context("invalid `from` in `--many-seeds=from..to")?
-    };
-    let to: u32 = to.parse().context("invalid `to` in `--many-seeds=from..to")?;
-    Ok(from..to)
-}
 
 #[derive(Clone, Debug, Subcommand)]
 pub enum Command {
@@ -81,9 +61,6 @@ pub enum Command {
         /// Show build progress.
         #[arg(long, short)]
         verbose: bool,
-        /// Run the driver with the seeds in the given range (`..to` or `from..to`, default: `0..64`).
-        #[arg(long, value_parser = parse_range)]
-        many_seeds: Option<Range<u32>>,
         /// The cross-interpretation target.
         #[arg(long)]
         target: Option<String>,

--- a/miri-script/src/util.rs
+++ b/miri-script/src/util.rs
@@ -1,9 +1,7 @@
 use std::ffi::{OsStr, OsString};
 use std::io::BufRead;
-use std::ops::Range;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
-use std::{env, iter, thread};
+use std::{env, iter};
 
 use anyhow::{Context, Result, anyhow, bail};
 use dunce::canonicalize;
@@ -29,7 +27,6 @@ pub fn flagsplit(flags: &str) -> Vec<String> {
 }
 
 /// Some extra state we track for building Miri, such as the right RUSTFLAGS.
-#[derive(Clone)]
 pub struct MiriEnv {
     /// miri_dir is the root of the miri repository checkout we are working in.
     pub miri_dir: PathBuf,
@@ -239,54 +236,5 @@ impl MiriEnv {
         }
 
         Ok(())
-    }
-
-    /// Run the given closure many times in parallel with access to the shell, once for each value in the `range`.
-    pub fn run_many_times(
-        &self,
-        range: Range<u32>,
-        run: impl Fn(&Self, u32) -> Result<()> + Sync,
-    ) -> Result<()> {
-        // `next` is atomic so threads can concurrently fetch their next value to run.
-        let next = AtomicU32::new(range.start);
-        let end = range.end; // exclusive!
-        let failed = AtomicBool::new(false);
-        thread::scope(|s| {
-            let mut handles = Vec::new();
-            // Spawn one worker per core.
-            for _ in 0..thread::available_parallelism()?.get() {
-                // Create a copy of the environment for this thread.
-                let local_miri = self.clone();
-                let handle = s.spawn(|| -> Result<()> {
-                    let local_miri = local_miri; // move the copy into this thread.
-                    // Each worker thread keeps asking for numbers until we're all done.
-                    loop {
-                        let cur = next.fetch_add(1, Ordering::Relaxed);
-                        if cur >= end {
-                            // We hit the upper limit and are done.
-                            break;
-                        }
-                        // Run the command with this seed.
-                        run(&local_miri, cur).inspect_err(|_| {
-                            // If we failed, tell everyone about this.
-                            failed.store(true, Ordering::Relaxed);
-                        })?;
-                        // Check if some other command failed (in which case we'll stop as well).
-                        if failed.load(Ordering::Relaxed) {
-                            return Ok(());
-                        }
-                    }
-                    Ok(())
-                });
-                handles.push(handle);
-            }
-            // Wait for all workers to be done.
-            for handle in handles {
-                handle.join().unwrap()?;
-            }
-            // If all workers succeeded, we can't have failed.
-            assert!(!failed.load(Ordering::Relaxed));
-            Ok(())
-        })
     }
 }

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -26,11 +26,17 @@ extern crate rustc_span;
 
 use std::env::{self, VarError};
 use std::num::NonZero;
+use std::ops::Range;
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
-use miri::{BacktraceStyle, BorrowTrackerMethod, ProvenanceMode, RetagFields, ValidationMode};
+use miri::{
+    BacktraceStyle, BorrowTrackerMethod, MiriConfig, ProvenanceMode, RetagFields, ValidationMode,
+};
 use rustc_abi::ExternAbi;
+use rustc_data_structures::sync;
 use rustc_data_structures::sync::Lrc;
 use rustc_driver::Compilation;
 use rustc_hir::def_id::LOCAL_CRATE;
@@ -52,7 +58,64 @@ use rustc_span::def_id::DefId;
 use tracing::debug;
 
 struct MiriCompilerCalls {
-    miri_config: miri::MiriConfig,
+    miri_config: Option<MiriConfig>,
+    many_seeds: Option<Range<u32>>,
+}
+
+impl MiriCompilerCalls {
+    fn new(miri_config: MiriConfig, many_seeds: Option<Range<u32>>) -> Self {
+        Self { miri_config: Some(miri_config), many_seeds }
+    }
+}
+
+fn entry_fn(tcx: TyCtxt<'_>) -> (DefId, EntryFnType) {
+    if let Some(entry_def) = tcx.entry_fn(()) {
+        return entry_def;
+    }
+    // Look for a symbol in the local crate named `miri_start`, and treat that as the entry point.
+    let sym = tcx.exported_symbols(LOCAL_CRATE).iter().find_map(|(sym, _)| {
+        if sym.symbol_name_for_local_instance(tcx).name == "miri_start" { Some(sym) } else { None }
+    });
+    if let Some(ExportedSymbol::NonGeneric(id)) = sym {
+        let start_def_id = id.expect_local();
+        let start_span = tcx.def_span(start_def_id);
+
+        let expected_sig = ty::Binder::dummy(tcx.mk_fn_sig(
+            [tcx.types.isize, Ty::new_imm_ptr(tcx, Ty::new_imm_ptr(tcx, tcx.types.u8))],
+            tcx.types.isize,
+            false,
+            hir::Safety::Safe,
+            ExternAbi::Rust,
+        ));
+
+        let correct_func_sig = check_function_signature(
+            tcx,
+            ObligationCause::new(start_span, start_def_id, ObligationCauseCode::Misc),
+            *id,
+            expected_sig,
+        )
+        .is_ok();
+
+        if correct_func_sig {
+            (*id, EntryFnType::Start)
+        } else {
+            tcx.dcx().fatal(
+                "`miri_start` must have the following signature:\n\
+                        fn miri_start(argc: isize, argv: *const *const u8) -> isize",
+            );
+        }
+    } else {
+        tcx.dcx().fatal(
+            "Miri can only run programs that have a main function.\n\
+            Alternatively, you can export a `miri_start` function:\n\
+            \n\
+            #[cfg(miri)]\n\
+            #[no_mangle]\n\
+            fn miri_start(argc: isize, argv: *const *const u8) -> isize {\
+            \n    // Call the actual start function that your project implements, based on your target's conventions.\n\
+            }"
+        );
+    }
 }
 
 impl rustc_driver::Callbacks for MiriCompilerCalls {
@@ -87,7 +150,7 @@ impl rustc_driver::Callbacks for MiriCompilerCalls {
         }
 
         let (entry_def_id, entry_type) = entry_fn(tcx);
-        let mut config = self.miri_config.clone();
+        let mut config = self.miri_config.take().expect("after_analysis must only be called once");
 
         // Add filename to `miri` arguments.
         config.args.insert(0, tcx.sess.io.input.filestem().to_string());
@@ -111,12 +174,31 @@ impl rustc_driver::Callbacks for MiriCompilerCalls {
                     optimizations is usually marginal at best.");
         }
 
-        if let Some(return_code) = miri::eval_entry(tcx, entry_def_id, entry_type, config) {
-            std::process::exit(i32::try_from(return_code).expect("Return value was too large!"));
+        if let Some(many_seeds) = self.many_seeds.take() {
+            assert!(config.seed.is_none());
+            sync::par_for_each_in(many_seeds, |seed| {
+                let mut config = config.clone();
+                config.seed = Some(seed.into());
+                eprintln!("Trying seed: {seed}");
+                let return_code = miri::eval_entry(tcx, entry_def_id, entry_type, config)
+                    .unwrap_or(rustc_driver::EXIT_FAILURE);
+                if return_code != rustc_driver::EXIT_SUCCESS {
+                    eprintln!("FAILING SEED: {seed}");
+                    tcx.dcx().abort_if_errors(); // exits with a different error message
+                    std::process::exit(return_code);
+                }
+            });
+            std::process::exit(rustc_driver::EXIT_SUCCESS);
+        } else {
+            let return_code = miri::eval_entry(tcx, entry_def_id, entry_type, config)
+                .unwrap_or_else(|| {
+                    tcx.dcx().abort_if_errors();
+                    rustc_driver::EXIT_FAILURE
+                });
+            std::process::exit(return_code);
         }
-        tcx.dcx().abort_if_errors();
 
-        Compilation::Stop
+        // Unreachable.
     }
 }
 
@@ -241,21 +323,28 @@ fn rustc_logger_config() -> rustc_log::LoggerConfig {
     cfg
 }
 
+/// The global logger can only be set once per process, so track
+/// whether that already happened.
+static LOGGER_INITED: AtomicBool = AtomicBool::new(false);
+
 fn init_early_loggers(early_dcx: &EarlyDiagCtxt) {
     // Now for rustc. We only initialize `rustc` if the env var is set (so the user asked for it).
     // If it is not set, we avoid initializing now so that we can initialize later with our custom
     // settings, and *not* log anything for what happens before `miri` gets started.
     if env::var_os("RUSTC_LOG").is_some() {
         rustc_driver::init_logger(early_dcx, rustc_logger_config());
+        assert!(!LOGGER_INITED.swap(true, Ordering::AcqRel));
     }
 }
 
 fn init_late_loggers(early_dcx: &EarlyDiagCtxt, tcx: TyCtxt<'_>) {
-    // If `RUSTC_LOG` is not set, then `init_early_loggers` did not call
-    // `rustc_driver::init_logger`, so we have to do this now.
-    if env::var_os("RUSTC_LOG").is_none() {
+    // If the logger is not yet initialized, initialize it.
+    if !LOGGER_INITED.swap(true, Ordering::AcqRel) {
         rustc_driver::init_logger(early_dcx, rustc_logger_config());
     }
+    // There's a little race condition here in many-seeds mode, where we don't wait for the thread
+    // that is doing the initializing. But if you want to debug things with extended logging you
+    // probably won't use many-seeds mode anyway.
 
     // If `MIRI_BACKTRACE` is set and `RUSTC_CTFE_BACKTRACE` is not, set `RUSTC_CTFE_BACKTRACE`.
     // Do this late, so we ideally only apply this to Miri's errors.
@@ -270,25 +359,14 @@ fn init_late_loggers(early_dcx: &EarlyDiagCtxt, tcx: TyCtxt<'_>) {
 }
 
 /// Execute a compiler with the given CLI arguments and callbacks.
-fn run_compiler(
-    mut args: Vec<String>,
-    target_crate: bool,
+fn run_compiler_and_exit(
+    args: &[String],
     callbacks: &mut (dyn rustc_driver::Callbacks + Send),
-    using_internal_features: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    using_internal_features: Arc<std::sync::atomic::AtomicBool>,
 ) -> ! {
-    // Don't insert `MIRI_DEFAULT_ARGS`, in particular, `--cfg=miri`, if we are building
-    // a "host" crate. That may cause procedural macros (and probably build scripts) to
-    // depend on Miri-only symbols, such as `miri_resolve_frame`:
-    // https://github.com/rust-lang/miri/issues/1760
-    if target_crate {
-        // Some options have different defaults in Miri than in plain rustc; apply those by making
-        // them the first arguments after the binary name (but later arguments can overwrite them).
-        args.splice(1..1, miri::MIRI_DEFAULT_ARGS.iter().map(ToString::to_string));
-    }
-
     // Invoke compiler, and handle return code.
     let exit_code = rustc_driver::catch_with_exit_code(move || {
-        rustc_driver::RunCompiler::new(&args, callbacks)
+        rustc_driver::RunCompiler::new(args, callbacks)
             .set_using_internal_features(using_internal_features)
             .run();
         Ok(())
@@ -309,6 +387,18 @@ fn parse_rate(input: &str) -> Result<f64, &'static str> {
         Ok(_) => Err("must be between `0.0` and `1.0`"),
         Err(_) => Err("requires a `f64` between `0.0` and `1.0`"),
     }
+}
+
+/// Parses a seed range
+///
+/// This function is used for the `-Zmiri-many-seeds` flag. It expects the range in the form
+/// `<from>..<to>`. `<from>` is inclusive, `<to>` is exclusive. `<from>` can be omitted,
+/// in which case it is assumed to be `0`.
+fn parse_range(val: &str) -> Result<Range<u32>, &'static str> {
+    let (from, to) = val.split_once("..").ok_or("expected `from..to`")?;
+    let from: u32 = if from.is_empty() { 0 } else { from.parse().map_err(|_| "invalid `from`")? };
+    let to: u32 = to.parse().map_err(|_| "invalid `to`")?;
+    Ok(from..to)
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos"))]
@@ -349,56 +439,6 @@ fn jemalloc_magic() {
     }
 }
 
-fn entry_fn(tcx: TyCtxt<'_>) -> (DefId, EntryFnType) {
-    if let Some(entry_def) = tcx.entry_fn(()) {
-        return entry_def;
-    }
-    // Look for a symbol in the local crate named `miri_start`, and treat that as the entry point.
-    let sym = tcx.exported_symbols(LOCAL_CRATE).iter().find_map(|(sym, _)| {
-        if sym.symbol_name_for_local_instance(tcx).name == "miri_start" { Some(sym) } else { None }
-    });
-    if let Some(ExportedSymbol::NonGeneric(id)) = sym {
-        let start_def_id = id.expect_local();
-        let start_span = tcx.def_span(start_def_id);
-
-        let expected_sig = ty::Binder::dummy(tcx.mk_fn_sig(
-            [tcx.types.isize, Ty::new_imm_ptr(tcx, Ty::new_imm_ptr(tcx, tcx.types.u8))],
-            tcx.types.isize,
-            false,
-            hir::Safety::Safe,
-            ExternAbi::Rust,
-        ));
-
-        let correct_func_sig = check_function_signature(
-            tcx,
-            ObligationCause::new(start_span, start_def_id, ObligationCauseCode::Misc),
-            *id,
-            expected_sig,
-        )
-        .is_ok();
-
-        if correct_func_sig {
-            (*id, EntryFnType::Start)
-        } else {
-            tcx.dcx().fatal(
-                "`miri_start` must have the following signature:\n\
-                        fn miri_start(argc: isize, argv: *const *const u8) -> isize",
-            );
-        }
-    } else {
-        tcx.dcx().fatal(
-            "Miri can only run programs that have a main function.\n\
-            Alternatively, you can export a `miri_start` function:\n\
-            \n\
-            #[cfg(miri)]\n\
-            #[no_mangle]\n\
-            fn miri_start(argc: isize, argv: *const *const u8) -> isize {\
-            \n    // Call the actual start function that your project implements, based on your target's conventions.\n\
-            }"
-        );
-    }
-}
-
 fn main() {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     jemalloc_magic();
@@ -431,10 +471,21 @@ fn main() {
             panic!("invalid `MIRI_BE_RUSTC` value: {crate_kind:?}")
         };
 
-        // We cannot use `rustc_driver::main` as we need to adjust the CLI arguments.
-        run_compiler(
-            args,
-            target_crate,
+        let mut args = args;
+        // Don't insert `MIRI_DEFAULT_ARGS`, in particular, `--cfg=miri`, if we are building
+        // a "host" crate. That may cause procedural macros (and probably build scripts) to
+        // depend on Miri-only symbols, such as `miri_resolve_frame`:
+        // https://github.com/rust-lang/miri/issues/1760
+        if target_crate {
+            // Splice in the default arguments after the program name.
+            // Some options have different defaults in Miri than in plain rustc; apply those by making
+            // them the first arguments after the binary name (but later arguments can overwrite them).
+            args.splice(1..1, miri::MIRI_DEFAULT_ARGS.iter().map(ToString::to_string));
+        }
+
+        // We cannot use `rustc_driver::main` as we want it to use `args` as the CLI arguments.
+        run_compiler_and_exit(
+            &args,
             &mut MiriBeRustCompilerCalls { target_crate },
             using_internal_features,
         )
@@ -448,7 +499,8 @@ fn main() {
     init_early_loggers(&early_dcx);
 
     // Parse our arguments and split them across `rustc` and `miri`.
-    let mut miri_config = miri::MiriConfig::default();
+    let mut many_seeds: Option<Range<u32>> = None;
+    let mut miri_config = MiriConfig::default();
     miri_config.env = env_snapshot;
 
     let mut rustc_args = vec![];
@@ -463,6 +515,8 @@ fn main() {
         if rustc_args.is_empty() {
             // Very first arg: binary name.
             rustc_args.push(arg);
+            // Also add the default arguments.
+            rustc_args.extend(miri::MIRI_DEFAULT_ARGS.iter().map(ToString::to_string));
         } else if after_dashdash {
             // Everything that comes after `--` is forwarded to the interpreted crate.
             miri_config.args.push(arg);
@@ -544,13 +598,19 @@ fn main() {
                 _ => show_error!("`-Zmiri-retag-fields` can only be `all`, `none`, or `scalar`"),
             };
         } else if let Some(param) = arg.strip_prefix("-Zmiri-seed=") {
-            if miri_config.seed.is_some() {
-                show_error!("Cannot specify -Zmiri-seed multiple times!");
-            }
             let seed = param.parse::<u64>().unwrap_or_else(|_| {
                 show_error!("-Zmiri-seed must be an integer that fits into u64")
             });
             miri_config.seed = Some(seed);
+        } else if let Some(param) = arg.strip_prefix("-Zmiri-many-seeds=") {
+            let range = parse_range(param).unwrap_or_else(|err| {
+                show_error!(
+                    "-Zmiri-many-seeds requires a range in the form `from..to` or `..to`: {err}"
+                )
+            });
+            many_seeds = Some(range);
+        } else if arg == "-Zmiri-many-seeds" {
+            many_seeds = Some(0..64);
         } else if let Some(_param) = arg.strip_prefix("-Zmiri-env-exclude=") {
             show_error!(
                 "`-Zmiri-env-exclude` has been removed; unset env vars before starting Miri instead"
@@ -665,13 +725,23 @@ fn main() {
             "Tree Borrows does not support integer-to-pointer casts, and is hence not compatible with permissive provenance"
         );
     }
+    // You can set either one seed or many.
+    if many_seeds.is_some() && miri_config.seed.is_some() {
+        show_error!("Only one of `-Zmiri-seed` and `-Zmiri-many-seeds can be set");
+    }
+    if many_seeds.is_some() && !rustc_args.iter().any(|arg| arg.starts_with("-Zthreads=")) {
+        // Ensure we have parallelism for many-seeds mode.
+        rustc_args.push(format!(
+            "-Zthreads={}",
+            std::thread::available_parallelism().map_or(1, |n| n.get())
+        ));
+    }
 
     debug!("rustc arguments: {:?}", rustc_args);
     debug!("crate arguments: {:?}", miri_config.args);
-    run_compiler(
-        rustc_args,
-        /* target_crate: */ true,
-        &mut MiriCompilerCalls { miri_config },
+    run_compiler_and_exit(
+        &rustc_args,
+        &mut MiriCompilerCalls::new(miri_config, many_seeds),
         using_internal_features,
     )
 }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -12,7 +12,7 @@ use crate::*;
 /// Details of premature program termination.
 pub enum TerminationInfo {
     Exit {
-        code: i64,
+        code: i32,
         leak_check: bool,
     },
     Abort(String),
@@ -214,7 +214,7 @@ pub fn prune_stacktrace<'tcx>(
 pub fn report_error<'tcx>(
     ecx: &InterpCx<'tcx, MiriMachine<'tcx>>,
     e: InterpErrorInfo<'tcx>,
-) -> Option<(i64, bool)> {
+) -> Option<(i32, bool)> {
     use InterpErrorKind::*;
     use UndefinedBehaviorInfo::*;
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,6 +1,4 @@
-use std::collections::BTreeSet;
 use std::num::NonZero;
-use std::sync::Mutex;
 use std::time::Duration;
 use std::{cmp, iter};
 
@@ -641,11 +639,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         match reject_with {
             RejectOpWith::Abort => isolation_abort_error(op_name),
             RejectOpWith::WarningWithoutBacktrace => {
-                // This exists to reduce verbosity; make sure we emit the warning at most once per
-                // operation.
-                static EMITTED_WARNINGS: Mutex<BTreeSet<String>> = Mutex::new(BTreeSet::new());
-
-                let mut emitted_warnings = EMITTED_WARNINGS.lock().unwrap();
+                let mut emitted_warnings = this.machine.reject_in_isolation_warned.borrow_mut();
                 if !emitted_warnings.contains(op_name) {
                     // First time we are seeing this.
                     emitted_warnings.insert(op_name.to_owned());
@@ -653,6 +647,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                         .dcx()
                         .warn(format!("{op_name} was made to return an error due to isolation"));
                 }
+
                 interp_ok(())
             }
             RejectOpWith::Warning => {

--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -428,7 +428,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "exit" => {
                 let [code] = this.check_shim(abi, Conv::C, link_name, args)?;
                 let code = this.read_scalar(code)?.to_i32()?;
-                throw_machine_stop!(TerminationInfo::Exit { code: code.into(), leak_check: false });
+                throw_machine_stop!(TerminationInfo::Exit { code, leak_check: false });
             }
             "abort" => {
                 let [] = this.check_shim(abi, Conv::C, link_name, args)?;

--- a/src/shims/native_lib.rs
+++ b/src/shims/native_lib.rs
@@ -1,5 +1,4 @@
 //! Implements calling functions from a native library.
-use std::cell::RefCell;
 use std::ops::Deref;
 
 use libffi::high::call as ffi;
@@ -174,16 +173,10 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     continue;
                 };
                 // The first time this happens, print a warning.
-                thread_local! {
-                    static HAVE_WARNED: RefCell<bool> = const { RefCell::new(false) };
+                if !this.machine.native_call_mem_warned.replace(true) {
+                    // Newly set, so first time we get here.
+                    this.emit_diagnostic(NonHaltingDiagnostic::NativeCallSharedMem);
                 }
-                HAVE_WARNED.with_borrow_mut(|have_warned| {
-                    if !*have_warned {
-                        // Newly inserted, so first time we see this span.
-                        this.emit_diagnostic(NonHaltingDiagnostic::NativeCallSharedMem);
-                        *have_warned = true;
-                    }
-                });
 
                 this.prepare_for_native_call(alloc_id, prov)?;
             }

--- a/src/shims/windows/foreign_items.rs
+++ b/src/shims/windows/foreign_items.rs
@@ -552,8 +552,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             // Miscellaneous
             "ExitProcess" => {
                 let [code] = this.check_shim(abi, sys_conv, link_name, args)?;
-                let code = this.read_scalar(code)?.to_u32()?;
-                throw_machine_stop!(TerminationInfo::Exit { code: code.into(), leak_check: false });
+                // Windows technically uses u32, but we unify everything to a Unix-style i32.
+                let code = this.read_scalar(code)?.to_i32()?;
+                throw_machine_stop!(TerminationInfo::Exit { code, leak_check: false });
             }
             "SystemFunction036" => {
                 // used by getrandom 0.1


### PR DESCRIPTION
That means we can remove the many-seeds mode from cargo-miri and miri-script. :) It also means we are building the MIR for the program only once, and then interpret it many times.

Fixes https://github.com/rust-lang/miri/issues/3877