### PR TITLE
fix toolchain flag parsing

### DIFF
--- a/miri-script/src/main.rs
+++ b/miri-script/src/main.rs
@@ -111,6 +111,7 @@ pub enum Command {
     /// `rustup-toolchain-install-master` must be installed for this to work.
     Toolchain {
         /// Flags that are passed through to `rustup-toolchain-install-master`.
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         flags: Vec<String>,
     },
     /// Pull and merge Miri changes from the rustc repo.


### PR DESCRIPTION
I think this one was missed in #4036, I was getting the following when trying `./miri toolchain -c rust-analyzer`:

```console
error: unexpected argument '-c' found

  tip: to pass '-c' as a value, use '-- -c'

Usage: miri-script toolchain [FLAGS]...

For more information, try '--help'.
```