### PR TITLE
adjust the way we build miri-script in RA, to fix proc-macros

### DIFF
--- a/etc/rust_analyzer_vscode.json
+++ b/etc/rust_analyzer_vscode.json
@@ -5,21 +5,19 @@
         "cargo-miri/Cargo.toml",
         "miri-script/Cargo.toml",
     ],
-    "rust-analyzer.check.invocationLocation": "root",
     "rust-analyzer.check.invocationStrategy": "once",
     "rust-analyzer.check.overrideCommand": [
-        "env",
-        "MIRI_AUTO_OPS=no",
         "./miri",
         "clippy", // make this `check` when working with a locally built rustc
         "--message-format=json",
     ],
+    "rust-analyzer.cargo.extraEnv": {
+        "MIRI_AUTO_OPS": "no",
+        "MIRI_IN_RA": "1",
+    },
     // Contrary to what the name suggests, this also affects proc macros.
-    "rust-analyzer.cargo.buildScripts.invocationLocation": "root",
     "rust-analyzer.cargo.buildScripts.invocationStrategy": "once",
     "rust-analyzer.cargo.buildScripts.overrideCommand": [
-        "env",
-        "MIRI_AUTO_OPS=no",
         "./miri",
         "check",
         "--message-format=json",

--- a/miri
+++ b/miri
@@ -3,12 +3,16 @@ set -e
 # We want to call the binary directly, so we need to know where it ends up.
 ROOT_DIR="$(dirname "$0")"
 MIRI_SCRIPT_TARGET_DIR="$ROOT_DIR"/miri-script/target
-# If stdout is not a terminal and we are not on CI, assume that we are being invoked by RA, and use JSON output.
-if ! [ -t 1 ] && [ -z "$CI" ]; then
+TOOLCHAIN="+nightly"
+# If we are being invoked for RA, use JSON output and the default toolchain (to make proc-macros
+# work in RA). This needs a different target dir to avoid mixing up the builds.
+if [ -n "$MIRI_IN_RA" ]; then
   MESSAGE_FORMAT="--message-format=json"
+  TOOLCHAIN=""
+  MIRI_SCRIPT_TARGET_DIR="$MIRI_SCRIPT_TARGET_DIR"/ra
 fi
 # We need a nightly toolchain, for `-Zroot-dir`.
-cargo +nightly build $CARGO_EXTRA_FLAGS --manifest-path "$ROOT_DIR"/miri-script/Cargo.toml \
+cargo $TOOLCHAIN build $CARGO_EXTRA_FLAGS --manifest-path "$ROOT_DIR"/miri-script/Cargo.toml \
   -Zroot-dir="$ROOT_DIR" \
   -q --target-dir "$MIRI_SCRIPT_TARGET_DIR" $MESSAGE_FORMAT || \
   ( echo "Failed to build miri-script. Is the 'nightly' toolchain installed?"; exit 1 )

--- a/miri-script/src/commands.rs
+++ b/miri-script/src/commands.rs
@@ -564,6 +564,10 @@ impl Command {
         if bless {
             e.sh.set_var("RUSTC_BLESS", "Gesundheit");
         }
+        if e.sh.var("MIRI_TEST_TARGET").is_ok() {
+            // Avoid trouble due to an incorrectly set env var.
+            bail!("MIRI_TEST_TARGET must not be set when invoking `./miri test`");
+        }
         if let Some(target) = target {
             // Tell the harness which target to test.
             e.sh.set_var("MIRI_TEST_TARGET", target);


### PR DESCRIPTION
RA doesn't seem to like it when different parts of the workspace are built with different compilers, and we can't even mix those in the same `target` dir it seems.

Also use a less repetitive way to set env vars for the cargo invocations.