### PR TITLE
Added Android to `epoll` and `eventfd` test targets

### DIFF
--- a/tests/fail-dep/libc/eventfd_block_read_twice.rs
+++ b/tests/fail-dep/libc/eventfd_block_read_twice.rs
@@ -1,4 +1,4 @@
-//@only-target: linux
+//@only-target: linux android
 //~^ERROR: deadlocked
 //~^^ERROR: deadlocked
 //@compile-flags: -Zmiri-preemption-rate=0

--- a/tests/fail-dep/libc/eventfd_block_write_twice.rs
+++ b/tests/fail-dep/libc/eventfd_block_write_twice.rs
@@ -1,4 +1,4 @@
-//@only-target: linux
+//@only-target: linux android
 //~^ERROR: deadlocked
 //~^^ERROR: deadlocked
 //@compile-flags: -Zmiri-preemption-rate=0

--- a/tests/fail-dep/libc/libc_epoll_unsupported_fd.rs
+++ b/tests/fail-dep/libc/libc_epoll_unsupported_fd.rs
@@ -1,4 +1,4 @@
-//@only-target: linux
+//@only-target: linux android
 
 // This is a test for registering unsupported fd with epoll.
 // Register epoll fd with epoll is allowed in real system, but we do not support this.


### PR DESCRIPTION
It seems like `android` was forgotten to be targeted in all `epoll` and `eventfd` tests while it's a Linux-based OS and supports these operations.