### PR TITLE
Use deref_poiner_as instead of deref_pointer

### DIFF
--- a/src/shims/unix/macos/foreign_items.rs
+++ b/src/shims/unix/macos/foreign_items.rs
@@ -120,7 +120,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 this.check_no_isolation("`_NSGetExecutablePath`")?;
 
                 let buf_ptr = this.read_pointer(buf)?;
-                let bufsize = this.deref_pointer(bufsize)?;
+                let bufsize = this.deref_pointer_as(bufsize, this.machine.layouts.u32)?;
 
                 // Using the host current_exe is a bit off, but consistent with Linux
                 // (where stdlib reads /proc/self/exe).


### PR DESCRIPTION
Links to #3841.