### PR TITLE
many-seeds: do not use more than 8 threads

### DIFF
--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -723,10 +723,9 @@ fn main() {
 
     // Ensure we have parallelism for many-seeds mode.
     if many_seeds.is_some() && !rustc_args.iter().any(|arg| arg.starts_with("-Zthreads=")) {
-        rustc_args.push(format!(
-            "-Zthreads={}",
-            std::thread::available_parallelism().map_or(1, |n| n.get())
-        ));
+        // Clamp to 8 threads; things get a lot less efficient beyond that due to lock contention.
+        let threads = std::thread::available_parallelism().map_or(1, |n| n.get()).min(8);
+        rustc_args.push(format!("-Zthreads={threads}"));
     }
     let many_seeds =
         many_seeds.map(|seeds| ManySeedsConfig { seeds, keep_going: many_seeds_keep_going });


### PR DESCRIPTION
Using 8 instead of 20 threads gives a 6x speedup here. Lock contention completely kills performance for higher thread counts (see [Zulip discussion](https://rust-lang.zulipchat.com/#narrow/channel/187679-t-compiler.2Fwg-parallel-rustc/topic/Miri.20not.20getting.20as.20much.20parallelism.20as.20expected)).