### PR TITLE
Pre-intern name when searching module children

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -38,9 +38,10 @@ fn try_resolve_did(tcx: TyCtxt<'_>, path: &[&str], namespace: Option<Namespace>)
         item: DefId,
         name: &'a str,
     ) -> impl Iterator<Item = DefId> + 'a {
+        let name = Symbol::intern(name);
         tcx.module_children(item)
             .iter()
-            .filter(move |item| item.ident.name.as_str() == name)
+            .filter(move |item| item.ident.name == name)
             .map(move |item| item.res.def_id())
     }
 


### PR DESCRIPTION
This avoids a good deal of work, since each module child can now just be compared via u32 comparison, rather than fetching the raw &str (requiring locking and indexing into the interner) and then comparing the two strings (also relatively expensive).

This significantly helps with contention problems in the Symbol map for the parallel many-seeds tests discussed on Zulip: https://rust-lang.zulipchat.com/#narrow/channel/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202025-01-23.5D, essentially eliminating that lock from profiling. I'll be filing a separate PR against rust-lang/rust for other fixes, but this was a self-contained change in miri that seems obviously good regardless of parallelism.