### PR TITLE
Bump ui test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,9 +1051,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ui_test"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180a1250feba0214b892e22c3a14e9f6688cc084d7b45ec4672106fcb7914641"
+checksum = "7484683d60d50ca1d1b6433c3dbf6c5ad71d20387acdcfb16fe79573f3fba576"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ windows-sys = { version = "0.52", features = [
 ] }
 
 [dev-dependencies]
-ui_test = "0.27.1"
+ui_test = "0.28.0"
 colored = "2"
 rustc_version = "0.4"
 regex = "1.5.5"


### PR DESCRIPTION
Manually confirmed that it now actually works with `run --dep`