### PR TITLE
increase thread limit for many-seeds mode

### DIFF
--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -723,8 +723,8 @@ fn main() {
 
     // Ensure we have parallelism for many-seeds mode.
     if many_seeds.is_some() && !rustc_args.iter().any(|arg| arg.starts_with("-Zthreads=")) {
-        // Clamp to 8 threads; things get a lot less efficient beyond that due to lock contention.
-        let threads = std::thread::available_parallelism().map_or(1, |n| n.get()).min(8);
+        // Clamp to 10 threads; things get a lot less efficient beyond that due to lock contention.
+        let threads = std::thread::available_parallelism().map_or(1, |n| n.get()).min(10);
         rustc_args.push(format!("-Zthreads={threads}"));
     }
     let many_seeds =


### PR DESCRIPTION
10 threads are actually faster than 8 threads now thanks to some of the recent changes. :)

On my system at least, 12 threads make it slower again, taking about as long as 8 threads.