### PR TITLE
allow code to call geteuid()

### DIFF
--- a/src/shims/unix/foreign_items.rs
+++ b/src/shims/unix/foreign_items.rs
@@ -815,7 +815,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 this.handle_miri_start_unwind(payload)?;
                 return interp_ok(EmulateItemResult::NeedsUnwind);
             }
-            "getuid" => {
+            "getuid" | "geteuid" => {
                 let [] = this.check_shim(abi, Conv::C, link_name, args)?;
                 // For now, just pretend we always have this fixed UID.
                 this.write_int(UID, dest)?;

--- a/tests/pass-dep/libc/libc-misc.rs
+++ b/tests/pass-dep/libc/libc-misc.rs
@@ -78,11 +78,16 @@ fn test_getuid() {
     let _val = unsafe { libc::getuid() };
 }
 
+fn test_geteuid() {
+    let _val = unsafe { libc::geteuid() };
+}
+
 fn main() {
     test_thread_local_errno();
     test_environ();
     test_dlsym();
     test_getuid();
+    test_geteuid();
 
     #[cfg(target_os = "linux")]
     test_sigrt();


### PR DESCRIPTION
Just return the effective UID like it's done for the real UID.

This fixes the `whoami` crate usage.