### PR TITLE
Remove GitHub job summaries

### DIFF
--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -217,6 +217,7 @@ fn run_tests(
         ui_test::default_file_filter,
         // This could be used to overwrite the `Config` on a per-test basis.
         |_, _| {},
+        // No GHA output as that would also show in the main rustc repo.
         match args.format {
             Format::Terse => status_emitter::Text::quiet(),
             Format::Pretty => status_emitter::Text::verbose(),

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -217,15 +217,10 @@ fn run_tests(
         ui_test::default_file_filter,
         // This could be used to overwrite the `Config` on a per-test basis.
         |_, _| {},
-        (
-            match args.format {
-                Format::Terse => status_emitter::Text::quiet(),
-                Format::Pretty => status_emitter::Text::verbose(),
-            },
-            status_emitter::Gha::</* GHA Actions groups*/ false> {
-                name: format!("{mode:?} {path} ({target})"),
-            },
-        ),
+        match args.format {
+            Format::Terse => status_emitter::Text::quiet(),
+            Format::Pretty => status_emitter::Text::verbose(),
+        },
     )
 }
 


### PR DESCRIPTION
They don't seem to be used by miri contributors, and they pollute job summaries in rust-lang/rust.