### PR TITLE
make sure we install the toolchain for the intended host target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/workflows/setup
+        with:
+          toolchain_flags: "--host ${{ matrix.host_target }}"
 
       # The `style` job only runs on Linux; this makes sure the Windows-host-specific
       # code is also covered by clippy.

--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -1,5 +1,9 @@
 name: "Miri CI setup"
 description: "Sets up Miri CI"
+inputs:
+  toolchain_flags:
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
@@ -45,7 +49,7 @@ runs:
             echo "Building against latest rustc git version"
             git ls-remote https://github.com/rust-lang/rust/ HEAD | cut -f 1 > rust-version
           fi
-          ./miri toolchain
+          ./miri toolchain ${{ inputs.toolchain_flags }}
         shell: bash
 
       - name: Show Rust version (miri toolchain)

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -eu
 
 function begingroup {
   echo "::group::$@"
@@ -10,6 +10,17 @@ function endgroup {
   set +x
   echo "::endgroup"
 }
+
+begingroup "Sanity-check environment"
+
+# Ensure the HOST_TARGET is what it should be.
+if ! rustc -vV | grep -q "^host: $HOST_TARGET\$"; then
+  echo "This runner should be using host target $HOST_TARGET but rustc disagrees:"
+  rustc -vV
+  exit 1
+fi
+
+endgroup
 
 begingroup "Building Miri"
 

--- a/tests/pass/float.rs
+++ b/tests/pass/float.rs
@@ -1327,15 +1327,24 @@ fn test_non_determinism() {
         ensure_nondet(|| 3.0f32.hypot(4.0f32));
         ensure_nondet(|| 1f32.sin());
         ensure_nondet(|| 0f32.cos());
-        ensure_nondet(|| 1.0f32.sinh());
+        // On i686-pc-windows-msvc , these functions are implemented by calling the `f64` version,
+        // which means the little rounding errors Miri introduces are discard by the cast down to `f32`.
+        // Just skip the test for them.
+        if !cfg!(all(target_os = "windows", target_env = "msvc", target_arch = "x86")) {
+            ensure_nondet(|| 1.0f32.tan());
+            ensure_nondet(|| 1.0f32.asin());
+            ensure_nondet(|| 5.0f32.acos());
+            ensure_nondet(|| 1.0f32.atan());
+            ensure_nondet(|| 1.0f32.atan2(2.0f32));
+            ensure_nondet(|| 1.0f32.sinh());
+            ensure_nondet(|| 1.0f32.cosh());
+            ensure_nondet(|| 1.0f32.tanh());
+        }
         ensure_nondet(|| 1.0f32.asinh());
-        ensure_nondet(|| 1.0f32.cosh());
         ensure_nondet(|| 2.0f32.acosh());
-        ensure_nondet(|| 1.0f32.tan());
-        ensure_nondet(|| 1.0f32.tanh());
-        ensure_nondet(|| 1.0f32.atan2(2.0f32));
         ensure_nondet(|| 0.5f32.atanh());
         ensure_nondet(|| 5.0f32.gamma());
+        ensure_nondet(|| 5.0f32.ln_gamma());
         ensure_nondet(|| 5.0f32.erf());
         ensure_nondet(|| 5.0f32.erfc());
     }
@@ -1348,18 +1357,23 @@ fn test_non_determinism() {
         ensure_nondet(|| 1f64.ln_1p());
         ensure_nondet(|| f64::consts::E.log10());
         ensure_nondet(|| f64::consts::E.log2());
-        ensure_nondet(|| 1f64.sin());
-        ensure_nondet(|| 0f64.cos());
         ensure_nondet(|| 27.0f64.cbrt());
         ensure_nondet(|| 3.0f64.hypot(4.0f64));
-        ensure_nondet(|| 1.0f64.sinh());
-        ensure_nondet(|| 1.0f64.asinh());
-        ensure_nondet(|| 1.0f64.cosh());
-        ensure_nondet(|| 3.0f64.acosh());
+        ensure_nondet(|| 1f64.sin());
+        ensure_nondet(|| 0f64.cos());
         ensure_nondet(|| 1.0f64.tan());
+        ensure_nondet(|| 1.0f64.asin());
+        ensure_nondet(|| 5.0f64.acos());
+        ensure_nondet(|| 1.0f64.atan());
+        ensure_nondet(|| 1.0f64.atan2(2.0f64));
+        ensure_nondet(|| 1.0f64.sinh());
+        ensure_nondet(|| 1.0f64.cosh());
         ensure_nondet(|| 1.0f64.tanh());
+        ensure_nondet(|| 1.0f64.asinh());
+        ensure_nondet(|| 3.0f64.acosh());
         ensure_nondet(|| 0.5f64.atanh());
         ensure_nondet(|| 5.0f64.gamma());
+        ensure_nondet(|| 5.0f64.ln_gamma());
         ensure_nondet(|| 5.0f64.erf());
         ensure_nondet(|| 5.0f64.erfc());
     }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/miri/issues/4204

Also fixes the float.rs test to pass on win32-msvc.