### PR TITLE
Fix tier 2 sysroots job

### DIFF
--- a/.github/workflows/sysroots.yml
+++ b/.github/workflows/sysroots.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build the sysroots
         run: |
+          rustup toolchain install nightly
           cargo install -f rustup-toolchain-install-master
           ./miri toolchain -c rust-docs # Docs are the only place targets are separated by tier
           ./miri install


### PR DESCRIPTION
The job has been failing for a while, but it's been failing in a way that doesn't send a notification :facepalm: 

I'm only fixing the reason the job has been failing, and not preventing this from happening again. Permitting a missing artifact isn't possible, so all the options to ensure the notification goes through on job failure seem hacky.

This diff _must_ land so I'm just landing it. I'll follow up later with some other improvements.