### PR TITLE
Show interpreter backtrace error on Ctrl+C

### DIFF
--- a/src/concurrency/thread.rs
+++ b/src/concurrency/thread.rs
@@ -1150,7 +1150,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         loop {
             if CTRL_C_RECEIVED.load(Relaxed) {
                 this.machine.handle_abnormal_termination();
-                std::process::exit(1);
+                throw_machine_stop!(TerminationInfo::Interrupted);
             }
             match this.machine.threads.schedule(&this.machine.clock)? {
                 SchedulingAction::ExecuteStep => {

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -16,6 +16,8 @@ pub enum TerminationInfo {
         leak_check: bool,
     },
     Abort(String),
+    /// Miri was interrupted by a Ctrl+C from the user
+    Interrupted,
     UnsupportedInIsolation(String),
     StackedBorrowsUb {
         msg: String,
@@ -63,6 +65,7 @@ impl fmt::Display for TerminationInfo {
         match self {
             Exit { code, .. } => write!(f, "the evaluated program completed with exit code {code}"),
             Abort(msg) => write!(f, "{msg}"),
+            Interrupted => write!(f, "interpretation was interrupted"),
             UnsupportedInIsolation(msg) => write!(f, "{msg}"),
             Int2PtrWithStrictProvenance =>
                 write!(
@@ -226,6 +229,7 @@ pub fn report_error<'tcx>(
         let title = match info {
             &Exit { code, leak_check } => return Some((code, leak_check)),
             Abort(_) => Some("abnormal termination"),
+            Interrupted => None,
             UnsupportedInIsolation(_) | Int2PtrWithStrictProvenance | UnsupportedForeignItem(_) =>
                 Some("unsupported operation"),
             StackedBorrowsUb { .. } | TreeBorrowsUb { .. } | DataRace { .. } =>


### PR DESCRIPTION
Closes #3116 by showing the following error message and interpreter backtrace on Ctrl+C:
```
error: interpretation was interrupted                                                                                                                                                            
 --> a.rs:2:5
  |
2 |     loop {}
  |     ^^^^^^^ interpretation was interrupted
  |
  = note: BACKTRACE:
  = note: inside `main` at a.rs:2:5: 2:12

note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

error: aborting due to 1 previous error
```

The contents of `a.rs` were:
```rust
fn main() {
    loop {}
}
```

No new tests were added because it seems unfeasible, see the discussion in https://github.com/rust-lang/miri/issues/3116#issuecomment-2705134484