### PR TITLE
catch_unwind: do not permit catch function to unwind

### DIFF
--- a/src/shims/panic.rs
+++ b/src/shims/panic.rs
@@ -144,7 +144,8 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // Directly return to caller of `try`.
                 StackPopCleanup::Goto {
                     ret: catch_unwind.ret,
-                    unwind: mir::UnwindAction::Continue,
+                    // `catch_fn` must not unwind.
+                    unwind: mir::UnwindAction::Unreachable,
                 },
             )?;
 


### PR DESCRIPTION
The intrinsic docs say
```
/// `catch_fn` must not unwind.
```