### PR TITLE
Fix Build Fail on MacOs because of libffi-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,9 +436,9 @@ checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libffi"
-version = "3.2.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce826c243048e3d5cec441799724de52e2d42f820468431fc3fceee2341871e2"
+checksum = "4a9434b6fc77375fb624698d5f8c49d7e80b10d59eb1219afda27d1f824d4074"
 dependencies = [
  "libc",
  "libffi-sys",
@@ -446,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "libffi-sys"
-version = "2.3.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36115160c57e8529781b4183c2bb51fdc1f6d6d1ed345591d84be7703befb3c"
+checksum = "ead36a2496acfc8edd6cc32352110e9478ac5b9b5f5b9856ebd3d28019addb84"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ features = ['unprefixed_malloc_on_supported_platforms']
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-libffi = "3.2.0"
+libffi = "4.0.0"
 libloading = "0.8"
 
 [target.'cfg(target_family = "windows")'.dependencies]


### PR DESCRIPTION
`libffi-sys 2.3.0` results in build failures on MacOS: [issue](https://github.com/tov/libffi-rs/issues/109#issue-2966233822).

This updates `libffi` to a new major version `4.0.0` which updates `libffi-sys` to `3.2.0`. On my Mac M1 Seqoia 15.3.2 this fixes the build.

Discussion here: [#miri > Can't run ./miri test: build failure](https://rust-lang.zulipchat.com/#narrow/channel/269128-miri/topic/Can't.20run.20.2E.2Fmiri.20test.3A.20build.20failure)