### PR TITLE
TB: add `Cell` state to support more fine-grained tracking of interior mutable data

### DIFF
--- a/src/borrow_tracker/tree_borrows/tree.rs
+++ b/src/borrow_tracker/tree_borrows/tree.rs
@@ -721,9 +721,14 @@ impl<'tcx> Tree {
                     // visit all children, skipping none
                     |_| ContinueTraversal::Recurse,
                     |args: NodeAppArgs<'_>| -> Result<(), TransitionError> {
-                        let NodeAppArgs { node, .. } = args;
+                        let NodeAppArgs { node, perm, .. } = args;
+                        let perm =
+                            perm.get().copied().unwrap_or_else(|| node.default_location_state());
                         if global.borrow().protected_tags.get(&node.tag)
                             == Some(&ProtectorKind::StrongProtector)
+                            // Don't check for protector if it is a Cell (see `unsafe_cell_deallocate` in `interior_mutability.rs`).
+                            // Related to https://github.com/rust-lang/rust/issues/55005.
+                            && !perm.permission().is_cell()
                         {
                             Err(TransitionError::ProtectedDealloc)
                         } else {
@@ -865,10 +870,9 @@ impl<'tcx> Tree {
                 let idx = self.tag_mapping.get(&tag).unwrap();
                 // Only visit initialized permissions
                 if let Some(p) = perms.get(idx)
+                    && let Some(access_kind) = p.permission.protector_end_access()
                     && p.initialized
                 {
-                    let access_kind =
-                        if p.permission.is_active() { AccessKind::Write } else { AccessKind::Read };
                     let access_cause = diagnostics::AccessCause::FnExit(access_kind);
                     TreeVisitor { nodes: &mut self.nodes, tag_mapping: &self.tag_mapping, perms }
                         .traverse_nonchildren(

--- a/tests/fail/tree_borrows/reserved/cell-protected-write.rs
+++ b/tests/fail/tree_borrows/reserved/cell-protected-write.rs
@@ -12,16 +12,16 @@ use std::cell::UnsafeCell;
 fn main() {
     unsafe {
         let n = &mut UnsafeCell::new(0u8);
-        name!(n.get(), "base");
+        name!(n as *mut _, "base");
         let x = &mut *(n as *mut UnsafeCell<_>);
-        name!(x.get(), "x");
-        let y = (&mut *n).get();
+        name!(x as *mut _, "x");
+        let y = (&mut *n) as *mut UnsafeCell<_> as *mut _;
         name!(y);
         write_second(x, y);
         unsafe fn write_second(x: &mut UnsafeCell<u8>, y: *mut u8) {
             let alloc_id = alloc_id!(x.get());
-            name!(x.get(), "callee:x");
-            name!(x.get()=>1, "caller:x");
+            name!(x as *mut _, "callee:x");
+            name!((x as *mut _)=>1, "caller:x");
             name!(y, "callee:y");
             name!(y, "caller:y");
             print_state!(alloc_id);

--- a/tests/fail/tree_borrows/reserved/cell-protected-write.stderr
+++ b/tests/fail/tree_borrows/reserved/cell-protected-write.stderr
@@ -21,7 +21,7 @@ LL |             *y = 1;
 help: the accessed tag <TAG> was created here
   --> tests/fail/tree_borrows/reserved/cell-protected-write.rs:LL:CC
    |
-LL |         let y = (&mut *n).get();
+LL |         let y = (&mut *n) as *mut UnsafeCell<_> as *mut _;
    |                 ^^^^^^^^^
 help: the protected tag <TAG> was created here, in the initial state Reserved
   --> tests/fail/tree_borrows/reserved/cell-protected-write.rs:LL:CC

--- a/tests/pass/tree_borrows/cell-alternate-writes.rs
+++ b/tests/pass/tree_borrows/cell-alternate-writes.rs
@@ -6,16 +6,16 @@ mod utils;
 
 use std::cell::UnsafeCell;
 
-// UnsafeCells use the parent tag, so it is possible to use them with
+// UnsafeCells use the `Cell` state, so it is possible to use them with
 // few restrictions when only among themselves.
 fn main() {
     unsafe {
         let data = &mut UnsafeCell::new(0u8);
-        name!(data.get(), "data");
+        name!(data as *mut _, "data");
         let x = &*data;
-        name!(x.get(), "x");
+        name!(x as *const _, "x");
         let y = &*data;
-        name!(y.get(), "y");
+        name!(y as *const _, "y");
         let alloc_id = alloc_id!(data.get());
         print_state!(alloc_id);
         // y and x tolerate alternating Writes

--- a/tests/pass/tree_borrows/cell-alternate-writes.stderr
+++ b/tests/pass/tree_borrows/cell-alternate-writes.stderr
@@ -2,11 +2,15 @@
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   1
 | Act |    └─┬──<TAG=root of the allocation>
-| ReIM|      └────<TAG=data, x, y>
+| ReIM|      └─┬──<TAG=data>
+| Cel |        ├────<TAG=x>
+| Cel |        └────<TAG=y>
 ──────────────────────────────────────────────────
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   1
 | Act |    └─┬──<TAG=root of the allocation>
-| Act |      └────<TAG=data, x, y>
+| Act |      └─┬──<TAG=data>
+| Cel |        ├────<TAG=x>
+| Cel |        └────<TAG=y>
 ──────────────────────────────────────────────────

--- a/tests/pass/tree_borrows/interior_mutability.rs
+++ b/tests/pass/tree_borrows/interior_mutability.rs
@@ -102,7 +102,12 @@ fn unsafe_cell_invalidate() {
     let raw1 = &mut x as *mut _;
     let ref1 = unsafe { &mut *raw1 };
     let raw2 = ref1 as *mut _;
-    // Now the borrow stack is: raw1, ref2, raw2.
+    // Now the borrow tree is:
+    //
+    // Act x
+    // Res `- raw1
+    // Res    `- ref1, raw2
+    //
     // So using raw1 invalidates raw2.
     f(unsafe { mem::transmute(raw2) }, raw1);
 }
@@ -139,7 +144,7 @@ fn refcell_basic() {
     }
 }
 
-// Adding a Stacked Borrows protector for `Ref` would break this
+// Adding a protector for `Ref` would break this
 fn ref_protector() {
     fn break_it(rc: &RefCell<i32>, r: Ref<'_, i32>) {
         // `r` has a shared reference, it is passed in as argument and hence

--- a/tests/pass/tree_borrows/reserved.rs
+++ b/tests/pass/tree_borrows/reserved.rs
@@ -43,11 +43,11 @@ unsafe fn read_second<T>(x: &mut T, y: *mut u8) {
 unsafe fn cell_protected_read() {
     print("[interior mut + protected] Foreign Read: Re* -> Frz");
     let base = &mut UnsafeCell::new(0u8);
-    name!(base.get(), "base");
+    name!(base as *mut _, "base");
     let alloc_id = alloc_id!(base.get());
     let x = &mut *(base as *mut UnsafeCell<u8>);
-    name!(x.get(), "x");
-    let y = (&mut *base).get();
+    name!(x as *mut _, "x");
+    let y = &mut *base as *mut UnsafeCell<u8> as *mut u8;
     name!(y);
     read_second(x, y); // Foreign Read for callee:x
     print_state!(alloc_id);
@@ -57,11 +57,11 @@ unsafe fn cell_protected_read() {
 unsafe fn cell_unprotected_read() {
     print("[interior mut] Foreign Read: Re* -> Re*");
     let base = &mut UnsafeCell::new(0u64);
-    name!(base.get(), "base");
+    name!(base as *mut _, "base");
     let alloc_id = alloc_id!(base.get());
     let x = &mut *(base as *mut UnsafeCell<_>);
-    name!(x.get(), "x");
-    let y = (&mut *base).get();
+    name!(x as *mut _, "x");
+    let y = &mut *base as *mut UnsafeCell<u64> as *mut u64;
     name!(y);
     let _val = *y; // Foreign Read for x
     print_state!(alloc_id);
@@ -72,11 +72,11 @@ unsafe fn cell_unprotected_read() {
 unsafe fn cell_unprotected_write() {
     print("[interior mut] Foreign Write: Re* -> Re*");
     let base = &mut UnsafeCell::new(0u64);
-    name!(base.get(), "base");
+    name!(base as *mut _, "base");
     let alloc_id = alloc_id!(base.get());
     let x = &mut *(base as *mut UnsafeCell<u64>);
-    name!(x.get(), "x");
-    let y = (&mut *base).get();
+    name!(x as *mut _, "x");
+    let y = &mut *base as *mut UnsafeCell<u64> as *mut u64;
     name!(y);
     *y = 1; // Foreign Write for x
     print_state!(alloc_id);


### PR DESCRIPTION
This adds a new `Cell` state to TB to represent shared references to interior mutable data. This is still a WIP for making the tracking of interior mutable data per-byte, like in Stacked Borrows.

cc @RalfJung @JoJoDeveloping 