### PR TITLE
Mark unsafe attributes as such

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ Miri knows where it is supposed to start execution:
 
 ```rust
 #[cfg(miri)]
-#[no_mangle]
+#[unsafe(no_mangle)]
 fn miri_start(argc: isize, argv: *const *const u8) -> isize {
     // Call the actual start function that your project implements, based on your target's conventions.
 }

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -106,7 +106,7 @@ fn entry_fn(tcx: TyCtxt<'_>) -> (DefId, MiriEntryFnType) {
         } else {
             tcx.dcx().fatal(
                 "`miri_start` must have the following signature:\n\
-                        fn miri_start(argc: isize, argv: *const *const u8) -> isize",
+                fn miri_start(argc: isize, argv: *const *const u8) -> isize",
             );
         }
     } else {
@@ -115,7 +115,7 @@ fn entry_fn(tcx: TyCtxt<'_>) -> (DefId, MiriEntryFnType) {
             Alternatively, you can export a `miri_start` function:\n\
             \n\
             #[cfg(miri)]\n\
-            #[no_mangle]\n\
+            #[unsafe(no_mangle)]\n\
             fn miri_start(argc: isize, argv: *const *const u8) -> isize {\
             \n    // Call the actual start function that your project implements, based on your target's conventions.\n\
             }"

--- a/tests/fail/no_main.stderr
+++ b/tests/fail/no_main.stderr
@@ -2,7 +2,7 @@ error: Miri can only run programs that have a main function.
        Alternatively, you can export a `miri_start` function:
        
        #[cfg(miri)]
-       #[no_mangle]
+       #[unsafe(no_mangle)]
        fn miri_start(argc: isize, argv: *const *const u8) -> isize {
            // Call the actual start function that your project implements, based on your target's conventions.
        }


### PR DESCRIPTION
Unsafe attributes are supported and recommended since Rust 1.82[^1] and mandated by edition 2024[^2].

[^1]: [Announcing Rust 1.82.0](https://blog.rust-lang.org/2024/10/17/Rust-1.82.0/#unsafe-attributes)
[^2]: [Unsafe attributes](https://doc.rust-lang.org/stable/edition-guide/rust-2024/unsafe-attributes.html)
