### PR TITLE
Tree Borrows: Correctly handle interior mutable data in `Box`

### DIFF
--- a/src/borrow_tracker/tree_borrows/mod.rs
+++ b/src/borrow_tracker/tree_borrows/mod.rs
@@ -173,7 +173,7 @@ impl<'tcx> NewPermission {
         pointee.is_unpin(*cx.tcx, cx.typing_env()).then_some(()).map(|()| {
             // Regular `Unpin` box, give it `noalias` but only a weak protector
             // because it is valid to deallocate it within the function.
-            let ty_is_freeze = ty.is_freeze(*cx.tcx, cx.typing_env());
+            let ty_is_freeze = pointee.is_freeze(*cx.tcx, cx.typing_env());
             let protected = kind == RetagKind::FnEntry;
             let initial_state = Permission::new_reserved(ty_is_freeze, protected);
             Self {

--- a/tests/pass/tree_borrows/cell-inside-box.rs
+++ b/tests/pass/tree_borrows/cell-inside-box.rs
@@ -8,12 +8,28 @@ use std::cell::UnsafeCell;
 
 pub fn main() {
     let cell = UnsafeCell::new(42);
-    let mut root = Box::new(cell);
+    let box1 = Box::new(cell);
 
-    let a = Box::as_mut_ptr(&mut root);
     unsafe {
-        name!(a);
-        let alloc_id = alloc_id!(a);
+        let ptr1: *mut UnsafeCell<i32> = Box::into_raw(box1);
+        name!(ptr1);
+
+        let mut box2 = Box::from_raw(ptr1);
+        // `ptr2` will be a descendant of `ptr1`.
+        let ptr2: *mut UnsafeCell<i32> = Box::as_mut_ptr(&mut box2);
+        name!(ptr2);
+
+        // We perform a write through `x`.
+        // Because `ptr1` is ReservedIM, a child write will make it transition to Active.
+        // Because `ptr2` is ReservedIM, a foreign write doesn't have any effect on it.
+        let x = (*ptr1).get();
+        *x = 1;
+
+        // We can still read from `ptr2`.
+        let val = *(*ptr2).get();
+        assert_eq!(val, 1);
+
+        let alloc_id = alloc_id!(ptr1);
         print_state!(alloc_id);
     }
 }

--- a/tests/pass/tree_borrows/cell-inside-box.rs
+++ b/tests/pass/tree_borrows/cell-inside-box.rs
@@ -1,0 +1,19 @@
+//@compile-flags: -Zmiri-tree-borrows
+#![feature(box_as_ptr)]
+#[path = "../../utils/mod.rs"]
+#[macro_use]
+mod utils;
+
+use std::cell::UnsafeCell;
+
+pub fn main() {
+    let cell = UnsafeCell::new(42);
+    let mut root = Box::new(cell);
+
+    let a = Box::as_mut_ptr(&mut root);
+    unsafe {
+        name!(a);
+        let alloc_id = alloc_id!(a);
+        print_state!(alloc_id);
+    }
+}

--- a/tests/pass/tree_borrows/cell-inside-box.stderr
+++ b/tests/pass/tree_borrows/cell-inside-box.stderr
@@ -2,5 +2,6 @@
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   4
 | Act |    └─┬──<TAG=root of the allocation>
-| ReIM|      └────<TAG=a>
+| Act |      └─┬──<TAG=ptr1>
+| ReIM|        └────<TAG=ptr2>
 ──────────────────────────────────────────────────

--- a/tests/pass/tree_borrows/cell-inside-box.stderr
+++ b/tests/pass/tree_borrows/cell-inside-box.stderr
@@ -1,0 +1,6 @@
+──────────────────────────────────────────────────
+Warning: this tree is indicative only. Some tags may have been hidden.
+0..   4
+| Act |    └─┬──<TAG=root of the allocation>
+| ReIM|      └────<TAG=a>
+──────────────────────────────────────────────────


### PR DESCRIPTION

Previously, the pointee type would be behind a `*const` pointer, so `ty_is_freeze` would always be `true`, even if there was an `UnsafeCell` in `Box`.  The output of the `cell-inside-box.rs` test would be 

```
| Act |    └─┬──<TAG=root of the allocation>
| Res |      └────<TAG=a>
``` 
But the `Res` should be `ReIM` because we have an `UnsafeCell` in `Box`.