### PR TITLE
Update to edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ name = "miri"
 repository = "https://github.com/rust-lang/miri"
 version = "0.1.0"
 default-run = "miri"
-edition = "2021"
+edition = "2024"
 
 [lib]
 test = true     # we have unit tests

--- a/cargo-miri/Cargo.toml
+++ b/cargo-miri/Cargo.toml
@@ -5,7 +5,7 @@ license = "MIT OR Apache-2.0"
 name = "cargo-miri"
 repository = "https://github.com/rust-lang/miri"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [[bin]]
 name = "cargo-miri"

--- a/miri-script/Cargo.toml
+++ b/miri-script/Cargo.toml
@@ -6,7 +6,7 @@ name = "miri-script"
 repository = "https://github.com/rust-lang/miri"
 version = "0.1.0"
 default-run = "miri-script"
-edition = "2021"
+edition = "2024"
 
 [workspace]
 # We make this a workspace root so that cargo does not go looking in ../Cargo.toml for the workspace root.

--- a/miri-script/src/util.rs
+++ b/miri-script/src/util.rs
@@ -213,7 +213,7 @@ impl MiriEnv {
             let toolchain = &self.toolchain;
             let mut cmd = cmd!(
                 self.sh,
-                "rustfmt +{toolchain} --edition=2021 --config-path {config_path} --unstable-features --skip-children {flags...}"
+                "rustfmt +{toolchain} --edition=2024 --config-path {config_path} --unstable-features --skip-children {flags...}"
             );
             if first {
                 // Log an abbreviating command, and only once.

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -459,7 +459,7 @@ fn jemalloc_magic() {
     // linking, so we need to explicitly depend on the function.
     #[cfg(target_os = "macos")]
     {
-        extern "C" {
+        unsafe extern "C" {
             fn _rjem_je_zone_register();
         }
 

--- a/src/borrow_tracker/tree_borrows/diagnostics.rs
+++ b/src/borrow_tracker/tree_borrows/diagnostics.rs
@@ -179,7 +179,7 @@ impl NodeDebugInfo {
     /// Add a name to the tag. If a same tag is associated to several pointers,
     /// it can have several names which will be separated by commas.
     pub fn add_name(&mut self, name: &str) {
-        if let Some(ref mut prev_name) = &mut self.name {
+        if let Some(prev_name) = &mut self.name {
             prev_name.push_str(", ");
             prev_name.push_str(name);
         } else {

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -648,8 +648,7 @@ impl<'tcx> MiriMachine<'tcx> {
             AccessedAlloc(AllocId(id), access_kind) =>
                 format!("{access_kind} to allocation with id {id}"),
             FreedAlloc(AllocId(id)) => format!("freed allocation with id {id}"),
-            RejectedIsolatedOp(ref op) =>
-                format!("{op} was made to return an error due to isolation"),
+            RejectedIsolatedOp(op) => format!("{op} was made to return an error due to isolation"),
             ProgressReport { .. } =>
                 format!("progress report: current operation being executed is here"),
             Int2Ptr { .. } => format!("integer-to-pointer cast"),

--- a/tests/pass/coroutine.rs
+++ b/tests/pass/coroutine.rs
@@ -183,18 +183,18 @@ fn basic() {
 
 fn smoke_resume_arg() {
     fn drain<G: Coroutine<R, Yield = Y> + Unpin, R, Y>(
-        gen: &mut G,
+        gen_: &mut G,
         inout: Vec<(R, CoroutineState<Y, G::Return>)>,
     ) where
         Y: Debug + PartialEq,
         G::Return: Debug + PartialEq,
     {
-        let mut gen = Pin::new(gen);
+        let mut gen_ = Pin::new(gen_);
 
         for (input, out) in inout {
-            assert_eq!(gen.as_mut().resume(input), out);
+            assert_eq!(gen_.as_mut().resume(input), out);
             // Test if the coroutine is valid (according to type invariants).
-            let _ = unsafe { ManuallyDrop::new(ptr::read(gen.as_mut().get_unchecked_mut())) };
+            let _ = unsafe { ManuallyDrop::new(ptr::read(gen_.as_mut().get_unchecked_mut())) };
         }
     }
 


### PR DESCRIPTION
Updates everything but the tests to edition 2024, of which a bunch are failing on older editions.

The edition 2024 is a prerequisite for removal of the `#![feature(let_chains)]`, and to forbidding let chains on edition 2021. I will do this in a later PR.

https://github.com/rust-lang/rust/issues/140722