### PR TITLE
miri-script: also overwrite CARGO_BUILD_BUILD_DIR

### DIFF
--- a/miri-script/src/util.rs
+++ b/miri-script/src/util.rs
@@ -62,7 +62,10 @@ impl MiriEnv {
         }
 
         // Hard-code the target dir, since we rely on all binaries ending up in the same spot.
-        sh.set_var("CARGO_TARGET_DIR", path!(miri_dir / "target"));
+        // Cargo provides multiple ways to adjust this and we need to overwrite all of them.
+        let target_dir = path!(miri_dir / "target");
+        sh.set_var("CARGO_TARGET_DIR", &target_dir);
+        sh.set_var("CARGO_BUILD_BUILD_DIR", &target_dir);
 
         // We configure dev builds to not be unusably slow.
         let devel_opt_level =


### PR DESCRIPTION
Setting just `CARGO_TARGET_DIR` is no longer enough to control where the build artifacts will go, there's now also `CARGO_BUILD_BUILD_DIR`. See https://github.com/RalfJung/rustc-build-sysroot/issues/25, https://github.com/rust-lang/cargo/issues/14125.