### PR TITLE
test suite: use CARGO_TARGET_TMPDIR for temporary build artifacts

### DIFF
--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -44,8 +44,7 @@ pub fn flagsplit(flags: &str) -> Vec<String> {
 fn build_native_lib() -> PathBuf {
     let cc = env::var("CC").unwrap_or_else(|_| "cc".into());
     // Target directory that we can write to.
-    let so_target_dir =
-        Path::new(&env::var_os("CARGO_TARGET_DIR").unwrap()).join("miri-native-lib");
+    let so_target_dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join("miri-native-lib");
     // Create the directory if it does not already exist.
     std::fs::create_dir_all(&so_target_dir)
         .expect("Failed to create directory for shared object file");
@@ -101,7 +100,7 @@ fn miri_config(
     let mut config = Config {
         target: Some(target.to_owned()),
         program,
-        out_dir: PathBuf::from(std::env::var_os("CARGO_TARGET_DIR").unwrap()).join("miri_ui"),
+        out_dir: PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join("miri_ui"),
         threads: std::env::var("MIRI_TEST_THREADS")
             .ok()
             .map(|threads| NonZero::new(threads.parse().unwrap()).unwrap()),


### PR DESCRIPTION
See discussion at https://github.com/rust-lang/cargo/issues/14125#issuecomment-2857356496.