### PR TITLE
Remove let_chains feature as it is stable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
 #![feature(variant_count)]
 #![feature(yeet_expr)]
 #![feature(nonzero_ops)]
-#![feature(let_chains)]
 #![feature(strict_overflow_ops)]
 #![feature(pointer_is_aligned_to)]
 #![feature(unqualified_local_imports)]


### PR DESCRIPTION
Followup of https://github.com/rust-lang/miri/pull/4311 to remove the `let_chains` feature as the feature is stable now as of https://github.com/rust-lang/rust/pull/132833.