### PR TITLE
Run some tests in ``disable-isolation``

### DIFF
--- a/tests/pass-dep/libc/libc-fs-with-isolation.rs
+++ b/tests/pass-dep/libc/libc-fs-with-isolation.rs
@@ -1,26 +1,8 @@
 //@ignore-target: windows # File handling is not implemented yet
-//@compile-flags: -Zmiri-isolation-error=warn-nobacktrace
-//@normalize-stderr-test: "(stat(x)?)" -> "$$STAT"
-
-use std::fs;
-use std::io::{Error, ErrorKind};
 
 fn main() {
     // test `fcntl(F_DUPFD): should work even with isolation.`
     unsafe {
         assert!(libc::fcntl(1, libc::F_DUPFD, 0) >= 0);
     }
-
-    // test `readlink`
-    let mut buf = vec![0; "foo_link.txt".len() + 1];
-    unsafe {
-        assert_eq!(libc::readlink(c"foo.txt".as_ptr(), buf.as_mut_ptr(), buf.len()), -1);
-        assert_eq!(Error::last_os_error().raw_os_error(), Some(libc::EACCES));
-    }
-
-    // test `stat`
-    let err = fs::metadata("foo.txt").unwrap_err();
-    assert_eq!(err.kind(), ErrorKind::PermissionDenied);
-    // check that it is the right kind of `PermissionDenied`
-    assert_eq!(err.raw_os_error(), Some(libc::EACCES));
 }

--- a/tests/pass-dep/libc/libc-fs-with-isolation.stderr
+++ b/tests/pass-dep/libc/libc-fs-with-isolation.stderr
@@ -1,4 +1,0 @@
-warning: `readlink` was made to return an error due to isolation
-
-warning: `$STAT` was made to return an error due to isolation
-

--- a/tests/pass-dep/libc/libc-fs.rs
+++ b/tests/pass-dep/libc/libc-fs.rs
@@ -1,5 +1,5 @@
 //@ignore-target: windows # File handling is not implemented yet
-//@compile-flags: -Zmiri-disable-isolation -Zmiri-isolation-error=warn-nobacktrace
+//@compile-flags: -Zmiri-disable-isolation
 
 #![feature(io_error_more)]
 #![feature(io_error_uncategorized)]

--- a/tests/pass-dep/libc/libc-fs.rs
+++ b/tests/pass-dep/libc/libc-fs.rs
@@ -1,10 +1,11 @@
 //@ignore-target: windows # File handling is not implemented yet
-//@compile-flags: -Zmiri-disable-isolation
+//@compile-flags: -Zmiri-disable-isolation -Zmiri-isolation-error=warn-nobacktrace
 
 #![feature(io_error_more)]
 #![feature(io_error_uncategorized)]
 
 use std::ffi::{CStr, CString, OsString};
+use std::fs;
 use std::fs::{File, canonicalize, remove_file};
 use std::io::{Error, ErrorKind, Write};
 use std::os::unix::ffi::OsStrExt;
@@ -40,6 +41,8 @@ fn main() {
     test_nofollow_not_symlink();
     #[cfg(target_os = "macos")]
     test_ioctl();
+    test_readlink();
+    test_stat();
 }
 
 fn test_file_open_unix_allow_two_args() {
@@ -450,4 +453,21 @@ fn test_ioctl() {
         let fd = libc::open(name_ptr, libc::O_RDONLY);
         assert_eq!(libc::ioctl(fd, libc::FIOCLEX), 0);
     }
+}
+
+/// Basic test for `readlink`.
+fn test_readlink() {
+    let mut buf = vec![0; "foo_link.txt".len() + 1];
+    unsafe {
+        assert_eq!(libc::readlink(c"foo.txt".as_ptr(), buf.as_mut_ptr(), buf.len()), -1);
+        assert_eq!(Error::last_os_error().raw_os_error(), Some(libc::ENOENT));
+    }
+}
+
+// Basic test for `stat`.
+fn test_stat() {
+    let err = fs::metadata("foo.txt").unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::NotFound);
+    // check that it is the right kind of `PermissionDenied`
+    assert_eq!(err.raw_os_error(), Some(libc::ENOENT));
 }


### PR DESCRIPTION
I was confused why tests that require ``disable-isolation`` are currently being run in isolation mode.

So I just took a stab and just move tests around.