### PR TITLE
bump rustc-build-sysroot

### DIFF
--- a/cargo-miri/Cargo.lock
+++ b/cargo-miri/Cargo.lock
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-build-sysroot"
-version = "0.5.4"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6d984a9db43148467059309bd1e5ad577085162f695d9fe2cf3543aeb25cd38"
+checksum = "10edc2e4393515193bd766e2f6c050b0536a68e56f2b6d56c07ababfdc114ff0"
 dependencies = [
  "anyhow",
  "rustc_version",

--- a/cargo-miri/Cargo.toml
+++ b/cargo-miri/Cargo.toml
@@ -18,7 +18,7 @@ directories = "6"
 rustc_version = "0.4"
 serde_json = "1.0.40"
 cargo_metadata = "0.19"
-rustc-build-sysroot = "0.5.4"
+rustc-build-sysroot = "0.5.7"
 
 # Enable some feature flags that dev-dependencies need but dependencies
 # do not.  This makes `./miri install` after `./miri build` faster.


### PR DESCRIPTION
This pulls in https://github.com/RalfJung/rustc-build-sysroot/commit/ac834e905aa81672b780cd8caf582f2172c61967 which should fix https://github.com/rust-lang/miri/issues/4320 or at least make it much less likely to occur.