### PR TITLE
run tests on mips-unknown-linux-gnu

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -156,11 +156,12 @@ case $HOST_TARGET in
     MANY_SEEDS=64 TEST_TARGET=i686-pc-windows-gnu run_tests
     MANY_SEEDS=64 TEST_TARGET=x86_64-pc-windows-msvc CARGO_MIRI_ENV=1 run_tests
     # Extra tier 2
-    TEST_TARGET=arm-unknown-linux-gnueabi run_tests
-    TEST_TARGET=s390x-unknown-linux-gnu run_tests # big-endian architecture of choice
+    MANY_SEEDS=16 TEST_TARGET=arm-unknown-linux-gnueabi run_tests
+    MANY_SEEDS=16 TEST_TARGET=s390x-unknown-linux-gnu run_tests # big-endian architecture of choice
     # Not officially supported tier 2
-    TEST_TARGET=x86_64-unknown-illumos run_tests
-    TEST_TARGET=x86_64-pc-solaris run_tests
+    MANY_SEEDS=16 TEST_TARGET=mips-unknown-linux-gnu run_tests # a 32bit big-endian target, and also a target without 64bit atomics
+    MANY_SEEDS=16 TEST_TARGET=x86_64-unknown-illumos run_tests
+    MANY_SEEDS=16 TEST_TARGET=x86_64-pc-solaris run_tests
     # Partially supported targets (tier 2)
     BASIC="empty_main integer heap_alloc libc-mem vec string btreemap" # ensures we have the basics: pre-main code, system allocator
     UNIX="hello panic/panic panic/unwind concurrency/simple atomic libc-mem libc-misc libc-random env num_cpus" # the things that are very similar across all Unixes, and hence easily supported there

--- a/tests/fail/concurrency/read_only_atomic_load_large.rs
+++ b/tests/fail/concurrency/read_only_atomic_load_large.rs
@@ -2,6 +2,7 @@
 //@compile-flags: -Zmiri-disable-stacked-borrows
 // Needs atomic accesses larger than the pointer size
 //@ignore-bitwidth: 64
+//@ignore-target: mips-
 
 use std::sync::atomic::{AtomicI64, Ordering};
 

--- a/tests/panic/transmute_fat2.rs
+++ b/tests/panic/transmute_fat2.rs
@@ -5,6 +5,8 @@ fn main() {
     let bad = unsafe { std::mem::transmute::<u128, &[u8]>(42 << 64) };
     #[cfg(all(target_endian = "little", target_pointer_width = "32"))]
     let bad = unsafe { std::mem::transmute::<u64, &[u8]>(42) };
+    #[cfg(all(target_endian = "big", target_pointer_width = "32"))]
+    let bad = unsafe { std::mem::transmute::<u64, &[u8]>(42 << 32) };
     // This created a slice with length 0, so the following will fail the bounds check.
     bad[0];
 }


### PR DESCRIPTION
That target has two unique properties we are not capturing yet:
- It is a 32bit big-endian target
- It does not have 64bit atomics (so std uses fallback paths for some logic)