### PR TITLE
bench: separate baseline results in gitignored dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ flamegraph*.svg
 rustc-ice*.txt
 tests/native-lib/libtestlib.so
 .auto-*
+*.json
 
 /genmc/

--- a/miri-script/src/commands.rs
+++ b/miri-script/src/commands.rs
@@ -568,11 +568,17 @@ impl Command {
             Ok(results)
         };
 
-        if let Some(baseline_file) = save_baseline {
+        if let Some(mut baseline_file) = save_baseline {
+            if !baseline_file.ends_with(".json") {
+                baseline_file.push_str(".json");
+            }
             let results = gather_results()?;
             let baseline = File::create(baseline_file)?;
             serde_json::to_writer_pretty(BufWriter::new(baseline), &results)?;
-        } else if let Some(baseline_file) = load_baseline {
+        } else if let Some(mut baseline_file) = load_baseline {
+            if !baseline_file.ends_with(".json") {
+                baseline_file.push_str(".json");
+            }
             let new_results = gather_results()?;
             let baseline_results: BTreeMap<String, BenchResult> = {
                 let f = File::open(baseline_file)?;


### PR DESCRIPTION
To hopefully avoid repeats of rust-lang/miri#4361.

Would there be any interest in extending the benchmark tool so that it could e.g. directly compare results from two git hashes? I found myself trying to mess with things for performance and having something like that might be helpful