### PR TITLE
Fix tokio/file-io.rs test relying on `read`/`write` not being short

### DIFF
--- a/tests/pass-dep/tokio/file-io.rs
+++ b/tests/pass-dep/tokio/file-io.rs
@@ -20,7 +20,7 @@ async fn test_create_and_write() -> io::Result<()> {
     let mut file = File::create(&path).await?;
 
     // Write 10 bytes to the file.
-    file.write(b"some bytes").await?;
+    file.write_all(b"some bytes").await?;
     assert_eq!(file.metadata().await.unwrap().len(), 10);
 
     remove_file(&path).unwrap();
@@ -31,10 +31,10 @@ async fn test_create_and_read() -> io::Result<()> {
     let bytes = b"more bytes";
     let path = utils::prepare_with_content("foo.txt", bytes);
     let mut file = OpenOptions::new().read(true).open(&path).await.unwrap();
-    let mut buffer = [0u8; 10];
+    let mut buffer = vec![];
 
     // Read the whole file.
-    file.read(&mut buffer[..]).await?;
+    file.read_to_end(&mut buffer).await?;
     assert_eq!(&buffer, b"more bytes");
 
     remove_file(&path).unwrap();


### PR DESCRIPTION
The test did `write` and `read` and hoped that it would read/write everything, which doesn't always happen and caused CI failures. Switch to `write_all` and `read_to_end` to make it more reliable.

Probably fixes rust-lang/miri#4367.