### PR TITLE
Make sure to sync on file-io.rs tokio test

### DIFF
--- a/tests/pass-dep/tokio/file-io.rs
+++ b/tests/pass-dep/tokio/file-io.rs
@@ -21,6 +21,7 @@ async fn test_create_and_write() -> io::Result<()> {
 
     // Write 10 bytes to the file.
     file.write_all(b"some bytes").await?;
+    file.sync_all().await?; // tokio doesn't necessarily complete writes until you sync.
     assert_eq!(file.metadata().await.unwrap().len(), 10);
 
     remove_file(&path).unwrap();


### PR DESCRIPTION
Tokio `AsyncWriteExt::write` doesn't actually ensure that the contents have written, it just *starts* the write operation. To ensure that the file has actually been written, we need to `sync_all` first.

actually fixes #4367