### PR TITLE
Include the name of the created tag in TB's Reborrow events

### DIFF
--- a/src/borrow_tracker/tree_borrows/diagnostics.rs
+++ b/src/borrow_tracker/tree_borrows/diagnostics.rs
@@ -15,7 +15,7 @@ use crate::*;
 #[derive(Clone, Copy, Debug)]
 pub enum AccessCause {
     Explicit(AccessKind),
-    Reborrow,
+    Reborrow(BorTag),
     Dealloc,
     FnExit(AccessKind),
 }
@@ -24,7 +24,7 @@ impl fmt::Display for AccessCause {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Explicit(kind) => write!(f, "{kind}"),
-            Self::Reborrow => write!(f, "reborrow"),
+            Self::Reborrow(tag) => write!(f, "reborrow to create {tag:?}"),
             Self::Dealloc => write!(f, "deallocation"),
             // This is dead code, since the protector release access itself can never
             // cause UB (while the protector is active, if some other access invalidates
@@ -40,7 +40,8 @@ impl AccessCause {
         let rel = if is_foreign { "foreign" } else { "child" };
         match self {
             Self::Explicit(kind) => format!("{rel} {kind}"),
-            Self::Reborrow => format!("reborrow (acting as a {rel} read access)"),
+            Self::Reborrow(tag) =>
+                format!("reborrow to create {tag:?} (acting as a {rel} read access)"),
             Self::Dealloc => format!("deallocation (acting as a {rel} write access)"),
             Self::FnExit(kind) => format!("protector release (acting as a {rel} {kind})"),
         }

--- a/src/borrow_tracker/tree_borrows/mod.rs
+++ b/src/borrow_tracker/tree_borrows/mod.rs
@@ -375,7 +375,11 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 tree_borrows.perform_access(
                     orig_tag,
-                    Some((range_in_alloc, AccessKind::Read, diagnostics::AccessCause::Reborrow)),
+                    Some((
+                        range_in_alloc,
+                        AccessKind::Read,
+                        diagnostics::AccessCause::Reborrow(new_tag),
+                    )),
                     this.machine.borrow_tracker.as_ref().unwrap(),
                     alloc_id,
                     this.machine.current_span(),

--- a/tests/fail/async-shared-mutable.tree.stderr
+++ b/tests/fail/async-shared-mutable.tree.stderr
@@ -21,7 +21,7 @@ help: the accessed tag <TAG> later transitioned to Active due to a child write a
 LL |             *x = 1;
    |             ^^^^^^
    = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
-help: the accessed tag <TAG> later transitioned to Frozen due to a reborrow (acting as a foreign read access) at offsets [OFFSET]
+help: the accessed tag <TAG> later transitioned to Frozen due to a reborrow to create <TAG> (acting as a foreign read access) at offsets [OFFSET]
   --> tests/fail/async-shared-mutable.rs:LL:CC
    |
 LL |     let _: Pin<&_> = f.as_ref(); // Or: `f.as_mut().into_ref()`.

--- a/tests/fail/both_borrows/aliasing_mut1.tree.stderr
+++ b/tests/fail/both_borrows/aliasing_mut1.tree.stderr
@@ -11,7 +11,7 @@ help: the accessed tag <TAG> was created here, in the initial state Reserved
    |
 LL | pub fn safe(x: &mut i32, y: &mut i32) {
    |             ^
-help: the accessed tag <TAG> later transitioned to Reserved (conflicted) due to a reborrow (acting as a foreign read access) at offsets [0x0..0x4]
+help: the accessed tag <TAG> later transitioned to Reserved (conflicted) due to a reborrow to create <TAG> (acting as a foreign read access) at offsets [0x0..0x4]
   --> tests/fail/both_borrows/aliasing_mut1.rs:LL:CC
    |
 LL | pub fn safe(x: &mut i32, y: &mut i32) {

--- a/tests/fail/both_borrows/aliasing_mut3.tree.stderr
+++ b/tests/fail/both_borrows/aliasing_mut3.tree.stderr
@@ -11,7 +11,7 @@ help: the accessed tag <TAG> was created here, in the initial state Reserved
    |
 LL | pub fn safe(x: &mut i32, y: &i32) {
    |             ^
-help: the accessed tag <TAG> later transitioned to Reserved (conflicted) due to a reborrow (acting as a foreign read access) at offsets [0x0..0x4]
+help: the accessed tag <TAG> later transitioned to Reserved (conflicted) due to a reborrow to create <TAG> (acting as a foreign read access) at offsets [0x0..0x4]
   --> tests/fail/both_borrows/aliasing_mut3.rs:LL:CC
    |
 LL | pub fn safe(x: &mut i32, y: &i32) {

--- a/tests/fail/both_borrows/load_invalid_shr.rs
+++ b/tests/fail/both_borrows/load_invalid_shr.rs
@@ -12,5 +12,5 @@ fn main() {
     unsafe { *xraw = 42 }; // unfreeze
     let _val = *xref_in_mem;
     //~[stack]^ ERROR: /retag .* tag does not exist in the borrow stack/
-    //~[tree]| ERROR: /reborrow through .* is forbidden/
+    //~[tree]| ERROR: /reborrow to create .* through .* is forbidden/
 }

--- a/tests/fail/both_borrows/load_invalid_shr.tree.stderr
+++ b/tests/fail/both_borrows/load_invalid_shr.tree.stderr
@@ -1,11 +1,11 @@
-error: Undefined Behavior: reborrow through <TAG> at ALLOC[0x0] is forbidden
+error: Undefined Behavior: reborrow to create <TAG> through <TAG> at ALLOC[0x0] is forbidden
   --> tests/fail/both_borrows/load_invalid_shr.rs:LL:CC
    |
 LL |     let _val = *xref_in_mem;
-   |                ^^^^^^^^^^^^ reborrow through <TAG> at ALLOC[0x0] is forbidden
+   |                ^^^^^^^^^^^^ reborrow to create <TAG> through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
-   = help: the accessed tag <TAG> has state Disabled which forbids this reborrow (acting as a child read access)
+   = help: the accessed tag <TAG> has state Disabled which forbids this reborrow to create <TAG> (acting as a child read access)
 help: the accessed tag <TAG> was created here, in the initial state Frozen
   --> tests/fail/both_borrows/load_invalid_shr.rs:LL:CC
    |

--- a/tests/fail/both_borrows/newtype_pair_retagging.tree.stderr
+++ b/tests/fail/both_borrows/newtype_pair_retagging.tree.stderr
@@ -18,7 +18,7 @@ help: the protected tag <TAG> was created here, in the initial state Reserved
    |
 LL | fn dealloc_while_running(_n: Newtype<'_>, dealloc: impl FnOnce()) {
    |                          ^^
-help: the protected tag <TAG> later transitioned to Reserved (conflicted) due to a reborrow (acting as a foreign read access) at offsets [0x0..0x4]
+help: the protected tag <TAG> later transitioned to Reserved (conflicted) due to a reborrow to create <TAG> (acting as a foreign read access) at offsets [0x0..0x4]
   --> tests/fail/both_borrows/newtype_pair_retagging.rs:LL:CC
    |
 LL |             || drop(Box::from_raw(ptr)),

--- a/tests/fail/both_borrows/newtype_retagging.tree.stderr
+++ b/tests/fail/both_borrows/newtype_retagging.tree.stderr
@@ -18,7 +18,7 @@ help: the protected tag <TAG> was created here, in the initial state Reserved
    |
 LL | fn dealloc_while_running(_n: Newtype<'_>, dealloc: impl FnOnce()) {
    |                          ^^
-help: the protected tag <TAG> later transitioned to Reserved (conflicted) due to a reborrow (acting as a foreign read access) at offsets [0x0..0x4]
+help: the protected tag <TAG> later transitioned to Reserved (conflicted) due to a reborrow to create <TAG> (acting as a foreign read access) at offsets [0x0..0x4]
   --> tests/fail/both_borrows/newtype_retagging.rs:LL:CC
    |
 LL |             || drop(Box::from_raw(ptr)),

--- a/tests/fail/both_borrows/pass_invalid_shr.rs
+++ b/tests/fail/both_borrows/pass_invalid_shr.rs
@@ -11,5 +11,5 @@ fn main() {
     unsafe { *xraw = 42 }; // unfreeze
     foo(xref);
     //~[stack]^ ERROR: /retag .* tag does not exist in the borrow stack/
-    //~[tree]| ERROR: /reborrow through .* is forbidden/
+    //~[tree]| ERROR: /reborrow to create .* through .* is forbidden/
 }

--- a/tests/fail/both_borrows/pass_invalid_shr.tree.stderr
+++ b/tests/fail/both_borrows/pass_invalid_shr.tree.stderr
@@ -1,11 +1,11 @@
-error: Undefined Behavior: reborrow through <TAG> at ALLOC[0x0] is forbidden
+error: Undefined Behavior: reborrow to create <TAG> through <TAG> at ALLOC[0x0] is forbidden
   --> tests/fail/both_borrows/pass_invalid_shr.rs:LL:CC
    |
 LL |     foo(xref);
-   |         ^^^^ reborrow through <TAG> at ALLOC[0x0] is forbidden
+   |         ^^^^ reborrow to create <TAG> through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
-   = help: the accessed tag <TAG> has state Disabled which forbids this reborrow (acting as a child read access)
+   = help: the accessed tag <TAG> has state Disabled which forbids this reborrow to create <TAG> (acting as a child read access)
 help: the accessed tag <TAG> was created here, in the initial state Frozen
   --> tests/fail/both_borrows/pass_invalid_shr.rs:LL:CC
    |

--- a/tests/fail/both_borrows/pass_invalid_shr_option.rs
+++ b/tests/fail/both_borrows/pass_invalid_shr_option.rs
@@ -11,5 +11,5 @@ fn main() {
     unsafe { *xraw = 42 }; // unfreeze
     foo(some_xref);
     //~[stack]^ ERROR: /retag .* tag does not exist in the borrow stack/
-    //~[tree]| ERROR: /reborrow through .* is forbidden/
+    //~[tree]| ERROR: /reborrow to create .* through .* is forbidden/
 }

--- a/tests/fail/both_borrows/pass_invalid_shr_option.tree.stderr
+++ b/tests/fail/both_borrows/pass_invalid_shr_option.tree.stderr
@@ -1,11 +1,11 @@
-error: Undefined Behavior: reborrow through <TAG> at ALLOC[0x0] is forbidden
+error: Undefined Behavior: reborrow to create <TAG> through <TAG> at ALLOC[0x0] is forbidden
   --> tests/fail/both_borrows/pass_invalid_shr_option.rs:LL:CC
    |
 LL |     foo(some_xref);
-   |         ^^^^^^^^^ reborrow through <TAG> at ALLOC[0x0] is forbidden
+   |         ^^^^^^^^^ reborrow to create <TAG> through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
-   = help: the accessed tag <TAG> has state Disabled which forbids this reborrow (acting as a child read access)
+   = help: the accessed tag <TAG> has state Disabled which forbids this reborrow to create <TAG> (acting as a child read access)
 help: the accessed tag <TAG> was created here, in the initial state Frozen
   --> tests/fail/both_borrows/pass_invalid_shr_option.rs:LL:CC
    |

--- a/tests/fail/both_borrows/pass_invalid_shr_tuple.rs
+++ b/tests/fail/both_borrows/pass_invalid_shr_tuple.rs
@@ -12,5 +12,5 @@ fn main() {
     unsafe { *xraw0 = 42 }; // unfreeze
     foo(pair_xref);
     //~[stack]^ ERROR: /retag .* tag does not exist in the borrow stack/
-    //~[tree]| ERROR: /reborrow through .* is forbidden/
+    //~[tree]| ERROR: /reborrow to create .* through .* is forbidden/
 }

--- a/tests/fail/both_borrows/pass_invalid_shr_tuple.tree.stderr
+++ b/tests/fail/both_borrows/pass_invalid_shr_tuple.tree.stderr
@@ -1,11 +1,11 @@
-error: Undefined Behavior: reborrow through <TAG> at ALLOC[0x0] is forbidden
+error: Undefined Behavior: reborrow to create <TAG> through <TAG> at ALLOC[0x0] is forbidden
   --> tests/fail/both_borrows/pass_invalid_shr_tuple.rs:LL:CC
    |
 LL |     foo(pair_xref);
-   |         ^^^^^^^^^ reborrow through <TAG> at ALLOC[0x0] is forbidden
+   |         ^^^^^^^^^ reborrow to create <TAG> through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
-   = help: the accessed tag <TAG> has state Disabled which forbids this reborrow (acting as a child read access)
+   = help: the accessed tag <TAG> has state Disabled which forbids this reborrow to create <TAG> (acting as a child read access)
 help: the accessed tag <TAG> was created here, in the initial state Frozen
   --> tests/fail/both_borrows/pass_invalid_shr_tuple.rs:LL:CC
    |

--- a/tests/fail/both_borrows/return_invalid_shr.rs
+++ b/tests/fail/both_borrows/return_invalid_shr.rs
@@ -8,7 +8,7 @@ fn foo(x: &mut (i32, i32)) -> &i32 {
     unsafe { *xraw = (42, 23) }; // unfreeze
     ret
     //~[stack]^ ERROR: /retag .* tag does not exist in the borrow stack/
-    //~[tree]| ERROR: /reborrow through .* is forbidden/
+    //~[tree]| ERROR: /reborrow to create .* through .* is forbidden/
 }
 
 fn main() {

--- a/tests/fail/both_borrows/return_invalid_shr.tree.stderr
+++ b/tests/fail/both_borrows/return_invalid_shr.tree.stderr
@@ -1,11 +1,11 @@
-error: Undefined Behavior: reborrow through <TAG> at ALLOC[0x4] is forbidden
+error: Undefined Behavior: reborrow to create <TAG> through <TAG> at ALLOC[0x4] is forbidden
   --> tests/fail/both_borrows/return_invalid_shr.rs:LL:CC
    |
 LL |     ret
-   |     ^^^ reborrow through <TAG> at ALLOC[0x4] is forbidden
+   |     ^^^ reborrow to create <TAG> through <TAG> at ALLOC[0x4] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
-   = help: the accessed tag <TAG> has state Disabled which forbids this reborrow (acting as a child read access)
+   = help: the accessed tag <TAG> has state Disabled which forbids this reborrow to create <TAG> (acting as a child read access)
 help: the accessed tag <TAG> was created here, in the initial state Frozen
   --> tests/fail/both_borrows/return_invalid_shr.rs:LL:CC
    |

--- a/tests/fail/both_borrows/return_invalid_shr_option.rs
+++ b/tests/fail/both_borrows/return_invalid_shr_option.rs
@@ -8,7 +8,7 @@ fn foo(x: &mut (i32, i32)) -> Option<&i32> {
     unsafe { *xraw = (42, 23) }; // unfreeze
     ret
     //~[stack]^ ERROR: /retag .* tag does not exist in the borrow stack/
-    //~[tree]| ERROR: /reborrow through .* is forbidden/
+    //~[tree]| ERROR: /reborrow to create .* through .* is forbidden/
 }
 
 fn main() {

--- a/tests/fail/both_borrows/return_invalid_shr_option.tree.stderr
+++ b/tests/fail/both_borrows/return_invalid_shr_option.tree.stderr
@@ -1,11 +1,11 @@
-error: Undefined Behavior: reborrow through <TAG> at ALLOC[0x4] is forbidden
+error: Undefined Behavior: reborrow to create <TAG> through <TAG> at ALLOC[0x4] is forbidden
   --> tests/fail/both_borrows/return_invalid_shr_option.rs:LL:CC
    |
 LL |     ret
-   |     ^^^ reborrow through <TAG> at ALLOC[0x4] is forbidden
+   |     ^^^ reborrow to create <TAG> through <TAG> at ALLOC[0x4] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
-   = help: the accessed tag <TAG> has state Disabled which forbids this reborrow (acting as a child read access)
+   = help: the accessed tag <TAG> has state Disabled which forbids this reborrow to create <TAG> (acting as a child read access)
 help: the accessed tag <TAG> was created here, in the initial state Frozen
   --> tests/fail/both_borrows/return_invalid_shr_option.rs:LL:CC
    |

--- a/tests/fail/both_borrows/return_invalid_shr_tuple.rs
+++ b/tests/fail/both_borrows/return_invalid_shr_tuple.rs
@@ -8,7 +8,7 @@ fn foo(x: &mut (i32, i32)) -> (&i32,) {
     unsafe { *xraw = (42, 23) }; // unfreeze
     ret
     //~[stack]^ ERROR: /retag .* tag does not exist in the borrow stack/
-    //~[tree]| ERROR: /reborrow through .* is forbidden/
+    //~[tree]| ERROR: /reborrow to create .* through .* is forbidden/
 }
 
 fn main() {

--- a/tests/fail/both_borrows/return_invalid_shr_tuple.tree.stderr
+++ b/tests/fail/both_borrows/return_invalid_shr_tuple.tree.stderr
@@ -1,11 +1,11 @@
-error: Undefined Behavior: reborrow through <TAG> at ALLOC[0x4] is forbidden
+error: Undefined Behavior: reborrow to create <TAG> through <TAG> at ALLOC[0x4] is forbidden
   --> tests/fail/both_borrows/return_invalid_shr_tuple.rs:LL:CC
    |
 LL |     ret
-   |     ^^^ reborrow through <TAG> at ALLOC[0x4] is forbidden
+   |     ^^^ reborrow to create <TAG> through <TAG> at ALLOC[0x4] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
-   = help: the accessed tag <TAG> has state Disabled which forbids this reborrow (acting as a child read access)
+   = help: the accessed tag <TAG> has state Disabled which forbids this reborrow to create <TAG> (acting as a child read access)
 help: the accessed tag <TAG> was created here, in the initial state Frozen
   --> tests/fail/both_borrows/return_invalid_shr_tuple.rs:LL:CC
    |

--- a/tests/fail/tree_borrows/fnentry_invalidation.stderr
+++ b/tests/fail/tree_borrows/fnentry_invalidation.stderr
@@ -17,7 +17,7 @@ help: the accessed tag <TAG> later transitioned to Active due to a child write a
 LL |         *z = 1;
    |         ^^^^^^
    = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
-help: the accessed tag <TAG> later transitioned to Frozen due to a reborrow (acting as a foreign read access) at offsets [0x0..0x4]
+help: the accessed tag <TAG> later transitioned to Frozen due to a reborrow to create <TAG> (acting as a foreign read access) at offsets [0x0..0x4]
   --> tests/fail/tree_borrows/fnentry_invalidation.rs:LL:CC
    |
 LL |     x.do_bad();

--- a/tests/fail/tree_borrows/parent_read_freezes_raw_mut.stderr
+++ b/tests/fail/tree_borrows/parent_read_freezes_raw_mut.stderr
@@ -17,7 +17,7 @@ help: the accessed tag <TAG> later transitioned to Active due to a child write a
 LL |         *ptr = 0; // Write
    |         ^^^^^^^^
    = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
-help: the accessed tag <TAG> later transitioned to Frozen due to a reborrow (acting as a foreign read access) at offsets [0x0..0x1]
+help: the accessed tag <TAG> later transitioned to Frozen due to a reborrow to create <TAG> (acting as a foreign read access) at offsets [0x0..0x1]
   --> tests/fail/tree_borrows/parent_read_freezes_raw_mut.rs:LL:CC
    |
 LL |         assert_eq!(root, 0); // Parent Read

--- a/tests/fail/tree_borrows/protector-write-lazy.rs
+++ b/tests/fail/tree_borrows/protector-write-lazy.rs
@@ -31,5 +31,5 @@ fn main() {
     let funky_ptr_lazy_on_fst_elem = the_other_function(ref_to_fst_elem, ptr_to_vec);
     // now we try to use the funky lazy pointer.
     // It should be UB, since the write-on-protector-end should disable it.
-    unsafe { println!("Value of funky: {}", *funky_ptr_lazy_on_fst_elem) } //~ ERROR: /reborrow through .* is forbidden/
+    unsafe { println!("Value of funky: {}", *funky_ptr_lazy_on_fst_elem) } //~ ERROR: /reborrow to create .* through .* is forbidden/
 }

--- a/tests/fail/tree_borrows/protector-write-lazy.stderr
+++ b/tests/fail/tree_borrows/protector-write-lazy.stderr
@@ -1,11 +1,11 @@
-error: Undefined Behavior: reborrow through <TAG> at ALLOC[0x0] is forbidden
+error: Undefined Behavior: reborrow to create <TAG> through <TAG> at ALLOC[0x0] is forbidden
   --> tests/fail/tree_borrows/protector-write-lazy.rs:LL:CC
    |
 LL |     unsafe { println!("Value of funky: {}", *funky_ptr_lazy_on_fst_elem) }
-   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reborrow through <TAG> at ALLOC[0x0] is forbidden
+   |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ reborrow to create <TAG> through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
-   = help: the accessed tag <TAG> has state Disabled which forbids this reborrow (acting as a child read access)
+   = help: the accessed tag <TAG> has state Disabled which forbids this reborrow to create <TAG> (acting as a child read access)
 help: the accessed tag <TAG> was created here, in the initial state Reserved
   --> tests/fail/tree_borrows/protector-write-lazy.rs:LL:CC
    |

--- a/tests/fail/tree_borrows/write-during-2phase.rs
+++ b/tests/fail/tree_borrows/write-during-2phase.rs
@@ -9,7 +9,7 @@
 struct Foo(u64);
 impl Foo {
     fn add(&mut self, n: u64) -> u64 {
-        //~^ ERROR: /reborrow through .* is forbidden/
+        //~^ ERROR: /reborrow to create .* through .* is forbidden/
         self.0 + n
     }
 }

--- a/tests/fail/tree_borrows/write-during-2phase.stderr
+++ b/tests/fail/tree_borrows/write-during-2phase.stderr
@@ -1,11 +1,11 @@
-error: Undefined Behavior: reborrow through <TAG> at ALLOC[0x0] is forbidden
+error: Undefined Behavior: reborrow to create <TAG> through <TAG> at ALLOC[0x0] is forbidden
   --> tests/fail/tree_borrows/write-during-2phase.rs:LL:CC
    |
 LL |     fn add(&mut self, n: u64) -> u64 {
-   |            ^^^^^^^^^ reborrow through <TAG> at ALLOC[0x0] is forbidden
+   |            ^^^^^^^^^ reborrow to create <TAG> through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
-   = help: the accessed tag <TAG> has state Disabled which forbids this reborrow (acting as a child read access)
+   = help: the accessed tag <TAG> has state Disabled which forbids this reborrow to create <TAG> (acting as a child read access)
 help: the accessed tag <TAG> was created here, in the initial state Reserved
   --> tests/fail/tree_borrows/write-during-2phase.rs:LL:CC
    |


### PR DESCRIPTION
This fixes https://github.com/rust-lang/miri/issues/4386 by recording and mentioning the created tag in a Reborrow event.