### PR TITLE
make ./miri work on stable again

### DIFF
--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -39,10 +39,6 @@ runs:
         run: cargo install -f rustup-toolchain-install-master hyperfine
         shell: bash
 
-      - name: Install nightly toolchain
-        run: rustup toolchain install nightly --profile minimal
-        shell: bash
-
       - name: Install "master" toolchain
         run: |
           if [[ ${{ github.event_name }} == 'schedule' ]]; then

--- a/miri
+++ b/miri
@@ -2,20 +2,24 @@
 set -e
 # We want to call the binary directly, so we need to know where it ends up.
 ROOT_DIR="$(dirname "$0")"
-MIRI_SCRIPT_TARGET_DIR="$ROOT_DIR"/miri-script/target
-TOOLCHAIN="+nightly"
+TARGET_DIR="$ROOT_DIR"/miri-script/target
+# Prepare cargo invocation.
+# We have to overwrite the toolchain since `+miri` might be activated and not installed.
+TOOLCHAIN="+stable"
+CARGO_FLAGS=("-q")
 # If we are being invoked for RA, use JSON output and the default toolchain (to make proc-macros
 # work in RA). This needs a different target dir to avoid mixing up the builds.
+# Also set `-Zroot-dir` so that RA can identify where the error occurred.
 if [ -n "$MIRI_IN_RA" ]; then
-  MESSAGE_FORMAT="--message-format=json"
   TOOLCHAIN=""
-  MIRI_SCRIPT_TARGET_DIR="$MIRI_SCRIPT_TARGET_DIR"/ra
+  CARGO_FLAGS+=("--message-format=json" "-Zroot-dir=$ROOT_DIR")
+  TARGET_DIR="$ROOT_DIR"/target
 fi
-# We need a nightly toolchain, for `-Zroot-dir`.
-cargo $TOOLCHAIN build $CARGO_EXTRA_FLAGS --manifest-path "$ROOT_DIR"/miri-script/Cargo.toml \
-  -Zroot-dir="$ROOT_DIR" \
-  -q --target-dir "$MIRI_SCRIPT_TARGET_DIR" $MESSAGE_FORMAT || \
-  ( echo "Failed to build miri-script. Is the 'nightly' toolchain installed?"; exit 1 )
-# Instead of doing just `cargo run --manifest-path .. $@`, we invoke miri-script binary directly. Invoking `cargo run` goes through
-# rustup (that sets it's own environmental variables), which is undesirable.
-"$MIRI_SCRIPT_TARGET_DIR"/debug/miri-script "$@"
+# Run cargo.
+cargo $TOOLCHAIN build --manifest-path "$ROOT_DIR"/miri-script/Cargo.toml \
+  --target-dir "$TARGET_DIR" "${CARGO_FLAGS[@]}" || \
+  ( echo "Failed to build miri-script. Is the 'stable' toolchain installed?"; exit 1 )
+# Instead of doing just `cargo run --manifest-path .. $@`, we invoke miri-script binary directly.
+# Invoking `cargo run` goes through rustup (that sets it's own environmental variables), which is
+# undesirable.
+"$TARGET_DIR"/debug/miri-script "$@"

--- a/miri-script/src/commands.rs
+++ b/miri-script/src/commands.rs
@@ -707,9 +707,12 @@ impl Command {
         let mut early_flags = Vec::<OsString>::new();
 
         // In `dep` mode, the target is already passed via `MIRI_TEST_TARGET`
-        if !dep && let Some(target) = &target {
-            early_flags.push("--target".into());
-            early_flags.push(target.into());
+        #[expect(clippy::collapsible_if)] // we need to wait until this is stable
+        if !dep {
+            if let Some(target) = &target {
+                early_flags.push("--target".into());
+                early_flags.push(target.into());
+            }
         }
         early_flags.push("--edition".into());
         early_flags.push(edition.as_deref().unwrap_or("2021").into());
@@ -737,8 +740,11 @@ impl Command {
         // Add Miri flags
         let mut cmd = cmd.args(&miri_flags).args(&early_flags).args(&flags);
         // For `--dep` we also need to set the target in the env var.
-        if dep && let Some(target) = &target {
-            cmd = cmd.env("MIRI_TEST_TARGET", target);
+        #[expect(clippy::collapsible_if)] // we need to wait until this is stable
+        if dep {
+            if let Some(target) = &target {
+                cmd = cmd.env("MIRI_TEST_TARGET", target);
+            }
         }
         // Finally, run the thing.
         Ok(cmd.run()?)

--- a/miri.bat
+++ b/miri.bat
@@ -5,8 +5,8 @@ set MIRI_SCRIPT_TARGET_DIR=%0\..\miri-script\target
 
 :: If any other steps are added, the "|| exit /b" must be appended to early
 :: return from the script. If not, it will continue execution.
-cargo +nightly build %CARGO_EXTRA_FLAGS% -q --target-dir %MIRI_SCRIPT_TARGET_DIR% --manifest-path %0\..\miri-script\Cargo.toml ^
-  || (echo Failed to build miri-script. Is the 'nightly' toolchain installed? & exit /b)
+cargo +stable build %CARGO_EXTRA_FLAGS% -q --target-dir %MIRI_SCRIPT_TARGET_DIR% --manifest-path %0\..\miri-script\Cargo.toml ^
+  || (echo Failed to build miri-script. Is the 'stable' toolchain installed? & exit /b)
 
 :: Forwards all arguments to this file to the executable.
 :: We invoke the binary directly to avoid going through rustup, which would set some extra


### PR DESCRIPTION
It suffices to set `-Zroot-dir` for the RA invocations. Humans reading the output from `./miri check` will hopefully be able to deal with the paths being relative to the crate root rather than the Miri root (only for miri-script build failures!) -- and it's good to not have to depend on a nightly toolchain here.