### PR TITLE
./miri toolchain: no need to run 'cargo metadata'

### DIFF
--- a/miri-script/src/commands.rs
+++ b/miri-script/src/commands.rs
@@ -231,11 +231,6 @@ impl Command {
         cmd!(sh, "rustup override set miri").run()?;
         // Cleanup.
         cmd!(sh, "cargo clean").run()?;
-        // Call `cargo metadata` on the sources in case that changes the lockfile
-        // (which fails under some setups when it is done from inside vscode).
-        let sysroot = cmd!(sh, "rustc --print sysroot").read()?;
-        let sysroot = sysroot.trim();
-        cmd!(sh, "cargo metadata --format-version 1 --manifest-path {sysroot}/lib/rustlib/rustc-src/rust/compiler/rustc/Cargo.toml").ignore_stdout().run()?;
         Ok(())
     }
 


### PR DESCRIPTION
With https://github.com/rust-lang/rust-analyzer/pull/20018, this is no longer necessary even for my setup where the toolchain is read-only in vscode.