### PR TITLE
miri-script: set msrv so clippy doesn't suggest too-new features

### DIFF
--- a/miri-script/Cargo.toml
+++ b/miri-script/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/rust-lang/miri"
 version = "0.1.0"
 default-run = "miri-script"
 edition = "2024"
+rust-version = "1.85"
 
 [workspace]
 # We make this a workspace root so that cargo does not go looking in ../Cargo.toml for the workspace root.

--- a/miri-script/src/commands.rs
+++ b/miri-script/src/commands.rs
@@ -702,7 +702,6 @@ impl Command {
         let mut early_flags = Vec::<OsString>::new();
 
         // In `dep` mode, the target is already passed via `MIRI_TEST_TARGET`
-        #[expect(clippy::collapsible_if)] // we need to wait until this is stable
         if !dep {
             if let Some(target) = &target {
                 early_flags.push("--target".into());
@@ -735,7 +734,6 @@ impl Command {
         // Add Miri flags
         let mut cmd = cmd.args(&miri_flags).args(&early_flags).args(&flags);
         // For `--dep` we also need to set the target in the env var.
-        #[expect(clippy::collapsible_if)] // we need to wait until this is stable
         if dep {
             if let Some(target) = &target {
                 cmd = cmd.env("MIRI_TEST_TARGET", target);


### PR DESCRIPTION
miri-script must *at least* work on the previous stable (since not all GHA runners get a new stable immediately), and it seems fine to support a bit more than that. By setting this, we stop clippy from making suggestions that require newer versions of Rust.

I'm not aware of an easy way to say "build this crate with its MSRV", but as long as CI otherwise passes it's not too big of a deal if the MSRV is wrong so :shrug: 