### PR TITLE
Add std::hint::spin_loop() to tests

### DIFF
--- a/tests/pass/0weak_memory_consistency_sc.rs
+++ b/tests/pass/0weak_memory_consistency_sc.rs
@@ -20,7 +20,7 @@ fn static_atomic_bool(val: bool) -> &'static AtomicBool {
 }
 
 /// Spins until it acquires a pre-determined value.
-fn loads_value(loc: &AtomicI32, ord: Ordering, val: i32) -> i32 {
+fn spin_until_i32(loc: &AtomicI32, ord: Ordering, val: i32) -> i32 {
     while loc.load(ord) != val {
         std::hint::spin_loop();
     }
@@ -28,7 +28,7 @@ fn loads_value(loc: &AtomicI32, ord: Ordering, val: i32) -> i32 {
 }
 
 /// Spins until it acquires a pre-determined boolean.
-fn loads_bool(loc: &AtomicBool, ord: Ordering, val: bool) -> bool {
+fn spin_until_bool(loc: &AtomicBool, ord: Ordering, val: bool) -> bool {
     while loc.load(ord) != val {
         std::hint::spin_loop();
     }
@@ -68,11 +68,11 @@ fn test_iriw_sc_rlx() {
     let a = spawn(move || x.store(true, Relaxed));
     let b = spawn(move || y.store(true, Relaxed));
     let c = spawn(move || {
-        loads_bool(x, SeqCst, true);
+        spin_until_bool(x, SeqCst, true);
         y.load(SeqCst)
     });
     let d = spawn(move || {
-        loads_bool(y, SeqCst, true);
+        spin_until_bool(y, SeqCst, true);
         x.load(SeqCst)
     });
 
@@ -144,7 +144,7 @@ fn test_cpp20_rwc_syncs() {
     });
 
     let j2 = spawn(move || {
-        loads_value(&x, Relaxed, 1);
+        spin_until_i32(&x, Relaxed, 1);
         fence(SeqCst);
         y.load(Relaxed)
     });

--- a/tests/pass/weak_memory/weak.rs
+++ b/tests/pass/weak_memory/weak.rs
@@ -119,12 +119,12 @@ fn faa_replaced_by_load() -> bool {
     let go = static_atomic(0);
 
     let t1 = spawn(move || {
-        while go.load(Relaxed) == 0 {}
+        reads_value(go, 1);
         rdmw(y, x, z)
     });
 
     let t2 = spawn(move || {
-        while go.load(Relaxed) == 0 {}
+        reads_value(go, 1);
         rdmw(z, x, y)
     });
 

--- a/tests/pass/weak_memory/weak.rs
+++ b/tests/pass/weak_memory/weak.rs
@@ -24,7 +24,7 @@ fn static_atomic(val: usize) -> &'static AtomicUsize {
 }
 
 // Spins until it reads the given value
-fn reads_value(loc: &AtomicUsize, val: usize) -> usize {
+fn spin_until(loc: &AtomicUsize, val: usize) -> usize {
     while loc.load(Relaxed) != val {
         std::hint::spin_loop();
     }
@@ -85,7 +85,7 @@ fn initialization_write(add_fence: bool) -> bool {
     });
 
     let j2 = spawn(move || {
-        reads_value(wait, 1);
+        spin_until(wait, 1);
         if add_fence {
             fence(AcqRel);
         }
@@ -119,12 +119,12 @@ fn faa_replaced_by_load() -> bool {
     let go = static_atomic(0);
 
     let t1 = spawn(move || {
-        reads_value(go, 1);
+        spin_until(go, 1);
         rdmw(y, x, z)
     });
 
     let t2 = spawn(move || {
-        reads_value(go, 1);
+        spin_until(go, 1);
         rdmw(z, x, y)
     });
 


### PR DESCRIPTION
Some Miri tests have spin loops that weren't marked by `std::hint::spin_loop()`. Adding this hint makes these tests run slightly faster (on `x86_64`), likely because Miri was spinning in that loop until the thread got randomly preempted.

Some tests use `thread::yield` instead of the hint, these are unchanged, but some of them could likely be switched to the `spin_loop` hint too (e.g., [windows_join_multiple.rs](https://github.com/rust-lang/miri/blob/9b0962c547dc35820775f29c39c40378b89bbcae/tests/pass-dep/concurrency/windows_join_multiple.rs#L21)).

Tests that have a comment about not yielding are also unchanged (e.g., [concurrency/spin_loop.rs](https://github.com/rust-lang/miri/blob/9b0962c547dc35820775f29c39c40378b89bbcae/tests/pass/concurrency/spin_loop.rs#L8-L10)).

r? @RalfJung