### PR TITLE
allow using different cargo binary

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -348,6 +348,7 @@ https. Add the following to your `.gitconfig`:
 
 The following environment variables are relevant to `./miri`:
 
+* `CARGO` sets the binary used to execute Cargo; if none is specified, defaults to `cargo`.
 * `MIRI_AUTO_OPS` indicates whether the automatic execution of rustfmt, clippy and toolchain setup
   (as controlled by the `./auto-*` files) should be skipped. If it is set to `no`, they are skipped.
   This is used to allow automated IDE actions to avoid the auto ops.

--- a/miri
+++ b/miri
@@ -15,8 +15,9 @@ if [ -n "$MIRI_IN_RA" ]; then
   CARGO_FLAGS+=("--message-format=json" "-Zroot-dir=$ROOT_DIR")
   TARGET_DIR="$ROOT_DIR"/target
 fi
+
 # Run cargo.
-cargo $TOOLCHAIN build --manifest-path "$ROOT_DIR"/miri-script/Cargo.toml \
+${CARGO:-cargo} $TOOLCHAIN build --manifest-path "$ROOT_DIR"/miri-script/Cargo.toml \
   --target-dir "$TARGET_DIR" "${CARGO_FLAGS[@]}" || \
   ( echo "Failed to build miri-script. Is the 'stable' toolchain installed?"; exit 1 )
 # Instead of doing just `cargo run --manifest-path .. $@`, we invoke miri-script binary directly.


### PR DESCRIPTION
Currently `./miri` and `miri-script` always assume that the correct cargo binary is just named `cargo`; this allows setting an env var to overwrite this. Useful for my setup, felt like a small enough change. The alternative was aliasing something to `cargo` instead but that can break things