### PR TITLE
Fix cronjob Zulip message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
           It would appear that the [Miri cron job build]('"https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"') failed.
 
           This likely means that rustc changed the miri directory and
-          we now need to do a [`./miri rustc-pull`](https://github.com/rust-lang/miri/blob/master/CONTRIBUTING.md#importing-changes-from-the-rustc-repo).
+          we now need to do a [`rustc-josh-sync pull`](https://github.com/rust-lang/miri/blob/master/CONTRIBUTING.md#importing-changes-from-the-rustc-repo).
 
           Would you mind investigating this issue?
 


### PR DESCRIPTION
It wasn't updated to `rustc-josh-sync` (which btw seems to be working :tada:!): [#miri > Miri Build Failure (2025-07) @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/269128-miri/topic/Miri.20Build.20Failure.20.282025-07.29/near/530693656).