### PR TITLE
call_function helper: dont ICE on return type mismatches

### DIFF
--- a/tests/fail/shims/ctor_wrong_ret_type.rs
+++ b/tests/fail/shims/ctor_wrong_ret_type.rs
@@ -1,0 +1,39 @@
+unsafe extern "C" fn ctor() -> i32 {
+    //~^ERROR: calling a function with return type i32 passing return place of type ()
+    0
+}
+
+#[rustfmt::skip]
+macro_rules! ctor {
+    ($ident:ident = $ctor:ident) => {
+        #[cfg_attr(
+            all(any(
+                target_os = "linux",
+                target_os = "android",
+                target_os = "dragonfly",
+                target_os = "freebsd",
+                target_os = "haiku",
+                target_os = "illumos",
+                target_os = "netbsd",
+                target_os = "openbsd",
+                target_os = "solaris",
+                target_os = "none",
+                target_family = "wasm",
+            )),
+            link_section = ".init_array"
+        )]
+        #[cfg_attr(windows, link_section = ".CRT$XCU")]
+        #[cfg_attr(
+            any(target_os = "macos", target_os = "ios"),
+            // We do not set the `mod_init_funcs` flag here since ctor/inventory also do not do
+            // that. See <https://github.com/rust-lang/miri/pull/4459#discussion_r2200115629>.
+            link_section = "__DATA,__mod_init_func"
+        )]
+        #[used]
+        static $ident: unsafe extern "C" fn() -> i32 = $ctor;
+    };
+}
+
+ctor! { CTOR = ctor }
+
+fn main() {}

--- a/tests/fail/shims/ctor_wrong_ret_type.stderr
+++ b/tests/fail/shims/ctor_wrong_ret_type.stderr
@@ -1,0 +1,12 @@
+error: Undefined Behavior: calling a function with return type i32 passing return place of type ()
+   |
+   = note: Undefined Behavior occurred here
+   = note: (no span available)
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+   = help: this means these two types are not *guaranteed* to be ABI-compatible across all targets
+   = help: if you think this code should be accepted anyway, please report an issue with Miri
+   = note: BACKTRACE:
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
This should fix https://github.com/rust-lang/miri/issues/4495.