### PR TITLE
Use GH app for authenticating pull PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,11 @@ jobs:
         run: rustup toolchain install nightly --profile minimal
       - name: Install rustup-toolchain-install-master
         run: cargo install -f rustup-toolchain-install-master
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Push changes to a branch and create PR
         run: |
           # Make it easier to see what happens.
@@ -200,7 +205,7 @@ jobs:
           git push -u origin $BRANCH
           gh pr create -B master --title 'Automatic Rustup' --body 'Please close and re-open this PR to trigger CI, then enable auto-merge.'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
   cron-fail-notify:
     name: cronjob failure notification

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -50,9 +50,6 @@ new_pr = true
 [autolabel."S-waiting-on-author"]
 new_draft = true
 
-# Automatically close and reopen PRs made by bots to run CI on them
-[bot-pull-requests]
-
 # Canonicalize issue numbers to avoid closing the wrong issue when upstreaming this subtree
 [canonicalize-issue-links]
 


### PR DESCRIPTION
This means that it will no longer be needed to close and reopen pull PRs in order for CI to run on them. The corresponding secret and variable has already been configured for this repo.