### PR TITLE
support `readdir` on FreeBSD

### DIFF
--- a/src/shims/unix/freebsd/foreign_items.rs
+++ b/src/shims/unix/freebsd/foreign_items.rs
@@ -159,7 +159,11 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let result = this.macos_fbsd_readdir_r(dirp, entry, result)?;
                 this.write_scalar(result, dest)?;
             }
-
+            "readdir" | "readdir@FBSD_1.0" => {
+                let [dirp] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
+                let result = this.readdir64("dirent", dirp)?;
+                this.write_scalar(result, dest)?;
+            }
             // Miscellaneous
             "__error" => {
                 let [] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;

--- a/src/shims/unix/linux/foreign_items.rs
+++ b/src/shims/unix/linux/foreign_items.rs
@@ -38,7 +38,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             // File related shims
             "readdir64" => {
                 let [dirp] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
-                let result = this.linux_solarish_readdir64("dirent64", dirp)?;
+                let result = this.readdir64("dirent64", dirp)?;
                 this.write_scalar(result, dest)?;
             }
             "sync_file_range" => {

--- a/src/shims/unix/solarish/foreign_items.rs
+++ b/src/shims/unix/solarish/foreign_items.rs
@@ -106,7 +106,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             }
             "readdir" => {
                 let [dirp] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
-                let result = this.linux_solarish_readdir64("dirent", dirp)?;
+                let result = this.readdir64("dirent", dirp)?;
                 this.write_scalar(result, dest)?;
             }
 

--- a/tests/pass/shims/fs.rs
+++ b/tests/pass/shims/fs.rs
@@ -28,8 +28,7 @@ fn main() {
     test_from_raw_os_error();
     test_file_clone();
     // Windows file handling is very incomplete.
-    // FIXME: read_dir broken on FreeBSD (https://github.com/rust-lang/miri/issues/4587)
-    if cfg!(not(windows)) && !cfg!(target_os = "freebsd") {
+    if cfg!(not(windows)) {
         test_file_set_len();
         test_file_sync();
         test_rename();


### PR DESCRIPTION
Fixes rust-lang/miri#4587.

Modifies the previously named `linux_solarish_readdir64` (now `readdir64`) to also work on `freebsd`.

