### PR TITLE
remove a bunch of unnecessary 'pub' from tests

### DIFF
--- a/tests/fail/both_borrows/aliasing_mut1.rs
+++ b/tests/fail/both_borrows/aliasing_mut1.rs
@@ -2,7 +2,7 @@
 //@[tree]compile-flags: -Zmiri-tree-borrows
 use std::mem;
 
-pub fn safe(x: &mut i32, y: &mut i32) {
+fn safe(x: &mut i32, y: &mut i32) {
     //~[stack]^ ERROR: protect
     *x = 1; //~[tree] ERROR: /write access through .* is forbidden/
     *y = 2;

--- a/tests/fail/both_borrows/aliasing_mut1.stack.stderr
+++ b/tests/fail/both_borrows/aliasing_mut1.stack.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: not granting access to tag <TAG> because that would remove [Unique for <TAG>] which is strongly protected
   --> tests/fail/both_borrows/aliasing_mut1.rs:LL:CC
    |
-LL | pub fn safe(x: &mut i32, y: &mut i32) {
-   |                          ^ Undefined Behavior occurred here
+LL | fn safe(x: &mut i32, y: &mut i32) {
+   |                      ^ Undefined Behavior occurred here
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
@@ -14,8 +14,8 @@ LL |     let xraw: *mut i32 = unsafe { mem::transmute(&mut x) };
 help: <TAG> is this argument
   --> tests/fail/both_borrows/aliasing_mut1.rs:LL:CC
    |
-LL | pub fn safe(x: &mut i32, y: &mut i32) {
-   |             ^
+LL | fn safe(x: &mut i32, y: &mut i32) {
+   |         ^
    = note: BACKTRACE (of the first span):
    = note: inside `safe` at tests/fail/both_borrows/aliasing_mut1.rs:LL:CC
 note: inside `main`

--- a/tests/fail/both_borrows/aliasing_mut1.tree.stderr
+++ b/tests/fail/both_borrows/aliasing_mut1.tree.stderr
@@ -10,13 +10,13 @@ LL |     *x = 1;
 help: the accessed tag <TAG> was created here, in the initial state Reserved
   --> tests/fail/both_borrows/aliasing_mut1.rs:LL:CC
    |
-LL | pub fn safe(x: &mut i32, y: &mut i32) {
-   |             ^
+LL | fn safe(x: &mut i32, y: &mut i32) {
+   |         ^
 help: the accessed tag <TAG> later transitioned to Reserved (conflicted) due to a reborrow (acting as a foreign read access) at offsets [0x0..0x4]
   --> tests/fail/both_borrows/aliasing_mut1.rs:LL:CC
    |
-LL | pub fn safe(x: &mut i32, y: &mut i32) {
-   |                          ^
+LL | fn safe(x: &mut i32, y: &mut i32) {
+   |                      ^
    = help: this transition corresponds to a temporary loss of write permissions until function exit
    = note: BACKTRACE (of the first span):
    = note: inside `safe` at tests/fail/both_borrows/aliasing_mut1.rs:LL:CC

--- a/tests/fail/both_borrows/aliasing_mut2.rs
+++ b/tests/fail/both_borrows/aliasing_mut2.rs
@@ -2,7 +2,7 @@
 //@[tree]compile-flags: -Zmiri-tree-borrows
 use std::mem;
 
-pub fn safe(x: &i32, y: &mut i32) {
+fn safe(x: &i32, y: &mut i32) {
     //~[stack]^ ERROR: protect
     let _v = *x;
     *y = 2; //~[tree] ERROR: /write access through .* is forbidden/

--- a/tests/fail/both_borrows/aliasing_mut2.stack.stderr
+++ b/tests/fail/both_borrows/aliasing_mut2.stack.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is strongly protected
   --> tests/fail/both_borrows/aliasing_mut2.rs:LL:CC
    |
-LL | pub fn safe(x: &i32, y: &mut i32) {
-   |                      ^ Undefined Behavior occurred here
+LL | fn safe(x: &i32, y: &mut i32) {
+   |                  ^ Undefined Behavior occurred here
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
@@ -14,8 +14,8 @@ LL |     let xref = &mut x;
 help: <TAG> is this argument
   --> tests/fail/both_borrows/aliasing_mut2.rs:LL:CC
    |
-LL | pub fn safe(x: &i32, y: &mut i32) {
-   |             ^
+LL | fn safe(x: &i32, y: &mut i32) {
+   |         ^
    = note: BACKTRACE (of the first span):
    = note: inside `safe` at tests/fail/both_borrows/aliasing_mut2.rs:LL:CC
 note: inside `main`

--- a/tests/fail/both_borrows/aliasing_mut2.tree.stderr
+++ b/tests/fail/both_borrows/aliasing_mut2.tree.stderr
@@ -10,8 +10,8 @@ LL |     *y = 2;
 help: the accessed tag <TAG> was created here, in the initial state Reserved
   --> tests/fail/both_borrows/aliasing_mut2.rs:LL:CC
    |
-LL | pub fn safe(x: &i32, y: &mut i32) {
-   |                      ^
+LL | fn safe(x: &i32, y: &mut i32) {
+   |                  ^
 help: the accessed tag <TAG> later transitioned to Reserved (conflicted) due to a foreign read access at offsets [0x0..0x4]
   --> tests/fail/both_borrows/aliasing_mut2.rs:LL:CC
    |

--- a/tests/fail/both_borrows/aliasing_mut3.rs
+++ b/tests/fail/both_borrows/aliasing_mut3.rs
@@ -2,7 +2,7 @@
 //@[tree]compile-flags: -Zmiri-tree-borrows
 use std::mem;
 
-pub fn safe(x: &mut i32, y: &i32) {
+fn safe(x: &mut i32, y: &i32) {
     //~[stack]^ ERROR: borrow stack
     *x = 1; //~[tree] ERROR: /write access through .* is forbidden/
     let _v = *y;

--- a/tests/fail/both_borrows/aliasing_mut3.stack.stderr
+++ b/tests/fail/both_borrows/aliasing_mut3.stack.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: trying to retag from <TAG> for SharedReadOnly permission at ALLOC[0x0], but that tag does not exist in the borrow stack for this location
   --> tests/fail/both_borrows/aliasing_mut3.rs:LL:CC
    |
-LL | pub fn safe(x: &mut i32, y: &i32) {
-   |                          ^ this error occurs as part of function-entry retag at ALLOC[0x0..0x4]
+LL | fn safe(x: &mut i32, y: &i32) {
+   |                      ^ this error occurs as part of function-entry retag at ALLOC[0x0..0x4]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information

--- a/tests/fail/both_borrows/aliasing_mut3.tree.stderr
+++ b/tests/fail/both_borrows/aliasing_mut3.tree.stderr
@@ -10,13 +10,13 @@ LL |     *x = 1;
 help: the accessed tag <TAG> was created here, in the initial state Reserved
   --> tests/fail/both_borrows/aliasing_mut3.rs:LL:CC
    |
-LL | pub fn safe(x: &mut i32, y: &i32) {
-   |             ^
+LL | fn safe(x: &mut i32, y: &i32) {
+   |         ^
 help: the accessed tag <TAG> later transitioned to Reserved (conflicted) due to a reborrow (acting as a foreign read access) at offsets [0x0..0x4]
   --> tests/fail/both_borrows/aliasing_mut3.rs:LL:CC
    |
-LL | pub fn safe(x: &mut i32, y: &i32) {
-   |                          ^
+LL | fn safe(x: &mut i32, y: &i32) {
+   |                      ^
    = help: this transition corresponds to a temporary loss of write permissions until function exit
    = note: BACKTRACE (of the first span):
    = note: inside `safe` at tests/fail/both_borrows/aliasing_mut3.rs:LL:CC

--- a/tests/fail/both_borrows/aliasing_mut4.rs
+++ b/tests/fail/both_borrows/aliasing_mut4.rs
@@ -5,7 +5,7 @@ use std::cell::Cell;
 use std::mem;
 
 // Make sure &mut UnsafeCell also is exclusive
-pub fn safe(x: &i32, y: &mut Cell<i32>) {
+fn safe(x: &i32, y: &mut Cell<i32>) {
     //~[stack]^ ERROR: protect
     y.set(1);
     let _load = *x;

--- a/tests/fail/both_borrows/aliasing_mut4.stack.stderr
+++ b/tests/fail/both_borrows/aliasing_mut4.stack.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: not granting access to tag <TAG> because that would remove [SharedReadOnly for <TAG>] which is strongly protected
   --> tests/fail/both_borrows/aliasing_mut4.rs:LL:CC
    |
-LL | pub fn safe(x: &i32, y: &mut Cell<i32>) {
-   |                      ^ Undefined Behavior occurred here
+LL | fn safe(x: &i32, y: &mut Cell<i32>) {
+   |                  ^ Undefined Behavior occurred here
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
@@ -14,8 +14,8 @@ LL |     let xref = &mut x;
 help: <TAG> is this argument
   --> tests/fail/both_borrows/aliasing_mut4.rs:LL:CC
    |
-LL | pub fn safe(x: &i32, y: &mut Cell<i32>) {
-   |             ^
+LL | fn safe(x: &i32, y: &mut Cell<i32>) {
+   |         ^
    = note: BACKTRACE (of the first span):
    = note: inside `safe` at tests/fail/both_borrows/aliasing_mut4.rs:LL:CC
 note: inside `main`

--- a/tests/fail/both_borrows/aliasing_mut4.tree.stderr
+++ b/tests/fail/both_borrows/aliasing_mut4.tree.stderr
@@ -17,8 +17,8 @@ LL |     y.set(1);
 help: the protected tag <TAG> was created here, in the initial state Frozen
   --> tests/fail/both_borrows/aliasing_mut4.rs:LL:CC
    |
-LL | pub fn safe(x: &i32, y: &mut Cell<i32>) {
-   |             ^
+LL | fn safe(x: &i32, y: &mut Cell<i32>) {
+   |         ^
    = note: BACKTRACE (of the first span):
    = note: inside `std::mem::replace::<i32>` at RUSTLIB/core/src/mem/mod.rs:LL:CC
    = note: inside `std::cell::Cell::<i32>::replace` at RUSTLIB/core/src/cell.rs:LL:CC

--- a/tests/fail/data_race/alloc_read_race.rs
+++ b/tests/fail/data_race/alloc_read_race.rs
@@ -12,7 +12,7 @@ struct EvilSend<T>(pub T);
 unsafe impl<T> Send for EvilSend<T> {}
 unsafe impl<T> Sync for EvilSend<T> {}
 
-pub fn main() {
+fn main() {
     // Shared atomic pointer
     let pointer = AtomicPtr::new(null_mut::<MaybeUninit<usize>>());
     let ptr = EvilSend(&pointer as *const AtomicPtr<MaybeUninit<usize>>);

--- a/tests/fail/data_race/alloc_write_race.rs
+++ b/tests/fail/data_race/alloc_write_race.rs
@@ -11,7 +11,7 @@ struct EvilSend<T>(pub T);
 unsafe impl<T> Send for EvilSend<T> {}
 unsafe impl<T> Sync for EvilSend<T> {}
 
-pub fn main() {
+fn main() {
     // Shared atomic pointer
     let pointer = AtomicPtr::new(null_mut::<usize>());
     let ptr = EvilSend(&pointer as *const AtomicPtr<usize>);

--- a/tests/fail/data_race/atomic_read_na_write_race1.rs
+++ b/tests/fail/data_race/atomic_read_na_write_race1.rs
@@ -10,7 +10,7 @@ struct EvilSend<T>(pub T);
 unsafe impl<T> Send for EvilSend<T> {}
 unsafe impl<T> Sync for EvilSend<T> {}
 
-pub fn main() {
+fn main() {
     let mut a = AtomicUsize::new(0);
     let b = &mut a as *mut AtomicUsize;
     let c = EvilSend(b);

--- a/tests/fail/data_race/atomic_read_na_write_race2.rs
+++ b/tests/fail/data_race/atomic_read_na_write_race2.rs
@@ -10,7 +10,7 @@ struct EvilSend<T>(pub T);
 unsafe impl<T> Send for EvilSend<T> {}
 unsafe impl<T> Sync for EvilSend<T> {}
 
-pub fn main() {
+fn main() {
     let mut a = AtomicUsize::new(0);
     let b = &mut a as *mut AtomicUsize;
     let c = EvilSend(b);

--- a/tests/fail/data_race/atomic_write_na_read_race1.rs
+++ b/tests/fail/data_race/atomic_write_na_read_race1.rs
@@ -10,7 +10,7 @@ struct EvilSend<T>(pub T);
 unsafe impl<T> Send for EvilSend<T> {}
 unsafe impl<T> Sync for EvilSend<T> {}
 
-pub fn main() {
+fn main() {
     let mut a = AtomicUsize::new(0);
     let b = &mut a as *mut AtomicUsize;
     let c = EvilSend(b);

--- a/tests/fail/data_race/atomic_write_na_read_race2.rs
+++ b/tests/fail/data_race/atomic_write_na_read_race2.rs
@@ -10,7 +10,7 @@ struct EvilSend<T>(pub T);
 unsafe impl<T> Send for EvilSend<T> {}
 unsafe impl<T> Sync for EvilSend<T> {}
 
-pub fn main() {
+fn main() {
     let mut a = AtomicUsize::new(0);
     let b = &mut a as *mut AtomicUsize;
     let c = EvilSend(b);

--- a/tests/fail/data_race/atomic_write_na_write_race1.rs
+++ b/tests/fail/data_race/atomic_write_na_write_race1.rs
@@ -10,7 +10,7 @@ struct EvilSend<T>(pub T);
 unsafe impl<T> Send for EvilSend<T> {}
 unsafe impl<T> Sync for EvilSend<T> {}
 
-pub fn main() {
+fn main() {
     let mut a = AtomicUsize::new(0);
     let b = &mut a as *mut AtomicUsize;
     let c = EvilSend(b);

--- a/tests/fail/data_race/atomic_write_na_write_race2.rs
+++ b/tests/fail/data_race/atomic_write_na_write_race2.rs
@@ -10,7 +10,7 @@ struct EvilSend<T>(pub T);
 unsafe impl<T> Send for EvilSend<T> {}
 unsafe impl<T> Sync for EvilSend<T> {}
 
-pub fn main() {
+fn main() {
     let mut a = AtomicUsize::new(0);
     let b = &mut a as *mut AtomicUsize;
     let c = EvilSend(b);

--- a/tests/fail/data_race/dealloc_read_race1.rs
+++ b/tests/fail/data_race/dealloc_read_race1.rs
@@ -16,7 +16,7 @@ extern "Rust" {
     fn __rust_dealloc(ptr: *mut u8, size: usize, align: usize);
 }
 
-pub fn main() {
+fn main() {
     // Shared atomic pointer
     let pointer: *mut usize = Box::into_raw(Box::new(0usize));
     let ptr = EvilSend(pointer);

--- a/tests/fail/data_race/dealloc_read_race2.rs
+++ b/tests/fail/data_race/dealloc_read_race2.rs
@@ -16,7 +16,7 @@ extern "Rust" {
     fn __rust_dealloc(ptr: *mut u8, size: usize, align: usize);
 }
 
-pub fn main() {
+fn main() {
     // Shared atomic pointer
     let pointer: *mut usize = Box::into_raw(Box::new(0usize));
     let ptr = EvilSend(pointer);

--- a/tests/fail/data_race/dealloc_read_race_stack.rs
+++ b/tests/fail/data_race/dealloc_read_race_stack.rs
@@ -12,7 +12,7 @@ struct EvilSend<T>(pub T);
 unsafe impl<T> Send for EvilSend<T> {}
 unsafe impl<T> Sync for EvilSend<T> {}
 
-pub fn main() {
+fn main() {
     // Shared atomic pointer
     let pointer = AtomicPtr::new(null_mut::<usize>());
     let ptr = EvilSend(&pointer as *const AtomicPtr<usize>);

--- a/tests/fail/data_race/dealloc_write_race1.rs
+++ b/tests/fail/data_race/dealloc_write_race1.rs
@@ -15,7 +15,7 @@ extern "Rust" {
     #[rustc_std_internal_symbol]
     fn __rust_dealloc(ptr: *mut u8, size: usize, align: usize);
 }
-pub fn main() {
+fn main() {
     // Shared atomic pointer
     let pointer: *mut usize = Box::into_raw(Box::new(0usize));
     let ptr = EvilSend(pointer);

--- a/tests/fail/data_race/dealloc_write_race2.rs
+++ b/tests/fail/data_race/dealloc_write_race2.rs
@@ -15,7 +15,7 @@ extern "Rust" {
     #[rustc_std_internal_symbol]
     fn __rust_dealloc(ptr: *mut u8, size: usize, align: usize);
 }
-pub fn main() {
+fn main() {
     // Shared atomic pointer
     let pointer: *mut usize = Box::into_raw(Box::new(0usize));
     let ptr = EvilSend(pointer);

--- a/tests/fail/data_race/dealloc_write_race_stack.rs
+++ b/tests/fail/data_race/dealloc_write_race_stack.rs
@@ -12,7 +12,7 @@ struct EvilSend<T>(pub T);
 unsafe impl<T> Send for EvilSend<T> {}
 unsafe impl<T> Sync for EvilSend<T> {}
 
-pub fn main() {
+fn main() {
     // Shared atomic pointer
     let pointer = AtomicPtr::new(null_mut::<usize>());
     let ptr = EvilSend(&pointer as *const AtomicPtr<usize>);

--- a/tests/fail/data_race/enable_after_join_to_main.rs
+++ b/tests/fail/data_race/enable_after_join_to_main.rs
@@ -9,7 +9,7 @@ struct EvilSend<T>(pub T);
 unsafe impl<T> Send for EvilSend<T> {}
 unsafe impl<T> Sync for EvilSend<T> {}
 
-pub fn main() {
+fn main() {
     // Enable and then join with multiple threads.
     let t1 = spawn(|| ());
     let t2 = spawn(|| ());

--- a/tests/fail/data_race/read_write_race.rs
+++ b/tests/fail/data_race/read_write_race.rs
@@ -9,7 +9,7 @@ struct EvilSend<T>(pub T);
 unsafe impl<T> Send for EvilSend<T> {}
 unsafe impl<T> Sync for EvilSend<T> {}
 
-pub fn main() {
+fn main() {
     let mut a = 0u32;
     let b = &mut a as *mut u32;
     let c = EvilSend(b);

--- a/tests/fail/data_race/read_write_race_stack.rs
+++ b/tests/fail/data_race/read_write_race_stack.rs
@@ -12,7 +12,7 @@ struct EvilSend<T>(pub T);
 unsafe impl<T> Send for EvilSend<T> {}
 unsafe impl<T> Sync for EvilSend<T> {}
 
-pub fn main() {
+fn main() {
     // Shared atomic pointer
     let pointer = AtomicPtr::new(null_mut::<usize>());
     let ptr = EvilSend(&pointer as *const AtomicPtr<usize>);

--- a/tests/fail/data_race/relax_acquire_race.rs
+++ b/tests/fail/data_race/relax_acquire_race.rs
@@ -12,7 +12,7 @@ unsafe impl<T> Sync for EvilSend<T> {}
 
 static SYNC: AtomicUsize = AtomicUsize::new(0);
 
-pub fn main() {
+fn main() {
     let mut a = 0u32;
     let b = &mut a as *mut u32;
     let c = EvilSend(b);

--- a/tests/fail/data_race/release_seq_race.rs
+++ b/tests/fail/data_race/release_seq_race.rs
@@ -13,7 +13,7 @@ unsafe impl<T> Sync for EvilSend<T> {}
 
 static SYNC: AtomicUsize = AtomicUsize::new(0);
 
-pub fn main() {
+fn main() {
     let mut a = 0u32;
     let b = &mut a as *mut u32;
     let c = EvilSend(b);

--- a/tests/fail/data_race/release_seq_race_same_thread.rs
+++ b/tests/fail/data_race/release_seq_race_same_thread.rs
@@ -12,7 +12,7 @@ unsafe impl<T> Sync for EvilSend<T> {}
 
 static SYNC: AtomicUsize = AtomicUsize::new(0);
 
-pub fn main() {
+fn main() {
     let mut a = 0u32;
     let b = &mut a as *mut u32;
     let c = EvilSend(b);

--- a/tests/fail/data_race/rmw_race.rs
+++ b/tests/fail/data_race/rmw_race.rs
@@ -12,7 +12,7 @@ unsafe impl<T> Sync for EvilSend<T> {}
 
 static SYNC: AtomicUsize = AtomicUsize::new(0);
 
-pub fn main() {
+fn main() {
     let mut a = 0u32;
     let b = &mut a as *mut u32;
     let c = EvilSend(b);

--- a/tests/fail/data_race/write_write_race.rs
+++ b/tests/fail/data_race/write_write_race.rs
@@ -9,7 +9,7 @@ struct EvilSend<T>(pub T);
 unsafe impl<T> Send for EvilSend<T> {}
 unsafe impl<T> Sync for EvilSend<T> {}
 
-pub fn main() {
+fn main() {
     let mut a = 0u32;
     let b = &mut a as *mut u32;
     let c = EvilSend(b);

--- a/tests/fail/data_race/write_write_race_stack.rs
+++ b/tests/fail/data_race/write_write_race_stack.rs
@@ -12,7 +12,7 @@ struct EvilSend<T>(pub T);
 unsafe impl<T> Send for EvilSend<T> {}
 unsafe impl<T> Sync for EvilSend<T> {}
 
-pub fn main() {
+fn main() {
     // Shared atomic pointer
     let pointer = AtomicPtr::new(null_mut::<usize>());
     let ptr = EvilSend(&pointer as *const AtomicPtr<usize>);

--- a/tests/fail/enum-set-discriminant-niche-variant-wrong.rs
+++ b/tests/fail/enum-set-discriminant-niche-variant-wrong.rs
@@ -25,7 +25,7 @@ fn set_discriminant(ptr: &mut Option<NonZero<i32>>) {
     }
 }
 
-pub fn main() {
+fn main() {
     let mut v = None;
     set_discriminant(&mut v);
 }

--- a/tests/fail/function_calls/arg_inplace_locals_alias.rs
+++ b/tests/fail/function_calls/arg_inplace_locals_alias.rs
@@ -28,7 +28,7 @@ fn main() {
     }
 }
 
-pub fn callee(x: S, mut y: S) {
+fn callee(x: S, mut y: S) {
     // With the setup above, if `x` and `y` are both moved,
     // then writing to `y` will change the value stored in `x`!
     y.0 = 0;

--- a/tests/fail/function_calls/arg_inplace_locals_alias_ret.rs
+++ b/tests/fail/function_calls/arg_inplace_locals_alias_ret.rs
@@ -29,6 +29,6 @@ fn main() {
     }
 }
 
-pub fn callee(x: S) -> S {
+fn callee(x: S) -> S {
     x
 }

--- a/tests/fail/function_calls/arg_inplace_mutate.rs
+++ b/tests/fail/function_calls/arg_inplace_mutate.rs
@@ -22,7 +22,7 @@ fn main() {
     }
 }
 
-pub fn callee(x: S, ptr: *mut S) {
+fn callee(x: S, ptr: *mut S) {
     // With the setup above, if `x` is indeed moved in
     // (i.e. we actually just get a pointer to the underlying storage),
     // then writing to `ptr` will change the value stored in `x`!

--- a/tests/fail/function_calls/arg_inplace_observe_after.rs
+++ b/tests/fail/function_calls/arg_inplace_observe_after.rs
@@ -22,6 +22,6 @@ fn main() {
     }
 }
 
-pub fn change_arg(mut x: S) {
+fn change_arg(mut x: S) {
     x.0 = 0;
 }

--- a/tests/fail/function_calls/arg_inplace_observe_during.rs
+++ b/tests/fail/function_calls/arg_inplace_observe_during.rs
@@ -23,7 +23,7 @@ fn main() {
     }
 }
 
-pub fn change_arg(mut x: S, ptr: *mut S) {
+fn change_arg(mut x: S, ptr: *mut S) {
     x.0 = 0;
     // If `x` got passed in-place, we'd see the write through `ptr`!
     // Make sure we are not allowed to do that read.

--- a/tests/fail/function_calls/return_pointer_aliasing_read.rs
+++ b/tests/fail/function_calls/return_pointer_aliasing_read.rs
@@ -7,7 +7,7 @@
 use std::intrinsics::mir::*;
 
 #[custom_mir(dialect = "runtime", phase = "optimized")]
-pub fn main() {
+fn main() {
     mir! {
         {
             let _x = 0;

--- a/tests/fail/function_calls/return_pointer_aliasing_write.rs
+++ b/tests/fail/function_calls/return_pointer_aliasing_write.rs
@@ -7,7 +7,7 @@
 use std::intrinsics::mir::*;
 
 #[custom_mir(dialect = "runtime", phase = "optimized")]
-pub fn main() {
+fn main() {
     mir! {
         {
             let _x = 0;

--- a/tests/fail/function_calls/return_pointer_aliasing_write_tail_call.rs
+++ b/tests/fail/function_calls/return_pointer_aliasing_write_tail_call.rs
@@ -9,7 +9,7 @@
 use std::intrinsics::mir::*;
 
 #[custom_mir(dialect = "runtime", phase = "optimized")]
-pub fn main() {
+fn main() {
     mir! {
         {
             let _x = 0;

--- a/tests/fail/function_calls/simd_feature_flag_difference.rs
+++ b/tests/fail/function_calls/simd_feature_flag_difference.rs
@@ -9,7 +9,7 @@ pub unsafe extern "C" fn foo(_y: f32, x: __m256) -> __m256 {
     x
 }
 
-pub fn bar(x: __m256) -> __m256 {
+fn bar(x: __m256) -> __m256 {
     // The first and second argument get mixed up here since caller
     // and callee do not have the same feature flags.
     // In Miri, we don't have a concept of "dynamically available feature flags",

--- a/tests/fail/intrinsics/ctlz_nonzero.rs
+++ b/tests/fail/intrinsics/ctlz_nonzero.rs
@@ -1,6 +1,6 @@
 #![feature(core_intrinsics)]
 
-pub fn main() {
+fn main() {
     unsafe {
         use std::intrinsics::*;
 

--- a/tests/fail/intrinsics/cttz_nonzero.rs
+++ b/tests/fail/intrinsics/cttz_nonzero.rs
@@ -1,6 +1,6 @@
 #![feature(core_intrinsics)]
 
-pub fn main() {
+fn main() {
     unsafe {
         use std::intrinsics::*;
 

--- a/tests/fail/issue-miri-1112.rs
+++ b/tests/fail/issue-miri-1112.rs
@@ -11,7 +11,7 @@ pub struct Meta {
 }
 
 impl Meta {
-    pub fn new() -> Self {
+    fn new() -> Self {
         Meta { drop_fn: |_| {}, size: 0, align: 1 }
     }
 }

--- a/tests/fail/overlapping_assignment.rs
+++ b/tests/fail/overlapping_assignment.rs
@@ -7,7 +7,7 @@ use std::intrinsics::mir::*;
 // which wants to prevent overlapping assignments...
 // So we use two separate pointer arguments, and then arrange for them to alias.
 #[custom_mir(dialect = "runtime", phase = "optimized")]
-pub fn self_copy(ptr1: *mut [i32; 4], ptr2: *mut [i32; 4]) {
+fn self_copy(ptr1: *mut [i32; 4], ptr2: *mut [i32; 4]) {
     mir! {
         {
             *ptr1 = *ptr2; //~ERROR: overlapping ranges
@@ -16,7 +16,7 @@ pub fn self_copy(ptr1: *mut [i32; 4], ptr2: *mut [i32; 4]) {
     }
 }
 
-pub fn main() {
+fn main() {
     let mut x = [0; 4];
     let ptr = std::ptr::addr_of_mut!(x);
     self_copy(ptr, ptr);

--- a/tests/fail/stacked_borrows/retag_data_race_read.tree.stderr
+++ b/tests/fail/stacked_borrows/retag_data_race_read.tree.stderr
@@ -16,7 +16,7 @@ LL |     panic::catch_unwind(move || unsafe { init(argc, argv, sigpipe) }).map_e
 help: the protected tag <TAG> was created here, in the initial state Active
   --> RUSTLIB/std/src/panic.rs:LL:CC
    |
-LL | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
+LL | fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
    |                                                       ^
    = note: BACKTRACE (of the first span):
    = note: inside `std::rt::lang_start_internal` at RUSTLIB/std/src/rt.rs:LL:CC

--- a/tests/fail/tls_macro_leak.rs
+++ b/tests/fail/tls_macro_leak.rs
@@ -2,7 +2,7 @@
 
 use std::cell::Cell;
 
-pub fn main() {
+fn main() {
     thread_local! {
         static TLS: Cell<Option<&'static i32>> = Cell::new(None);
     }

--- a/tests/fail/tls_static_leak.rs
+++ b/tests/fail/tls_static_leak.rs
@@ -6,7 +6,7 @@ use std::cell::Cell;
 
 /// Ensure that leaks through `thread_local` statics *not in the main thread*
 /// are detected.
-pub fn main() {
+fn main() {
     #[thread_local]
     static TLS: Cell<Option<&'static i32>> = Cell::new(None);
 

--- a/tests/fail/tree_borrows/alternate-read-write.rs
+++ b/tests/fail/tree_borrows/alternate-read-write.rs
@@ -2,7 +2,7 @@
 
 // Check that TB properly rejects alternating Reads and Writes, but tolerates
 // alternating only Reads to Reserved mutable references.
-pub fn main() {
+fn main() {
     let x = &mut 0u8;
     let y = unsafe { &mut *(x as *mut u8) };
     // Foreign Read, but this is a no-op from the point of view of y (still Reserved)

--- a/tests/fail/tree_borrows/cell-inside-struct.rs
+++ b/tests/fail/tree_borrows/cell-inside-struct.rs
@@ -11,7 +11,7 @@ struct Foo {
     field2: Cell<u32>,
 }
 
-pub fn main() {
+fn main() {
     let root = Foo { field1: 42, field2: Cell::new(88) };
     unsafe {
         let a = &root;

--- a/tests/fail/tree_borrows/repeated_foreign_read_lazy_conflicted.rs
+++ b/tests/fail/tree_borrows/repeated_foreign_read_lazy_conflicted.rs
@@ -11,7 +11,7 @@ unsafe fn access_after_sub_1(x: &mut u8, orig_ptr: *mut u8) {
     *(x as *mut u8).byte_sub(1) = 42; //~ ERROR: /write access through .* is forbidden/
 }
 
-pub fn main() {
+fn main() {
     unsafe {
         let mut alloc = [0u8, 0u8];
         let orig_ptr = addr_of_mut!(alloc) as *mut u8;

--- a/tests/fail/tree_borrows/write-during-2phase.rs
+++ b/tests/fail/tree_borrows/write-during-2phase.rs
@@ -14,7 +14,7 @@ impl Foo {
     }
 }
 
-pub fn main() {
+fn main() {
     let mut f = Foo(0);
     let alias = &mut f.0 as *mut u64;
     let res = f.add(unsafe {

--- a/tests/fail/uninit/padding-struct-in-union.rs
+++ b/tests/fail/uninit/padding-struct-in-union.rs
@@ -18,7 +18,7 @@ union FooBar {
     bar: Bar,
 }
 
-pub fn main() {
+fn main() {
     // Initialize as u8 to ensure padding bytes are zeroed.
     let mut foobar = FooBar { bar: Bar { bytes: [0u8; 8] } };
     // Reading either field is ok.

--- a/tests/fail/validity/invalid_char_cast.rs
+++ b/tests/fail/validity/invalid_char_cast.rs
@@ -15,7 +15,7 @@ fn cast(ptr: *const char) -> u32 {
     }
 }
 
-pub fn main() {
+fn main() {
     let v = u32::MAX;
     cast(&v as *const u32 as *const char);
 }

--- a/tests/fail/validity/invalid_char_match.rs
+++ b/tests/fail/validity/invalid_char_match.rs
@@ -20,7 +20,7 @@ fn switch_int(ptr: *const char) {
     }
 }
 
-pub fn main() {
+fn main() {
     let v = u32::MAX;
     switch_int(&v as *const u32 as *const char);
 }

--- a/tests/fail/validity/invalid_enum_cast.rs
+++ b/tests/fail/validity/invalid_enum_cast.rs
@@ -15,7 +15,7 @@ fn cast(ptr: *const E) {
     }
 }
 
-pub fn main() {
+fn main() {
     let v = u32::MAX;
     cast(&v as *const u32 as *const E);
 }

--- a/tests/fail/weak_memory/weak_uninit.rs
+++ b/tests/fail/weak_memory/weak_uninit.rs
@@ -34,7 +34,7 @@ fn relaxed() {
     j2.join().unwrap();
 }
 
-pub fn main() {
+fn main() {
     // If we try often enough, we should hit UB.
     for _ in 0..100 {
         relaxed();

--- a/tests/panic/mir-validation.rs
+++ b/tests/panic/mir-validation.rs
@@ -13,7 +13,7 @@
 use core::intrinsics::mir::*;
 
 #[custom_mir(dialect = "runtime", phase = "optimized")]
-pub fn main() {
+fn main() {
     mir! {
         let x: i32;
         let tuple: (*mut i32,);

--- a/tests/pass-dep/concurrency/tls_pthread_drop_order.rs
+++ b/tests/pass-dep/concurrency/tls_pthread_drop_order.rs
@@ -29,7 +29,7 @@ pub unsafe fn set(key: Key, value: *mut u8) {
     assert_eq!(r, 0);
 }
 
-pub fn record(r: usize) {
+fn record(r: usize) {
     assert!(r < 10);
     unsafe { RECORD = RECORD * 10 + r };
 }

--- a/tests/pass-dep/foreign-fn-linkname.rs
+++ b/tests/pass-dep/foreign-fn-linkname.rs
@@ -14,7 +14,7 @@ fn strlen(str: String) -> usize {
     unsafe { mlibc::my_strlen(s.as_ptr()) as usize }
 }
 
-pub fn main() {
+fn main() {
     let len = strlen("Rust".to_string());
     assert_eq!(len, 4);
 }

--- a/tests/pass-dep/regions-mock-trans.rs
+++ b/tests/pass-dep/regions-mock-trans.rs
@@ -39,7 +39,7 @@ fn f(ccx: &Ccx) {
     return g(&fcx);
 }
 
-pub fn main() {
+fn main() {
     let ccx = Ccx { x: 0 };
     f(&ccx);
 }

--- a/tests/pass-dep/wcslen.rs
+++ b/tests/pass-dep/wcslen.rs
@@ -13,7 +13,7 @@ fn to_c_wchar_t_str(s: &str) -> Vec<libc::wchar_t> {
     r
 }
 
-pub fn main() {
+fn main() {
     let s = to_c_wchar_t_str("Rust");
     let len = unsafe { libc::wcslen(s.as_ptr()) };
     assert_eq!(len, 4);

--- a/tests/pass/0weak_memory/consistency.rs
+++ b/tests/pass/0weak_memory/consistency.rs
@@ -212,7 +212,7 @@ fn test_single_thread() {
 fn test_sync_through_rmw_and_fences() {
     // Example from https://github.com/llvm/llvm-project/issues/56450#issuecomment-1183695905
     #[no_mangle]
-    pub fn rdmw(storing: &AtomicI32, sync: &AtomicI32, loading: &AtomicI32) -> i32 {
+    fn rdmw(storing: &AtomicI32, sync: &AtomicI32, loading: &AtomicI32) -> i32 {
         storing.store(1, Relaxed);
         fence(Release);
         sync.fetch_add(0, Relaxed);
@@ -245,7 +245,7 @@ fn test_sync_through_rmw_and_fences() {
     assert_ne!((a, b), (0, 0));
 }
 
-pub fn main() {
+fn main() {
     for _ in 0..50 {
         test_single_thread();
         test_mixed_access();

--- a/tests/pass/0weak_memory/consistency_sc.rs
+++ b/tests/pass/0weak_memory/consistency_sc.rs
@@ -348,7 +348,7 @@ fn test_sc_relaxed() {
     assert!(!bad);
 }
 
-pub fn main() {
+fn main() {
     for _ in 0..32 {
         test_sc_store_buffering();
         test_iriw_sc_rlx();

--- a/tests/pass/0weak_memory/extra_cpp.rs
+++ b/tests/pass/0weak_memory/extra_cpp.rs
@@ -72,7 +72,7 @@ fn from_mut_split() {
     assert_eq!(x_lo_atomic.load(Relaxed), u16::from_be(0xfafa));
 }
 
-pub fn main() {
+fn main() {
     get_mut_write();
     from_mut_split();
     assign_to_mut();

--- a/tests/pass/0weak_memory/weak.rs
+++ b/tests/pass/0weak_memory/weak.rs
@@ -115,7 +115,7 @@ fn initialization_write(add_fence: bool) {
 fn faa_replaced_by_load() {
     check_all_outcomes([true, false], || {
         // Example from https://github.com/llvm/llvm-project/issues/56450#issuecomment-1183695905
-        pub fn rdmw(storing: &AtomicUsize, sync: &AtomicUsize, loading: &AtomicUsize) -> usize {
+        fn rdmw(storing: &AtomicUsize, sync: &AtomicUsize, loading: &AtomicUsize) -> usize {
             storing.store(1, Relaxed);
             fence(Release);
             // sync.fetch_add(0, Relaxed);
@@ -226,7 +226,7 @@ fn old_release_store() {
     });
 }
 
-pub fn main() {
+fn main() {
     relaxed();
     seq_cst();
     initialization_write(false);

--- a/tests/pass/align_repeat_into_well_aligned_array.rs
+++ b/tests/pass/align_repeat_into_well_aligned_array.rs
@@ -24,7 +24,7 @@ pub const KEYBYTES: usize = 8 * size_of::<u64>();
 pub const BLOCKBYTES: usize = 16 * size_of::<u64>();
 
 impl Params {
-    pub fn new() -> Self {
+    fn new() -> Self {
         Self {
             hash_length: OUTBYTES as u8,
             key_length: 0,

--- a/tests/pass/async-closure-captures.rs
+++ b/tests/pass/async-closure-captures.rs
@@ -6,7 +6,7 @@ use std::future::Future;
 use std::pin::pin;
 use std::task::*;
 
-pub fn block_on<T>(fut: impl Future<Output = T>) -> T {
+fn block_on<T>(fut: impl Future<Output = T>) -> T {
     let mut fut = pin!(fut);
     let ctx = &mut Context::from_waker(Waker::noop());
 

--- a/tests/pass/async-closure-drop.rs
+++ b/tests/pass/async-closure-drop.rs
@@ -4,7 +4,7 @@ use std::future::Future;
 use std::pin::pin;
 use std::task::*;
 
-pub fn block_on<T>(fut: impl Future<Output = T>) -> T {
+fn block_on<T>(fut: impl Future<Output = T>) -> T {
     let mut fut = pin!(fut);
     let ctx = &mut Context::from_waker(Waker::noop());
 
@@ -29,7 +29,7 @@ impl Drop for DropMe {
     }
 }
 
-pub fn main() {
+fn main() {
     block_on(async {
         let b = DropMe("hello");
         let async_closure = async move |a: DropMe| {

--- a/tests/pass/async-closure.rs
+++ b/tests/pass/async-closure.rs
@@ -6,7 +6,7 @@ use std::ops::{AsyncFn, AsyncFnMut, AsyncFnOnce};
 use std::pin::pin;
 use std::task::*;
 
-pub fn block_on<T>(fut: impl Future<Output = T>) -> T {
+fn block_on<T>(fut: impl Future<Output = T>) -> T {
     let mut fut = pin!(fut);
     let ctx = &mut Context::from_waker(Waker::noop());
 
@@ -38,7 +38,7 @@ async fn call_normal_mut<F: Future<Output = ()>>(f: &mut impl FnMut(i32) -> F) {
     f(1).await;
 }
 
-pub fn main() {
+fn main() {
     block_on(async {
         let b = 2i32;
         let mut async_closure = async move |a: i32| {

--- a/tests/pass/binops.rs
+++ b/tests/pass/binops.rs
@@ -71,7 +71,7 @@ fn test_class() {
     assert!(q != r);
 }
 
-pub fn main() {
+fn main() {
     test_nil();
     test_bool();
     test_ptr();

--- a/tests/pass/btreemap.rs
+++ b/tests/pass/btreemap.rs
@@ -25,7 +25,7 @@ fn test_all_refs<'a, T: 'a>(dummy: &mut T, iter: impl Iterator<Item = &'a mut T>
     }
 }
 
-pub fn main() {
+fn main() {
     let mut b = BTreeSet::new();
     b.insert(Foo::A("\'"));
     b.insert(Foo::A("/="));

--- a/tests/pass/calls.rs
+++ b/tests/pass/calls.rs
@@ -35,7 +35,7 @@ fn const_fn_call() -> i64 {
 }
 
 fn call_return_into_passed_reference() {
-    pub fn func<T>(v: &mut T, f: fn(&T) -> T) {
+    fn func<T>(v: &mut T, f: fn(&T) -> T) {
         // MIR building will introduce a temporary, so this becomes
         // `let temp = f(v); *v = temp;`.
         // If this got optimized to `*v = f(v)` on the MIR level we'd have UB

--- a/tests/pass/concurrency/data_race.rs
+++ b/tests/pass/concurrency/data_race.rs
@@ -57,7 +57,7 @@ fn test_multiple_reads() {
     assert_eq!(var, 10);
 }
 
-pub fn test_rmw_no_block() {
+fn test_rmw_no_block() {
     static SYNC: AtomicUsize = AtomicUsize::new(0);
 
     let mut a = 0u32;
@@ -89,7 +89,7 @@ pub fn test_rmw_no_block() {
     }
 }
 
-pub fn test_simple_release() {
+fn test_simple_release() {
     static SYNC: AtomicUsize = AtomicUsize::new(0);
 
     let mut a = 0u32;
@@ -214,7 +214,7 @@ fn failing_rmw_is_read() {
     });
 }
 
-pub fn main() {
+fn main() {
     test_fence_sync();
     test_multiple_reads();
     test_rmw_no_block();

--- a/tests/pass/concurrency/disable_data_race_detector.rs
+++ b/tests/pass/concurrency/disable_data_race_detector.rs
@@ -10,7 +10,7 @@ struct EvilSend<T>(pub T);
 unsafe impl<T> Send for EvilSend<T> {}
 unsafe impl<T> Sync for EvilSend<T> {}
 
-pub fn main() {
+fn main() {
     let mut a = 0u32;
     let b = &mut a as *mut u32;
     let c = EvilSend(b);

--- a/tests/pass/const-vec-of-fns.rs
+++ b/tests/pass/const-vec-of-fns.rs
@@ -8,7 +8,7 @@
 fn f() {}
 static mut CLOSURES: &'static mut [fn()] = &mut [f as fn(), f as fn()];
 
-pub fn main() {
+fn main() {
     unsafe {
         for closure in &mut *CLOSURES {
             (*closure)()

--- a/tests/pass/drop_type_without_drop_glue.rs
+++ b/tests/pass/drop_type_without_drop_glue.rs
@@ -15,7 +15,7 @@ fn drop_in_place_with_terminator(ptr: *mut i32) {
     }
 }
 
-pub fn main() {
+fn main() {
     drop_in_place_with_terminator(std::ptr::without_provenance_mut(0));
     drop_in_place_with_terminator(std::ptr::without_provenance_mut(1));
 }

--- a/tests/pass/dst-raw.rs
+++ b/tests/pass/dst-raw.rs
@@ -19,7 +19,7 @@ struct Foo<T: ?Sized> {
     f: T,
 }
 
-pub fn main() {
+fn main() {
     // raw trait object
     let x = A { f: 42 };
     let z: *const dyn Trait = &x;

--- a/tests/pass/dst-struct-sole.rs
+++ b/tests/pass/dst-struct-sole.rs
@@ -33,7 +33,7 @@ impl ToBar for Bar {
     }
 }
 
-pub fn main() {
+fn main() {
     // With a vec of ints.
     let f1 = Fat { ptr: [1, 2, 3] };
     foo(&f1);

--- a/tests/pass/dst-struct.rs
+++ b/tests/pass/dst-struct.rs
@@ -48,7 +48,7 @@ impl ToBar for Bar {
     }
 }
 
-pub fn main() {
+fn main() {
     // With a vec of ints.
     let f1: Fat<[isize; 3]> = Fat { f1: 5, f2: "some str", ptr: [1, 2, 3] };
     foo(&f1);

--- a/tests/pass/enum-nullable-const-null-with-fields.rs
+++ b/tests/pass/enum-nullable-const-null-with-fields.rs
@@ -3,6 +3,6 @@ static C: Result<(), Box<isize>> = Ok(());
 // This is because of yet another bad assertion (ICE) about the null side of a nullable enum.
 // So we won't actually compile if the bug is present, but we check the value in main anyway.
 
-pub fn main() {
+fn main() {
     assert!(C.is_ok());
 }

--- a/tests/pass/float.rs
+++ b/tests/pass/float.rs
@@ -1037,7 +1037,7 @@ fn mul_add() {
     assert_eq!(f.to_bits(), f32::to_bits(-0.0));
 }
 
-pub fn libm() {
+fn libm() {
     fn ldexp(a: f64, b: i32) -> f64 {
         extern "C" {
             fn ldexp(x: f64, n: i32) -> f64;
@@ -1300,7 +1300,7 @@ fn test_fast() {
     use std::intrinsics::{fadd_fast, fdiv_fast, fmul_fast, frem_fast, fsub_fast};
 
     #[inline(never)]
-    pub fn test_operations_f16(a: f16, b: f16) {
+    fn test_operations_f16(a: f16, b: f16) {
         // make sure they all map to the correct operation
         unsafe {
             assert_approx_eq!(fadd_fast(a, b), a + b);
@@ -1312,7 +1312,7 @@ fn test_fast() {
     }
 
     #[inline(never)]
-    pub fn test_operations_f32(a: f32, b: f32) {
+    fn test_operations_f32(a: f32, b: f32) {
         // make sure they all map to the correct operation
         unsafe {
             assert_approx_eq!(fadd_fast(a, b), a + b);
@@ -1324,7 +1324,7 @@ fn test_fast() {
     }
 
     #[inline(never)]
-    pub fn test_operations_f64(a: f64, b: f64) {
+    fn test_operations_f64(a: f64, b: f64) {
         // make sure they all map to the correct operation
         unsafe {
             assert_approx_eq!(fadd_fast(a, b), a + b);
@@ -1336,7 +1336,7 @@ fn test_fast() {
     }
 
     #[inline(never)]
-    pub fn test_operations_f128(a: f128, b: f128) {
+    fn test_operations_f128(a: f128, b: f128) {
         // make sure they all map to the correct operation
         unsafe {
             assert_approx_eq!(fadd_fast(a, b), a + b);
@@ -1363,7 +1363,7 @@ fn test_algebraic() {
     };
 
     #[inline(never)]
-    pub fn test_operations_f16(a: f16, b: f16) {
+    fn test_operations_f16(a: f16, b: f16) {
         // make sure they all map to the correct operation
         assert_approx_eq!(fadd_algebraic(a, b), a + b);
         assert_approx_eq!(fsub_algebraic(a, b), a - b);
@@ -1373,7 +1373,7 @@ fn test_algebraic() {
     }
 
     #[inline(never)]
-    pub fn test_operations_f32(a: f32, b: f32) {
+    fn test_operations_f32(a: f32, b: f32) {
         // make sure they all map to the correct operation
         assert_approx_eq!(fadd_algebraic(a, b), a + b);
         assert_approx_eq!(fsub_algebraic(a, b), a - b);
@@ -1383,7 +1383,7 @@ fn test_algebraic() {
     }
 
     #[inline(never)]
-    pub fn test_operations_f64(a: f64, b: f64) {
+    fn test_operations_f64(a: f64, b: f64) {
         // make sure they all map to the correct operation
         assert_approx_eq!(fadd_algebraic(a, b), a + b);
         assert_approx_eq!(fsub_algebraic(a, b), a - b);
@@ -1393,7 +1393,7 @@ fn test_algebraic() {
     }
 
     #[inline(never)]
-    pub fn test_operations_f128(a: f128, b: f128) {
+    fn test_operations_f128(a: f128, b: f128) {
         // make sure they all map to the correct operation
         assert_approx_eq!(fadd_algebraic(a, b), a + b);
         assert_approx_eq!(fsub_algebraic(a, b), a - b);
@@ -1418,12 +1418,12 @@ fn test_fmuladd() {
     // FIXME(f16_f128): add when supported
 
     #[inline(never)]
-    pub fn test_operations_f32(a: f32, b: f32, c: f32) {
+    fn test_operations_f32(a: f32, b: f32, c: f32) {
         assert_approx_eq!(fmuladdf32(a, b, c), a * b + c);
     }
 
     #[inline(never)]
-    pub fn test_operations_f64(a: f64, b: f64, c: f64) {
+    fn test_operations_f64(a: f64, b: f64, c: f64) {
         assert_approx_eq!(fmuladdf64(a, b, c), a * b + c);
     }
 
@@ -1468,10 +1468,10 @@ fn test_non_determinism() {
         };
     }
 
-    pub fn test_operations_f16(a: f16, b: f16) {
+    fn test_operations_f16(a: f16, b: f16) {
         test_operations_f!(a, b);
     }
-    pub fn test_operations_f32(a: f32, b: f32) {
+    fn test_operations_f32(a: f32, b: f32) {
         test_operations_f!(a, b);
         check_nondet(|| a.powf(b));
         check_nondet(|| a.powi(2));
@@ -1507,7 +1507,7 @@ fn test_non_determinism() {
         check_nondet(|| 5.0f32.erf());
         check_nondet(|| 5.0f32.erfc());
     }
-    pub fn test_operations_f64(a: f64, b: f64) {
+    fn test_operations_f64(a: f64, b: f64) {
         test_operations_f!(a, b);
         check_nondet(|| a.powf(b));
         check_nondet(|| a.powi(2));
@@ -1538,7 +1538,7 @@ fn test_non_determinism() {
         check_nondet(|| 5.0f64.erf());
         check_nondet(|| 5.0f64.erfc());
     }
-    pub fn test_operations_f128(a: f128, b: f128) {
+    fn test_operations_f128(a: f128, b: f128) {
         test_operations_f!(a, b);
     }
 

--- a/tests/pass/function_calls/return_place_on_heap.rs
+++ b/tests/pass/function_calls/return_place_on_heap.rs
@@ -5,7 +5,7 @@ use std::intrinsics::mir::*;
 
 // Make sure calls with the return place "on the heap" work.
 #[custom_mir(dialect = "runtime", phase = "optimized")]
-pub fn main() {
+fn main() {
     mir! {
         {
             let x = 0;

--- a/tests/pass/integer-ops.rs
+++ b/tests/pass/integer-ops.rs
@@ -56,7 +56,7 @@ fn basic() {
     assert_eq!(match_int_range(), 4);
 }
 
-pub fn main() {
+fn main() {
     basic();
 
     // This tests that we do (not) do sign extension properly when loading integers

--- a/tests/pass/intrinsics/integer.rs
+++ b/tests/pass/intrinsics/integer.rs
@@ -4,7 +4,7 @@
 #![feature(core_intrinsics, funnel_shifts)]
 use std::intrinsics::*;
 
-pub fn main() {
+fn main() {
     unsafe {
         [assert_eq!(ctpop(0u8), 0), assert_eq!(ctpop(0i8), 0)];
         [assert_eq!(ctpop(0u16), 0), assert_eq!(ctpop(0i16), 0)];

--- a/tests/pass/intrinsics/volatile.rs
+++ b/tests/pass/intrinsics/volatile.rs
@@ -2,7 +2,7 @@
 #![feature(core_intrinsics)]
 use std::intrinsics::{volatile_load, volatile_store};
 
-pub fn main() {
+fn main() {
     unsafe {
         let i: &mut (isize, isize) = &mut (0, 0);
         volatile_store(i, (1, 2));

--- a/tests/pass/issues/issue-30530.rs
+++ b/tests/pass/issues/issue-30530.rs
@@ -21,7 +21,7 @@ fn main() {
 }
 
 #[inline(never)]
-pub fn take(h: Handler, f: Box<dyn Fn()>) -> Box<dyn Fn()> {
+fn take(h: Handler, f: Box<dyn Fn()>) -> Box<dyn Fn()> {
     unsafe {
         match h {
             Handler::Custom(ptr) => *Box::from_raw(ptr),

--- a/tests/pass/issues/issue-3794.rs
+++ b/tests/pass/issues/issue-3794.rs
@@ -22,7 +22,7 @@ fn print_s(s: &S) {
     s.print();
 }
 
-pub fn main() {
+fn main() {
     let s: Box<S> = Box::new(S { s: 5 });
     print_s(&*s);
     let t: Box<dyn T> = s as Box<dyn T>;

--- a/tests/pass/issues/issue-5917.rs
+++ b/tests/pass/issues/issue-5917.rs
@@ -1,6 +1,6 @@
 struct T(&'static [isize]);
 static STATIC: T = T(&[5, 4, 3]);
-pub fn main() {
+fn main() {
     let T(ref v) = STATIC;
     assert_eq!(v[0], 5);
 }

--- a/tests/pass/issues/issue-miri-184.rs
+++ b/tests/pass/issues/issue-miri-184.rs
@@ -1,5 +1,5 @@
 #![allow(unnecessary_transmutes)]
-pub fn main() {
+fn main() {
     let bytes: [u8; 8] = unsafe { ::std::mem::transmute(0u64) };
     let _val: &[u8] = &bytes;
 }

--- a/tests/pass/issues/issue-miri-2068.rs
+++ b/tests/pass/issues/issue-miri-2068.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll, Waker};
 
-pub fn fuzzing_block_on<O, F: Future<Output = O>>(fut: F) -> O {
+fn fuzzing_block_on<O, F: Future<Output = O>>(fut: F) -> O {
     let mut fut = std::pin::pin!(fut);
     let mut context = Context::from_waker(Waker::noop());
     loop {

--- a/tests/pass/issues/issue-miri-3541-dyn-vtable-trait-normalization.rs
+++ b/tests/pass/issues/issue-miri-3541-dyn-vtable-trait-normalization.rs
@@ -25,7 +25,7 @@ where
     }
 }
 
-pub fn box_new_with<T>()
+fn box_new_with<T>()
 where
     T: ?Sized,
 {

--- a/tests/pass/last-use-in-cap-clause.rs
+++ b/tests/pass/last-use-in-cap-clause.rs
@@ -12,6 +12,6 @@ fn foo() -> Box<dyn FnMut() -> isize + 'static> {
     Box::new(result)
 }
 
-pub fn main() {
+fn main() {
     assert_eq!(foo()(), 22);
 }

--- a/tests/pass/loop-break-value.rs
+++ b/tests/pass/loop-break-value.rs
@@ -8,7 +8,7 @@ fn never_returns() {
     }
 }
 
-pub fn main() {
+fn main() {
     let value = 'outer: loop {
         if 1 == 1 {
             break 13;

--- a/tests/pass/move-arg-2-unique.rs
+++ b/tests/pass/move-arg-2-unique.rs
@@ -2,7 +2,7 @@ fn test(foo: Box<Vec<isize>>) {
     assert_eq!((*foo)[0], 10);
 }
 
-pub fn main() {
+fn main() {
     let x = Box::new(vec![10]);
     // Test forgetting a local by move-in
     test(x);

--- a/tests/pass/move-arg-3-unique.rs
+++ b/tests/pass/move-arg-3-unique.rs
@@ -1,4 +1,4 @@
-pub fn main() {
+fn main() {
     let x = Box::new(10);
     let y = x;
     assert_eq!(*y, 10);

--- a/tests/pass/mpsc.rs
+++ b/tests/pass/mpsc.rs
@@ -1,6 +1,6 @@
 use std::sync::mpsc::channel;
 
-pub fn main() {
+fn main() {
     let (tx, rx) = channel::<Box<_>>();
     tx.send(Box::new(100)).unwrap();
     let v = rx.recv().unwrap();

--- a/tests/pass/panic/unwind_dwarf.rs
+++ b/tests/pass/panic/unwind_dwarf.rs
@@ -15,7 +15,7 @@ struct Exception {
     cause: Box<dyn Any + Send>,
 }
 
-pub fn panic(data: Box<dyn Any + Send>) -> u32 {
+fn panic(data: Box<dyn Any + Send>) -> u32 {
     extern "C" fn exception_cleanup(
         _unwind_code: uw::_Unwind_Reason_Code,
         _exception: *mut uw::_Unwind_Exception,
@@ -53,7 +53,7 @@ fn miri_exception_class() -> uw::_Unwind_Exception_Class {
     0x4d4f5a_00_4d495249
 }
 
-pub fn catch_unwind<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<dyn Any + Send>> {
+fn catch_unwind<R, F: FnOnce() -> R>(f: F) -> Result<R, Box<dyn Any + Send>> {
     struct Data<F, R> {
         f: Option<F>,
         r: Option<R>,

--- a/tests/pass/regions-lifetime-nonfree-late-bound.rs
+++ b/tests/pass/regions-lifetime-nonfree-late-bound.rs
@@ -12,7 +12,7 @@
 // doing region-folding, when really all clients of the region-folding
 // case only want to see *free* lifetime variables, not bound ones.
 
-pub fn main() {
+fn main() {
     fn explicit() {
         fn test<F>(_x: Option<Box<F>>)
         where

--- a/tests/pass/sendable-class.rs
+++ b/tests/pass/sendable-class.rs
@@ -12,7 +12,7 @@ fn foo(i: isize, j: char) -> Foo {
     Foo { i: i, j: j }
 }
 
-pub fn main() {
+fn main() {
     let (tx, rx) = channel();
     tx.send(foo(42, 'c')).unwrap();
     let _val = rx;

--- a/tests/pass/tag-align-dyn-u64.rs
+++ b/tests/pass/tag-align-dyn-u64.rs
@@ -24,7 +24,7 @@ fn is_u64_aligned(u: &Tag<u64>) -> bool {
     return (p & (u64_align - 1)) == 0;
 }
 
-pub fn main() {
+fn main() {
     let x = mk_rec();
     assert!(is_u64_aligned(&x.t));
 }

--- a/tests/pass/tls/tls_leak_main_thread_allowed.rs
+++ b/tests/pass/tls/tls_leak_main_thread_allowed.rs
@@ -6,7 +6,7 @@ use std::cell::Cell;
 // as long as the program does), so make sure we treat them the same for leak purposes.
 //
 // The test covers both TLS statics and the TLS macro.
-pub fn main() {
+fn main() {
     #[thread_local]
     static TLS: Cell<Option<&'static i32>> = Cell::new(None);
 

--- a/tests/pass/tree_borrows/cell-inside-box.rs
+++ b/tests/pass/tree_borrows/cell-inside-box.rs
@@ -6,7 +6,7 @@ mod utils;
 
 use std::cell::UnsafeCell;
 
-pub fn main() {
+fn main() {
     let cell = UnsafeCell::new(42);
     let box1 = Box::new(cell);
 

--- a/tests/pass/tree_borrows/cell-inside-struct.rs
+++ b/tests/pass/tree_borrows/cell-inside-struct.rs
@@ -12,7 +12,7 @@ struct Foo {
     field2: Cell<u32>,
 }
 
-pub fn main() {
+fn main() {
     let root = Foo { field1: 42, field2: Cell::new(88) };
     unsafe {
         let a = &root;

--- a/tests/pass/tree_borrows/copy-nonoverlapping.rs
+++ b/tests/pass/tree_borrows/copy-nonoverlapping.rs
@@ -2,7 +2,7 @@
 
 // copy_nonoverlapping works regardless of the order in which we construct
 // the arguments.
-pub fn main() {
+fn main() {
     test_to_from();
     test_from_to();
 }

--- a/tests/pass/tree_borrows/tree-borrows.rs
+++ b/tests/pass/tree_borrows/tree-borrows.rs
@@ -28,7 +28,7 @@ fn local_addr_of_mut() {
 // Tree Borrows has no issue with several mutable references existing
 // at the same time, as long as they are used only immutably.
 // I.e. multiple Reserved can coexist.
-pub fn aliasing_read_only_mutable_refs() {
+fn aliasing_read_only_mutable_refs() {
     unsafe {
         let base = &mut 42u64;
         let r1 = &mut *(base as *mut u64);
@@ -38,7 +38,7 @@ pub fn aliasing_read_only_mutable_refs() {
     }
 }
 
-pub fn string_as_mut_ptr() {
+fn string_as_mut_ptr() {
     // This errors in Stacked Borrows since as_mut_ptr restricts the provenance,
     // but with Tree Borrows it should work.
     unsafe {

--- a/tests/pass/unsized.rs
+++ b/tests/pass/unsized.rs
@@ -4,10 +4,10 @@
 #![feature(custom_mir, core_intrinsics)]
 
 fn unsized_params() {
-    pub fn f0(_f: dyn FnOnce()) {}
-    pub fn f1(_s: str) {}
-    pub fn f2(_x: i32, _y: [i32]) {}
-    pub fn f3(_p: dyn Send) {}
+    fn f0(_f: dyn FnOnce()) {}
+    fn f1(_s: str) {}
+    fn f2(_x: i32, _y: [i32]) {}
+    fn f3(_p: dyn Send) {}
 
     let c: Box<dyn FnOnce()> = Box::new(|| {});
     f0(*c);

--- a/tests/pass/vec-matching-fold.rs
+++ b/tests/pass/vec-matching-fold.rs
@@ -29,7 +29,7 @@ where
     }
 }
 
-pub fn main() {
+fn main() {
     let x = &[1, 2, 3, 4, 5];
 
     let product = foldl(x, 1, |a, b| a * *b);

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -30,11 +30,6 @@ fn miri_path() -> PathBuf {
     PathBuf::from(env::var("MIRI").unwrap_or_else(|_| env!("CARGO_BIN_EXE_miri").into()))
 }
 
-pub fn flagsplit(flags: &str) -> Vec<String> {
-    // This code is taken from `RUSTFLAGS` handling in cargo.
-    flags.split(' ').map(str::trim).filter(|s| !s.is_empty()).map(str::to_string).collect()
-}
-
 // Build the shared object file for testing native function calls.
 fn build_native_lib(target: &str) -> PathBuf {
     // Loosely follow the logic of the `cc` crate for finding the compiler.


### PR DESCRIPTION
`pub` can mask "unused code" warnings so let's avoid them.