### PR TITLE
Avoid panicking when `Cargo.toml` is not present

### DIFF
--- a/cargo-miri/src/util.rs
+++ b/cargo-miri/src/util.rs
@@ -213,7 +213,11 @@ fn cargo_extra_flags() -> Vec<String> {
 
 pub fn get_cargo_metadata() -> Metadata {
     // This will honor the `CARGO` env var the same way our `cargo()` does.
-    MetadataCommand::new().no_deps().other_options(cargo_extra_flags()).exec().unwrap()
+    MetadataCommand::new()
+        .no_deps()
+        .other_options(cargo_extra_flags())
+        .exec()
+        .unwrap_or_else(|err| show_error!("{}", err))
 }
 
 /// Pulls all the crates in this workspace from the cargo metadata.


### PR DESCRIPTION
Hello!
This is my first contribution here to Miri, and hopefully the first of many! :)

When running `cargo clippy` in a directory that does not contain a `Cargo.toml`, it displays an informative message such as:
`could not find Cargo.toml in [dir] or any parent directory`.

In contrast, running `cargo miri [test|run]` without a `Cargo.toml` currently causes a panic.
While it is expected that this command should fail, a more user-friendly behavior, similar to `clippy`, would be to print a descriptive error message instead of panicking.

I'd appreciate your feedback on the following:
I was considering simply calling `bail!` on the error, as done in `cargo` (see [here](https://github.com/rust-lang/cargo/blob/344c4567c634a25837e3c3476aac08af84cf9203/src/cargo/util/important_paths.rs#L21-L33)), but that would require adding `anyhow` as a dependency to `cargo-miri`. Since we already have a `show_error!` macro available, I believe it might be better to use that instead.

Thank you in advance for your time and input!