### PR TITLE
user-relevant span: if no frame is in a local crate, use topmost non-track_caller frame

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1088,11 +1088,18 @@ impl<'tcx> MiriMachine<'tcx> {
         self.threads.active_thread_ref().top_user_relevant_frame()
     }
 
-    /// This is the source of truth for the `is_user_relevant` flag in our `FrameExtra`.
-    pub fn is_user_relevant(&self, frame: &Frame<'tcx, Provenance>) -> bool {
-        let def_id = frame.instance().def_id();
-        (def_id.is_local() || self.user_relevant_crates.contains(&def_id.krate))
-            && !frame.instance().def.requires_caller_location(self.tcx)
+    /// This is the source of truth for the `user_relevance` flag in our `FrameExtra`.
+    pub fn user_relevance(&self, frame: &Frame<'tcx, Provenance>) -> u8 {
+        if frame.instance().def.requires_caller_location(self.tcx) {
+            return 0;
+        }
+        if self.is_local(frame.instance()) {
+            u8::MAX
+        } else {
+            // A non-relevant frame, but at least it doesn't require a caller location, so
+            // better than nothing.
+            1
+        }
     }
 }
 

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -139,11 +139,10 @@ pub struct FrameExtra<'tcx> {
     /// we use this to register a completed event with `measureme`.
     pub timing: Option<measureme::DetachedTiming>,
 
-    /// Indicates whether a `Frame` is part of a workspace-local crate and is also not
-    /// `#[track_caller]`. We compute this once on creation and store the result, as an
-    /// optimization.
-    /// This is used by `MiriMachine::current_span` and `MiriMachine::caller_span`
-    pub is_user_relevant: bool,
+    /// Indicates how user-relevant this frame is. `#[track_caller]` frames are never relevant.
+    /// Frames from user-relevant crates are maximally relevant; frames from other crates are less
+    /// relevant.
+    pub user_relevance: u8,
 
     /// Data race detector per-frame data.
     pub data_race: Option<data_race::FrameState>,
@@ -152,12 +151,12 @@ pub struct FrameExtra<'tcx> {
 impl<'tcx> std::fmt::Debug for FrameExtra<'tcx> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Omitting `timing`, it does not support `Debug`.
-        let FrameExtra { borrow_tracker, catch_unwind, timing: _, is_user_relevant, data_race } =
+        let FrameExtra { borrow_tracker, catch_unwind, timing: _, user_relevance, data_race } =
             self;
         f.debug_struct("FrameData")
             .field("borrow_tracker", borrow_tracker)
             .field("catch_unwind", catch_unwind)
-            .field("is_user_relevant", is_user_relevant)
+            .field("user_relevance", user_relevance)
             .field("data_race", data_race)
             .finish()
     }
@@ -165,13 +164,8 @@ impl<'tcx> std::fmt::Debug for FrameExtra<'tcx> {
 
 impl VisitProvenance for FrameExtra<'_> {
     fn visit_provenance(&self, visit: &mut VisitWith<'_>) {
-        let FrameExtra {
-            catch_unwind,
-            borrow_tracker,
-            timing: _,
-            is_user_relevant: _,
-            data_race: _,
-        } = self;
+        let FrameExtra { catch_unwind, borrow_tracker, timing: _, user_relevance: _, data_race: _ } =
+            self;
 
         catch_unwind.visit_provenance(visit);
         borrow_tracker.visit_provenance(visit);
@@ -910,8 +904,8 @@ impl<'tcx> MiriMachine<'tcx> {
     }
 
     /// Check whether the stack frame that this `FrameInfo` refers to is part of a local crate.
-    pub(crate) fn is_local(&self, frame: &FrameInfo<'_>) -> bool {
-        let def_id = frame.instance.def_id();
+    pub(crate) fn is_local(&self, instance: ty::Instance<'tcx>) -> bool {
+        let def_id = instance.def_id();
         def_id.is_local() || self.user_relevant_crates.contains(&def_id.krate)
     }
 
@@ -1702,7 +1696,7 @@ impl<'tcx> Machine<'tcx> for MiriMachine<'tcx> {
             borrow_tracker: borrow_tracker.map(|bt| bt.borrow_mut().new_frame()),
             catch_unwind: None,
             timing,
-            is_user_relevant: ecx.machine.is_user_relevant(&frame),
+            user_relevance: ecx.machine.user_relevance(&frame),
             data_race: ecx
                 .machine
                 .data_race
@@ -1758,9 +1752,9 @@ impl<'tcx> Machine<'tcx> for MiriMachine<'tcx> {
 
     #[inline(always)]
     fn after_stack_push(ecx: &mut InterpCx<'tcx, Self>) -> InterpResult<'tcx> {
-        if ecx.frame().extra.is_user_relevant {
-            // We just pushed a local frame, so we know that the topmost local frame is the topmost
-            // frame. If we push a non-local frame, there's no need to do anything.
+        if ecx.frame().extra.user_relevance >= ecx.active_thread_ref().current_user_relevance() {
+            // We just pushed a frame that's at least as relevant as the so-far most relevant frame.
+            // That means we are now the most relevant frame.
             let stack_len = ecx.active_thread_stack().len();
             ecx.active_thread_mut().set_top_user_relevant_frame(stack_len - 1);
         }
@@ -1774,9 +1768,14 @@ impl<'tcx> Machine<'tcx> for MiriMachine<'tcx> {
         if ecx.machine.borrow_tracker.is_some() {
             ecx.on_stack_pop(frame)?;
         }
-        if frame.extra.is_user_relevant {
-            // All that we store is whether or not the frame we just removed is local, so now we
-            // have no idea where the next topmost local frame is. So we recompute it.
+        if ecx
+            .active_thread_ref()
+            .top_user_relevant_frame()
+            .expect("there should always be a most relevant frame for a non-empty stack")
+            == ecx.frame_idx()
+        {
+            // We are popping the most relevant frame. We have no clue what the next relevant frame
+            // below that is, so we recompute that.
             // (If this ever becomes a bottleneck, we could have `push` store the previous
             // user-relevant frame and restore that here.)
             // We have to skip the frame that is just being popped.

--- a/tests/fail/panic/tls_macro_drop_panic.stderr
+++ b/tests/fail/panic/tls_macro_drop_panic.stderr
@@ -4,5 +4,6 @@ ow
 fatal runtime error: thread local panicked on drop, aborting
 error: abnormal termination: the program aborted execution
 
+
 error: aborting due to 1 previous error
 

--- a/tests/genmc/pass/std/arc.check_count.stderr
+++ b/tests/genmc/pass/std/arc.check_count.stderr
@@ -1,9 +1,9 @@
 Running GenMC Verification...
 warning: GenMC currently does not model spurious failures of `compare_exchange_weak`. Miri with GenMC might miss bugs related to spurious failures.
-  --> RUSTLIB/core/src/sync/atomic.rs:LL:CC
+  --> RUSTLIB/std/src/thread/mod.rs:LL:CC
    |
-LL |                 intrinsics::atomic_cxchgweak::<T, { AO::Relaxed }, { AO::Relaxed }>(dst, old, new)
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
+LL |                     match COUNTER.compare_exchange_weak(last, id, Ordering::Relaxed, Ordering::Relaxed) {
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
    |
    = note: BACKTRACE:
    = note: inside closure at RUSTLIB/std/src/thread/current.rs:LL:CC
@@ -91,19 +91,34 @@ LL |     handle.join().unwrap();
    |     ^^^^^^^^^^^^^
 
 warning: GenMC currently does not model spurious failures of `compare_exchange_weak`. Miri with GenMC might miss bugs related to spurious failures.
-  --> RUSTLIB/core/src/sync/atomic.rs:LL:CC
+  --> RUSTLIB/std/src/rt.rs:LL:CC
    |
-LL |                 intrinsics::atomic_cxchgweak::<T, { AO::Acquire }, { AO::Acquire }>(dst, old, new)
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
+LL | /     CLEANUP.call_once(|| unsafe {
+LL | |         // Flush stdout and disable buffering.
+LL | |         crate::io::cleanup();
+...  |
+LL | |     });
+   | |______^ GenMC might miss possible behaviors of this code
    |
    = note: BACKTRACE:
    = note: inside closure at RUSTLIB/std/src/rt.rs:LL:CC
 
-warning: GenMC currently does not model the failure ordering for `compare_exchange`. Due to success ordering 'Acquire', the failure ordering 'Relaxed' is treated like 'Acquire'. Miri with GenMC might miss bugs related to this memory access.
-  --> RUSTLIB/core/src/sync/atomic.rs:LL:CC
+warning: GenMC currently does not model spurious failures of `compare_exchange_weak`. Miri with GenMC might miss bugs related to spurious failures.
+  --> RUSTLIB/std/src/sync/once.rs:LL:CC
    |
-LL |                 intrinsics::atomic_cxchg::<T, { AO::Acquire }, { AO::Relaxed }>(dst, old, new)
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
+LL |         self.inner.call(true, &mut |p| f.take().unwrap()(p));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
+   |
+   = note: BACKTRACE:
+   = note: inside closure at RUSTLIB/std/src/rt.rs:LL:CC
+   = note: inside closure at RUSTLIB/std/src/sync/once.rs:LL:CC
+   = note: inside closure at RUSTLIB/std/src/rt.rs:LL:CC
+
+warning: GenMC currently does not model the failure ordering for `compare_exchange`. Due to success ordering 'Acquire', the failure ordering 'Relaxed' is treated like 'Acquire'. Miri with GenMC might miss bugs related to this memory access.
+  --> RUSTLIB/std/src/sys/exit_guard.rs:LL:CC
+   |
+LL |             match EXITING_THREAD_ID.compare_exchange(ptr::null_mut(), this_thread_id, Acquire, Relaxed) {
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
    |
    = note: BACKTRACE:
    = note: inside closure at RUSTLIB/std/src/rt.rs:LL:CC

--- a/tests/genmc/pass/std/arc.try_upgrade.stderr
+++ b/tests/genmc/pass/std/arc.try_upgrade.stderr
@@ -1,9 +1,9 @@
 Running GenMC Verification...
 warning: GenMC currently does not model spurious failures of `compare_exchange_weak`. Miri with GenMC might miss bugs related to spurious failures.
-  --> RUSTLIB/core/src/sync/atomic.rs:LL:CC
+  --> RUSTLIB/std/src/thread/mod.rs:LL:CC
    |
-LL |                 intrinsics::atomic_cxchgweak::<T, { AO::Relaxed }, { AO::Relaxed }>(dst, old, new)
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
+LL |                     match COUNTER.compare_exchange_weak(last, id, Ordering::Relaxed, Ordering::Relaxed) {
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
    |
    = note: BACKTRACE:
    = note: inside closure at RUSTLIB/std/src/thread/current.rs:LL:CC
@@ -91,19 +91,34 @@ LL |     handle.join().unwrap();
    |     ^^^^^^^^^^^^^
 
 warning: GenMC currently does not model spurious failures of `compare_exchange_weak`. Miri with GenMC might miss bugs related to spurious failures.
-  --> RUSTLIB/core/src/sync/atomic.rs:LL:CC
+  --> RUSTLIB/std/src/rt.rs:LL:CC
    |
-LL |                 intrinsics::atomic_cxchgweak::<T, { AO::Acquire }, { AO::Acquire }>(dst, old, new)
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
+LL | /     CLEANUP.call_once(|| unsafe {
+LL | |         // Flush stdout and disable buffering.
+LL | |         crate::io::cleanup();
+...  |
+LL | |     });
+   | |______^ GenMC might miss possible behaviors of this code
    |
    = note: BACKTRACE:
    = note: inside closure at RUSTLIB/std/src/rt.rs:LL:CC
 
-warning: GenMC currently does not model the failure ordering for `compare_exchange`. Due to success ordering 'Acquire', the failure ordering 'Relaxed' is treated like 'Acquire'. Miri with GenMC might miss bugs related to this memory access.
-  --> RUSTLIB/core/src/sync/atomic.rs:LL:CC
+warning: GenMC currently does not model spurious failures of `compare_exchange_weak`. Miri with GenMC might miss bugs related to spurious failures.
+  --> RUSTLIB/std/src/sync/once.rs:LL:CC
    |
-LL |                 intrinsics::atomic_cxchg::<T, { AO::Acquire }, { AO::Relaxed }>(dst, old, new)
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
+LL |         self.inner.call(true, &mut |p| f.take().unwrap()(p));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
+   |
+   = note: BACKTRACE:
+   = note: inside closure at RUSTLIB/std/src/rt.rs:LL:CC
+   = note: inside closure at RUSTLIB/std/src/sync/once.rs:LL:CC
+   = note: inside closure at RUSTLIB/std/src/rt.rs:LL:CC
+
+warning: GenMC currently does not model the failure ordering for `compare_exchange`. Due to success ordering 'Acquire', the failure ordering 'Relaxed' is treated like 'Acquire'. Miri with GenMC might miss bugs related to this memory access.
+  --> RUSTLIB/std/src/sys/exit_guard.rs:LL:CC
+   |
+LL |             match EXITING_THREAD_ID.compare_exchange(ptr::null_mut(), this_thread_id, Acquire, Relaxed) {
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
    |
    = note: BACKTRACE:
    = note: inside closure at RUSTLIB/std/src/rt.rs:LL:CC

--- a/tests/genmc/pass/std/empty_main.stderr
+++ b/tests/genmc/pass/std/empty_main.stderr
@@ -1,28 +1,43 @@
 Running GenMC Verification...
 warning: GenMC currently does not model spurious failures of `compare_exchange_weak`. Miri with GenMC might miss bugs related to spurious failures.
-  --> RUSTLIB/core/src/sync/atomic.rs:LL:CC
+  --> RUSTLIB/std/src/thread/mod.rs:LL:CC
    |
-LL |                 intrinsics::atomic_cxchgweak::<T, { AO::Relaxed }, { AO::Relaxed }>(dst, old, new)
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
+LL |                     match COUNTER.compare_exchange_weak(last, id, Ordering::Relaxed, Ordering::Relaxed) {
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
    |
    = note: BACKTRACE:
    = note: inside closure at RUSTLIB/std/src/thread/current.rs:LL:CC
    = note: inside closure at RUSTLIB/std/src/rt.rs:LL:CC
 
 warning: GenMC currently does not model spurious failures of `compare_exchange_weak`. Miri with GenMC might miss bugs related to spurious failures.
-  --> RUSTLIB/core/src/sync/atomic.rs:LL:CC
+  --> RUSTLIB/std/src/rt.rs:LL:CC
    |
-LL |                 intrinsics::atomic_cxchgweak::<T, { AO::Acquire }, { AO::Acquire }>(dst, old, new)
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
+LL | /     CLEANUP.call_once(|| unsafe {
+LL | |         // Flush stdout and disable buffering.
+LL | |         crate::io::cleanup();
+...  |
+LL | |     });
+   | |______^ GenMC might miss possible behaviors of this code
    |
    = note: BACKTRACE:
    = note: inside closure at RUSTLIB/std/src/rt.rs:LL:CC
 
-warning: GenMC currently does not model the failure ordering for `compare_exchange`. Due to success ordering 'Acquire', the failure ordering 'Relaxed' is treated like 'Acquire'. Miri with GenMC might miss bugs related to this memory access.
-  --> RUSTLIB/core/src/sync/atomic.rs:LL:CC
+warning: GenMC currently does not model spurious failures of `compare_exchange_weak`. Miri with GenMC might miss bugs related to spurious failures.
+  --> RUSTLIB/std/src/sync/once.rs:LL:CC
    |
-LL |                 intrinsics::atomic_cxchg::<T, { AO::Acquire }, { AO::Relaxed }>(dst, old, new)
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
+LL |         self.inner.call(true, &mut |p| f.take().unwrap()(p));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
+   |
+   = note: BACKTRACE:
+   = note: inside closure at RUSTLIB/std/src/rt.rs:LL:CC
+   = note: inside closure at RUSTLIB/std/src/sync/once.rs:LL:CC
+   = note: inside closure at RUSTLIB/std/src/rt.rs:LL:CC
+
+warning: GenMC currently does not model the failure ordering for `compare_exchange`. Due to success ordering 'Acquire', the failure ordering 'Relaxed' is treated like 'Acquire'. Miri with GenMC might miss bugs related to this memory access.
+  --> RUSTLIB/std/src/sys/exit_guard.rs:LL:CC
+   |
+LL |             match EXITING_THREAD_ID.compare_exchange(ptr::null_mut(), this_thread_id, Acquire, Relaxed) {
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
    |
    = note: BACKTRACE:
    = note: inside closure at RUSTLIB/std/src/rt.rs:LL:CC

--- a/tests/genmc/pass/std/spawn_std_threads.stderr
+++ b/tests/genmc/pass/std/spawn_std_threads.stderr
@@ -1,9 +1,9 @@
 Running GenMC Verification...
 warning: GenMC currently does not model spurious failures of `compare_exchange_weak`. Miri with GenMC might miss bugs related to spurious failures.
-  --> RUSTLIB/core/src/sync/atomic.rs:LL:CC
+  --> RUSTLIB/std/src/thread/mod.rs:LL:CC
    |
-LL |                 intrinsics::atomic_cxchgweak::<T, { AO::Relaxed }, { AO::Relaxed }>(dst, old, new)
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
+LL |                     match COUNTER.compare_exchange_weak(last, id, Ordering::Relaxed, Ordering::Relaxed) {
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
    |
    = note: BACKTRACE:
    = note: inside closure at RUSTLIB/std/src/thread/current.rs:LL:CC
@@ -95,19 +95,34 @@ LL |     handles.into_iter().for_each(|handle| handle.join().unwrap());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: GenMC currently does not model spurious failures of `compare_exchange_weak`. Miri with GenMC might miss bugs related to spurious failures.
-  --> RUSTLIB/core/src/sync/atomic.rs:LL:CC
+  --> RUSTLIB/std/src/rt.rs:LL:CC
    |
-LL |                 intrinsics::atomic_cxchgweak::<T, { AO::Acquire }, { AO::Acquire }>(dst, old, new)
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
+LL | /     CLEANUP.call_once(|| unsafe {
+LL | |         // Flush stdout and disable buffering.
+LL | |         crate::io::cleanup();
+...  |
+LL | |     });
+   | |______^ GenMC might miss possible behaviors of this code
    |
    = note: BACKTRACE:
    = note: inside closure at RUSTLIB/std/src/rt.rs:LL:CC
 
-warning: GenMC currently does not model the failure ordering for `compare_exchange`. Due to success ordering 'Acquire', the failure ordering 'Relaxed' is treated like 'Acquire'. Miri with GenMC might miss bugs related to this memory access.
-  --> RUSTLIB/core/src/sync/atomic.rs:LL:CC
+warning: GenMC currently does not model spurious failures of `compare_exchange_weak`. Miri with GenMC might miss bugs related to spurious failures.
+  --> RUSTLIB/std/src/sync/once.rs:LL:CC
    |
-LL |                 intrinsics::atomic_cxchg::<T, { AO::Acquire }, { AO::Relaxed }>(dst, old, new)
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
+LL |         self.inner.call(true, &mut |p| f.take().unwrap()(p));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
+   |
+   = note: BACKTRACE:
+   = note: inside closure at RUSTLIB/std/src/rt.rs:LL:CC
+   = note: inside closure at RUSTLIB/std/src/sync/once.rs:LL:CC
+   = note: inside closure at RUSTLIB/std/src/rt.rs:LL:CC
+
+warning: GenMC currently does not model the failure ordering for `compare_exchange`. Due to success ordering 'Acquire', the failure ordering 'Relaxed' is treated like 'Acquire'. Miri with GenMC might miss bugs related to this memory access.
+  --> RUSTLIB/std/src/sys/exit_guard.rs:LL:CC
+   |
+LL |             match EXITING_THREAD_ID.compare_exchange(ptr::null_mut(), this_thread_id, Acquire, Relaxed) {
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
    |
    = note: BACKTRACE:
    = note: inside closure at RUSTLIB/std/src/rt.rs:LL:CC

--- a/tests/genmc/pass/std/thread_locals.stderr
+++ b/tests/genmc/pass/std/thread_locals.stderr
@@ -1,9 +1,9 @@
 Running GenMC Verification...
 warning: GenMC currently does not model spurious failures of `compare_exchange_weak`. Miri with GenMC might miss bugs related to spurious failures.
-  --> RUSTLIB/core/src/sync/atomic.rs:LL:CC
+  --> RUSTLIB/std/src/thread/mod.rs:LL:CC
    |
-LL |                 intrinsics::atomic_cxchgweak::<T, { AO::Relaxed }, { AO::Relaxed }>(dst, old, new)
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
+LL |                     match COUNTER.compare_exchange_weak(last, id, Ordering::Relaxed, Ordering::Relaxed) {
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
    |
    = note: BACKTRACE:
    = note: inside closure at RUSTLIB/std/src/thread/current.rs:LL:CC
@@ -78,19 +78,34 @@ LL |     handles.into_iter().for_each(|handle| handle.join().unwrap());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: GenMC currently does not model spurious failures of `compare_exchange_weak`. Miri with GenMC might miss bugs related to spurious failures.
-  --> RUSTLIB/core/src/sync/atomic.rs:LL:CC
+  --> RUSTLIB/std/src/rt.rs:LL:CC
    |
-LL |                 intrinsics::atomic_cxchgweak::<T, { AO::Acquire }, { AO::Acquire }>(dst, old, new)
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
+LL | /     CLEANUP.call_once(|| unsafe {
+LL | |         // Flush stdout and disable buffering.
+LL | |         crate::io::cleanup();
+...  |
+LL | |     });
+   | |______^ GenMC might miss possible behaviors of this code
    |
    = note: BACKTRACE:
    = note: inside closure at RUSTLIB/std/src/rt.rs:LL:CC
 
-warning: GenMC currently does not model the failure ordering for `compare_exchange`. Due to success ordering 'Acquire', the failure ordering 'Relaxed' is treated like 'Acquire'. Miri with GenMC might miss bugs related to this memory access.
-  --> RUSTLIB/core/src/sync/atomic.rs:LL:CC
+warning: GenMC currently does not model spurious failures of `compare_exchange_weak`. Miri with GenMC might miss bugs related to spurious failures.
+  --> RUSTLIB/std/src/sync/once.rs:LL:CC
    |
-LL |                 intrinsics::atomic_cxchg::<T, { AO::Acquire }, { AO::Relaxed }>(dst, old, new)
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
+LL |         self.inner.call(true, &mut |p| f.take().unwrap()(p));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
+   |
+   = note: BACKTRACE:
+   = note: inside closure at RUSTLIB/std/src/rt.rs:LL:CC
+   = note: inside closure at RUSTLIB/std/src/sync/once.rs:LL:CC
+   = note: inside closure at RUSTLIB/std/src/rt.rs:LL:CC
+
+warning: GenMC currently does not model the failure ordering for `compare_exchange`. Due to success ordering 'Acquire', the failure ordering 'Relaxed' is treated like 'Acquire'. Miri with GenMC might miss bugs related to this memory access.
+  --> RUSTLIB/std/src/sys/exit_guard.rs:LL:CC
+   |
+LL |             match EXITING_THREAD_ID.compare_exchange(ptr::null_mut(), this_thread_id, Acquire, Relaxed) {
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GenMC might miss possible behaviors of this code
    |
    = note: BACKTRACE:
    = note: inside closure at RUSTLIB/std/src/rt.rs:LL:CC


### PR DESCRIPTION
Our logic for the user-relevant span ignores all frames that are in non-user-relevant crates. Unfortunately, if the stack consists *entirely* of frames from non-user-relevant crates, the result is something like this:
```
    --> /home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:1944:9
     |
1944 |         intrinsics::write_via_move(dst, src)
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
In other words, we fall back to the topmost frame of the stack. That's not great.

This adjusts the logic so that we instead fall back to the topmost non-track_caller frame. Only if we find no such frame do we use the topmost frame.

This is done by replacing the `is_user_relevant: bool` with a `user_relevance: u8` indicating how relevant the frame is. The current top relevant frame is the topmost frame with the highest relevance. The code that runs on push/pop is adjusted to incrementally update the topmost frame index with the new metric; this should only be marginally more expensive than what we did here before.

r? @saethlin 