### PR TITLE
Refactor TreeVisitor and Access Relatedness.

### DIFF
--- a/src/borrow_tracker/tree_borrows/perms.rs
+++ b/src/borrow_tracker/tree_borrows/perms.rs
@@ -640,7 +640,7 @@ mod propagation_optimization_checks {
     impl Exhaustive for AccessRelatedness {
         fn exhaustive() -> Box<dyn Iterator<Item = Self>> {
             use AccessRelatedness::*;
-            Box::new(vec![This, StrictChildAccess, AncestorAccess, CousinAccess].into_iter())
+            Box::new(vec![ForeignAccess, LocalAccess].into_iter())
         }
     }
 
@@ -716,13 +716,11 @@ mod propagation_optimization_checks {
                 // We now assert it is idempotent, and never causes UB.
                 // First, if the SIFA includes foreign reads, assert it is idempotent under foreign reads.
                 if access >= IdempotentForeignAccess::Read {
-                    // We use `CousinAccess` here. We could also use `AncestorAccess`, since `transition::perform_access` treats these the same.
-                    // The only place they are treated differently is in protector end accesses, but these are not handled here.
-                    assert_eq!(perm, transition::perform_access(AccessKind::Read, AccessRelatedness::CousinAccess, perm, prot).unwrap());
+                    assert_eq!(perm, transition::perform_access(AccessKind::Read, AccessRelatedness::ForeignAccess, perm, prot).unwrap());
                 }
                 // Then, if the SIFA includes foreign writes, assert it is idempotent under foreign writes.
                 if access >= IdempotentForeignAccess::Write {
-                    assert_eq!(perm, transition::perform_access(AccessKind::Write, AccessRelatedness::CousinAccess, perm, prot).unwrap());
+                    assert_eq!(perm, transition::perform_access(AccessKind::Write, AccessRelatedness::ForeignAccess, perm, prot).unwrap());
                 }
             }
         }

--- a/src/borrow_tracker/tree_borrows/tree/tests.rs
+++ b/src/borrow_tracker/tree_borrows/tree/tests.rs
@@ -263,15 +263,15 @@ mod spurious_read {
             match xy_rel {
                 RelPosXY::MutuallyForeign =>
                     match self {
-                        PtrSelector::X => (This, CousinAccess),
-                        PtrSelector::Y => (CousinAccess, This),
-                        PtrSelector::Other => (CousinAccess, CousinAccess),
+                        PtrSelector::X => (LocalAccess, ForeignAccess),
+                        PtrSelector::Y => (ForeignAccess, LocalAccess),
+                        PtrSelector::Other => (ForeignAccess, ForeignAccess),
                     },
                 RelPosXY::XChildY =>
                     match self {
-                        PtrSelector::X => (This, StrictChildAccess),
-                        PtrSelector::Y => (AncestorAccess, This),
-                        PtrSelector::Other => (CousinAccess, CousinAccess),
+                        PtrSelector::X => (LocalAccess, LocalAccess),
+                        PtrSelector::Y => (ForeignAccess, LocalAccess),
+                        PtrSelector::Other => (ForeignAccess, ForeignAccess),
                     },
             }
         }


### PR DESCRIPTION
Refactors `TreeVisitor` in preparation for wildcard support for tree borrows.

Also simplifies `AccessRelatedness` to only track if an access is foreign or local. 