### PR TITLE
Remove implementation of LLVM SIMD intrinsics that are not needed anymore

### DIFF
--- a/src/shims/x86/mod.rs
+++ b/src/shims/x86/mod.rs
@@ -59,28 +59,6 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 this.write_immediate(*sum, &this.project_field(dest, FieldIdx::ONE)?)?;
             }
 
-            // Used to implement the `_addcarryx_u{32, 64}` functions. They are semantically identical with the `_addcarry_u{32, 64}` functions,
-            // except for a slightly different type signature and the requirement for the "adx" target feature.
-            // https://www.intel.com/content/www/us/en/docs/cpp-compiler/developer-guide-reference/2021-8/addcarryx-u32-addcarryx-u64.html
-            "addcarryx.u32" | "addcarryx.u64" => {
-                this.expect_target_feature_for_intrinsic(link_name, "adx")?;
-
-                let is_u64 = unprefixed_name.ends_with("64");
-                if is_u64 && this.tcx.sess.target.arch != Arch::X86_64 {
-                    return interp_ok(EmulateItemResult::NotSupported);
-                }
-                let [c_in, a, b, out] =
-                    this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
-                let out = this.deref_pointer_as(
-                    out,
-                    if is_u64 { this.machine.layouts.u64 } else { this.machine.layouts.u32 },
-                )?;
-
-                let (sum, c_out) = carrying_add(this, c_in, a, b, mir::BinOp::AddWithOverflow)?;
-                this.write_scalar(c_out, dest)?;
-                this.write_immediate(*sum, &out)?;
-            }
-
             // Used to implement the `_mm_pause` function.
             // The intrinsic is used to hint the processor that the code is in a spin-loop.
             // It is compiled down to a `pause` instruction. When SSE2 is not available,
@@ -714,36 +692,6 @@ fn convert_float_to_int<'tcx>(
     for i in op_len..dest_len {
         let dest = ecx.project_index(&dest, i)?;
         ecx.write_scalar(Scalar::from_int(0, dest.layout.size), &dest)?;
-    }
-
-    interp_ok(())
-}
-
-/// Calculates absolute value of integers in `op` and stores the result in `dest`.
-///
-/// In case of overflow (when the operand is the minimum value), the operation
-/// will wrap around.
-fn int_abs<'tcx>(
-    ecx: &mut crate::MiriInterpCx<'tcx>,
-    op: &OpTy<'tcx>,
-    dest: &MPlaceTy<'tcx>,
-) -> InterpResult<'tcx, ()> {
-    let (op, op_len) = ecx.project_to_simd(op)?;
-    let (dest, dest_len) = ecx.project_to_simd(dest)?;
-
-    assert_eq!(op_len, dest_len);
-
-    let zero = ImmTy::from_int(0, op.layout.field(ecx, 0));
-
-    for i in 0..dest_len {
-        let op = ecx.read_immediate(&ecx.project_index(&op, i)?)?;
-        let dest = ecx.project_index(&dest, i)?;
-
-        let lt_zero = ecx.binary_op(mir::BinOp::Lt, &op, &zero)?;
-        let res =
-            if lt_zero.to_scalar().to_bool()? { ecx.unary_op(mir::UnOp::Neg, &op)? } else { op };
-
-        ecx.write_immediate(*res, &dest)?;
     }
 
     interp_ok(())

--- a/src/shims/x86/sse2.rs
+++ b/src/shims/x86/sse2.rs
@@ -36,42 +36,6 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // Intrinsincs sufixed with "epiX" or "epuX" operate with X-bit signed or unsigned
         // vectors.
         match unprefixed_name {
-            // Used to implement the _mm_madd_epi16 function.
-            // Multiplies packed signed 16-bit integers in `left` and `right`, producing
-            // intermediate signed 32-bit integers. Horizontally add adjacent pairs of
-            // intermediate 32-bit integers, and pack the results in `dest`.
-            "pmadd.wd" => {
-                let [left, right] =
-                    this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
-
-                let (left, left_len) = this.project_to_simd(left)?;
-                let (right, right_len) = this.project_to_simd(right)?;
-                let (dest, dest_len) = this.project_to_simd(dest)?;
-
-                assert_eq!(left_len, right_len);
-                assert_eq!(dest_len.strict_mul(2), left_len);
-
-                for i in 0..dest_len {
-                    let j1 = i.strict_mul(2);
-                    let left1 = this.read_scalar(&this.project_index(&left, j1)?)?.to_i16()?;
-                    let right1 = this.read_scalar(&this.project_index(&right, j1)?)?.to_i16()?;
-
-                    let j2 = j1.strict_add(1);
-                    let left2 = this.read_scalar(&this.project_index(&left, j2)?)?.to_i16()?;
-                    let right2 = this.read_scalar(&this.project_index(&right, j2)?)?.to_i16()?;
-
-                    let dest = this.project_index(&dest, i)?;
-
-                    // Multiplications are i16*i16->i32, which will not overflow.
-                    let mul1 = i32::from(left1).strict_mul(right1.into());
-                    let mul2 = i32::from(left2).strict_mul(right2.into());
-                    // However, this addition can overflow in the most extreme case
-                    // (-0x8000)*(-0x8000)+(-0x8000)*(-0x8000) = 0x80000000
-                    let res = mul1.wrapping_add(mul2);
-
-                    this.write_scalar(Scalar::from_i32(res), &dest)?;
-                }
-            }
             // Used to implement the _mm_sad_epu8 function.
             // Computes the absolute differences of packed unsigned 8-bit integers in `a`
             // and `b`, then horizontally sum each consecutive 8 differences to produce
@@ -320,10 +284,10 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 this.write_immediate(*res, dest)?;
             }
-            // Used to implement the _mm_cvtsd_ss and _mm_cvtss_sd functions.
-            // Converts the first f64/f32 from `right` to f32/f64 and copies
-            // the remaining elements from `left`
-            "cvtsd2ss" | "cvtss2sd" => {
+            // Used to implement the _mm_cvtsd_ss function.
+            // Converts the first f64 from `right` to f32 and copies the remaining
+            // elements from `left`
+            "cvtsd2ss" => {
                 let [left, right] =
                     this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
 
@@ -336,8 +300,6 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // Convert first element of `right`
                 let right0 = this.read_immediate(&this.project_index(&right, 0)?)?;
                 let dest0 = this.project_index(&dest, 0)?;
-                // `float_to_float_or_int` here will convert from f64 to f32 (cvtsd2ss) or
-                // from f32 to f64 (cvtss2sd).
                 let res0 = this.float_to_float_or_int(&right0, dest0.layout)?;
                 this.write_immediate(*res0, &dest0)?;
 

--- a/src/shims/x86/sse3.rs
+++ b/src/shims/x86/sse3.rs
@@ -1,10 +1,8 @@
 use rustc_abi::CanonAbi;
-use rustc_middle::mir;
 use rustc_middle::ty::Ty;
 use rustc_span::Symbol;
 use rustc_target::callconv::FnAbi;
 
-use super::horizontal_bin_op;
 use crate::*;
 
 impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
@@ -22,21 +20,6 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let unprefixed_name = link_name.as_str().strip_prefix("llvm.x86.sse3.").unwrap();
 
         match unprefixed_name {
-            // Used to implement the _mm_h{add,sub}_p{s,d} functions.
-            // Horizontally add/subtract adjacent floating point values
-            // in `left` and `right`.
-            "hadd.ps" | "hadd.pd" | "hsub.ps" | "hsub.pd" => {
-                let [left, right] =
-                    this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
-
-                let which = match unprefixed_name {
-                    "hadd.ps" | "hadd.pd" => mir::BinOp::Add,
-                    "hsub.ps" | "hsub.pd" => mir::BinOp::Sub,
-                    _ => unreachable!(),
-                };
-
-                horizontal_bin_op(this, which, /*saturating*/ false, left, right, dest)?;
-            }
             // Used to implement the _mm_lddqu_si128 function.
             // Reads a 128-bit vector from an unaligned pointer. This intrinsic
             // is expected to perform better than a regular unaligned read when

--- a/src/shims/x86/sse41.rs
+++ b/src/shims/x86/sse41.rs
@@ -157,20 +157,13 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 mpsadbw(this, left, right, imm, dest)?;
             }
-            // Used to implement the _mm_testz_si128, _mm_testc_si128
-            // and _mm_testnzc_si128 functions.
-            // Tests `(op & mask) == 0`, `(op & mask) == mask` or
-            // `(op & mask) != 0 && (op & mask) != mask`
-            "ptestz" | "ptestc" | "ptestnzc" => {
+            // Used to implement the _mm_testnzc_si128 function.
+            // Tests `(op & mask) != 0 && (op & mask) != mask`
+            "ptestnzc" => {
                 let [op, mask] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
 
                 let (all_zero, masked_set) = test_bits_masked(this, op, mask)?;
-                let res = match unprefixed_name {
-                    "ptestz" => all_zero,
-                    "ptestc" => masked_set,
-                    "ptestnzc" => !all_zero && !masked_set,
-                    _ => unreachable!(),
-                };
+                let res = !all_zero && !masked_set;
 
                 this.write_scalar(Scalar::from_i32(res.into()), dest)?;
             }


### PR DESCRIPTION

Fixes https://github.com/rust-lang/miri/issues/4659