### PR TITLE
apple os_unfair_lock: throw 'unsupported' when we would behave different from the real implementation

### DIFF
--- a/tests/fail-dep/concurrency/apple_os_unfair_lock_move_deadlock.rs
+++ b/tests/fail-dep/concurrency/apple_os_unfair_lock_move_deadlock.rs
@@ -9,5 +9,5 @@ fn main() {
     let lock = lock;
     // This needs to either error or deadlock.
     unsafe { libc::os_unfair_lock_lock(lock.get()) };
-    //~^ error: deadlock
+    //~^ error: lock an os_unfair_lock that was copied while being locked
 }

--- a/tests/fail-dep/concurrency/apple_os_unfair_lock_move_deadlock.stderr
+++ b/tests/fail-dep/concurrency/apple_os_unfair_lock_move_deadlock.stderr
@@ -1,8 +1,10 @@
-error: the evaluated program deadlocked
+error: unsupported operation: attempted to lock an os_unfair_lock that was copied while being locked
   --> tests/fail-dep/concurrency/apple_os_unfair_lock_move_deadlock.rs:LL:CC
    |
 LL |     unsafe { libc::os_unfair_lock_lock(lock.get()) };
-   |                                                  ^ this thread got stuck here
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsupported operation occurred here
+   |
+   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 


### PR DESCRIPTION
Apparently the real implementation remembers who owned the lock before it got moved, and then the new lock still behaves as-if it is owned by that thread. In Miri we don't currently track the owner across moves so we can't behave like that. Make sure we halt execution in cases where we risk behaving different than the real implementation.