### PR TITLE
./miri toolchain: also install rust-analyzer

### DIFF
--- a/miri-script/src/commands.rs
+++ b/miri-script/src/commands.rs
@@ -153,7 +153,7 @@ impl Command {
         // Install and setup new toolchain.
         cmd!(sh, "rustup toolchain uninstall miri").run()?;
 
-        cmd!(sh, "rustup-toolchain-install-master -n miri -c cargo -c rust-src -c rustc-dev -c llvm-tools -c rustfmt -c clippy {flags...} -- {new_commit}")
+        cmd!(sh, "rustup-toolchain-install-master -n miri -c cargo -c rust-src -c rustc-dev -c llvm-tools -c rustfmt -c clippy -c rust-analyzer {flags...} -- {new_commit}")
             .run()
             .context("Failed to run rustup-toolchain-install-master. If it is not installed, run 'cargo install rustup-toolchain-install-master'.")?;
         cmd!(sh, "rustup override set miri").run()?;


### PR DESCRIPTION
This is required for working editor integration if the editor extension does not ship an RA binary itself.

The component is around 8.9 MiB in size, adding around 2.5% to the overall download size. So the question is, do we want to add this for everyone even though most people won't need it, or do we instead provide some other way for people to add more components to the miri toolchain? @rust-lang/miri what do you think?