### PR TITLE
genmc: remove macOS FIXMEs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ nix = { version = "0.30.1", features = ["mman", "ptrace", "signal"], optional = 
 ipc-channel = { version = "0.20.0", optional = true }
 capstone = { version = "0.13", optional = true }
 
-# FIXME(genmc,macos): Add `target_os = "macos"` once https://github.com/dtolnay/cxx/issues/1535 is fixed.
 [target.'cfg(all(target_os = "linux", target_pointer_width = "64", target_endian = "little"))'.dependencies]
 genmc-sys = { path = "./genmc-sys/", version = "0.1.0", optional = true }
 

--- a/src/concurrency/genmc/run.rs
+++ b/src/concurrency/genmc/run.rs
@@ -30,7 +30,7 @@ pub fn run_genmc_mode<'tcx>(
     config: &MiriConfig,
     eval_entry: impl Fn(Rc<GenmcCtx>) -> Result<(), NonZeroI32>,
 ) -> Result<(), NonZeroI32> {
-    // Check for supported target.
+    // Check for supported target: endianess and pointer size must match the host.
     if tcx.data_layout.endian != Endian::Little || tcx.data_layout.pointer_size().bits() != 64 {
         tcx.dcx().fatal("GenMC only supports 64bit little-endian targets");
     }

--- a/src/concurrency/mod.rs
+++ b/src/concurrency/mod.rs
@@ -9,7 +9,6 @@ pub mod weak_memory;
 
 // Import either the real genmc adapter or a dummy module.
 // On unsupported platforms, we always include the dummy module, even if the `genmc` feature is enabled.
-// FIXME(genmc,macos): Add `target_os = "macos"` once `https://github.com/dtolnay/cxx/issues/1535` is fixed.
 #[cfg_attr(
     not(all(
         feature = "genmc",

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -338,8 +338,8 @@ fn main() -> Result<()> {
     }
 
     // We only enable GenMC tests when the `genmc` feature is enabled, but also only on platforms we support:
-    // FIXME(genmc,macos): Add `target_os = "macos"` once `https://github.com/dtolnay/cxx/issues/1535` is fixed.
-    // FIXME(genmc,cross-platform): remove `host == target` check once cross-platform support with GenMC is possible.
+    // FIXME(genmc,cross-platform): Technically we do support cross-target execution as long as the
+    // target is also 64bit little-endian, so `host == target` is too strict.
     if cfg!(all(
         feature = "genmc",
         target_os = "linux",


### PR DESCRIPTION
This doesn't need FIXMEs in the code, we have https://github.com/rust-lang/miri/issues/4703 to track it.