### PR TITLE
test that target features given in the target spec are enabled

### DIFF
--- a/tests/pass/target-spec-implies-target-feature.rs
+++ b/tests/pass/target-spec-implies-target-feature.rs
@@ -1,0 +1,8 @@
+//! Ensure that the target features given in the target spec are actually enabled.
+//@only-target: armv7
+
+fn main() {
+    assert!(cfg!(target_feature = "v7"));
+    assert!(cfg!(target_feature = "vfp2"));
+    assert!(cfg!(target_feature = "thumb2"));
+}


### PR DESCRIPTION
This currently fails... not sure if that is a regression, but it might be the same as https://github.com/rust-lang/rust/issues/149314.
@bjorn3 do you think your PR will fix this?