### PR TITLE
TreeBorrows: Put accesses diagnostic parameters into a single struct

### DIFF
--- a/src/borrow_tracker/tree_borrows/tree.rs
+++ b/src/borrow_tracker/tree_borrows/tree.rs
@@ -18,12 +18,12 @@ use rustc_data_structures::fx::FxHashSet;
 use rustc_span::Span;
 use smallvec::SmallVec;
 
-use super::Permission;
 use super::diagnostics::{
-    self, AccessCause, NodeDebugInfo, TbError, TransitionError, no_valid_exposed_references_error,
+    AccessCause, DiagnosticInfo, NodeDebugInfo, TbError, TransitionError,
+    no_valid_exposed_references_error,
 };
 use super::foreign_access_skipping::IdempotentForeignAccess;
-use super::perms::PermTransition;
+use super::perms::{PermTransition, Permission};
 use super::tree_visitor::{ChildrenVisitMode, ContinueTraversal, NodeAppArgs, TreeVisitor};
 use super::unimap::{UniIndex, UniKeyMap, UniValMap};
 use super::wildcard::WildcardState;
@@ -91,12 +91,9 @@ impl LocationState {
         nodes: &mut UniValMap<Node>,
         wildcard_accesses: &mut UniValMap<WildcardState>,
         access_kind: AccessKind,
-        access_cause: AccessCause,        //diagnostics
-        access_range: Option<AllocRange>, //diagnostics
         relatedness: AccessRelatedness,
-        span: Span,                 //diagnostics
-        location_range: Range<u64>, //diagnostics
         protected: bool,
+        diagnostics: &DiagnosticInfo,
     ) -> Result<(), TransitionError> {
         // Call this function now (i.e. only if we know `relatedness`), which
         // ensures it is only called when `skip_if_known_noop` returns
@@ -107,14 +104,9 @@ impl LocationState {
         if !transition.is_noop() {
             let node = nodes.get_mut(idx).unwrap();
             // Record the event as part of the history.
-            node.debug_info.history.push(diagnostics::Event {
-                transition,
-                is_foreign: relatedness.is_foreign(),
-                access_cause,
-                access_range,
-                transition_range: location_range,
-                span,
-            });
+            node.debug_info
+                .history
+                .push(diagnostics.create_event(transition, relatedness.is_foreign()));
 
             // We need to update the wildcard state, if the permission
             // of an exposed pointer changes.
@@ -546,7 +538,7 @@ impl<'tcx> Tree {
             prov,
             access_range,
             AccessKind::Write,
-            diagnostics::AccessCause::Dealloc,
+            AccessCause::Dealloc,
             global,
             alloc_id,
             span,
@@ -560,6 +552,13 @@ impl<'tcx> Tree {
         // Check if this breaks any strong protector.
         // (Weak protectors are already handled by `perform_access`.)
         for (loc_range, loc) in self.locations.iter_mut(access_range.start, access_range.size) {
+            let diagnostics = DiagnosticInfo {
+                alloc_id,
+                span,
+                transition_range: loc_range,
+                access_range: Some(access_range),
+                access_cause: AccessCause::Dealloc,
+            };
             // Checks the tree containing `idx` for strong protector violations.
             // It does this in traversal order.
             let mut check_tree = |idx| {
@@ -586,12 +585,10 @@ impl<'tcx> Tree {
                                 && perm.accessed
                             {
                                 Err(TbError {
-                                    conflicting_info: &node.debug_info,
-                                    access_cause: diagnostics::AccessCause::Dealloc,
-                                    alloc_id,
-                                    error_offset: loc_range.start,
                                     error_kind: TransitionError::ProtectedDealloc,
-                                    accessed_info: start_idx
+                                    access_info: &diagnostics,
+                                    conflicting_node_info: &node.debug_info,
+                                    accessed_node_info: start_idx
                                         .map(|idx| &args.nodes.get(idx).unwrap().debug_info),
                                 }
                                 .build())
@@ -649,18 +646,21 @@ impl<'tcx> Tree {
         };
         // We iterate over affected locations and traverse the tree for each of them.
         for (loc_range, loc) in self.locations.iter_mut(access_range.start, access_range.size) {
+            let diagnostics = DiagnosticInfo {
+                access_cause,
+                access_range: Some(access_range),
+                alloc_id,
+                span,
+                transition_range: loc_range,
+            };
             loc.perform_access(
                 self.roots.iter().copied(),
                 &mut self.nodes,
                 source_idx,
-                loc_range,
-                Some(access_range),
                 access_kind,
-                access_cause,
                 global,
-                alloc_id,
-                span,
                 ChildrenVisitMode::VisitChildrenOfAccessed,
+                &diagnostics,
             )?;
         }
         interp_ok(())
@@ -701,19 +701,21 @@ impl<'tcx> Tree {
                 && let Some(access_kind) = p.permission.protector_end_access()
                 && p.accessed
             {
-                let access_cause = diagnostics::AccessCause::FnExit(access_kind);
+                let diagnostics = DiagnosticInfo {
+                    access_cause: AccessCause::FnExit(access_kind),
+                    access_range: None,
+                    alloc_id,
+                    span,
+                    transition_range: loc_range,
+                };
                 loc.perform_access(
                     self.roots.iter().copied(),
                     &mut self.nodes,
                     Some(source_idx),
-                    loc_range,
-                    None,
                     access_kind,
-                    access_cause,
                     global,
-                    alloc_id,
-                    span,
                     ChildrenVisitMode::SkipChildrenOfAccessed,
+                    &diagnostics,
                 )?;
             }
         }
@@ -882,27 +884,19 @@ impl<'tcx> LocationTree {
         roots: impl Iterator<Item = UniIndex>,
         nodes: &mut UniValMap<Node>,
         access_source: Option<UniIndex>,
-        loc_range: Range<u64>,            // diagnostics
-        access_range: Option<AllocRange>, // diagnostics
         access_kind: AccessKind,
-        access_cause: diagnostics::AccessCause, // diagnostics
         global: &GlobalState,
-        alloc_id: AllocId, // diagnostics
-        span: Span,        // diagnostics
         visit_children: ChildrenVisitMode,
+        diagnostics: &DiagnosticInfo,
     ) -> InterpResult<'tcx> {
         let accessed_root = if let Some(idx) = access_source {
             Some(self.perform_normal_access(
                 idx,
                 nodes,
-                loc_range.clone(),
-                access_range,
                 access_kind,
-                access_cause,
                 global,
-                alloc_id,
-                span,
                 visit_children,
+                diagnostics,
             )?)
         } else {
             // `SkipChildrenOfAccessed` only gets set on protector release, which only
@@ -936,13 +930,9 @@ impl<'tcx> LocationTree {
                 access_source,
                 /*max_local_tag*/ accessed_root_tag,
                 nodes,
-                loc_range.clone(),
-                access_range,
                 access_kind,
-                access_cause,
                 global,
-                alloc_id,
-                span,
+                diagnostics,
             )?;
         }
         interp_ok(())
@@ -958,14 +948,10 @@ impl<'tcx> LocationTree {
         &mut self,
         access_source: UniIndex,
         nodes: &mut UniValMap<Node>,
-        loc_range: Range<u64>,            // diagnostics
-        access_range: Option<AllocRange>, // diagnostics
         access_kind: AccessKind,
-        access_cause: diagnostics::AccessCause, // diagnostics
         global: &GlobalState,
-        alloc_id: AllocId, // diagnostics
-        span: Span,        // diagnostics
         visit_children: ChildrenVisitMode,
+        diagnostics: &DiagnosticInfo,
     ) -> InterpResult<'tcx, UniIndex> {
         // Performs the per-node work:
         // - insert the permission if it does not exist
@@ -997,21 +983,18 @@ impl<'tcx> LocationTree {
                     args.nodes,
                     &mut args.data.wildcard_accesses,
                     access_kind,
-                    access_cause,
-                    access_range,
                     args.rel_pos,
-                    span,
-                    loc_range.clone(),
                     protected,
+                    diagnostics,
                 )
                 .map_err(|error_kind| {
                     TbError {
-                        conflicting_info: &args.nodes.get(args.idx).unwrap().debug_info,
-                        access_cause,
-                        alloc_id,
-                        error_offset: loc_range.start,
                         error_kind,
-                        accessed_info: Some(&args.nodes.get(access_source).unwrap().debug_info),
+                        access_info: diagnostics,
+                        conflicting_node_info: &args.nodes.get(args.idx).unwrap().debug_info,
+                        accessed_node_info: Some(
+                            &args.nodes.get(access_source).unwrap().debug_info,
+                        ),
                     }
                     .build()
                 })
@@ -1040,13 +1023,9 @@ impl<'tcx> LocationTree {
         access_source: Option<UniIndex>,
         max_local_tag: Option<BorTag>,
         nodes: &mut UniValMap<Node>,
-        loc_range: Range<u64>,            // diagnostics
-        access_range: Option<AllocRange>, // diagnostics
         access_kind: AccessKind,
-        access_cause: diagnostics::AccessCause, // diagnostics
         global: &GlobalState,
-        alloc_id: AllocId, // diagnostics
-        span: Span,        // diagnostics
+        diagnostics: &DiagnosticInfo,
     ) -> InterpResult<'tcx> {
         let get_relatedness = |idx: UniIndex, node: &Node, loc: &LocationTree| {
             let wildcard_state = loc.wildcard_accesses.get(idx).cloned().unwrap_or_default();
@@ -1100,11 +1079,7 @@ impl<'tcx> LocationTree {
                     // This can only happen if `root` is the main root: We set
                     // `max_foreign_access==Write` on all wildcard roots, so at least a foreign access
                     // is always possible on all nodes in a wildcard subtree.
-                    return Err(no_valid_exposed_references_error(
-                        alloc_id,
-                        loc_range.start,
-                        access_cause,
-                    ));
+                    return Err(no_valid_exposed_references_error(diagnostics));
                 };
 
                 let Some(relatedness) = wildcard_relatedness.to_relatedness() else {
@@ -1123,22 +1098,17 @@ impl<'tcx> LocationTree {
                     args.nodes,
                     &mut args.data.wildcard_accesses,
                     access_kind,
-                    access_cause,
-                    access_range,
                     relatedness,
-                    span,
-                    loc_range.clone(),
                     protected,
+                    diagnostics,
                 )
                 .map_err(|trans| {
                     let node = args.nodes.get(args.idx).unwrap();
                     TbError {
-                        conflicting_info: &node.debug_info,
-                        access_cause,
-                        alloc_id,
-                        error_offset: loc_range.start,
                         error_kind: trans,
-                        accessed_info: access_source
+                        access_info: diagnostics,
+                        conflicting_node_info: &node.debug_info,
+                        accessed_node_info: access_source
                             .map(|idx| &args.nodes.get(idx).unwrap().debug_info),
                     }
                     .build()


### PR DESCRIPTION
All the `perform_access` functions take 5 parameters that are purely used for diagnostic purposes. This puts them all into a single struct and passes them by reference.