### PR TITLE
Remove `[no-mentions]` handler in the triagebot config

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -53,8 +53,5 @@ new_draft = true
 # Canonicalize issue numbers to avoid closing the wrong issue when upstreaming this subtree.
 [canonicalize-issue-links]
 
-# Prevents mentions in commits to avoid users being spammed.
-[no-mentions]
-
 # Show range-diff links on force pushes.
 [range-diff]


### PR DESCRIPTION
This PR removes the `[no-mentions]` handler in the triagebot config as [GitHub is removing notifications for @-mentions in commit messages on December 8th 2025.](https://github.blog/changelog/2025-11-07-removing-notifications-for-mentions-in-commit-messages/)

cf. https://github.com/rust-lang/triagebot/issues/2225