### PR TITLE
fix clippy::manual_let_else

### DIFF
--- a/src/borrow_tracker/stacked_borrows/mod.rs
+++ b/src/borrow_tracker/stacked_borrows/mod.rs
@@ -826,15 +826,12 @@ trait EvalContextPrivExt<'tcx, 'ecx>: crate::MiriInterpCxExt<'tcx> {
         // FIXME: If we cannot determine the size (because the unsized tail is an `extern type`),
         // bail out -- we cannot reasonably figure out which memory range to reborrow.
         // See https://github.com/rust-lang/unsafe-code-guidelines/issues/276.
-        let size = match size {
-            Some(size) => size,
-            None => {
-                static DEDUP: AtomicBool = AtomicBool::new(false);
-                if !DEDUP.swap(true, std::sync::atomic::Ordering::Relaxed) {
-                    this.emit_diagnostic(NonHaltingDiagnostic::ExternTypeReborrow);
-                }
-                return interp_ok(place.clone());
+        let Some(size) = size else {
+            static DEDUP: AtomicBool = AtomicBool::new(false);
+            if !DEDUP.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                this.emit_diagnostic(NonHaltingDiagnostic::ExternTypeReborrow);
             }
+            return interp_ok(place.clone());
         };
 
         // Compute new borrow.

--- a/src/concurrency/weak_memory.rs
+++ b/src/concurrency/weak_memory.rs
@@ -208,11 +208,10 @@ impl StoreBufferAlloc {
         range: AllocRange,
     ) -> InterpResult<'tcx, Option<Ref<'_, StoreBuffer>>> {
         let access_type = self.store_buffers.borrow().access_type(range);
-        let pos = match access_type {
-            AccessType::PerfectlyOverlapping(pos) => pos,
+        let AccessType::PerfectlyOverlapping(pos) = access_type else {
             // If there is nothing here yet, that means there wasn't an atomic write yet so
             // we can't return anything outdated.
-            _ => return interp_ok(None),
+            return interp_ok(None);
         };
         let store_buffer = Ref::map(self.store_buffers.borrow(), |buffer| &buffer[pos]);
         interp_ok(Some(store_buffer))

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -543,9 +543,7 @@ where
 {
     // Parse argv[0]. Slashes aren't escaped. Literal double quotes are not allowed.
     let mut cmd = {
-        let arg0 = if let Some(arg0) = args.next() {
-            arg0
-        } else {
+        let Some(arg0) = args.next() else {
             return vec![0];
         };
         let arg0 = arg0.as_ref();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,12 @@
     rustc::potential_query_instability,
     rustc::untranslatable_diagnostic,
 )]
-#![warn(rust_2018_idioms, unqualified_local_imports, clippy::as_conversions)]
+#![warn(
+    rust_2018_idioms,
+    unqualified_local_imports,
+    clippy::as_conversions,
+    clippy::manual_let_else
+)]
 // Needed for rustdoc from bootstrap (with `-Znormalize-docs`).
 #![recursion_limit = "256"]
 

--- a/src/shims/backtrace.rs
+++ b/src/shims/backtrace.rs
@@ -92,21 +92,18 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let (alloc_id, offset, _prov) = this.ptr_get_alloc_id(ptr, 0)?;
 
         // This has to be an actual global fn ptr, not a dlsym function.
-        let fn_instance = if let Some(GlobalAlloc::Function { instance, .. }) =
-            this.tcx.try_get_global_alloc(alloc_id)
-        {
-            instance
-        } else {
+        let Some(GlobalAlloc::Function { instance, .. }) = this.tcx.try_get_global_alloc(alloc_id)
+        else {
             throw_ub_format!("expected static function pointer, found {:?}", ptr);
         };
 
         let lo =
             this.tcx.sess.source_map().lookup_char_pos(BytePos(offset.bytes().try_into().unwrap()));
 
-        let name = fn_instance.to_string();
+        let name = instance.to_string();
         let filename = lo.file.name.prefer_remapped_unconditionally().to_string();
 
-        interp_ok((fn_instance, lo, name, filename))
+        interp_ok((instance, lo, name, filename))
     }
 
     fn handle_miri_resolve_frame(

--- a/src/shims/native_lib/mod.rs
+++ b/src/shims/native_lib/mod.rs
@@ -459,12 +459,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     ) -> InterpResult<'tcx, bool> {
         let this = self.eval_context_mut();
         // Get the pointer to the function in the shared object file if it exists.
-        let code_ptr = match this.get_func_ptr_explicitly_from_lib(link_name) {
-            Some(ptr) => ptr,
-            None => {
-                // Shared object file does not export this function -- try the shims next.
-                return interp_ok(false);
-            }
+        let Some(code_ptr) = this.get_func_ptr_explicitly_from_lib(link_name) else {
+            // Shared object file does not export this function -- try the shims next.
+            return interp_ok(false);
         };
 
         // Do we have ptrace?

--- a/src/shims/time.rs
+++ b/src/shims/time.rs
@@ -337,11 +337,8 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let duration = this.deref_pointer_as(duration, this.libc_ty_layout("timespec"))?;
         let _rem = this.read_pointer(rem)?; // Signal handlers are not supported, so rem will never be written to.
 
-        let duration = match this.read_timespec(&duration)? {
-            Some(duration) => duration,
-            None => {
-                return this.set_last_error_and_return_i32(LibcError("EINVAL"));
-            }
+        let Some(duration) = this.read_timespec(&duration)? else {
+            return this.set_last_error_and_return_i32(LibcError("EINVAL"));
         };
 
         this.block_thread(
@@ -378,11 +375,8 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             throw_unsup_format!("clock_nanosleep: only CLOCK_MONOTONIC is supported");
         }
 
-        let duration = match this.read_timespec(&timespec)? {
-            Some(duration) => duration,
-            None => {
-                return this.set_last_error_and_return_i32(LibcError("EINVAL"));
-            }
+        let Some(duration) = this.read_timespec(&timespec)? else {
+            return this.set_last_error_and_return_i32(LibcError("EINVAL"));
         };
 
         let timeout_anchor = if flags == 0 {

--- a/src/shims/unix/linux_like/sync.rs
+++ b/src/shims/unix/linux_like/sync.rs
@@ -71,11 +71,8 @@ pub fn futex<'tcx>(
             let timeout = if ecx.ptr_is_null(timeout.ptr())? {
                 None
             } else {
-                let duration = match ecx.read_timespec(&timeout)? {
-                    Some(duration) => duration,
-                    None => {
-                        return ecx.set_last_error_and_return(LibcError("EINVAL"), dest);
-                    }
+                let Some(duration) = ecx.read_timespec(&timeout)? else {
+                    return ecx.set_last_error_and_return(LibcError("EINVAL"), dest);
                 };
                 let timeout_clock = if op & futex_realtime == futex_realtime {
                     ecx.check_no_isolation(

--- a/src/shims/unix/sync.rs
+++ b/src/shims/unix/sync.rs
@@ -887,15 +887,12 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let mutex_ref = mutex_get_data(this, mutex_op)?.mutex_ref.clone();
 
         // Extract the timeout.
-        let duration = match this
+        let Some(duration) = this
             .read_timespec(&this.deref_pointer_as(timeout_op, this.libc_ty_layout("timespec"))?)?
-        {
-            Some(duration) => duration,
-            None => {
-                let einval = this.eval_libc("EINVAL");
-                this.write_scalar(einval, dest)?;
-                return interp_ok(());
-            }
+        else {
+            let einval = this.eval_libc("EINVAL");
+            this.write_scalar(einval, dest)?;
+            return interp_ok(());
         };
 
         let (clock, anchor) = if macos_relative_np {

--- a/src/shims/windows/fs.rs
+++ b/src/shims/windows/fs.rs
@@ -321,11 +321,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             this.windows_ty_layout("BY_HANDLE_FILE_INFORMATION"),
         )?;
 
-        let fd_num = if let Handle::File(fd_num) = file {
-            fd_num
-        } else {
-            this.invalid_handle("GetFileInformationByHandle")?
-        };
+        let Handle::File(fd_num) = file else { this.invalid_handle("GetFileInformationByHandle")? };
 
         let Some(desc) = this.machine.fds.get(fd_num) else {
             this.invalid_handle("GetFileInformationByHandle")?
@@ -448,10 +444,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             throw_unsup_format!("`NtWriteFile` `Key` parameter is non-null, which is unsupported");
         }
 
-        let fd = match handle {
-            Handle::File(fd) => fd,
-            _ => this.invalid_handle("NtWriteFile")?,
-        };
+        let Handle::File(fd) = handle else { this.invalid_handle("NtWriteFile")? };
 
         let Some(desc) = this.machine.fds.get(fd) else { this.invalid_handle("NtWriteFile")? };
 
@@ -561,10 +554,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         };
         let io_status_info = this.project_field_named(&io_status_block, "Information")?;
 
-        let fd = match handle {
-            Handle::File(fd) => fd,
-            _ => this.invalid_handle("NtWriteFile")?,
-        };
+        let Handle::File(fd) = handle else { this.invalid_handle("NtWriteFile")? };
 
         let Some(desc) = this.machine.fds.get(fd) else { this.invalid_handle("NtReadFile")? };
 
@@ -620,10 +610,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let new_fp_ptr = this.read_pointer(new_fp)?;
         let move_method = this.read_scalar(move_method)?.to_u32()?;
 
-        let fd = match file {
-            Handle::File(fd) => fd,
-            _ => this.invalid_handle("SetFilePointerEx")?,
-        };
+        let Handle::File(fd) = file else { this.invalid_handle("SetFilePointerEx")? };
 
         let Some(desc) = this.machine.fds.get(fd) else {
             throw_unsup_format!("`SetFilePointerEx` is only supported on file backed handles");


### PR DESCRIPTION
Just yesterday I was wondering if clippy could detect when we can convert things to let-else, and today I learn about this lint. :)  It's still allow-by-default, so let's manually enable it.