### PR TITLE
Refactor libc pipe tests to use utility functions for error handling and data operations

### DIFF
--- a/tests/pass-dep/libc/libc-pipe.rs
+++ b/tests/pass-dep/libc/libc-pipe.rs
@@ -38,13 +38,11 @@ fn test_pipe() {
     let data = b"123";
     write_all_from_slice(fds[1], data).unwrap();
     let mut buf4: [u8; 5] = [0; 5];
-    let res = read_into_slice(fds[0], &mut buf4).unwrap().0.len();
-    assert_eq!(buf4[..res], data[..res]);
-    if res < 3 {
-        // Drain the rest from the read end.
-        let res = read_into_slice(fds[0], &mut buf4[res..]).unwrap().0.len();
-        assert!(res > 0);
-    }
+    let (part1, rest) = read_into_slice(fds[0], &mut buf4).unwrap();
+    assert_eq!(part1[..], data[..part1.len()]);
+    // Write 2 more bytes so we can exactly fill the `rest`.
+    write_all_from_slice(fds[1], b"34").unwrap();
+    read_all_into_slice(fds[0], rest).unwrap();
 }
 
 fn test_pipe_threaded() {

--- a/tests/utils/libc.rs
+++ b/tests/utils/libc.rs
@@ -40,19 +40,8 @@ pub unsafe fn read_all(
     return read_so_far as libc::ssize_t;
 }
 
-/// Read exactly `N` bytes from `fd`. Error if that many bytes could not be read.
+/// Try to fill the given slice by reading from `fd`. Error if that many bytes could not be read.
 #[track_caller]
-pub fn read_all_into_array<const N: usize>(fd: libc::c_int) -> Result<[u8; N], libc::ssize_t> {
-    let mut buf = [0; N];
-    let res = unsafe { read_all(fd, buf.as_mut_ptr().cast(), buf.len()) };
-    if res >= 0 {
-        assert_eq!(res as usize, buf.len());
-        Ok(buf)
-    } else {
-        Err(res)
-    }
-}
-
 pub fn read_all_into_slice(fd: libc::c_int, buf: &mut [u8]) -> Result<(), libc::ssize_t> {
     let res = unsafe { read_all(fd, buf.as_mut_ptr().cast(), buf.len()) };
     if res >= 0 {
@@ -63,6 +52,17 @@ pub fn read_all_into_slice(fd: libc::c_int, buf: &mut [u8]) -> Result<(), libc::
     }
 }
 
+/// Read exactly `N` bytes from `fd`. Error if that many bytes could not be read.
+#[track_caller]
+pub fn read_all_into_array<const N: usize>(fd: libc::c_int) -> Result<[u8; N], libc::ssize_t> {
+    let mut buf = [0; N];
+    read_all_into_slice(fd, &mut buf)?;
+    Ok(buf)
+}
+
+/// Do a single read from `fd` and return the part of the buffer that was written into,
+/// and the rest.
+#[track_caller]
 pub fn read_into_slice(
     fd: libc::c_int,
     buf: &mut [u8],


### PR DESCRIPTION
Related to rust-lang/miri#4725