### PR TITLE
Add supprot for FLS functions on Windows

### DIFF
--- a/src/shims/windows/foreign_items.rs
+++ b/src/shims/windows/foreign_items.rs
@@ -487,6 +487,51 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 this.write_int(1, dest)?;
             }
 
+            // Fiber-local storage - similar to TLS but supports destructors.
+            "FlsAlloc" => {
+                // Create key and return it.
+                let [dtor] = this.check_shim_sig_lenient(abi, sys_conv, link_name, args)?;
+                let dtor = this.read_pointer(dtor)?;
+
+                // Extract the function type out of the signature (that seems easier than constructing it ourselves).
+                let dtor = if !this.ptr_is_null(dtor)? {
+                    Some((
+                        this.get_ptr_fn(dtor)?.as_instance()?,
+                        this.machine.current_user_relevant_span(),
+                    ))
+                } else {
+                    None
+                };
+
+                let key = this.machine.tls.create_tls_key(dtor, dest.layout.size)?;
+                this.write_scalar(Scalar::from_uint(key, dest.layout.size), dest)?;
+            }
+            "FlsGetValue" => {
+                let [key] = this.check_shim_sig_lenient(abi, sys_conv, link_name, args)?;
+                let key = u128::from(this.read_scalar(key)?.to_u32()?);
+                let active_thread = this.active_thread();
+                let ptr = this.machine.tls.load_tls(key, active_thread, this)?;
+                this.write_scalar(ptr, dest)?;
+            }
+            "FlsSetValue" => {
+                let [key, new_ptr] = this.check_shim_sig_lenient(abi, sys_conv, link_name, args)?;
+                let key = u128::from(this.read_scalar(key)?.to_u32()?);
+                let active_thread = this.active_thread();
+                let new_data = this.read_scalar(new_ptr)?;
+                this.machine.tls.store_tls(key, active_thread, new_data, &*this.tcx)?;
+
+                // Return success (`1`).
+                this.write_int(1, dest)?;
+            }
+            "FlsFree" => {
+                let [key] = this.check_shim_sig_lenient(abi, sys_conv, link_name, args)?;
+                let key = u128::from(this.read_scalar(key)?.to_u32()?);
+                this.machine.tls.delete_tls_key(key)?;
+
+                // Return success (`1`).
+                this.write_int(1, dest)?;
+            }
+
             // Access to command-line arguments
             "GetCommandLineW" => {
                 let [] = this.check_shim_sig_lenient(abi, sys_conv, link_name, args)?;

--- a/tests/pass/tls/windows-tls.rs
+++ b/tests/pass/tls/windows-tls.rs
@@ -1,13 +1,18 @@
 //@only-target: windows # this directly tests windows-only functions
 
 use std::ffi::c_void;
-use std::ptr;
+use std::{ptr, thread};
 
 extern "system" {
     fn TlsAlloc() -> u32;
     fn TlsSetValue(key: u32, val: *mut c_void) -> bool;
     fn TlsGetValue(key: u32) -> *mut c_void;
     fn TlsFree(key: u32) -> bool;
+
+    fn FlsAlloc(lpcallback: Option<unsafe extern "system" fn(lpflsdata: *mut c_void)>) -> u32;
+    fn FlsSetValue(key: u32, val: *mut c_void) -> bool;
+    fn FlsGetValue(key: u32) -> *mut c_void;
+    fn FlsFree(key: u32) -> bool;
 }
 
 fn main() {
@@ -15,4 +20,28 @@ fn main() {
     assert!(unsafe { TlsSetValue(key, ptr::without_provenance_mut(1)) });
     assert_eq!(unsafe { TlsGetValue(key).addr() }, 1);
     assert!(unsafe { TlsFree(key) });
+
+    extern "system" fn dtor1(val: *mut c_void) {
+        assert_eq!(val.addr(), 1);
+        println!("dtor1");
+    }
+
+    extern "system" fn dtor2(val: *mut c_void) {
+        assert_eq!(val.addr(), 1);
+        println!("dtor2");
+    }
+
+    thread::spawn(|| {
+        let fls_key_1 = unsafe { FlsAlloc(Some(dtor1)) };
+        assert!(unsafe { FlsSetValue(fls_key_1, ptr::without_provenance_mut(1)) });
+        assert_eq!(unsafe { FlsGetValue(fls_key_1).addr() }, 1);
+        assert!(unsafe { FlsFree(fls_key_1) });
+
+        let fls_key_2 = unsafe { FlsAlloc(Some(dtor2)) };
+        assert!(unsafe { FlsSetValue(fls_key_2, ptr::without_provenance_mut(1)) });
+        assert_eq!(unsafe { FlsGetValue(fls_key_2).addr() }, 1);
+        println!("exiting thread");
+    })
+    .join()
+    .unwrap();
 }

--- a/tests/pass/tls/windows-tls.stdout
+++ b/tests/pass/tls/windows-tls.stdout
@@ -1,0 +1,2 @@
+exiting thread
+dtor2


### PR DESCRIPTION
This PR adds support for the `Fls{Alloc,GetValue,SetValue,Free}` functions that are available on Windows. They enable native thread-local storage **with** destructor callbacks ([MSDN](https://learn.microsoft.com/en-us/windows/win32/api/fibersapi/nf-fibersapi-flsalloc)).

I also have a [PR to std](https://github.com/rust-lang/rust/pull/148799) that switches the default impl to use these functions, but I think supporting them in Miri can be useful anyway 🪟  