### PR TITLE
native-lib/trace: Intercept allocating calls, but do nothing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,6 +197,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,6 +244,17 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -447,6 +487,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,6 +621,12 @@ dependencies = [
  "openssl-sys",
  "url",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
@@ -741,6 +793,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,12 +879,33 @@ dependencies = [
 
 [[package]]
 name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "libloading"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
 dependencies = [
  "cfg-if",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "libproc"
+version = "0.14.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78a09b56be5adbcad5aa1197371688dc6bb249a26da3bca2011ee2fb987ebfb"
+dependencies = [
+ "bindgen",
+ "errno",
+ "libc",
 ]
 
 [[package]]
@@ -885,6 +967,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "measureme"
 version = "12.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,6 +1003,12 @@ checksum = "723e3ebdcdc5c023db1df315364573789f8857c11b631a2fdfad7c00f5c046b4"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -949,9 +1046,10 @@ dependencies = [
  "ipc-channel",
  "libc",
  "libffi",
- "libloading",
+ "libloading 0.9.0",
  "measureme",
  "nix",
+ "proc-maps",
  "rand",
  "regex",
  "rustc_version",
@@ -972,6 +1070,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1136,12 +1244,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-maps"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db44c5aa60e193a25fcd93bb9ed27423827e8f118897866f946e2cf936c44fb"
+dependencies = [
+ "anyhow",
+ "bindgen",
+ "libc",
+ "libproc",
+ "mach2",
+ "winapi",
 ]
 
 [[package]]
@@ -1716,6 +1848,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1723,6 +1871,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ serde = { version = "1.0.219", features = ["derive"], optional = true }
 nix = { version = "0.30.1", features = ["mman", "ptrace", "signal"], optional = true }
 ipc-channel = { version = "0.20.0", optional = true }
 capstone = { version = "0.13", optional = true }
+proc-maps = { version = "0.4.0", optional = true }
 
 [target.'cfg(all(target_os = "linux", target_pointer_width = "64", target_endian = "little"))'.dependencies]
 genmc-sys = { path = "./genmc-sys/", version = "0.1.0", optional = true }
@@ -66,8 +67,8 @@ genmc = ["dep:genmc-sys"]
 stack-cache = []
 expensive-consistency-checks = ["stack-cache"]
 tracing = ["serde_json"]
-native-lib = ["dep:libffi", "dep:libloading", "dep:capstone", "dep:ipc-channel", "dep:nix", "dep:serde"]
 jemalloc = []
+native-lib = ["dep:libffi", "dep:libloading", "dep:capstone", "dep:ipc-channel", "dep:nix", "dep:serde", "dep:proc-maps"]
 
 [lints.rust.unexpected_cfgs]
 level = "warn"

--- a/src/shims/native_lib/mod.rs
+++ b/src/shims/native_lib/mod.rs
@@ -27,6 +27,7 @@ mod ffi;
 pub mod trace;
 
 use self::ffi::OwnedArg;
+use self::trace::EvalContextExt as _;
 use crate::*;
 
 /// The final results of an FFI trace, containing every relevant event detected
@@ -85,13 +86,9 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
         libffi_args: &mut [OwnedArg],
     ) -> InterpResult<'tcx, (crate::ImmTy<'tcx>, Option<MemEvents>)> {
         let this = self.eval_context_mut();
-        #[cfg(target_os = "linux")]
-        let alloc = this.machine.allocator.as_ref().unwrap();
-        #[cfg(not(target_os = "linux"))]
-        // Placeholder value.
-        let alloc = ();
 
-        trace::Supervisor::do_ffi(alloc, || {
+        let ty_is_sized = dest.layout.ty.is_sized(*this.tcx, this.typing_env());
+        this.do_ffi(|| {
             // Call the function (`ptr`) with arguments `libffi_args`, and obtain the return value
             // as the specified primitive integer type
             let scalar = match dest.layout.ty.kind() {
@@ -117,7 +114,12 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 }
                 ty::Int(IntTy::Isize) => {
                     let x = unsafe { ffi::call::<isize>(fun, libffi_args) };
-                    Scalar::from_target_isize(x.try_into().unwrap(), this)
+                    // We already know native-lib mode means target == host, so
+                    // this is ok.
+                    Scalar::from_int(
+                        i128::try_from(x).unwrap(),
+                        Size::from_bytes(size_of::<isize>()),
+                    )
                 }
                 // uints
                 ty::Uint(UintTy::U8) => {
@@ -138,7 +140,10 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 }
                 ty::Uint(UintTy::Usize) => {
                     let x = unsafe { ffi::call::<usize>(fun, libffi_args) };
-                    Scalar::from_target_usize(x.try_into().unwrap(), this)
+                    Scalar::from_uint(
+                        u128::try_from(x).unwrap(),
+                        Size::from_bytes(size_of::<usize>()),
+                    )
                 }
                 ty::Float(FloatTy::F32) => {
                     let x = unsafe { ffi::call::<f32>(fun, libffi_args) };
@@ -154,10 +159,10 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     unsafe { ffi::call::<()>(fun, libffi_args) };
                     return interp_ok(ImmTy::uninit(dest.layout));
                 }
-                ty::RawPtr(ty, ..) if ty.is_sized(*this.tcx, this.typing_env()) => {
+                ty::RawPtr(ty, ..) if ty_is_sized => {
                     let x = unsafe { ffi::call::<*const ()>(fun, libffi_args) };
                     let ptr = StrictPointer::new(Provenance::Wildcard, Size::from_bytes(x.addr()));
-                    Scalar::from_pointer(ptr, this)
+                    Scalar::Ptr(ptr, u8::try_from(size_of::<*const ()>()).unwrap())
                 }
                 _ =>
                     return Err(err_unsup_format!(
@@ -225,7 +230,6 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
     /// assumed to be exact.
     fn tracing_apply_accesses(&mut self, events: MemEvents) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
-
         for evt in events.acc_events {
             let evt_rg = evt.get_range();
             // LLVM at least permits vectorising accesses to adjacent allocations,
@@ -235,7 +239,11 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let Some(alloc_id) =
                     this.alloc_id_from_addr(curr.to_u64(), rg.len().try_into().unwrap())
                 else {
-                    throw_ub_format!("Foreign code did an out-of-bounds access!")
+                    throw_ub_format!(
+                        "Foreign code did an out-of-bounds access at {:#0x} for {:#0x} bytes!",
+                        curr,
+                        rg.len(),
+                    );
                 };
                 let alloc = this.get_alloc_raw(alloc_id)?;
                 // The logical and physical address of the allocation coincide, so we can use
@@ -526,7 +534,8 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             this.call_native_with_args(link_name, dest, code_ptr, &mut libffi_args)?;
 
         if tracing {
-            this.tracing_apply_accesses(maybe_memevents.unwrap())?;
+            let mm = maybe_memevents.unwrap();
+            this.tracing_apply_accesses(mm)?;
         }
 
         this.write_immediate(*ret, dest)?;

--- a/src/shims/native_lib/trace/mod.rs
+++ b/src/shims/native_lib/trace/mod.rs
@@ -2,7 +2,7 @@ mod child;
 pub mod messages;
 mod parent;
 
-pub use self::child::{Supervisor, init_sv, register_retcode_sv};
+pub use self::child::{EvalContextExt, Supervisor, init_sv, register_retcode_sv};
 
 /// The size of the temporary stack we use for callbacks that the server executes in the client.
 /// This should be big enough that `mempr_on` and `mempr_off` can safely be jumped into with the

--- a/src/shims/native_lib/trace/parent.rs
+++ b/src/shims/native_lib/trace/parent.rs
@@ -1,4 +1,5 @@
-use std::sync::atomic::{AtomicPtr, AtomicUsize};
+use std::sync;
+use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicUsize, Ordering};
 
 use ipc_channel::ipc;
 use nix::sys::{ptrace, signal, wait};
@@ -23,14 +24,42 @@ const ARCH_WORD_SIZE: usize = 8;
 // See vol. 3B section 24.25.
 const ARCH_MAX_INSTR_SIZE: usize = 15;
 
-/// The address of the page set to be edited, initialised to a sentinel null
-/// pointer.
-static PAGE_ADDR: AtomicPtr<u8> = AtomicPtr::new(std::ptr::null_mut());
+/// Opcode for an instruction to raise SIGTRAP, to be written in the child process.
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+const BREAKPT_INSTR: i16 = 0xCC;
+
+/// The size of the breakpoint-triggering instruction, in bytes.
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+const BREAKPT_INSTR_SIZE: usize = 1;
+
 /// The host pagesize, initialised to a sentinel zero value.
 pub static PAGE_SIZE: AtomicUsize = AtomicUsize::new(0);
+/// The address of the page set to be edited, initialised to a sentinel null
+/// pointer.
+pub(super) static PAGE_ADDR: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
 /// How many consecutive pages to unprotect. 1 by default, unlikely to be set
 /// higher than 2.
-static PAGE_COUNT: AtomicUsize = AtomicUsize::new(1);
+pub(super) static PAGE_COUNT: AtomicUsize = AtomicUsize::new(1);
+/// A pointer to the `MiriInterpCx` for use within the libc shims.
+pub(super) static MACHINE_PTR: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
+/// Is the return address within the libc-mapped area(s)?
+pub(super) static RET_IS_LIBC: AtomicBool = AtomicBool::new(false);
+
+/// Information about which pages were allocated/deallocated after a single
+/// libc intercepted event. After use, these are reset to 0.
+///
+/// INVARIANT: A single libc event can only allocate/deallocate one contiguous
+/// block of pages (as would be the case in a large `realloc`).
+pub(super) static NEW_PAGES_ADDR: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
+pub(super) static NEW_PAGES_COUNT: AtomicUsize = AtomicUsize::new(0);
+pub(super) static DEL_PAGES_ADDR: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
+pub(super) static DEL_PAGES_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+/// The `event_rx` channel from the supervisor struct. The libc interceptors must
+/// know which accesses happened before they were triggered, so e.g. an access in
+/// an allocation that was later freed before the FFI call returned doesn't mistakenly
+/// get marked as incorrect.
+pub(super) static EVT_RX: sync::Mutex<Option<ipc::IpcReceiver<MemEvents>>> = sync::Mutex::new(None);
 
 /// Allows us to get common arguments from the `user_regs_t` across architectures.
 /// Normally this would land us ABI hell, but thankfully all of our usecases
@@ -39,6 +68,8 @@ static PAGE_COUNT: AtomicUsize = AtomicUsize::new(1);
 trait ArchIndependentRegs {
     /// Gets the address of the instruction pointer.
     fn ip(&self) -> usize;
+    /// Gets the address of the stack pointer.
+    fn sp(&self) -> usize;
     /// Set the instruction pointer; remember to also set the stack pointer, or
     /// else the stack might get messed up!
     fn set_ip(&mut self, ip: usize);
@@ -54,6 +85,8 @@ impl ArchIndependentRegs for libc::user_regs_struct {
     #[inline]
     fn ip(&self) -> usize { self.rip.try_into().unwrap() }
     #[inline]
+    fn sp(&self) -> usize { self.rsp.try_into().unwrap() }
+    #[inline]
     fn set_ip(&mut self, ip: usize) { self.rip = ip.try_into().unwrap() }
     #[inline]
     fn set_sp(&mut self, sp: usize) { self.rsp = sp.try_into().unwrap() }
@@ -64,6 +97,8 @@ impl ArchIndependentRegs for libc::user_regs_struct {
 impl ArchIndependentRegs for libc::user_regs_struct {
     #[inline]
     fn ip(&self) -> usize { self.eip.cast_unsigned().try_into().unwrap() }
+    #[inline]
+    fn sp(&self) -> usize { self.esp.cast_unsigned().try_into().unwrap() }
     #[inline]
     fn set_ip(&mut self, ip: usize) { self.eip = ip.cast_signed().try_into().unwrap() }
     #[inline]
@@ -83,7 +118,7 @@ pub enum ExecEvent {
     Status(unistd::Pid, signal::Signal),
     /// The child process with the specified pid entered or existed a syscall.
     Syscall(unistd::Pid),
-    /// A child process exited or was killed; if we have a return code, it is
+    /// The child exited or was killed; if we have a return code, it is
     /// specified.
     Died(Option<i32>),
 }
@@ -204,7 +239,7 @@ pub fn sv_loop(
     confirm_tx: ipc::IpcSender<Confirmation>,
 ) -> Result<!, ExecEnd> {
     // Get the pagesize set and make sure it isn't still on the zero sentinel value!
-    let page_size = PAGE_SIZE.load(std::sync::atomic::Ordering::Relaxed);
+    let page_size = PAGE_SIZE.load(Ordering::Relaxed);
     assert_ne!(page_size, 0);
 
     // Things that we return to the child process.
@@ -242,11 +277,15 @@ pub fn sv_loop(
                 // We can't trust simply calling `Pid::this()` in the child process to give the right
                 // PID for us, so we get it this way.
                 curr_pid = wait_for_signal(None, signal::SIGSTOP, InitialCont::No).unwrap();
+                // Intercept libc events we care about.
+                trap_libc(curr_pid);
                 // Continue until next syscall.
                 ptrace::syscall(curr_pid, None).unwrap();
             }
             // Child wants to end tracing.
             ExecEvent::End => {
+                // Stop intercepting libc events.
+                fixup_libc(curr_pid);
                 // Hand over the access info we traced.
                 event_tx.send(MemEvents { acc_events }).unwrap();
                 // And reset our values.
@@ -270,6 +309,8 @@ pub fn sv_loop(
                             &cs,
                             &mut acc_events,
                         )?,
+                    signal::SIGTRAP =>
+                        handle_sigtrap(pid, page_size, &mut ch_pages, &event_tx, &mut acc_events)?,
                     // Something weird happened.
                     _ => {
                         eprintln!("Process unexpectedly got {signal}; continuing...");
@@ -285,13 +326,61 @@ pub fn sv_loop(
             ExecEvent::Syscall(pid) => {
                 ptrace::syscall(pid, None).unwrap();
             }
-            ExecEvent::Died(code) => {
-                return Err(ExecEnd(code));
-            }
+            ExecEvent::Died(code) => return Err(ExecEnd(code)),
         }
     }
 
     unreachable!()
+}
+
+/// Set up SIGTRAPs on the first few bytes of malloc/free/etc.
+#[expect(clippy::as_conversions)]
+fn trap_libc(pid: unistd::Pid) {
+    ptrace::write(pid, libc::malloc as *mut _, BREAKPT_INSTR.into()).unwrap();
+    ptrace::write(pid, libc::calloc as *mut _, BREAKPT_INSTR.into()).unwrap();
+    ptrace::write(pid, libc::posix_memalign as *mut _, BREAKPT_INSTR.into()).unwrap();
+    ptrace::write(pid, libc::aligned_alloc as *mut _, BREAKPT_INSTR.into()).unwrap();
+    ptrace::write(pid, libc::realloc as *mut _, BREAKPT_INSTR.into()).unwrap();
+    ptrace::write(pid, libc::free as *mut _, BREAKPT_INSTR.into()).unwrap();
+}
+
+/// Fix up the libc values.
+#[expect(clippy::as_conversions)]
+fn fixup_libc(pid: unistd::Pid) {
+    unsafe {
+        ptrace::write(
+            pid,
+            libc::malloc as *mut _,
+            (libc::malloc as *mut libc::c_long).read_volatile(),
+        )
+        .unwrap();
+        ptrace::write(
+            pid,
+            libc::calloc as *mut _,
+            (libc::calloc as *mut libc::c_long).read_volatile(),
+        )
+        .unwrap();
+        ptrace::write(
+            pid,
+            libc::posix_memalign as *mut _,
+            (libc::posix_memalign as *mut libc::c_long).read_volatile(),
+        )
+        .unwrap();
+        ptrace::write(
+            pid,
+            libc::aligned_alloc as *mut _,
+            (libc::aligned_alloc as *mut libc::c_long).read_volatile(),
+        )
+        .unwrap();
+        ptrace::write(
+            pid,
+            libc::realloc as *mut _,
+            (libc::realloc as *mut libc::c_long).read_volatile(),
+        )
+        .unwrap();
+        ptrace::write(pid, libc::free as *mut _, (libc::free as *mut libc::c_long).read_volatile())
+            .unwrap();
+    }
 }
 
 /// Spawns a Capstone disassembler for the host architecture.
@@ -501,7 +590,7 @@ fn handle_segfault(
 
     // Move the instr ptr into the deprotection code.
     #[expect(clippy::as_conversions)]
-    new_regs.set_ip(mempr_off as *const () as usize);
+    new_regs.set_ip(super::child::mempr_off as *const () as usize);
     // Don't mess up the stack by accident!
     new_regs.set_sp(stack_ptr);
 
@@ -553,7 +642,7 @@ fn handle_segfault(
 
     // Reprotect everything and continue.
     #[expect(clippy::as_conversions)]
-    new_regs.set_ip(mempr_on as *const () as usize);
+    new_regs.set_ip(super::child::mempr_on as *const () as usize);
     new_regs.set_sp(stack_ptr);
     ptrace::setregs(pid, new_regs).unwrap();
     wait_for_signal(Some(pid), signal::SIGSTOP, InitialCont::Yes)?;
@@ -563,54 +652,145 @@ fn handle_segfault(
     Ok(())
 }
 
-// We only get dropped into these functions via offsetting the instr pointer
-// manually, so we *must not ever* unwind from them.
+/// Determines what libc function was called that caused a sigtrap, giving control
+/// to our shims to handle it instead.
+fn handle_sigtrap(
+    pid: unistd::Pid,
+    page_size: usize,
+    pages: &mut Vec<usize>,
+    _event_tx: &ipc::IpcSender<MemEvents>,
+    _acc_events: &mut Vec<AccessEvent>,
+) -> Result<(), ExecEnd> {
+    /// The libc functions we shim.
+    enum LibcFn {
+        Malloc,
+        Calloc,
+        AlignedAlloc,
+        PosixMemalign,
+        Realloc,
+        Free,
+    }
 
-/// Disables protections on the page whose address is currently in `PAGE_ADDR`.
-///
-/// SAFETY: `PAGE_ADDR` should be set to a page-aligned pointer to an owned page,
-/// `PAGE_SIZE` should be the host pagesize, and the range from `PAGE_ADDR` to
-/// `PAGE_SIZE` * `PAGE_COUNT` must be owned and allocated memory. No other threads
-/// should be running.
-pub unsafe extern "C" fn mempr_off() {
-    use std::sync::atomic::Ordering;
-
-    // Again, cannot allow unwinds to happen here.
-    let len = PAGE_SIZE.load(Ordering::Relaxed).saturating_mul(PAGE_COUNT.load(Ordering::Relaxed));
-    // SAFETY: Upheld by "caller".
-    unsafe {
-        // It's up to the caller to make sure this doesn't actually overflow, but
-        // we mustn't unwind from here, so...
-        if libc::mprotect(
-            PAGE_ADDR.load(Ordering::Relaxed).cast(),
-            len,
-            libc::PROT_READ | libc::PROT_WRITE,
-        ) != 0
-        {
-            // Can't return or unwind, but we can do this.
-            std::process::exit(-1);
+    /// Gets the libc function that a given instruction pointer corresponds to.
+    fn get_libc_fn(addr: usize) -> Option<LibcFn> {
+        // We'll be one instruction past the start
+        #[expect(clippy::as_conversions)]
+        match addr.strict_sub(BREAKPT_INSTR_SIZE) {
+            a if a == (libc::malloc as *const () as usize) => Some(LibcFn::Malloc),
+            a if a == (libc::calloc as *const () as usize) => Some(LibcFn::Calloc),
+            a if a == (libc::aligned_alloc as *const () as usize) => Some(LibcFn::AlignedAlloc),
+            a if a == (libc::posix_memalign as *const () as usize) => Some(LibcFn::PosixMemalign),
+            a if a == (libc::realloc as *const () as usize) => Some(LibcFn::Realloc),
+            a if a == (libc::free as *const () as usize) => Some(LibcFn::Free),
+            _ => None,
         }
     }
-    // If this fails somehow we're doomed.
-    if signal::raise(signal::SIGSTOP).is_err() {
-        std::process::exit(-1);
-    }
-}
 
-/// Reenables protection on the page set by `PAGE_ADDR`.
-///
-/// SAFETY: See `mempr_off()`.
-pub unsafe extern "C" fn mempr_on() {
-    use std::sync::atomic::Ordering;
+    let regs = ptrace::getregs(pid).unwrap();
+    match get_libc_fn(regs.ip()) {
+        Some(_) => {
+            // We'll possibly want to call libc functions in the interceptor shims,
+            // so make sure they're working.
+            fixup_libc(pid);
+            // On x86, the return address will be the last item on the stack.
+            let ret_addr: usize = ptrace::read(pid, std::ptr::without_provenance_mut(regs.sp()))
+                .unwrap()
+                .cast_unsigned()
+                .try_into()
+                .unwrap();
 
-    let len = PAGE_SIZE.load(Ordering::Relaxed).wrapping_mul(PAGE_COUNT.load(Ordering::Relaxed));
-    // SAFETY: Upheld by "caller".
-    unsafe {
-        if libc::mprotect(PAGE_ADDR.load(Ordering::Relaxed).cast(), len, libc::PROT_NONE) != 0 {
-            std::process::exit(-1);
+            // When libc is calling its own functions, we explicitly need to not
+            // intercept them; therefore, we parse the process maps to determine
+            // whether this is happening.
+            let child_mappings = proc_maps::get_process_maps(pid.as_raw()).unwrap();
+            // We know for sure libc functions are mapped *somewhere*, and they will be in a file
+            // (unless something has gone awfully wrong).
+            let libc_name = child_mappings
+                .iter()
+                .find(|&mp| {
+                    // We use exit and not malloc since it seems malloc can be
+                    // reported as being inside of the Miri binary's address space.
+                    #[expect(clippy::as_conversions)]
+                    (mp.start()..mp.start().strict_add(mp.size()))
+                        .contains(&(libc::exit as *const () as usize))
+                })
+                .unwrap()
+                .filename()
+                .unwrap();
+            // Is the return address inside of a block mapped from the same
+            // file as libc functions?
+            let ret_is_libc = child_mappings.iter().any(|mp| {
+                if mp.filename().iter().any(|&name| name == libc_name) {
+                    (mp.start()..mp.start().strict_add(mp.size())).contains(&ret_addr)
+                } else {
+                    false
+                }
+            });
+            ptrace::write(pid, RET_IS_LIBC.as_ptr().cast(), ret_is_libc.into()).unwrap();
+
+            // Override the return address to give us another sigtrap
+            // (but save the original bytes).
+            let ret_addr_bytes =
+                ptrace::read(pid, std::ptr::without_provenance_mut(ret_addr)).unwrap();
+            ptrace::write(pid, std::ptr::without_provenance_mut(ret_addr), BREAKPT_INSTR.into())
+                .unwrap();
+            wait_for_signal(Some(pid), signal::SIGTRAP, InitialCont::Yes).unwrap();
+
+            // Unset the breakpoint stuff and move the ip back an instruction to compensate.
+            ptrace::write(pid, std::ptr::without_provenance_mut(ret_addr), ret_addr_bytes).unwrap();
+            let mut regs = ptrace::getregs(pid).unwrap();
+            regs.set_ip(regs.ip().strict_sub(BREAKPT_INSTR_SIZE));
+            ptrace::setregs(pid, regs).unwrap();
+
+            // If the intercept modified the list of pages we need to monitor,
+            // update our list accordingly.
+            let new_pg_addr: usize = ptrace::read(pid, NEW_PAGES_ADDR.as_ptr().cast())
+                .unwrap()
+                .cast_unsigned()
+                .try_into()
+                .unwrap();
+            if new_pg_addr != 0 {
+                let new_pg_count: usize = ptrace::read(pid, NEW_PAGES_COUNT.as_ptr().cast())
+                    .unwrap()
+                    .cast_unsigned()
+                    .try_into()
+                    .unwrap();
+                for add_fac in 0..new_pg_count {
+                    pages.push(new_pg_addr.strict_add(add_fac.strict_mul(page_size)));
+                }
+            }
+
+            let del_pg_addr: usize = ptrace::read(pid, DEL_PAGES_ADDR.as_ptr().cast())
+                .unwrap()
+                .cast_unsigned()
+                .try_into()
+                .unwrap();
+            if del_pg_addr != 0 {
+                let del_pg_count: usize = ptrace::read(pid, DEL_PAGES_COUNT.as_ptr().cast())
+                    .unwrap()
+                    .cast_unsigned()
+                    .try_into()
+                    .unwrap();
+                for add_fac in 0..del_pg_count {
+                    let pos = pages
+                        .iter()
+                        .position(|&pg| pg == del_pg_addr.strict_add(add_fac.strict_mul(page_size)))
+                        .unwrap();
+                    pages.remove(pos);
+                }
+            }
+            // Now reenable stopping the process on libc calls.
+            trap_libc(pid);
         }
-    }
-    if signal::raise(signal::SIGSTOP).is_err() {
-        std::process::exit(-1);
-    }
+        // This is a random sigtrap unrelated to our code.
+        None => {
+            eprintln!(
+                "Process got an unexpected SIGTRAP at addr {:#0x?}; continuing...",
+                regs.ip()
+            );
+        }
+    };
+    // Continue the process.
+    ptrace::syscall(pid, None).unwrap();
+    Ok(())
 }

--- a/src/shims/native_lib/trace/stub.rs
+++ b/src/shims/native_lib/trace/stub.rs
@@ -12,9 +12,12 @@ impl Supervisor {
     pub fn is_enabled() -> bool {
         false
     }
+}
 
-    pub fn do_ffi<'tcx, T>(
-        _: T,
+impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
+pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
+    fn do_ffi(
+        &mut self,
         f: impl FnOnce() -> InterpResult<'tcx, crate::ImmTy<'tcx>>,
     ) -> InterpResult<'tcx, (crate::ImmTy<'tcx>, Option<super::MemEvents>)> {
         // We acquire the lock to ensure that no two FFI calls run concurrently.


### PR DESCRIPTION
This is part 1 of rust-lang/miri#4791; it adds the bits needed to intercept allocating/deallocating calls to libc, but silently ignores them for now. In a follow-up PR this will forward them to shims we control.