### PR TITLE
add check_only feature for faster check builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,22 +123,21 @@ dependencies = [
 
 [[package]]
 name = "capstone"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "015ef5d5ca1743e3f94af9509ba6bd2886523cfee46e48d15c2ef5216fd4ac9a"
+checksum = "f442ae0f2f3f1b923334b4a5386c95c69c1cfa072bafa23d6fae6d9682eb1dd4"
 dependencies = [
  "capstone-sys",
- "libc",
+ "static_assertions",
 ]
 
 [[package]]
 name = "capstone-sys"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2267cb8d16a1e4197863ec4284ffd1aec26fe7e57c58af46b02590a0235809a0"
+checksum = "a4e8087cab6731295f5a2a2bd82989ba4f41d3a428aab2e7c98d8f4db38aac05"
 dependencies = [
  "cc",
- "libc",
 ]
 
 [[package]]
@@ -1403,6 +1402,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ serde = { version = "1.0.219", features = ["derive"], optional = true }
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = { version = "0.30.1", features = ["mman", "ptrace", "signal"], optional = true }
 ipc-channel = { version = "0.20.0", optional = true }
-capstone = { version = "0.13", optional = true }
+capstone = { version = "0.14", optional = true }
 
 [target.'cfg(all(target_os = "linux", target_pointer_width = "64", target_endian = "little"))'.dependencies]
 genmc-sys = { path = "./genmc-sys/", version = "0.1.0", optional = true }
@@ -68,6 +68,7 @@ expensive-consistency-checks = ["stack-cache"]
 tracing = ["serde_json"]
 native-lib = ["dep:libffi", "dep:libloading", "dep:capstone", "dep:ipc-channel", "dep:nix", "dep:serde"]
 jemalloc = []
+check_only = ["libffi?/check_only", "capstone?/check_only", "genmc-sys?/check_only"]
 
 [lints.rust.unexpected_cfgs]
 level = "warn"

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -30,14 +30,15 @@ export CARGO_INCREMENTAL=0
 export CARGO_EXTRA_FLAGS="--locked"
 
 # Determine configuration for installed build (used by test-cargo-miri and `./miri bench`).
+# We use the default set of features for this.
 echo "Installing release version of Miri"
 time ./miri install
 
 # Prepare debug build for direct `./miri` invocations.
-# We enable all features to make sure the Stacked Borrows consistency check runs.
+# Here we enable some more features and checks.
 echo "Building debug version of Miri"
-export CARGO_EXTRA_FLAGS="$CARGO_EXTRA_FLAGS --all-features"
-time ./miri build # the build that all the `./miri test` below will use
+export FEATURES="--features=expensive-consistency-checks,genmc"
+time ./miri build $FEATURES # the build that all the `./miri test` below will use
 
 endgroup
 
@@ -63,7 +64,7 @@ function run_tests {
   if [ -n "${GC_STRESS-}" ]; then
     time MIRIFLAGS="${MIRIFLAGS-} -Zmiri-provenance-gc=1" ./miri test $TARGET_FLAG
   else
-    time ./miri test $TARGET_FLAG
+    time ./miri test $FEATURES $TARGET_FLAG
   fi
 
   ## advanced tests
@@ -74,20 +75,20 @@ function run_tests {
     # them. Also error locations change so we don't run the failing tests.
     # We explicitly enable debug-assertions here, they are disabled by -O but we have tests
     # which exist to check that we panic on debug assertion failures.
-    time MIRIFLAGS="${MIRIFLAGS-} -O -Zmir-opt-level=4 -Cdebug-assertions=yes" MIRI_SKIP_UI_CHECKS=1 ./miri test $TARGET_FLAG tests/{pass,panic}
+    time MIRIFLAGS="${MIRIFLAGS-} -O -Zmir-opt-level=4 -Cdebug-assertions=yes" MIRI_SKIP_UI_CHECKS=1 ./miri test $FEATURES $TARGET_FLAG tests/{pass,panic}
   fi
   if [ -n "${MANY_SEEDS-}" ]; then
     # Run many-seeds tests. (Also tests `./miri run`.)
     time for FILE in tests/many-seeds/*.rs; do
-      ./miri run "-Zmiri-many-seeds=0..$MANY_SEEDS" $TARGET_FLAG "$FILE"
+      ./miri run $FEATURES "-Zmiri-many-seeds=0..$MANY_SEEDS" $TARGET_FLAG "$FILE"
     done
+    # Smoke-test `./miri run --dep`.
+    ./miri run $FEATURES $TARGET_FLAG --dep tests/pass-dep/getrandom.rs
   fi
   if [ -n "${TEST_BENCH-}" ]; then
     # Check that the benchmarks build and run, but only once.
     time HYPERFINE="hyperfine -w0 -r1 --show-output" ./miri bench $TARGET_FLAG --no-install
   fi
-  # Smoke-test `./miri run --dep`.
-  ./miri run $TARGET_FLAG --dep tests/pass-dep/getrandom.rs
 
   ## test-cargo-miri
   # On Windows, there is always "python", not "python3" or "python2".

--- a/etc/rust_analyzer_helix.toml
+++ b/etc/rust_analyzer_helix.toml
@@ -27,7 +27,6 @@ invocationStrategy = "once"
 overrideCommand = [
     "./miri",
     "check",
-    "--no-default-features",
     "-Zunstable-options",
     "--compile-time-deps",
     "--message-format=json",

--- a/etc/rust_analyzer_vscode.json
+++ b/etc/rust_analyzer_vscode.json
@@ -21,7 +21,6 @@
     "rust-analyzer.cargo.buildScripts.overrideCommand": [
         "./miri",
         "check",
-        "--no-default-features",
         "-Zunstable-options",
         "--compile-time-deps",
         "--message-format=json",

--- a/etc/rust_analyzer_zed.json
+++ b/etc/rust_analyzer_zed.json
@@ -30,7 +30,6 @@
                         "overrideCommand": [
                             "./miri",
                             "check",
-                            "--no-default-features",
                             "-Zunstable-options",
                             "--compile-time-deps",
                             "--message-format=json"

--- a/genmc-sys/Cargo.toml
+++ b/genmc-sys/Cargo.toml
@@ -13,3 +13,6 @@ cc = "1.2.16"
 cmake = "0.1.54"
 git2 = { version = "0.20.2", default-features = false, features = ["https"] }
 cxx-build = { version = "1.0.173", features = ["parallel"] }
+
+[features]
+check_only = []

--- a/genmc-sys/build.rs
+++ b/genmc-sys/build.rs
@@ -202,6 +202,11 @@ fn compile_cpp_dependencies(genmc_path: &Path, always_configure: bool) {
 }
 
 fn main() {
+    // For check-only builds, we don't need to do anything.
+    if cfg!(feature = "check_only") {
+        return;
+    }
+
     // Select which path to use for the GenMC repo:
     let (genmc_path, always_configure) = if let Some(genmc_src_path) = option_env!("GENMC_SRC_PATH")
     {

--- a/miri-script/src/commands.rs
+++ b/miri-script/src/commands.rs
@@ -391,7 +391,8 @@ impl Command {
         Ok(())
     }
 
-    fn check(features: Vec<String>, flags: Vec<String>) -> Result<()> {
+    fn check(mut features: Vec<String>, flags: Vec<String>) -> Result<()> {
+        features.push("check_only".into());
         let e = MiriEnv::new()?;
         e.check(".", &features, &flags)?;
         e.check("cargo-miri", &[], &flags)?;
@@ -405,7 +406,8 @@ impl Command {
         Ok(())
     }
 
-    fn clippy(features: Vec<String>, flags: Vec<String>) -> Result<()> {
+    fn clippy(mut features: Vec<String>, flags: Vec<String>) -> Result<()> {
+        features.push("check_only".into());
         let e = MiriEnv::new()?;
         e.clippy(".", &features, &flags)?;
         e.clippy("cargo-miri", &[], &flags)?;


### PR DESCRIPTION
libffi and capstone both have a feature to speed up check builds now, let's use that -- and let's add one for genmc-sys as well.