### PR TITLE
Add a validity testcase for uninhabited variants

### DIFF
--- a/tests/fail/validity/uninhabited_variant.rs
+++ b/tests/fail/validity/uninhabited_variant.rs
@@ -1,0 +1,17 @@
+// NOTE: this is essentially a smoke-test, with more comprehensive tests living in the rustc
+// repository at tests/ui/consts/const-eval/ub-enum.rs
+#![feature(never_type)]
+
+#[repr(C)]
+#[allow(dead_code)]
+enum E {
+    V1,    // discriminant: 0
+    V2(!), // 1
+}
+
+fn main() {
+    unsafe {
+        std::mem::transmute::<u32, E>(1);
+        //~^ ERROR: encountered an uninhabited enum variant
+    }
+}

--- a/tests/fail/validity/uninhabited_variant.stderr
+++ b/tests/fail/validity/uninhabited_variant.stderr
@@ -1,0 +1,13 @@
+error: Undefined Behavior: constructing invalid value at .<enum-tag>: encountered an uninhabited enum variant
+  --> tests/fail/validity/uninhabited_variant.rs:LL:CC
+   |
+LL |         std::mem::transmute::<u32, E>(1);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Found this testcase in a random unmerged branch of mine. Looks like I wrote it as part of my work on rust-lang/rust#138961, and then forgot to submit it when plans wrt the scope of that PR have changed.

I have double checked by grepping for the error message and it looks like we still don't have any similar tests in miri.