### PR TITLE
readme: clarify 'single-threaded interpreter'

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,8 @@ and macOS targets are usually on par. Windows is supported less well.
 
 ### Running tests in parallel
 
-Though it implements Rust threading, Miri itself is a single-threaded interpreter.
+Though it implements Rust threading, Miri itself is a single-threaded interpreter
+(it works like a multi-threaded OS on a single-core CPU).
 This means that when running `cargo miri test`, you will probably see a dramatic
 increase in the amount of time it takes to run your whole test suite due to the
 inherent interpreter slowdown and a loss of parallelism.

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -710,7 +710,7 @@ fn main() {
     if !miri_config.native_lib.is_empty() && miri_config.provenance_mode == ProvenanceMode::Strict {
         fatal_error!("strict provenance is not compatible with calling native functions");
     }
-    // Native calls and many-seeds are an "intersting" combination.
+    // Native calls and many-seeds are an "interesting" combination.
     if !miri_config.native_lib.is_empty() && many_seeds.is_some() {
         eprintln!(
             "warning: `-Zmiri-many-seeds` runs multiple instances of the program in the same address space, \


### PR DESCRIPTION
also fix an unrelated typo