### PR TITLE
add avx512 `pack*` family of instructions to shims

### DIFF
--- a/src/shims/x86/avx512.rs
+++ b/src/shims/x86/avx512.rs
@@ -3,7 +3,7 @@ use rustc_middle::ty::Ty;
 use rustc_span::Symbol;
 use rustc_target::callconv::FnAbi;
 
-use super::{permute, pmaddbw, pmaddwd, psadbw, pshufb};
+use super::{packssdw, packsswb, packusdw, packuswb, permute, pmaddbw, pmaddwd, psadbw, pshufb};
 use crate::*;
 
 impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
@@ -129,6 +129,38 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let [src, a, b] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
 
                 vpdpbusd(this, src, a, b, dest)?;
+            }
+            // Used to implement the _mm512_packs_epi16 function
+            "packsswb.512" => {
+                this.expect_target_feature_for_intrinsic(link_name, "avx512bw")?;
+
+                let [a, b] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
+
+                packsswb(this, a, b, dest)?;
+            }
+            // Used to implement the _mm512_packus_epi16 function
+            "packuswb.512" => {
+                this.expect_target_feature_for_intrinsic(link_name, "avx512bw")?;
+
+                let [a, b] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
+
+                packuswb(this, a, b, dest)?;
+            }
+            // Used to implement the _mm512_packs_epi32 function
+            "packssdw.512" => {
+                this.expect_target_feature_for_intrinsic(link_name, "avx512bw")?;
+
+                let [a, b] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
+
+                packssdw(this, a, b, dest)?;
+            }
+            // Used to implement the _mm512_packus_epi32 function
+            "packusdw.512" => {
+                this.expect_target_feature_for_intrinsic(link_name, "avx512bw")?;
+
+                let [a, b] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
+
+                packusdw(this, a, b, dest)?;
             }
             _ => return interp_ok(EmulateItemResult::NotSupported),
         }


### PR DESCRIPTION
Adds the pack family of instructions for the avx512 instruction set aka:

- `_mm512_packs_epi16`
- `_mm512_packus_epi16`
- `_mm512_packs_epi32`
- `_mm512_packus_epi32`
