### PR TITLE
Windows: Implement MoveFileExW shim

### DIFF
--- a/src/shims/windows/foreign_items.rs
+++ b/src/shims/windows/foreign_items.rs
@@ -451,6 +451,16 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     this.SetFilePointerEx(file, distance_to_move, new_file_pointer, move_method)?;
                 this.write_scalar(res, dest)?;
             }
+            "MoveFileExW" => {
+                let [existing_name, new_name, flags] = this.check_shim_sig(
+                    shim_sig!(extern "system" fn(*const _, *const _, u32) -> winapi::BOOL),
+                    link_name,
+                    abi,
+                    args,
+                )?;
+                let res = this.MoveFileExW(existing_name, new_name, flags)?;
+                this.write_scalar(res, dest)?;
+            }
 
             // Allocation
             "HeapAlloc" => {

--- a/src/shims/windows/fs.rs
+++ b/src/shims/windows/fs.rs
@@ -490,6 +490,36 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         }
     }
 
+    fn MoveFileExW(
+        &mut self,
+        existing_name: &OpTy<'tcx>,
+        new_name: &OpTy<'tcx>,
+        flags: &OpTy<'tcx>,
+    ) -> InterpResult<'tcx, Scalar> {
+        let this = self.eval_context_mut();
+
+        let existing_name = this.read_path_from_wide_str(this.read_pointer(existing_name)?)?;
+        let new_name = this.read_path_from_wide_str(this.read_pointer(new_name)?)?;
+
+        let flags = this.read_scalar(flags)?.to_u32()?;
+
+        // Flag to indicate whether we should replace an existing file.
+        // https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefileexw
+        let movefile_replace_existing = this.eval_windows_u32("c", "MOVEFILE_REPLACE_EXISTING");
+
+        if flags != movefile_replace_existing {
+            throw_unsup_format!("MoveFileExW: Unsupported `dwFlags` value {}", flags);
+        }
+
+        match std::fs::rename(existing_name, new_name) {
+            Ok(_) => interp_ok(this.eval_windows("c", "TRUE")),
+            Err(e) => {
+                this.set_last_error(e)?;
+                interp_ok(this.eval_windows("c", "FALSE"))
+            }
+        }
+    }
+
     fn DeleteFileW(
         &mut self,
         file_name: &OpTy<'tcx>, // LPCWSTR

--- a/tests/pass/shims/fs.rs
+++ b/tests/pass/shims/fs.rs
@@ -30,9 +30,9 @@ fn main() {
     test_file_clone();
     test_file_set_len();
     test_file_sync();
+    test_rename();
     // Windows file handling is very incomplete.
     if cfg!(not(windows)) {
-        test_rename();
         test_directory();
         test_canonicalize();
         #[cfg(unix)]


### PR DESCRIPTION
This allows `rename` to work. Doesn't support renaming to directory form yet, as that requires a form of SetFileInfo