### PR TITLE
call unblock callbacks only when the thread is scheduled again

### DIFF
--- a/tests/pass-dep/concurrency/apple-futex.rs
+++ b/tests/pass-dep/concurrency/apple-futex.rs
@@ -188,6 +188,9 @@ fn wait_wake_multiple() {
                 0
             );
 
+            // Allow the newly woken thread to execute.
+            thread::yield_now();
+
             assert_eq!(
                 libc::os_sync_wake_by_address_any(
                     ptr::from_ref(futex).cast_mut().cast(),
@@ -196,6 +199,8 @@ fn wait_wake_multiple() {
                 ),
                 0
             );
+
+            thread::yield_now();
 
             // Wake both remaining threads at the same time.
             assert_eq!(


### PR DESCRIPTION
I'm trying to shim [waitable timer objects](https://learn.microsoft.com/en-us/windows/win32/sync/waitable-timer-objects) since I want to make use of them in `std` (see https://github.com/rust-lang/rust/pull/151553). My idea is to modify the central `schedule` function to not only look for timed out blocking operations but also go through all active timers and look for ones whose deadline has passed. This however necessitates waking up multiple threads from `schedule` – which currently would run their wakeup callbacks, violating the principle that `schedule` is not supposed to run things. I could try to work my way around this, but I think a more principled solution is the following:

This PR changes the scheduling of callback functions: Instead of being immediately invoked when an operation unblocks a thread, the thread is instead put into the newly created `ThreadState::Unblocked`. Threads with `ThreadState::Unblocked` are eligible for scheduling, but will, upon being selected, execute a callback instead of executing the next `step`.

This has the nice side-effect of exploring more possible executions of the macOS futex functions – these retrieve the current futex waiter count in their wakeup callback, so by making this callback depend on scheduling, there are more possible values that can be returned. If I read the XNU sources correctly, that also matches the system behaviour (the waiter count is [retrieved](https://github.com/apple-oss-distributions/xnu/blob/f6217f891ac0bb64f3d375211650a4c1ff8ca1ea/bsd/kern/sys_ulock.c#L818) in `ulock_wait_cleanup` which is called from the `ulock_wait_continue` continuation).

I have no clue about how this interacts with GenMC, that could potentially cause issues with the `BlockReason::GenMC` hack.