### PR TITLE
add a bug to the trophy shelf

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,6 +626,7 @@ Definite bugs found:
 * [`ReentrantLock` not correctly dealing with reuse of addresses for TLS storage of different threads](https://github.com/rust-lang/rust/pull/141248)
 * [Rare Deadlock in the thread (un)parking example code](https://github.com/rust-lang/rust/issues/145816)
 * [`winit` registering a global constructor with the wrong ABI on Windows](https://github.com/rust-windowing/winit/issues/4435)
+* [`VecDeque::splice` confusing physical and logical indices](https://github.com/rust-lang/rust/issues/151758)
 
 Violations of [Stacked Borrows] found that are likely bugs (but Stacked Borrows is currently just an experiment):
 


### PR DESCRIPTION
Does it count if the issue reporter didn't use miri, but miri helped to find the bug?

CC https://github.com/rust-lang/rust/issues/151758