### PR TITLE
trophy case: oneshot data race

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,7 @@ Definite bugs found:
 * [Rare Deadlock in the thread (un)parking example code](https://github.com/rust-lang/rust/issues/145816)
 * [`winit` registering a global constructor with the wrong ABI on Windows](https://github.com/rust-windowing/winit/issues/4435)
 * [`VecDeque::splice` confusing physical and logical indices](https://github.com/rust-lang/rust/issues/151758)
+* [Data race in `oneshot` channel](https://github.com/faern/oneshot/issues/69)
 
 Violations of [Stacked Borrows] found that are likely bugs (but Stacked Borrows is currently just an experiment):
 


### PR DESCRIPTION
Adds https://github.com/faern/oneshot/issues/69 to trophy case