### PR TITLE
chore: fix typos suggested by typos-cli

### DIFF
--- a/src/alloc/isolated_alloc.rs
+++ b/src/alloc/isolated_alloc.rs
@@ -66,10 +66,10 @@ impl IsolatedAlloc {
         // And make sure the align is at least one page
         let align = std::cmp::max(layout.align(), self.page_size);
         // pg_count gives us the # of pages needed to satisfy the size. For
-        // align > page_size where align = n * page_size, a sufficently-aligned
+        // align > page_size where align = n * page_size, a sufficiently-aligned
         // address must exist somewhere in the range of
         // some_page_aligned_address..some_page_aligned_address + (n-1) * page_size
-        // (since if some_page_aligned_address + n * page_size is sufficently aligned,
+        // (since if some_page_aligned_address + n * page_size is sufficiently aligned,
         // then so is some_page_aligned_address itself per the definition of n, so we
         // can avoid using that 1 extra page).
         // Thus we allocate n-1 extra pages

--- a/src/bin/log/tracing_chrome_instant.rs
+++ b/src/bin/log/tracing_chrome_instant.rs
@@ -2,7 +2,7 @@
 //! <https://github.com/tikv/minstant/blob/27c9ec5ec90b5b67113a748a4defee0d2519518c/src/tsc_now.rs>.
 //! A useful resource is also
 //! <https://www.pingcap.com/blog/how-we-trace-a-kv-database-with-less-than-5-percent-performance-impact/>,
-//! although this file does not implement TSC synchronization but insteads pins threads to CPUs,
+//! although this file does not implement TSC synchronization but instead pins threads to CPUs,
 //! since the former is not reliable (i.e. it might lead to non-monotonic time measurements).
 //! Another useful resource for future improvements might be measureme's time measurement utils:
 //! <https://github.com/rust-lang/measureme/blob/master/measureme/src/counters.rs>.
@@ -11,7 +11,7 @@
 #![cfg(feature = "tracing")]
 
 /// This alternative `TracingChromeInstant` implementation was made entirely to suit the needs of
-/// [crate::log::tracing_chrome], and shouldn't be used for anything else. It featues two functions:
+/// [crate::log::tracing_chrome], and shouldn't be used for anything else. It features two functions:
 /// - [TracingChromeInstant::setup_for_thread_and_start], which sets up the current thread to do
 ///   proper time tracking and returns a point in time to use as "t=0", and
 /// - [TracingChromeInstant::with_elapsed_micros_subtracting_tracing], which allows

--- a/src/borrow_tracker/tree_borrows/perms.rs
+++ b/src/borrow_tracker/tree_borrows/perms.rs
@@ -578,7 +578,7 @@ pub mod diagnostics {
                         // - created as Reserved { conflicted: false },
                         //   then Unique -> Disabled is forbidden
                         // A potential `Reserved { conflicted: false }
-                        //   -> Reserved { conflicted: true }` is inexistant or irrelevant,
+                        //   -> Reserved { conflicted: true }` is inexistent or irrelevant,
                         // and so is the `Reserved { conflicted: false } -> Unique`
                         (Unique, Frozen) => false,
                         (ReservedFrz { conflicted: true }, _) => false,

--- a/src/borrow_tracker/tree_borrows/tree.rs
+++ b/src/borrow_tracker/tree_borrows/tree.rs
@@ -226,7 +226,7 @@ impl LocationState {
 
     /// Records a new access, so that future access can potentially be skipped
     /// by `skip_if_known_noop`. This must be called on child accesses, and otherwise
-    /// shoud be called on foreign accesses for increased performance. It should not be called
+    /// should be called on foreign accesses for increased performance. It should not be called
     /// when `skip_if_known_noop` indicated skipping, since it then is a no-op.
     /// See `foreign_access_skipping.rs`
     fn record_new_access(&mut self, access_kind: AccessKind, rel_pos: AccessRelatedness) {

--- a/src/borrow_tracker/tree_borrows/tree/tests.rs
+++ b/src/borrow_tracker/tree_borrows/tree/tests.rs
@@ -741,7 +741,7 @@ mod spurious_read {
                     );
                     eprintln!("  (arbitrary code instanciated with '{opaque}')");
                     err += 1;
-                    // We found an instanciation of the opaque code that makes this Pattern
+                    // We found an instantiation of the opaque code that makes this Pattern
                     // fail, we don't really need to check the rest.
                     break;
                 }

--- a/src/borrow_tracker/tree_borrows/tree_visitor.rs
+++ b/src/borrow_tracker/tree_borrows/tree_visitor.rs
@@ -99,7 +99,7 @@ where
         assert!(self.stack.is_empty());
         // First, handle accessed node. A bunch of things need to
         // be handled differently here compared to the further parents
-        // of `accesssed_node`.
+        // of `accessesed_node`.
         {
             self.propagate_at(this, accessed_node, AccessRelatedness::LocalAccess)?;
             if matches!(visit_children, ChildrenVisitMode::VisitChildrenOfAccessed) {

--- a/src/concurrency/data_race.rs
+++ b/src/concurrency/data_race.rs
@@ -371,7 +371,7 @@ impl AccessType {
 
         if let Some(size) = size {
             if size == Size::ZERO {
-                // In this case there were multiple read accesss with different sizes and then a write.
+                // In this case there were multiple read accesses with different sizes and then a write.
                 // We will be reporting *one* of the other reads, but we don't have enough information
                 // to determine which one had which size.
                 assert!(self == AccessType::AtomicLoad);

--- a/src/concurrency/genmc/global_allocations.rs
+++ b/src/concurrency/genmc/global_allocations.rs
@@ -62,7 +62,7 @@ impl GlobalStateInner {
         let entry = match self.base_addr.entry(alloc_id) {
             Entry::Occupied(occupied_entry) => {
                 // Looks like some other thread allocated this for us
-                // between when we released the read lock and aquired the write lock,
+                // between when we released the read lock and acquired the write lock,
                 // so we just return that value.
                 return interp_ok(*occupied_entry.get());
             }

--- a/src/concurrency/genmc/mod.rs
+++ b/src/concurrency/genmc/mod.rs
@@ -252,7 +252,7 @@ impl GenmcCtx {
     /// Inform GenMC about an atomic load.
     /// Returns that value that the load should read.
     ///
-    /// `old_value` is the value that a non-atomic load would read here, or `None` if the memory is uninitalized.
+    /// `old_value` is the value that a non-atomic load would read here, or `None` if the memory is uninitialized.
     pub(crate) fn atomic_load<'tcx>(
         &self,
         ecx: &InterpCx<'tcx, MiriMachine<'tcx>>,
@@ -275,7 +275,7 @@ impl GenmcCtx {
     /// Inform GenMC about an atomic store.
     /// Returns `true` if the stored value should be reflected in Miri's memory.
     ///
-    /// `old_value` is the value that a non-atomic load would read here, or `None` if the memory is uninitalized.
+    /// `old_value` is the value that a non-atomic load would read here, or `None` if the memory is uninitialized.
     pub(crate) fn atomic_store<'tcx>(
         &self,
         ecx: &InterpCx<'tcx, MiriMachine<'tcx>>,
@@ -320,7 +320,7 @@ impl GenmcCtx {
     ///
     /// Returns `(old_val, Option<new_val>)`. `new_val` might not be the latest write in coherence order, which is indicated by `None`.
     ///
-    /// `old_value` is the value that a non-atomic load would read here, or `None` if the memory is uninitalized.
+    /// `old_value` is the value that a non-atomic load would read here, or `None` if the memory is uninitialized.
     pub(crate) fn atomic_rmw_op<'tcx>(
         &self,
         ecx: &InterpCx<'tcx, MiriMachine<'tcx>>,
@@ -345,7 +345,7 @@ impl GenmcCtx {
 
     /// Returns `(old_val, Option<new_val>)`. `new_val` might not be the latest write in coherence order, which is indicated by `None`.
     ///
-    /// `old_value` is the value that a non-atomic load would read here, or `None` if the memory is uninitalized.
+    /// `old_value` is the value that a non-atomic load would read here, or `None` if the memory is uninitialized.
     pub(crate) fn atomic_exchange<'tcx>(
         &self,
         ecx: &InterpCx<'tcx, MiriMachine<'tcx>>,
@@ -370,7 +370,7 @@ impl GenmcCtx {
     ///
     /// Returns the old value read by the compare exchange, optionally the value that Miri should write back to its memory, and whether the compare-exchange was a success or not.
     ///
-    /// `old_value` is the value that a non-atomic load would read here, or `None` if the memory is uninitalized.
+    /// `old_value` is the value that a non-atomic load would read here, or `None` if the memory is uninitialized.
     pub(crate) fn atomic_compare_exchange<'tcx>(
         &self,
         ecx: &InterpCx<'tcx, MiriMachine<'tcx>>,

--- a/src/concurrency/genmc/run.rs
+++ b/src/concurrency/genmc/run.rs
@@ -30,7 +30,7 @@ pub fn run_genmc_mode<'tcx>(
     config: &MiriConfig,
     eval_entry: impl Fn(Rc<GenmcCtx>) -> Result<(), NonZeroI32>,
 ) -> Result<(), NonZeroI32> {
-    // Check for supported target: endianess and pointer size must match the host.
+    // Check for supported target: endianness and pointer size must match the host.
     if tcx.data_layout.endian != Endian::Little || tcx.data_layout.pointer_size().bits() != 64 {
         tcx.dcx().fatal("GenMC only supports 64bit little-endian targets");
     }

--- a/src/concurrency/weak_memory.rs
+++ b/src/concurrency/weak_memory.rs
@@ -389,7 +389,7 @@ impl<'tcx> StoreBuffer {
             })
             .filter(|&store_elem| {
                 if is_seqcst && store_elem.is_seqcst {
-                    // An SC load needs to ignore all but last store maked SC (stores not marked SC are not
+                    // An SC load needs to ignore all but last store made SC (stores not marked SC are not
                     // affected)
                     let include = !found_sc;
                     found_sc = true;

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -113,7 +113,7 @@ pub struct MiriConfig {
     pub float_nondet: bool,
     /// Whether floating-point operations can have a non-deterministic rounding error.
     pub float_rounding_error: FloatRoundingErrorMode,
-    /// Whether Miri artifically introduces short reads/writes on file descriptors.
+    /// Whether Miri artificially introduces short reads/writes on file descriptors.
     pub short_fd_operations: bool,
     /// A list of crates that are considered user-relevant.
     pub user_relevant_crates: Vec<String>,

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -138,7 +138,7 @@ pub fn iter_exported_symbols<'tcx>(
     }
 
     // Next, all our dependencies.
-    // `dependency_formats` includes all the transitive informations needed to link a crate,
+    // `dependency_formats` includes all the transitive information needed to link a crate,
     // which is what we need here since we need to dig out `exported_symbols` from all transitive
     // dependencies.
     let dependency_formats = tcx.dependency_formats(());
@@ -1148,7 +1148,7 @@ impl ToUsize for u32 {
 }
 
 /// Similarly, a maximum address size of `u64` is assumed widely here, so let's have ergonomic
-/// converion from `usize` to `u64`.
+/// conversion from `usize` to `u64`.
 pub trait ToU64 {
     fn to_u64(self) -> u64;
 }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -654,7 +654,7 @@ pub struct MiriMachine<'tcx> {
     /// Whether floating-point operations can have a non-deterministic rounding error.
     pub float_rounding_error: FloatRoundingErrorMode,
 
-    /// Whether Miri artifically introduces short reads/writes on file descriptors.
+    /// Whether Miri artificially introduces short reads/writes on file descriptors.
     pub short_fd_operations: bool,
 }
 
@@ -1802,7 +1802,7 @@ impl<'tcx> Machine<'tcx> for MiriMachine<'tcx> {
             // We have to skip the frame that is just being popped.
             ecx.active_thread_mut().recompute_top_user_relevant_frame(/* skip */ 1);
         }
-        // tracing-tree can autoamtically annotate scope changes, but it gets very confused by our
+        // tracing-tree can automatically annotate scope changes, but it gets very confused by our
         // concurrency and what it prints is just plain wrong. So we print our own information
         // instead. (Cc https://github.com/rust-lang/miri/issues/2266)
         info!("Leaving {}", ecx.frame().instance());

--- a/src/shims/native_lib/trace/child.rs
+++ b/src/shims/native_lib/trace/child.rs
@@ -31,7 +31,7 @@ pub struct Supervisor {
     /// Used for synchronisation, allowing us to receive confirmation that the
     /// parent process has handled the request from `message_tx`.
     confirm_rx: ipc::IpcReceiver<Confirmation>,
-    /// Receiver for memory acceses that ocurred during the FFI call.
+    /// Receiver for memory accesses that occurred during the FFI call.
     event_rx: ipc::IpcReceiver<MemEvents>,
 }
 

--- a/src/shims/os_str.rs
+++ b/src/shims/os_str.rs
@@ -316,7 +316,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // The new path is still absolute on Windows.
                 path.remove(0);
             }
-            // If this starts withs a `\` but not a `\\`, then this was absolute on Unix but is
+            // If this starts with a `\` but not a `\\`, then this was absolute on Unix but is
             // relative on Windows (relative to "the root of the current directory", e.g. the
             // drive letter).
             else if path.first() == Some(&sep) && path.get(1) != Some(&sep) {

--- a/src/shims/time.rs
+++ b/src/shims/time.rs
@@ -401,11 +401,11 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         };
 
         let timeout_anchor = if flags == 0 {
-            // No flags set, the timespec should be interperted as a duration
+            // No flags set, the timespec should be interpreted as a duration
             // to sleep for
             TimeoutAnchor::Relative
         } else if flags == this.eval_libc_i32("TIMER_ABSTIME") {
-            // Only flag TIMER_ABSTIME set, the timespec should be interperted as
+            // Only flag TIMER_ABSTIME set, the timespec should be interpreted as
             // an absolute time.
             TimeoutAnchor::Absolute
         } else {

--- a/src/shims/unix/foreign_items.rs
+++ b/src/shims/unix/foreign_items.rs
@@ -1045,7 +1045,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     &[Os::Linux, Os::FreeBsd, Os::Illumos, Os::Solaris, Os::Android, Os::MacOs],
                     link_name,
                 )?;
-                // This function looks and behaves excatly like miri_start_unwind.
+                // This function looks and behaves exactly like miri_start_unwind.
                 let [payload] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
                 this.handle_miri_start_unwind(payload)?;
                 return interp_ok(EmulateItemResult::NeedsUnwind);

--- a/src/shims/unix/freebsd/sync.rs
+++ b/src/shims/unix/freebsd/sync.rs
@@ -169,7 +169,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let Some(futex_ref) =
                     this.get_sync_or_init(obj, |_| FreeBsdFutex { futex: Default::default() })
                 else {
-                    // From Linux implemenation:
+                    // From Linux implementation:
                     // No AllocId, or no live allocation at that AllocId.
                     // Return an error code. (That seems nicer than silently doing something non-intuitive.)
                     // This means that if an address gets reused by a new allocation,

--- a/src/shims/unix/linux/foreign_items.rs
+++ b/src/shims/unix/linux/foreign_items.rs
@@ -165,7 +165,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 )? {
                     ThreadNameResult::Ok => Scalar::from_u32(0),
                     ThreadNameResult::NameTooLong => this.eval_libc("ERANGE"),
-                    // Act like we faild to open `/proc/self/task/$tid/comm`.
+                    // Act like we failed to open `/proc/self/task/$tid/comm`.
                     ThreadNameResult::ThreadNotFound => this.eval_libc("ENOENT"),
                 };
                 this.write_scalar(res, dest)?;
@@ -186,7 +186,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     )? {
                         ThreadNameResult::Ok => Scalar::from_u32(0),
                         ThreadNameResult::NameTooLong => unreachable!(),
-                        // Act like we faild to open `/proc/self/task/$tid/comm`.
+                        // Act like we failed to open `/proc/self/task/$tid/comm`.
                         ThreadNameResult::ThreadNotFound => this.eval_libc("ENOENT"),
                     }
                 } else {

--- a/src/shims/unix/linux_like/epoll.rs
+++ b/src/shims/unix/linux_like/epoll.rs
@@ -176,7 +176,7 @@ impl EpollInterestTable {
         if let Some(epolls) = self.0.remove(&id) {
             for epoll in epolls.iter().filter_map(|(_id, epoll)| epoll.upgrade()) {
                 // This is a still-live epoll with interest in this FD. Remove all
-                // relevent interests (including from the ready set).
+                // relevant interests (including from the ready set).
                 epoll
                     .interest_list
                     .borrow_mut()

--- a/src/shims/unix/macos/sync.rs
+++ b/src/shims/unix/macos/sync.rs
@@ -169,7 +169,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
         let is_shared = flags == shared;
         let timeout = clock_timeout.map(|(_, anchor, timeout)| {
-            // The only clock that is currenlty supported is the monotonic clock.
+            // The only clock that is currently supported is the monotonic clock.
             // While the deadline argument of `os_sync_wait_on_address_with_deadline`
             // is actually not in nanoseconds but in the units of `mach_current_time`,
             // the two are equivalent in miri.

--- a/src/shims/windows/foreign_items.rs
+++ b/src/shims/windows/foreign_items.rs
@@ -1199,7 +1199,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                         "`_Unwind_RaiseException` is not supported on non-MinGW Windows",
                     );
                 }
-                // This function looks and behaves excatly like miri_start_unwind.
+                // This function looks and behaves exactly like miri_start_unwind.
                 let [payload] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*mut _) -> unwind::libunwind::_Unwind_Reason_Code),
                     link_name,

--- a/src/shims/windows/sync.rs
+++ b/src/shims/windows/sync.rs
@@ -67,7 +67,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
         )
     }
 
-    /// Returns `true` if we were succssful, `false` if we would block.
+    /// Returns `true` if we were successful, `false` if we would block.
     fn init_once_try_begin(
         &mut self,
         init_once_ref: &InitOnceRef,

--- a/src/shims/x86/avx2.rs
+++ b/src/shims/x86/avx2.rs
@@ -194,7 +194,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             // Used to implement the _mm256_sign_epi{8,16,32} functions.
             // Negates elements from `left` when the corresponding element in
             // `right` is negative. If an element from `right` is zero, zero
-            // is writen to the corresponding output element.
+            // is written to the corresponding output element.
             // Basically, we multiply `left` with `right.signum()`.
             "psign.b" | "psign.w" | "psign.d" => {
                 let [left, right] =

--- a/src/shims/x86/bmi.rs
+++ b/src/shims/x86/bmi.rs
@@ -44,7 +44,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let right = if is_64_bit { right.to_u64()? } else { u64::from(right.to_u32()?) };
 
         let result = match unprefixed_name {
-            // Extract a contigous range of bits from an unsigned integer.
+            // Extract a contiguous range of bits from an unsigned integer.
             // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_bextr_u32
             "bextr" => {
                 let start = u32::try_from(right & 0xff).unwrap();

--- a/src/shims/x86/sse.rs
+++ b/src/shims/x86/sse.rs
@@ -24,8 +24,8 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // Prefix should have already been checked.
         let unprefixed_name = link_name.as_str().strip_prefix("llvm.x86.sse.").unwrap();
         // All these intrinsics operate on 128-bit (f32x4) SIMD vectors unless stated otherwise.
-        // Many intrinsic names are sufixed with "ps" (packed single) or "ss" (scalar single),
-        // where single means single precision floating point (f32). "ps" means thet the operation
+        // Many intrinsic names are suffixed with "ps" (packed single) or "ss" (scalar single),
+        // where single means single precision floating point (f32). "ps" means that the operation
         // is performed on each element of the vector, while "ss" means that the operation is
         // performed only on the first element, copying the remaining elements from the input
         // vector (for binary operations, from the left-hand side).

--- a/src/shims/x86/sse2.rs
+++ b/src/shims/x86/sse2.rs
@@ -26,14 +26,14 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
         // These intrinsics operate on 128-bit (f32x4, f64x2, i8x16, i16x8, i32x4, i64x2) SIMD
         // vectors unless stated otherwise.
-        // Many intrinsic names are sufixed with "ps" (packed single), "ss" (scalar signle),
+        // Many intrinsic names are suffixed with "ps" (packed single), "ss" (scalar single),
         // "pd" (packed double) or "sd" (scalar double), where single means single precision
         // floating point (f32) and double means double precision floating point (f64). "ps"
-        // and "pd" means thet the operation is performed on each element of the vector, while
+        // and "pd" means that the operation is performed on each element of the vector, while
         // "ss" and "sd" means that the operation is performed only on the first element, copying
         // the remaining elements from the input vector (for binary operations, from the left-hand
         // side).
-        // Intrinsincs sufixed with "epiX" or "epuX" operate with X-bit signed or unsigned
+        // Intrinsics suffixed with "epiX" or "epuX" operate with X-bit signed or unsigned
         // vectors.
         match unprefixed_name {
             // Used to implement the _mm_sad_epu8 function.

--- a/src/shims/x86/sse41.rs
+++ b/src/shims/x86/sse41.rs
@@ -115,7 +115,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 round_all::<rustc_apfloat::ieee::Double>(this, op, rounding, dest)?;
             }
             // Used to implement the _mm_minpos_epu16 function.
-            // Find the minimum unsinged 16-bit integer in `op` and
+            // Find the minimum unsigned 16-bit integer in `op` and
             // returns its value and position.
             "phminposuw" => {
                 let [op] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;

--- a/src/shims/x86/sse42.rs
+++ b/src/shims/x86/sse42.rs
@@ -213,7 +213,7 @@ fn deconstruct_args<'tcx>(
     };
 
     // The fourth letter of each string comparison intrinsic is either 'e' for "explicit" or 'i' for "implicit".
-    // The distinction will correspond to the intrinsics type signature. In this constext, "explicit" and "implicit"
+    // The distinction will correspond to the intrinsics type signature. In this context, "explicit" and "implicit"
     // refer to the way the string length is determined. The length is either passed explicitly in the "explicit"
     // case or determined by a null terminator in the "implicit" case.
     let is_explicit = match unprefixed_name.as_bytes().get(4) {
@@ -297,7 +297,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     deconstruct_args(unprefixed_name, this, link_name, abi, args)?;
                 let mask = compare_strings(this, &str1, &str2, len, imm)?;
 
-                // The sixth bit inside the immediate byte distiguishes
+                // The sixth bit inside the immediate byte distinguishes
                 // between a bit mask or a byte mask when generating a mask.
                 if imm & 0b100_0000 != 0 {
                     let (array_layout, size) = if imm & USE_WORDS != 0 {
@@ -347,7 +347,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let mask = compare_strings(this, &str1, &str2, len, imm)?;
 
                 let len = default_len::<u32>(imm);
-                // The sixth bit inside the immediate byte distiguishes between the least
+                // The sixth bit inside the immediate byte distinguishes between the least
                 // significant bit and the most significant bit when generating an index.
                 let result = if imm & 0b100_0000 != 0 {
                     // most significant bit

--- a/src/shims/x86/ssse3.rs
+++ b/src/shims/x86/ssse3.rs
@@ -68,7 +68,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             // Used to implement the _mm_sign_epi{8,16,32} functions.
             // Negates elements from `left` when the corresponding element in
             // `right` is negative. If an element from `right` is zero, zero
-            // is writen to the corresponding output element.
+            // is written to the corresponding output element.
             // Basically, we multiply `left` with `right.signum()`.
             "psign.b.128" | "psign.w.128" | "psign.d.128" => {
                 let [left, right] =


### PR DESCRIPTION
Fix typos suggested by typos-cli.
I edit the files manually to avoid false-pos by typos-cli.