### PR TITLE
add test for deallocating partially-interior-mutable ref

### DIFF
--- a/tests/fail/both_borrows/mixed_cell_deallocate.rs
+++ b/tests/fail/both_borrows/mixed_cell_deallocate.rs
@@ -1,0 +1,18 @@
+//@revisions: stack tree
+//@[tree]compile-flags: -Zmiri-tree-borrows
+
+use std::alloc;
+use std::cell::Cell;
+
+type T = (Cell<i32>, i32);
+
+// Deallocating `x` is UB because not all bytes are in an `UnsafeCell`.
+fn foo(x: &T) {
+    let layout = alloc::Layout::new::<T>();
+    unsafe { alloc::dealloc(x as *const _ as *mut T as *mut u8, layout) }; //~ERROR: dealloc
+}
+
+fn main() {
+    let b: Box<T> = Box::new((Cell::new(0), 0));
+    foo(unsafe { std::mem::transmute(Box::into_raw(b)) });
+}

--- a/tests/fail/both_borrows/mixed_cell_deallocate.stack.stderr
+++ b/tests/fail/both_borrows/mixed_cell_deallocate.stack.stderr
@@ -1,0 +1,23 @@
+error: Undefined Behavior: attempting deallocation using <TAG> at ALLOC, but that tag only grants SharedReadOnly permission for this location
+  --> tests/fail/both_borrows/mixed_cell_deallocate.rs:LL:CC
+   |
+LL |     unsafe { alloc::dealloc(x as *const _ as *mut T as *mut u8, layout) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+   |
+   = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
+   = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
+help: <TAG> was created by a SharedReadOnly retag at offsets [0x4..0xc]
+  --> tests/fail/both_borrows/mixed_cell_deallocate.rs:LL:CC
+   |
+LL |     unsafe { alloc::dealloc(x as *const _ as *mut T as *mut u8, layout) };
+   |                             ^
+   = note: stack backtrace:
+           0: foo
+               at tests/fail/both_borrows/mixed_cell_deallocate.rs:LL:CC
+           1: main
+               at tests/fail/both_borrows/mixed_cell_deallocate.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/tests/fail/both_borrows/mixed_cell_deallocate.tree.stderr
+++ b/tests/fail/both_borrows/mixed_cell_deallocate.tree.stderr
@@ -1,0 +1,24 @@
+error: Undefined Behavior: deallocation through <TAG> at ALLOC[0x4] is forbidden
+  --> tests/fail/both_borrows/mixed_cell_deallocate.rs:LL:CC
+   |
+LL |     unsafe { alloc::dealloc(x as *const _ as *mut T as *mut u8, layout) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+   |
+   = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
+   = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/tree-borrows.md for further information
+   = help: the accessed tag <TAG> has state Frozen which forbids this deallocation (acting as a child write access)
+help: the accessed tag <TAG> was created here, in the initial state Cell
+  --> tests/fail/both_borrows/mixed_cell_deallocate.rs:LL:CC
+   |
+LL | fn foo(x: &T) {
+   |        ^
+   = note: stack backtrace:
+           0: foo
+               at tests/fail/both_borrows/mixed_cell_deallocate.rs:LL:CC
+           1: main
+               at tests/fail/both_borrows/mixed_cell_deallocate.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
It seems like this crucial case is not covered by any existing tests.