### PR TITLE
Add network socket `listen` and `bind` shims

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -150,6 +150,13 @@ pub enum NonHaltingDiagnostic {
         effective_failure_ordering: AtomicReadOrd,
     },
     FileInProcOpened,
+    SocketListenUnsupportedBacklog {
+        details: bool,
+        /// Unsupported backlog value provided the by the program.
+        provided: i32,
+        /// Supported backlog value by Miri.
+        supported: i32,
+    },
 }
 
 /// Level of Miri specific diagnostics
@@ -656,6 +663,8 @@ impl<'tcx> MiriMachine<'tcx> {
             | WeakMemoryOutdatedLoad { .. } =>
                 ("tracking was triggered here".to_string(), DiagLevel::Note),
             FileInProcOpened => ("open a file in `/proc`".to_string(), DiagLevel::Warning),
+            SocketListenUnsupportedBacklog { .. } =>
+                ("call to `listen` with unsupported backlog value".to_string(), DiagLevel::Warning),
         };
 
         let title = match &e {
@@ -703,13 +712,18 @@ impl<'tcx> MiriMachine<'tcx> {
                 };
                 format!("GenMC currently does not model the failure ordering for `compare_exchange`. {was_upgraded_msg}. Miri with GenMC might miss bugs related to this memory access.")
             }
-            FileInProcOpened => format!("files in `/proc` can bypass the Abstract Machine and might not work properly in Miri")
+            FileInProcOpened => format!("files in `/proc` can bypass the Abstract Machine and might not work properly in Miri"),
+            SocketListenUnsupportedBacklog { provided, supported, .. } => format!("called `listen` on socket with backlog value of {provided} but only {supported} is supported")
         };
 
         let notes = match &e {
             ProgressReport { block_count } => {
                 vec![note!("so far, {block_count} basic blocks have been executed")]
             }
+            SocketListenUnsupportedBacklog { details: true, supported, .. } =>
+                vec![note!(
+                    "the given value will be ignored and a backlog of {supported} will be used instead"
+                )],
             _ => vec![],
         };
 

--- a/src/shims/unix/foreign_items.rs
+++ b/src/shims/unix/foreign_items.rs
@@ -550,6 +550,37 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let result = this.socket(domain, type_, protocol)?;
                 this.write_scalar(result, dest)?;
             }
+            "bind" => {
+                let [socket, address, address_len] = this.check_shim_sig(
+                    shim_sig!(extern "C" fn(i32, *const _, libc::socklen_t) -> i32),
+                    link_name,
+                    abi,
+                    args,
+                )?;
+                let result = this.bind(socket, address, address_len)?;
+                this.write_scalar(result, dest)?;
+            }
+            "listen" => {
+                let [socket, backlog] = this.check_shim_sig(
+                    shim_sig!(extern "C" fn(i32, i32) -> i32),
+                    link_name,
+                    abi,
+                    args,
+                )?;
+                let result = this.listen(socket, backlog)?;
+                this.write_scalar(result, dest)?;
+            }
+            "setsockopt" => {
+                let [socket, level, option_name, option_value, option_len] = this.check_shim_sig(
+                    shim_sig!(extern "C" fn(i32, i32, i32, *const _, libc::socklen_t) -> i32),
+                    link_name,
+                    abi,
+                    args,
+                )?;
+                let result =
+                    this.setsockopt(socket, level, option_name, option_value, option_len)?;
+                this.write_scalar(result, dest)?;
+            }
 
             // Time
             "gettimeofday" => {

--- a/src/shims/unix/socket.rs
+++ b/src/shims/unix/socket.rs
@@ -1,12 +1,17 @@
-use std::cell::Cell;
-use std::net::{TcpListener, TcpStream};
+use std::cell::{Cell, RefCell};
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6, TcpListener};
 
+use rustc_abi::Size;
 use rustc_const_eval::interpret::{InterpResult, interp_ok};
 use rustc_middle::throw_unsup_format;
 use rustc_target::spec::Os;
 
+use crate::diagnostics::SpanDedupDiagnostic;
 use crate::shims::files::{FdId, FileDescription};
 use crate::{OpTy, Scalar, *};
+
+/// Backlog value passed to the `listen` syscall by the standard library
+const SUPPORTED_LISTEN_BACKLOG: i32 = 128;
 
 #[derive(Debug, PartialEq)]
 enum SocketFamily {
@@ -17,27 +22,25 @@ enum SocketFamily {
 }
 
 #[derive(Debug)]
-enum SocketType {
-    /// Reliable full-duplex communication, based on connections.
-    Stream,
+enum SocketState {
+    /// No syscall after `socket` has been made.
+    Initial,
+    /// The `bind` syscall has been called on the socket.
+    /// This is only reachable from the [`SocketState::Initial`] state.
+    Bound(SocketAddr),
+    /// The `listen` syscall has been called on the socket.
+    /// This is only reachable from the [`SocketState::Bound`] state.
+    #[expect(unused)]
+    Listening(TcpListener),
 }
 
-#[allow(unused)]
-#[derive(Debug)]
-enum SocketKind {
-    TcpListener(TcpListener),
-    TcpStream(TcpStream),
-}
-
-#[allow(unused)]
 #[derive(Debug)]
 struct Socket {
     /// Family of the socket, used to ensure socket only binds/connects to address of
     /// same family.
     family: SocketFamily,
-    /// Type of the socket, either datagram or stream.
-    /// Only stream is supported at the moment!
-    socket_type: SocketType,
+    /// Current state of the inner socket.
+    state: RefCell<SocketState>,
     /// Whether this fd is non-blocking or not.
     is_non_block: Cell<bool>,
 }
@@ -97,16 +100,19 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // Reject if isolation is enabled
         if let IsolatedOp::Reject(reject_with) = this.machine.isolated_op {
             this.reject_in_isolation("`socket`", reject_with)?;
-            this.set_last_error(LibcError("EACCES"))?;
-            return interp_ok(Scalar::from_i32(-1));
+            return this.set_last_error_and_return_i32(LibcError("EACCES"));
         }
 
         let mut is_sock_nonblock = false;
 
         // Interpret the flag. Every flag we recognize is "subtracted" from `flags`, so
         // if there is anything left at the end, that's an unsupported flag.
-        if matches!(this.tcx.sess.target.os, Os::Linux | Os::Android | Os::FreeBsd) {
-            // SOCK_NONBLOCK and SOCK_CLOEXEC only exist on Linux, Android and FreeBSD.
+        if matches!(
+            this.tcx.sess.target.os,
+            Os::Linux | Os::Android | Os::FreeBsd | Os::Solaris | Os::Illumos
+        ) {
+            // SOCK_NONBLOCK and SOCK_CLOEXEC only exist on Linux, Android, FreeBSD,
+            // Solaris, and Illumos targets
             let sock_nonblock = this.eval_libc_i32("SOCK_NONBLOCK");
             let sock_cloexec = this.eval_libc_i32("SOCK_CLOEXEC");
             if flags & sock_nonblock == sock_nonblock {
@@ -148,10 +154,311 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let fds = &mut this.machine.fds;
         let fd = fds.new_ref(Socket {
             family,
+            state: RefCell::new(SocketState::Initial),
             is_non_block: Cell::new(is_sock_nonblock),
-            socket_type: SocketType::Stream,
         });
 
         interp_ok(Scalar::from_i32(fds.insert(fd)))
+    }
+
+    fn bind(
+        &mut self,
+        socket: &OpTy<'tcx>,
+        address: &OpTy<'tcx>,
+        address_len: &OpTy<'tcx>,
+    ) -> InterpResult<'tcx, Scalar> {
+        let this = self.eval_context_mut();
+
+        let socket = this.read_scalar(socket)?.to_i32()?;
+        let address = match this.socket_address(address, address_len, "bind")? {
+            Ok(addr) => addr,
+            Err(e) => return this.set_last_error_and_return_i32(e),
+        };
+
+        // Get the file handle
+        let Some(fd) = this.machine.fds.get(socket) else {
+            return interp_ok(this.eval_libc("EBADF"));
+        };
+
+        let Some(socket) = fd.downcast::<Socket>() else {
+            // Man page specifies to return ENOTSOCK if `fd` is not a socket.
+            return interp_ok(this.eval_libc("ENOTSOCK"));
+        };
+
+        assert!(this.machine.communicate(), "cannot have `Socket` with isolation enabled!");
+
+        let mut state = socket.state.borrow_mut();
+
+        match *state {
+            SocketState::Initial => {
+                let address_family = match &address {
+                    SocketAddr::V4(_) => SocketFamily::IPv4,
+                    SocketAddr::V6(_) => SocketFamily::IPv6,
+                };
+
+                if socket.family != address_family {
+                    // Attempted to bind an address from a family that doesn't match
+                    // the family of the socket.
+                    let err = if matches!(this.tcx.sess.target.os, Os::Linux | Os::Android) {
+                        // Linux man page states that `EINVAL` is used when there is an addres family mismatch.
+                        // See <https://man7.org/linux/man-pages/man2/bind.2.html>
+                        LibcError("EINVAL")
+                    } else {
+                        // POSIX man page states that `EAFNOSUPPORT` should be used when there is an address
+                        // family mismatch.
+                        // See <https://man7.org/linux/man-pages/man3/bind.3p.html>
+                        LibcError("EAFNOSUPPORT")
+                    };
+                    return this.set_last_error_and_return_i32(err);
+                }
+
+                *state = SocketState::Bound(address);
+            }
+            SocketState::Bound(_) | SocketState::Listening(_) =>
+                throw_unsup_format!(
+                    "bind: socket is already bound and binding a socket \
+                                    multiple times is unsupported"
+                ),
+        }
+
+        interp_ok(Scalar::from_i32(0))
+    }
+
+    fn listen(&mut self, socket: &OpTy<'tcx>, backlog: &OpTy<'tcx>) -> InterpResult<'tcx, Scalar> {
+        let this = self.eval_context_mut();
+
+        let socket = this.read_scalar(socket)?.to_i32()?;
+        let backlog = this.read_scalar(backlog)?.to_i32()?;
+
+        // Get the file handle
+        let Some(fd) = this.machine.fds.get(socket) else {
+            return interp_ok(this.eval_libc("EBADF"));
+        };
+
+        let Some(socket) = fd.downcast::<Socket>() else {
+            // Man page specifies to return ENOTSOCK if `fd` is not a socket.
+            return interp_ok(this.eval_libc("ENOTSOCK"));
+        };
+
+        assert!(this.machine.communicate(), "cannot have `Socket` with isolation enabled!");
+
+        // Only allow the same backlog value as the standard library uses since the standard library
+        // doesn't provide a way to set a custom value.
+        if backlog != SUPPORTED_LISTEN_BACKLOG {
+            // The first time this happens at a particular location, print a warning.
+            static DEDUP: SpanDedupDiagnostic = SpanDedupDiagnostic::new();
+            this.dedup_diagnostic(&DEDUP, |first| {
+                NonHaltingDiagnostic::SocketListenUnsupportedBacklog {
+                    details: first,
+                    provided: backlog,
+                    supported: SUPPORTED_LISTEN_BACKLOG,
+                }
+            });
+        }
+
+        let mut state = socket.state.borrow_mut();
+
+        match &*state {
+            SocketState::Bound(socket_addr) =>
+                match TcpListener::bind(socket_addr) {
+                    Ok(listener) => *state = SocketState::Listening(listener),
+                    Err(e) => return this.set_last_error_and_return_i32(e),
+                },
+            SocketState::Initial => {
+                throw_unsup_format!(
+                    "listen: listening on a socket which isn't bound is unsupported"
+                )
+            }
+            SocketState::Listening(_) => {
+                throw_unsup_format!("listen: listening on a socket multiple times is unsupported")
+            }
+        }
+
+        interp_ok(Scalar::from_i32(0))
+    }
+
+    fn setsockopt(
+        &mut self,
+        socket: &OpTy<'tcx>,
+        level: &OpTy<'tcx>,
+        option_name: &OpTy<'tcx>,
+        option_value: &OpTy<'tcx>,
+        option_len: &OpTy<'tcx>,
+    ) -> InterpResult<'tcx, Scalar> {
+        let this = self.eval_context_mut();
+
+        let socket = this.read_scalar(socket)?.to_i32()?;
+        let level = this.read_scalar(level)?.to_i32()?;
+        let option_name = this.read_scalar(option_name)?.to_i32()?;
+        let socklen_layout = this.libc_ty_layout("socklen_t");
+        let option_len = this.read_scalar(option_len)?.to_int(socklen_layout.size)?;
+
+        // Get the file handle
+        let Some(fd) = this.machine.fds.get(socket) else {
+            return interp_ok(this.eval_libc("EBADF"));
+        };
+
+        let Some(_socket) = fd.downcast::<Socket>() else {
+            // Man page specifies to return ENOTSOCK if `fd` is not a socket.
+            return interp_ok(this.eval_libc("ENOTSOCK"));
+        };
+
+        if level == this.eval_libc_i32("SOL_SOCKET") {
+            let opt_so_reuseaddr = this.eval_libc_i32("SO_REUSEADDR");
+
+            if matches!(this.tcx.sess.target.os, Os::MacOs | Os::FreeBsd | Os::NetBsd) {
+                // SO_NOSIGPIPE only exists on MacOS, FreeBSD, and NetBSD.
+                let opt_so_nosigpipe = this.eval_libc_i32("SO_NOSIGPIPE");
+
+                if option_name == opt_so_nosigpipe {
+                    if option_len != 4 {
+                        // Option value should be C-int which is usually 4 bytes.
+                        return this.set_last_error_and_return_i32(LibcError("EINVAL"));
+                    }
+                    let option_value =
+                        this.deref_pointer_as(option_value, this.machine.layouts.i32)?;
+                    let _val = this.read_scalar(&option_value)?.to_i32()?;
+                    // We entirely ignore this value since we do not support signals anyway.
+
+                    return interp_ok(Scalar::from_i32(0));
+                }
+            }
+
+            if option_name == opt_so_reuseaddr {
+                if option_len != 4 {
+                    // Option value should be C-int which is usually 4 bytes.
+                    return this.set_last_error_and_return_i32(LibcError("EINVAL"));
+                }
+                let option_value = this.deref_pointer_as(option_value, this.machine.layouts.i32)?;
+                let _val = this.read_scalar(&option_value)?.to_i32()?;
+                // We entirely ignore this: std always sets REUSEADDR for us, and in the end it's more of a
+                // hint to bypass some arbitrary timeout anyway.
+                return interp_ok(Scalar::from_i32(0));
+            } else {
+                throw_unsup_format!(
+                    "setsockopt: option {option_name:#x} is unsupported for level SOL_SOCKET",
+                );
+            }
+        }
+
+        throw_unsup_format!(
+            "setsockopt: level {level:#x} is unsupported, only SOL_SOCKET is allowed"
+        );
+    }
+}
+
+impl<'tcx> EvalContextPrivExt<'tcx> for crate::MiriInterpCx<'tcx> {}
+trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
+    /// Attempt to turn an address and length operand into a standard library socket address.
+    ///
+    /// Returns an IO error should the address length not match the address family length.
+    fn socket_address(
+        &self,
+        address: &OpTy<'tcx>,
+        address_len: &OpTy<'tcx>,
+        foreign_name: &'static str,
+    ) -> InterpResult<'tcx, Result<SocketAddr, IoError>> {
+        let this = self.eval_context_ref();
+
+        let socklen_layout = this.libc_ty_layout("socklen_t");
+        // We only support address lengths which can be stored in a u64 since the
+        // size of a layout is also stored in a u64.
+        let address_len: u64 =
+            this.read_scalar(address_len)?.to_int(socklen_layout.size)?.try_into().unwrap();
+
+        // Initially, treat address as generic sockaddr just to extract the family field.
+        let sockaddr_layout = this.libc_ty_layout("sockaddr");
+        if address_len < sockaddr_layout.size.bytes() {
+            // Address length should be at least as big as the generic sockaddr
+            return interp_ok(Err(LibcError("EINVAL")));
+        }
+        let address = this.deref_pointer_as(address, sockaddr_layout)?;
+
+        let family_field = this.project_field_named(&address, "sa_family")?;
+        let family_layout = this.libc_ty_layout("sa_family_t");
+        let family = this.read_scalar(&family_field)?.to_int(family_layout.size)?;
+
+        // Depending on the family, decide whether it's IPv4 or IPv6 and use specialized layout
+        // to extract address and port.
+        let socket_addr = if family == this.eval_libc_i32("AF_INET").into() {
+            let sockaddr_in_layout = this.libc_ty_layout("sockaddr_in");
+            if address_len != sockaddr_in_layout.size.bytes() {
+                // Address length should be exactly the length of an IPv4 address.
+                return interp_ok(Err(LibcError("EINVAL")));
+            }
+            let address = address.transmute(sockaddr_in_layout, this)?;
+
+            let port_field = this.project_field_named(&address, "sin_port")?;
+            // Read bytes and treat them as big endian since port is stored in network byte order.
+            let port_bytes: [u8; 2] = this
+                .read_bytes_ptr_strip_provenance(port_field.ptr(), Size::from_bytes(2))?
+                .try_into()
+                .unwrap();
+            let port = u16::from_be_bytes(port_bytes);
+
+            let addr_field = this.project_field_named(&address, "sin_addr")?;
+            let s_addr_field = this.project_field_named(&addr_field, "s_addr")?;
+            // Read bytes and treat them as big endian since address is stored in network byte order.
+            let addr_bytes: [u8; 4] = this
+                .read_bytes_ptr_strip_provenance(s_addr_field.ptr(), Size::from_bytes(4))?
+                .try_into()
+                .unwrap();
+            let addr_bits = u32::from_be_bytes(addr_bytes);
+
+            SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::from_bits(addr_bits), port))
+        } else if family == this.eval_libc_i32("AF_INET6").into() {
+            let sockaddr_in6_layout = this.libc_ty_layout("sockaddr_in6");
+            if address_len != sockaddr_in6_layout.size.bytes() {
+                // Address length should be exactly the length of an IPv6 address.
+                return interp_ok(Err(LibcError("EINVAL")));
+            }
+            // We cannot transmute since the `sockaddr_in6` layout is bigger than the `sockaddr` layout.
+            let address = address.offset(Size::ZERO, sockaddr_in6_layout, this)?;
+
+            let port_field = this.project_field_named(&address, "sin6_port")?;
+            // Read bytes and treat them as big endian since port is stored in network byte order.
+            let port_bytes: [u8; 2] = this
+                .read_bytes_ptr_strip_provenance(port_field.ptr(), Size::from_bytes(2))?
+                .try_into()
+                .unwrap();
+            let port = u16::from_be_bytes(port_bytes);
+
+            let addr_field = this.project_field_named(&address, "sin6_addr")?;
+            let s_addr_field = this
+                .project_field_named(&addr_field, "s6_addr")?
+                .transmute(this.machine.layouts.u128, this)?;
+            // Read bytes and treat them as big endian since address is stored in network byte order.
+            let addr_bytes: [u8; 16] = this
+                .read_bytes_ptr_strip_provenance(s_addr_field.ptr(), Size::from_bytes(16))?
+                .try_into()
+                .unwrap();
+            let addr_bits = u128::from_be_bytes(addr_bytes);
+
+            let flowinfo_field = this.project_field_named(&address, "sin6_flowinfo")?;
+            // flowinfo doesn't get the big endian treatment as this field is stored in native byte order
+            // and not in network byte order.
+            let flowinfo = this.read_scalar(&flowinfo_field)?.to_u32()?;
+
+            let scope_id_field = this.project_field_named(&address, "sin6_scope_id")?;
+            // scope_id doesn't get the big endian treatment as this field is stored in native byte order
+            // and not in network byte order.
+            let scope_id = this.read_scalar(&scope_id_field)?.to_u32()?;
+
+            SocketAddr::V6(SocketAddrV6::new(
+                Ipv6Addr::from_bits(addr_bits),
+                port,
+                flowinfo,
+                scope_id,
+            ))
+        } else {
+            // Socket of other types shouldn't be created in a first place and
+            // thus also no address family of another type should be supported.
+            throw_unsup_format!(
+                "{foreign_name}: address family {family:#x} is unsupported, \
+                                only AF_INET and AF_INET6 are allowed"
+            );
+        };
+
+        interp_ok(Ok(socket_addr))
     }
 }

--- a/src/shims/unix/solarish/foreign_items.rs
+++ b/src/shims/unix/solarish/foreign_items.rs
@@ -111,6 +111,29 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 this.write_scalar(result, dest)?;
             }
 
+            // Network sockets
+            "__xnet_socket" | "__xnet7_socket" => {
+                let [domain, type_, protocol] = this.check_shim_sig(
+                    shim_sig!(extern "C" fn(i32, i32, i32) -> i32),
+                    link_name,
+                    abi,
+                    args,
+                )?;
+                let result = this.socket(domain, type_, protocol)?;
+                this.write_scalar(result, dest)?;
+            }
+
+            "__xnet_bind" => {
+                let [socket, address, address_len] = this.check_shim_sig(
+                    shim_sig!(extern "C" fn(i32, *const _, libc::socklen_t) -> i32),
+                    link_name,
+                    abi,
+                    args,
+                )?;
+                let result = this.bind(socket, address, address_len)?;
+                this.write_scalar(result, dest)?;
+            }
+
             // Miscellaneous
             "___errno" => {
                 let [] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;

--- a/tests/pass-dep/libc/libc-socket-with-isolation.rs
+++ b/tests/pass-dep/libc/libc-socket-with-isolation.rs
@@ -1,6 +1,4 @@
 //@ignore-target: windows # No libc socket on Windows
-//@ignore-target: solaris # Socket is a macro for __xnet7_socket which has no shim
-//@ignore-target: illumos # Socket is a macro for __xnet7_socket which has no shim
 //@compile-flags: -Zmiri-isolation-error=warn-nobacktrace
 
 use std::io::ErrorKind;

--- a/tests/pass-dep/libc/libc-socket.rs
+++ b/tests/pass-dep/libc/libc-socket.rs
@@ -1,14 +1,31 @@
 //@ignore-target: windows # No libc socket on Windows
-//@ignore-target: solaris # Does socket is a macro for __xnet7_socket which has no shim
-//@ignore-target: illumos # Does socket is a macro for __xnet7_socket which has no shim
 //@compile-flags: -Zmiri-disable-isolation
 
 #[path = "../../utils/libc.rs"]
 mod libc_utils;
+use std::io::{self, ErrorKind};
+
 use libc_utils::*;
 
 fn main() {
     test_socket_close();
+    test_bind_ipv4();
+    test_bind_ipv4_reuseaddr();
+    test_set_reuseaddr_invalid_len();
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "dragonfly"
+    ))]
+    {
+        test_bind_ipv4_nosigpipe();
+        test_set_nosigpipe_invalid_len();
+    }
+    test_bind_ipv4_invalid_addr_len();
+    test_bind_ipv6();
+
+    test_listen();
 }
 
 fn test_socket_close() {
@@ -16,4 +33,162 @@ fn test_socket_close() {
         let sockfd = errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap();
         errno_check(libc::close(sockfd));
     }
+}
+
+fn test_bind_ipv4() {
+    let sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+    let addr = net::ipv4_sock_addr(net::IPV4_LOCALHOST, 1234);
+    unsafe {
+        errno_check(libc::bind(
+            sockfd,
+            (&addr as *const libc::sockaddr_in).cast::<libc::sockaddr>(),
+            size_of::<libc::sockaddr_in>() as libc::socklen_t,
+        ));
+    }
+}
+
+/// Tests binding after the `SO_REUSEADDR` socket option has been set on the newly created socket.
+fn test_bind_ipv4_reuseaddr() {
+    let sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+    let addr = net::ipv4_sock_addr(net::IPV4_LOCALHOST, 1234);
+    setsockopt(sockfd, libc::SOL_SOCKET, libc::SO_REUSEADDR, 1 as libc::c_int).unwrap();
+    unsafe {
+        errno_check(libc::bind(
+            sockfd,
+            (&addr as *const libc::sockaddr_in).cast::<libc::sockaddr>(),
+            size_of::<libc::sockaddr_in>() as libc::socklen_t,
+        ));
+    }
+}
+
+/// Tests setting the `SO_REUSEADDR` socket option but with an invalid length.
+fn test_set_reuseaddr_invalid_len() {
+    let sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+    // Value should be of type `libc::c_int` which has size 4 bytes.
+    // By providing a u64 of size 8 bytes we trigger an invalid length error.
+    let err = setsockopt(sockfd, libc::SOL_SOCKET, libc::SO_REUSEADDR, 1u64).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::InvalidInput);
+    // check that it is the right kind of `InvalidInput`
+    assert_eq!(err.raw_os_error(), Some(libc::EINVAL));
+}
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+))]
+/// Tests binding after the `SO_NOSIGPIPE` socket option has been set on the newly created socket.
+/// That flag only exists on BSD-like OSes.
+fn test_bind_ipv4_nosigpipe() {
+    let sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+    let addr = net::ipv4_sock_addr(net::IPV4_LOCALHOST, 1234);
+    setsockopt(sockfd, libc::SOL_SOCKET, libc::SO_NOSIGPIPE, 1 as libc::c_int).unwrap();
+    unsafe {
+        errno_check(libc::bind(
+            sockfd,
+            (&addr as *const libc::sockaddr_in).cast::<libc::sockaddr>(),
+            size_of::<libc::sockaddr_in>() as libc::socklen_t,
+        ));
+    }
+}
+
+#[cfg(any(
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+))]
+/// Tests setting the `SO_NOSIGPIPE` socket option but with an invalid length.
+fn test_set_nosigpipe_invalid_len() {
+    let sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+    // Value should be of type `libc::c_int` which has size 4 bytes.
+    // By providing a u64 of size 8 bytes we trigger an invalid length error.
+    let err = setsockopt(sockfd, libc::SOL_SOCKET, libc::SO_NOSIGPIPE, 1u64).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::InvalidInput);
+    // check that it is the right kind of `InvalidInput`
+    assert_eq!(err.raw_os_error(), Some(libc::EINVAL));
+}
+
+/// Tests binding an IPv4 socket with an IPv4 address but the addrlen argument
+/// has the wrong size.
+fn test_bind_ipv4_invalid_addr_len() {
+    let sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+    let addr = net::ipv4_sock_addr(net::IPV4_LOCALHOST, 1234);
+    let err = unsafe {
+        errno_result(libc::bind(
+            sockfd,
+            (&addr as *const libc::sockaddr_in).cast::<libc::sockaddr>(),
+            // Add 1 to the address to make the size invalid.
+            (size_of::<libc::sockaddr_in>() + 1) as libc::socklen_t,
+        ))
+        .unwrap_err()
+    };
+    assert_eq!(err.kind(), ErrorKind::InvalidInput);
+    // check that it is the right kind of `InvalidInput`
+    assert_eq!(err.raw_os_error(), Some(libc::EINVAL));
+}
+
+fn test_bind_ipv6() {
+    let sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET6, libc::SOCK_STREAM, 0)).unwrap() };
+    let addr = net::ipv6_sock_addr(net::IPV6_LOCALHOST, 1234);
+    unsafe {
+        errno_check(libc::bind(
+            sockfd,
+            (&addr as *const libc::sockaddr_in6).cast::<libc::sockaddr>(),
+            size_of::<libc::sockaddr_in6>() as libc::socklen_t,
+        ));
+    }
+}
+
+fn test_listen() {
+    let sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+    let addr = net::ipv4_sock_addr(net::IPV4_LOCALHOST, 1234);
+    unsafe {
+        errno_check(libc::bind(
+            sockfd,
+            (&addr as *const libc::sockaddr_in).cast::<libc::sockaddr>(),
+            size_of::<libc::sockaddr_in>() as libc::socklen_t,
+        ));
+    }
+
+    // Use the supported backlog value to avoid the warning.
+    let backlog = 128;
+
+    unsafe {
+        errno_check(libc::listen(sockfd, backlog));
+    }
+}
+
+/// Set a socket option. It's the caller's responsibility to ensure that `T` is
+/// associated with the given socket option.
+///
+/// This function is directly copied from the standard library implementation
+/// for sockets on UNIX targets.
+fn setsockopt<T>(
+    sockfd: i32,
+    level: libc::c_int,
+    option_name: libc::c_int,
+    option_value: T,
+) -> io::Result<()> {
+    let option_len = size_of::<T>() as libc::socklen_t;
+
+    errno_result(unsafe {
+        libc::setsockopt(
+            sockfd,
+            level,
+            option_name,
+            (&raw const option_value) as *const _,
+            option_len,
+        )
+    })?;
+    Ok(())
 }

--- a/tests/pass-dep/libc/socket-unsupported-listen-backlog.rs
+++ b/tests/pass-dep/libc/socket-unsupported-listen-backlog.rs
@@ -1,0 +1,27 @@
+//@ignore-target: windows # No libc socket on Windows
+//@compile-flags: -Zmiri-disable-isolation
+
+#[path = "../../utils/libc.rs"]
+mod libc_utils;
+use libc_utils::*;
+
+fn main() {
+    let sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+    let addr = net::ipv4_sock_addr(net::IPV4_LOCALHOST, 2345);
+    unsafe {
+        errno_check(libc::bind(
+            sockfd,
+            (&addr as *const libc::sockaddr_in).cast::<libc::sockaddr>(),
+            size_of::<libc::sockaddr_in>() as libc::socklen_t,
+        ));
+    }
+
+    // Only supported value is 128, thus we use 127 to trigger the warning.
+    let backlog = 127;
+
+    unsafe {
+        let errno = libc::listen(sockfd, backlog);
+        errno_check(errno);
+    }
+}

--- a/tests/pass-dep/libc/socket-unsupported-listen-backlog.stderr
+++ b/tests/pass-dep/libc/socket-unsupported-listen-backlog.stderr
@@ -1,0 +1,8 @@
+warning: called `listen` on socket with backlog value of 127 but only 128 is supported
+  --> tests/pass-dep/libc/socket-unsupported-listen-backlog.rs:LL:CC
+   |
+LL |         let errno = libc::listen(sockfd, backlog);
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ call to `listen` with unsupported backlog value
+   |
+   = note: the given value will be ignored and a backlog of 128 will be used instead
+

--- a/tests/pass-dep/shims/socket.rs
+++ b/tests/pass-dep/shims/socket.rs
@@ -1,0 +1,17 @@
+//@ignore-target: windows # No libc socket on Windows
+//@compile-flags: -Zmiri-disable-isolation
+
+use std::net::TcpListener;
+
+fn main() {
+    create_ipv4_listener();
+    create_ipv6_listener();
+}
+
+fn create_ipv4_listener() {
+    let _listener_ipv4 = TcpListener::bind("127.0.0.1:3456").unwrap();
+}
+
+fn create_ipv6_listener() {
+    let _listener_ipv6 = TcpListener::bind("[::1]:2345").unwrap();
+}

--- a/tests/utils/libc.rs
+++ b/tests/utils/libc.rs
@@ -157,3 +157,51 @@ pub mod epoll {
         check_epoll_wait::<N>(epfd, expected, 0);
     }
 }
+
+pub mod net {
+    /// IPv4 localhost address bytes
+    pub const IPV4_LOCALHOST: [u8; 4] = [127, 0, 0, 1];
+    /// IPv6 localhost address bytes
+    pub const IPV6_LOCALHOST: [u8; 16] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
+
+    /// Create a libc representation of an IPv4 address given the address bytes and a port.
+    pub fn ipv4_sock_addr(addr_bytes: [u8; 4], port: u16) -> libc::sockaddr_in {
+        libc::sockaddr_in {
+            sin_family: libc::AF_INET as libc::sa_family_t,
+            sin_port: port.to_be(),
+            // `addr_bytes` is already in big-endian and that's the format `sin_addr` expects.
+            #[expect(unnecessary_transmutes)]
+            sin_addr: libc::in_addr {
+                s_addr: unsafe { std::mem::transmute::<[u8; 4], u32>(addr_bytes) },
+            },
+            ..unsafe { core::mem::zeroed() }
+        }
+    }
+
+    /// Create a libc representation of an IPv6 address given the address bytes and a port.
+    ///
+    /// This method sets `flowinfo` and `scope_id` to 0.
+    pub fn ipv6_sock_addr(addr_bytes: [u8; 16], port: u16) -> libc::sockaddr_in6 {
+        ipv6_sock_addr_full(addr_bytes, port, 0, 0)
+    }
+
+    /// Create a libc representation of a full IPv6 address given the address bytes, a port
+    /// as well as a flowinfo and scope id.
+    pub fn ipv6_sock_addr_full(
+        addr_bytes: [u8; 16],
+        port: u16,
+        flowinfo: u32,
+        scope_id: u32,
+    ) -> libc::sockaddr_in6 {
+        #[allow(clippy::needless_update)]
+        libc::sockaddr_in6 {
+            sin6_family: libc::AF_INET6 as libc::sa_family_t,
+            sin6_port: port.to_be(),
+            sin6_addr: libc::in6_addr { s6_addr: addr_bytes },
+            sin6_flowinfo: flowinfo,
+            sin6_scope_id: scope_id,
+            // This is only needed on some targets where an additional `sin6_len` field exists.
+            ..unsafe { core::mem::zeroed() }
+        }
+    }
+}


### PR DESCRIPTION
Hi,

This pull request adds shims for the `bind` and `listen` syscalls. To support the implementation of `TcpListener::bind` from the standard library, a small set of options for the `setsockopt` syscall are added as well.

For the `bind` shim I'm a bit uncertain about the validation we should perform there. Since we effectively only execute this syscall when seeing a `listen` later on, the current implementation tries to validate the things it can easily do with the data available (e.g. whether socket and address family match or whether address length is valid). 
Things like `EADDRINUSE` for example wouldn't be caught with the current implementation as it would require looking up the address manually and I don't know whether that would be worth it. 

I can see that it might be confusing for users when we only throw a subset of errors after the `bind` syscall and also when we then afterwards throw errors for the `bind` syscall once they call `listen` but I think this problem is unavoidable.