### PR TITLE
Clarify `-Zmiri-disable-validation` in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,10 +421,11 @@ to Miri failing to detect cases of undefined behavior in a program.
   are experimental). Later flags take precedence: borrow tracking can be reactivated
   by `-Zmiri-tree-borrows`.
 * `-Zmiri-disable-validation` disables enforcing validity invariants, which are
-  enforced by default.  This is mostly useful to focus on other failures (such
-  as out-of-bounds accesses) first.  Setting this flag means Miri can miss bugs
-  in your program.  However, this can also help to make Miri run faster.  Using
-  this flag is **unsound**.
+  enforced by default. This only disables these checks for typed copies; using
+  invalid values in any other operation will still cause an error. This is mostly useful 
+  to focus on other failures (such as out-of-bounds accesses) first. Setting this 
+  flag means Miri can miss bugs in your program. However, this can also help to 
+  make Miri run faster. Using this flag is **unsound**.
 * `-Zmiri-disable-weak-memory-emulation` disables the emulation of some C++11 weak
   memory effects.
 * `-Zmiri-fixed-schedule` disables preemption (like `-Zmiri-preemption-rate=0.0`) and furthermore


### PR DESCRIPTION
After [a short discussion](https://rust-lang.zulipchat.com/#narrow/channel/269128-miri/topic/Stricter.20validity.20checks.20.3F/with/577019502) to clarify this flag on Zulip, I lightly edited the documentation for `-Zmiri-disable-validation`.

In particular, validity checks are only disabled for typed copies; uses of invalid values still trigger validity checks, e.g. [in this example](https://github.com/rust-lang/miri/blob/2cab98f640cf916892286079ba58949d71fc639b/tests/fail/validity/invalid_bool_op.rs#L8), which might not be clear from the previous doc.
```rust
let b = unsafe { std::mem::transmute::<u8, bool>(2) };
let _x = b == std::hint::black_box(true); //~ ERROR: interpreting an invalid 8-bit value as a bool
```