### PR TITLE
  shims: improve Linux statx

### DIFF
--- a/src/shims/unix/fs.rs
+++ b/src/shims/unix/fs.rs
@@ -243,12 +243,12 @@ trait EvalContextExtPrivate<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
         this.write_int_fields_named(
             &[
-                ("st_dev", metadata.dev.into()),
+                ("st_dev", metadata.dev.unwrap_or(0).into()),
                 ("st_mode", mode.into()),
-                ("st_nlink", 0),
-                ("st_ino", 0),
-                ("st_uid", metadata.uid.into()),
-                ("st_gid", metadata.gid.into()),
+                ("st_nlink", metadata.nlink.unwrap_or(0).into()),
+                ("st_ino", metadata.ino.unwrap_or(0).into()),
+                ("st_uid", metadata.uid.unwrap_or(0).into()),
+                ("st_gid", metadata.gid.unwrap_or(0).into()),
                 ("st_rdev", 0),
                 ("st_atime", access_sec.into()),
                 ("st_atime_nsec", access_nsec.into()),
@@ -257,8 +257,8 @@ trait EvalContextExtPrivate<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 ("st_ctime", 0),
                 ("st_ctime_nsec", 0),
                 ("st_size", metadata.size.into()),
-                ("st_blocks", 0),
-                ("st_blksize", 0),
+                ("st_blocks", metadata.blocks.unwrap_or(0).into()),
+                ("st_blksize", metadata.blksize.unwrap_or(0).into()),
             ],
             &buf,
         )?;
@@ -730,12 +730,6 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return this.set_last_error_and_return_i32(ecode);
         }
 
-        // the `_mask_op` parameter specifies the file information that the caller requested.
-        // However `statx` is allowed to return information that was not requested or to not
-        // return information that was requested. This `mask` represents the information we can
-        // actually provide for any target.
-        let mut mask = this.eval_libc_u32("STATX_TYPE") | this.eval_libc_u32("STATX_SIZE");
-
         // If the `AT_SYMLINK_NOFOLLOW` flag is set, we query the file's metadata without following
         // symbolic links.
         let follow_symlink = flags & this.eval_libc_i32("AT_SYMLINK_NOFOLLOW") == 0;
@@ -751,6 +745,29 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             Ok(metadata) => metadata,
             Err(err) => return this.set_last_error_and_return_i32(err),
         };
+
+        // The `_mask_op` parameter specifies the file information that the caller requested.
+        // However, `statx` is allowed to return information that was not requested or to not
+        // return information that was requested. This `mask` represents the information we can
+        // actually provide for any target.
+        let mut mask = this.eval_libc_u32("STATX_TYPE") | this.eval_libc_u32("STATX_SIZE");
+
+        // Check which pieces of metadata we acquired, and set the appropriate flags in the mask.
+        if metadata.ino.is_some() {
+            mask |= this.eval_libc_u32("STATX_INO");
+        }
+        if metadata.nlink.is_some() {
+            mask |= this.eval_libc_u32("STATX_NLINK");
+        }
+        if metadata.uid.is_some() {
+            mask |= this.eval_libc_u32("STATX_UID");
+        }
+        if metadata.gid.is_some() {
+            mask |= this.eval_libc_u32("STATX_GID");
+        }
+        if metadata.blocks.is_some() {
+            mask |= this.eval_libc_u32("STATX_BLOCKS");
+        }
 
         // `statx.stx_mode` is `__u16`. `libc::S_IF*` are of type `mode_t`, which varies in
         // width across targets (`u16` on macOS, `u32` on Linux). Read using `mode_t`'s size.
@@ -791,15 +808,15 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         this.write_int_fields_named(
             &[
                 ("stx_mask", mask.into()),
-                ("stx_blksize", 0),
+                ("stx_blksize", metadata.blksize.unwrap_or(0).into()),
                 ("stx_attributes", 0),
-                ("stx_nlink", 0),
-                ("stx_uid", 0),
-                ("stx_gid", 0),
+                ("stx_nlink", metadata.nlink.unwrap_or(0).into()),
+                ("stx_uid", metadata.uid.unwrap_or(0).into()),
+                ("stx_gid", metadata.gid.unwrap_or(0).into()),
                 ("stx_mode", mode.into()),
-                ("stx_ino", 0),
+                ("stx_ino", metadata.ino.unwrap_or(0).into()),
                 ("stx_size", metadata.size.into()),
-                ("stx_blocks", 0),
+                ("stx_blocks", metadata.blocks.unwrap_or(0).into()),
                 ("stx_attributes_mask", 0),
                 ("stx_rdev_major", 0),
                 ("stx_rdev_minor", 0),
@@ -1664,15 +1681,24 @@ fn file_type_to_mode_name(file_type: std::fs::FileType) -> &'static str {
 
 /// Stores a file's metadata in order to avoid code duplication in the different metadata related
 /// shims.
+///
+/// Some fields are host/platform-specific. `None` means that Miri does not have a real value for
+/// this field, for example because the metadata is synthetic or because the host platform does not
+/// expose it. `statx` must only advertise the corresponding `STATX_*` bit when the field is `Some`;
+/// legacy `stat` writes zero for `None` to preserve the old fallback behavior.
 struct FileMetadata {
     mode: Scalar,
     size: u64,
     created: Option<(u64, u32)>,
     accessed: Option<(u64, u32)>,
     modified: Option<(u64, u32)>,
-    dev: u64,
-    uid: u32,
-    gid: u32,
+    dev: Option<u64>,
+    ino: Option<u64>,
+    nlink: Option<u64>,
+    uid: Option<u32>,
+    gid: Option<u32>,
+    blksize: Option<u64>,
+    blocks: Option<u64>,
 }
 
 impl FileMetadata {
@@ -1711,9 +1737,13 @@ impl FileMetadata {
             created: None,
             accessed: None,
             modified: None,
-            dev: 0,
-            uid: 0,
-            gid: 0,
+            dev: None,
+            uid: None,
+            gid: None,
+            blksize: None,
+            blocks: None,
+            ino: None,
+            nlink: None,
         }))
     }
 
@@ -1743,16 +1773,42 @@ impl FileMetadata {
             unix => {
                 use std::os::unix::fs::MetadataExt;
                 let dev = metadata.dev();
+                let ino = metadata.ino();
+                let nlink = metadata.nlink();
                 let uid = metadata.uid();
                 let gid = metadata.gid();
-            }
-            _ => {
-                let dev = 0;
-                let uid = 0;
-                let gid = 0;
-            }
-        }
+                let blksize = metadata.blksize();
+                let blocks = metadata.blocks();
 
-        interp_ok(Ok(FileMetadata { mode, size, created, accessed, modified, dev, uid, gid }))
+                interp_ok(Ok(FileMetadata {
+                    mode,
+                    size,
+                    created,
+                    accessed,
+                    modified,
+                    dev: Some(dev),
+                    ino: Some(ino),
+                    nlink: Some(nlink),
+                    uid: Some(uid),
+                    gid: Some(gid),
+                    blksize: Some(blksize),
+                    blocks: Some(blocks),
+                }))
+            }
+            _ => interp_ok(Ok(FileMetadata {
+                mode,
+                size,
+                created,
+                accessed,
+                modified,
+                dev: None,
+                ino: None,
+                nlink: None,
+                uid: None,
+                gid: None,
+                blksize: None,
+                blocks: None,
+            })),
+        }
     }
 }

--- a/src/shims/unix/linux/foreign_items.rs
+++ b/src/shims/unix/linux/foreign_items.rs
@@ -124,7 +124,6 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 this.write_scalar(result, dest)?;
             }
             "statx" => {
-                // FIXME: This does not have a direct test (#3179).
                 let [dirfd, pathname, flags, mask, statxbuf] =
                     this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
                 let result = this.linux_statx(dirfd, pathname, flags, mask, statxbuf)?;

--- a/tests/pass-dep/libc/libc-fs.rs
+++ b/tests/pass-dep/libc/libc-fs.rs
@@ -50,6 +50,147 @@ fn main() {
     test_ioctl();
     test_opendir_closedir();
     test_readdir();
+    #[cfg(target_os = "linux")]
+    test_statx_on_file_path();
+    #[cfg(target_os = "linux")]
+    test_statx_on_file_descriptor();
+    #[cfg(target_os = "linux")]
+    test_statx_empty_path_on_pipe();
+}
+
+#[cfg(target_os = "linux")]
+#[track_caller]
+fn assert_statx_matches_metadata(stx: &libc::statx, meta: &std::fs::Metadata, expected_size: u64) {
+    use std::os::unix::fs::MetadataExt;
+    let mask = stx.stx_mask;
+
+    // Guaranteed by the shim on any Linux target.
+    assert!(mask & libc::STATX_TYPE != 0);
+    assert!(mask & libc::STATX_SIZE != 0);
+    assert_eq!(stx.stx_size, expected_size);
+    assert_eq!((stx.stx_mode as u32) & libc::S_IFMT, libc::S_IFREG);
+
+    // Host-dependent enrichment: only assert when the mask says the field is real.
+    if mask & libc::STATX_INO != 0 {
+        assert_eq!(stx.stx_ino, meta.ino());
+    }
+    if mask & libc::STATX_NLINK != 0 {
+        assert_eq!(stx.stx_nlink as u64, meta.nlink());
+    }
+    if mask & libc::STATX_UID != 0 {
+        assert_eq!(stx.stx_uid, meta.uid());
+    }
+    if mask & libc::STATX_GID != 0 {
+        assert_eq!(stx.stx_gid, meta.gid());
+    }
+    if mask & libc::STATX_BLOCKS != 0 {
+        assert_eq!(stx.stx_blocks, meta.blocks());
+    }
+
+    // We don't support non-S_IFMT bits in stx_mode.
+    assert_eq!(mask & libc::STATX_MODE, 0);
+
+    // Do not assert stx_blksize and stx_dev_* : there are no mask bits for them.
+}
+
+#[cfg(target_os = "linux")]
+fn test_statx_on_file_descriptor() {
+    use std::mem::MaybeUninit;
+
+    let bytes = b"hello";
+    let path = utils::prepare_with_content("miri_test_libc_statx_fd.txt", bytes);
+    let file = File::open(&path).unwrap();
+
+    unsafe {
+        let mut stx = MaybeUninit::<libc::statx>::zeroed();
+        let ret = libc::statx(
+            file.as_raw_fd(),
+            c"".as_ptr(),
+            libc::AT_EMPTY_PATH,
+            libc::STATX_BASIC_STATS | libc::STATX_BTIME,
+            stx.as_mut_ptr(),
+        );
+        assert_eq!(ret, 0, "statx failed: {}", std::io::Error::last_os_error());
+
+        let stx = stx.assume_init();
+        let meta = file.metadata().unwrap();
+        assert_statx_matches_metadata(&stx, &meta, bytes.len() as u64);
+    }
+
+    drop(file);
+    remove_file(&path).unwrap();
+}
+
+#[cfg(target_os = "linux")]
+fn test_statx_on_file_path() {
+    use std::mem::MaybeUninit;
+
+    let bytes = b"hello";
+    let path = utils::prepare_with_content("miri_test_libc_statx.txt", bytes);
+    let c_path = CString::new(path.as_os_str().as_bytes()).expect("CString::new failed");
+
+    unsafe {
+        let mut stx = MaybeUninit::<libc::statx>::zeroed();
+        let ret = libc::statx(
+            libc::AT_FDCWD,
+            c_path.as_ptr(),
+            0,
+            libc::STATX_BASIC_STATS | libc::STATX_BTIME,
+            stx.as_mut_ptr(),
+        );
+        assert_eq!(ret, 0, "statx failed: {}", std::io::Error::last_os_error());
+
+        let stx = stx.assume_init();
+        let meta = std::fs::metadata(&path).unwrap();
+        assert_statx_matches_metadata(&stx, &meta, bytes.len() as u64);
+    }
+
+    remove_file(&path).unwrap();
+}
+
+#[cfg(target_os = "linux")]
+fn test_statx_empty_path_on_pipe() {
+    use libc_utils::errno_check;
+
+    unsafe {
+        let mut fds = [0; 2];
+        errno_check(libc::pipe(fds.as_mut_ptr()));
+
+        let mut statx_buf = std::mem::MaybeUninit::<libc::statx>::zeroed();
+
+        let ret = libc::statx(
+            fds[0],
+            c"".as_ptr(),
+            libc::AT_EMPTY_PATH,
+            libc::STATX_BASIC_STATS,
+            statx_buf.as_mut_ptr(),
+        );
+
+        assert_eq!(
+            ret,
+            0,
+            "statx on pipe with AT_EMPTY_PATH failed: {}",
+            std::io::Error::last_os_error()
+        );
+
+        let statx_buf = statx_buf.assume_init();
+
+        assert_ne!(statx_buf.stx_mask & libc::STATX_TYPE, 0);
+        assert_ne!(statx_buf.stx_mask & libc::STATX_SIZE, 0);
+        assert_eq!(statx_buf.stx_mask & libc::STATX_MODE, 0);
+        assert_eq!((statx_buf.stx_mode as libc::mode_t) & libc::S_IFMT, libc::S_IFIFO);
+        assert_eq!(statx_buf.stx_size, 0);
+
+        // Synthetic metadata must not advertise host-only fields.
+        assert_eq!(statx_buf.stx_mask & libc::STATX_INO, 0);
+        assert_eq!(statx_buf.stx_mask & libc::STATX_NLINK, 0);
+        assert_eq!(statx_buf.stx_mask & libc::STATX_UID, 0);
+        assert_eq!(statx_buf.stx_mask & libc::STATX_GID, 0);
+        assert_eq!(statx_buf.stx_mask & libc::STATX_BLOCKS, 0);
+
+        errno_check(libc::close(fds[0]));
+        errno_check(libc::close(fds[1]));
+    }
 }
 
 fn test_file_open_unix_allow_two_args() {


### PR DESCRIPTION
    shims/unix: improve Linux statx
    
    - Track more fields in `FileMetadata`.
    - Populate these new fields in the `statx` shim and update the returned mask.
    - Implement `linux_decode_dev` helper to split `dev_t` using glibc / musl layout (initially, now removed)
    - Add an integration test in `tests/pass-dep/libc/libc-fs.rs` and remove
      the FIXME in `foreign_items.rs`.
