### PR TITLE
Add `stat` and `lstat` shims for all Unixes

### DIFF
--- a/src/shims/unix/foreign_items.rs
+++ b/src/shims/unix/foreign_items.rs
@@ -350,6 +350,16 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let result = this.fstat(fd, buf)?;
                 this.write_scalar(result, dest)?;
             }
+            "lstat" => {
+                let [path, buf] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
+                let result = this.lstat(path, buf)?;
+                this.write_scalar(result, dest)?;
+            }
+            "stat" => {
+                let [path, buf] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
+                let result = this.stat(path, buf)?;
+                this.write_scalar(result, dest)?;
+            }
             "rename" => {
                 // FIXME: This does not have a direct test (#3179).
                 let [oldpath, newpath] = this.check_shim_sig(

--- a/src/shims/unix/freebsd/foreign_items.rs
+++ b/src/shims/unix/freebsd/foreign_items.rs
@@ -136,15 +136,13 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             }
 
             // File related shims
-            // For those, we both intercept `func` and `call@FBSD_1.0` symbols cases
-            // since freebsd 12 the former form can be expected.
-            "stat" | "stat@FBSD_1.0" => {
+            "stat@FBSD_1.0" => {
                 // FIXME: This does not have a direct test (#3179).
                 let [path, buf] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
                 let result = this.stat(path, buf)?;
                 this.write_scalar(result, dest)?;
             }
-            "lstat" | "lstat@FBSD_1.0" => {
+            "lstat@FBSD_1.0" => {
                 // FIXME: This does not have a direct test (#3179).
                 let [path, buf] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
                 let result = this.lstat(path, buf)?;

--- a/src/shims/unix/freebsd/foreign_items.rs
+++ b/src/shims/unix/freebsd/foreign_items.rs
@@ -137,13 +137,11 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
             // File related shims
             "stat@FBSD_1.0" => {
-                // FIXME: This does not have a direct test (#3179).
                 let [path, buf] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
                 let result = this.stat(path, buf)?;
                 this.write_scalar(result, dest)?;
             }
             "lstat@FBSD_1.0" => {
-                // FIXME: This does not have a direct test (#3179).
                 let [path, buf] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
                 let result = this.lstat(path, buf)?;
                 this.write_scalar(result, dest)?;

--- a/src/shims/unix/fs.rs
+++ b/src/shims/unix/fs.rs
@@ -586,9 +586,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
         if !matches!(
             &this.tcx.sess.target.os,
-            Os::MacOs | Os::FreeBsd | Os::Solaris | Os::Illumos | Os::Android
+            Os::MacOs | Os::FreeBsd | Os::Solaris | Os::Illumos | Os::Android | Os::Linux
         ) {
-            panic!("`macos_fbsd_solaris_stat` should not be called on {}", this.tcx.sess.target.os);
+            panic!("`stat` should not be called on {}", this.tcx.sess.target.os);
         }
 
         let path_scalar = this.read_pointer(path_op)?;
@@ -615,12 +615,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
         if !matches!(
             &this.tcx.sess.target.os,
-            Os::MacOs | Os::FreeBsd | Os::Solaris | Os::Illumos | Os::Android
+            Os::MacOs | Os::FreeBsd | Os::Solaris | Os::Illumos | Os::Android | Os::Linux
         ) {
-            panic!(
-                "`macos_fbsd_solaris_lstat` should not be called on {}",
-                this.tcx.sess.target.os
-            );
+            panic!("`lstat` should not be called on {}", this.tcx.sess.target.os);
         }
 
         let path_scalar = this.read_pointer(path_op)?;

--- a/src/shims/unix/macos/foreign_items.rs
+++ b/src/shims/unix/macos/foreign_items.rs
@@ -46,13 +46,13 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let result = this.close(result)?;
                 this.write_scalar(result, dest)?;
             }
-            "stat" | "stat$INODE64" => {
+            "stat$INODE64" => {
                 // FIXME: This does not have a direct test (#3179).
                 let [path, buf] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
                 let result = this.stat(path, buf)?;
                 this.write_scalar(result, dest)?;
             }
-            "lstat" | "lstat$INODE64" => {
+            "lstat$INODE64" => {
                 // FIXME: This does not have a direct test (#3179).
                 let [path, buf] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
                 let result = this.lstat(path, buf)?;

--- a/src/shims/unix/macos/foreign_items.rs
+++ b/src/shims/unix/macos/foreign_items.rs
@@ -47,13 +47,11 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 this.write_scalar(result, dest)?;
             }
             "stat$INODE64" => {
-                // FIXME: This does not have a direct test (#3179).
                 let [path, buf] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
                 let result = this.stat(path, buf)?;
                 this.write_scalar(result, dest)?;
             }
             "lstat$INODE64" => {
-                // FIXME: This does not have a direct test (#3179).
                 let [path, buf] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
                 let result = this.lstat(path, buf)?;
                 this.write_scalar(result, dest)?;

--- a/tests/pass-dep/libc/libc-fs.rs
+++ b/tests/pass-dep/libc/libc-fs.rs
@@ -43,6 +43,8 @@ fn main() {
     #[cfg(target_os = "linux")]
     test_sync_file_range();
     test_fstat();
+    test_stat();
+    test_lstat();
     test_isatty();
     test_read_and_uninit();
     test_nofollow_not_symlink();
@@ -464,21 +466,52 @@ fn test_fstat() {
     assert_eq!(stat.st_mode & libc::S_IFMT, libc::S_IFREG);
 
     // Check that all fields are initialized.
-    let _st_nlink = stat.st_nlink;
-    let _st_blksize = stat.st_blksize;
-    let _st_blocks = stat.st_blocks;
-    let _st_ino = stat.st_ino;
-    let _st_dev = stat.st_dev;
-    let _st_uid = stat.st_uid;
-    let _st_gid = stat.st_gid;
-    let _st_rdev = stat.st_rdev;
-    let _st_atime = stat.st_atime;
-    let _st_mtime = stat.st_mtime;
-    let _st_ctime = stat.st_ctime;
-    let _st_atime_nsec = stat.st_atime_nsec;
-    let _st_mtime_nsec = stat.st_mtime_nsec;
-    let _st_ctime_nsec = stat.st_ctime_nsec;
+    libc_utils::check_stat_fields(stat);
 
+    remove_file(&path).unwrap();
+}
+
+fn test_stat() {
+    use std::mem::MaybeUninit;
+
+    let path = utils::prepare_with_content("miri_test_libc_stat.txt", b"hello");
+    let cpath = CString::new(path.as_os_str().as_bytes()).unwrap();
+
+    let mut stat = MaybeUninit::<libc::stat>::uninit();
+    let res = unsafe { libc::stat(cpath.as_ptr(), stat.as_mut_ptr()) };
+    assert_eq!(res, 0);
+    let stat = unsafe { stat.assume_init_ref() };
+
+    assert_eq!(stat.st_size, 5);
+    assert_eq!(stat.st_mode & libc::S_IFMT, libc::S_IFREG);
+
+    // Check that all fields are initialized.
+    libc_utils::check_stat_fields(stat);
+
+    remove_file(&path).unwrap();
+}
+
+fn test_lstat() {
+    use std::mem::MaybeUninit;
+
+    let path = utils::prepare_with_content("miri_test_libc_lstat.txt", b"hello");
+    let symlink_path = utils::prepare("miri_test_libc_lstat_symlink.txt");
+
+    std::os::unix::fs::symlink(&path, &symlink_path).unwrap();
+
+    let cpath = CString::new(symlink_path.as_os_str().as_bytes()).unwrap();
+
+    let mut stat = MaybeUninit::<libc::stat>::uninit();
+    let res = unsafe { libc::lstat(cpath.as_ptr(), stat.as_mut_ptr()) };
+    assert_eq!(res, 0);
+    let stat = unsafe { stat.assume_init_ref() };
+
+    assert_eq!(stat.st_mode & libc::S_IFMT, libc::S_IFLNK);
+
+    // Check that all fields are initialized.
+    libc_utils::check_stat_fields(stat);
+
+    remove_file(&symlink_path).unwrap();
     remove_file(&path).unwrap();
 }
 

--- a/tests/pass-dep/libc/libc-fs.rs
+++ b/tests/pass-dep/libc/libc-fs.rs
@@ -466,7 +466,7 @@ fn test_fstat() {
     assert_eq!(stat.st_mode & libc::S_IFMT, libc::S_IFREG);
 
     // Check that all fields are initialized.
-    libc_utils::check_stat_fields(stat);
+    check_stat_fields(stat);
 
     remove_file(&path).unwrap();
 }
@@ -486,7 +486,7 @@ fn test_stat() {
     assert_eq!(stat.st_mode & libc::S_IFMT, libc::S_IFREG);
 
     // Check that all fields are initialized.
-    libc_utils::check_stat_fields(stat);
+    check_stat_fields(stat);
 
     remove_file(&path).unwrap();
 }
@@ -509,7 +509,7 @@ fn test_lstat() {
     assert_eq!(stat.st_mode & libc::S_IFMT, libc::S_IFLNK);
 
     // Check that all fields are initialized.
-    libc_utils::check_stat_fields(stat);
+    check_stat_fields(stat);
 
     remove_file(&symlink_path).unwrap();
     remove_file(&path).unwrap();
@@ -683,4 +683,22 @@ fn test_readdir() {
     remove_file(&file1).unwrap();
     remove_file(&file2).unwrap();
     remove_dir(&dir_path).unwrap();
+}
+
+/// Check that all common fields of a `stat` struct are initialized.
+pub fn check_stat_fields(stat: &libc::stat) {
+    let _st_nlink = stat.st_nlink;
+    let _st_blksize = stat.st_blksize;
+    let _st_blocks = stat.st_blocks;
+    let _st_ino = stat.st_ino;
+    let _st_dev = stat.st_dev;
+    let _st_uid = stat.st_uid;
+    let _st_gid = stat.st_gid;
+    let _st_rdev = stat.st_rdev;
+    let _st_atime = stat.st_atime;
+    let _st_mtime = stat.st_mtime;
+    let _st_ctime = stat.st_ctime;
+    let _st_atime_nsec = stat.st_atime_nsec;
+    let _st_mtime_nsec = stat.st_mtime_nsec;
+    let _st_ctime_nsec = stat.st_ctime_nsec;
 }

--- a/tests/utils/libc.rs
+++ b/tests/utils/libc.rs
@@ -141,24 +141,6 @@ pub unsafe fn write_all(
     write_all_generic(buf, count, NoRetry, |buf, count| libc::write(fd, buf, count))
 }
 
-/// Check that all common fields of a `stat` struct are initialized.
-pub fn check_stat_fields(stat: &libc::stat) {
-    let _st_nlink = stat.st_nlink;
-    let _st_blksize = stat.st_blksize;
-    let _st_blocks = stat.st_blocks;
-    let _st_ino = stat.st_ino;
-    let _st_dev = stat.st_dev;
-    let _st_uid = stat.st_uid;
-    let _st_gid = stat.st_gid;
-    let _st_rdev = stat.st_rdev;
-    let _st_atime = stat.st_atime;
-    let _st_mtime = stat.st_mtime;
-    let _st_ctime = stat.st_ctime;
-    let _st_atime_nsec = stat.st_atime_nsec;
-    let _st_mtime_nsec = stat.st_mtime_nsec;
-    let _st_ctime_nsec = stat.st_ctime_nsec;
-}
-
 /// Write the entire `buf` to `fd`. Panic if not all bytes could be written.
 #[track_caller]
 pub fn write_all_from_slice(fd: libc::c_int, buf: &[u8]) -> io::Result<()> {

--- a/tests/utils/libc.rs
+++ b/tests/utils/libc.rs
@@ -141,6 +141,24 @@ pub unsafe fn write_all(
     write_all_generic(buf, count, NoRetry, |buf, count| libc::write(fd, buf, count))
 }
 
+/// Check that all common fields of a `stat` struct are initialized.
+pub fn check_stat_fields(stat: &libc::stat) {
+    let _st_nlink = stat.st_nlink;
+    let _st_blksize = stat.st_blksize;
+    let _st_blocks = stat.st_blocks;
+    let _st_ino = stat.st_ino;
+    let _st_dev = stat.st_dev;
+    let _st_uid = stat.st_uid;
+    let _st_gid = stat.st_gid;
+    let _st_rdev = stat.st_rdev;
+    let _st_atime = stat.st_atime;
+    let _st_mtime = stat.st_mtime;
+    let _st_ctime = stat.st_ctime;
+    let _st_atime_nsec = stat.st_atime_nsec;
+    let _st_mtime_nsec = stat.st_mtime_nsec;
+    let _st_ctime_nsec = stat.st_ctime_nsec;
+}
+
 /// Write the entire `buf` to `fd`. Panic if not all bytes could be written.
 #[track_caller]
 pub fn write_all_from_slice(fd: libc::c_int, buf: &[u8]) -> io::Result<()> {


### PR DESCRIPTION
Closes rust-lang/miri#4744

Adds `stat` and `lstat` shims for Linux, following the same approach as rust-lang/miri#4714 did for `fstat`.

- Add `"stat"` and `"lstat"` arms to the generic Unix foreign items handler
- Add `Os::Linux` to the supported targets in `fs.rs` for both functions
- Add tests for `stat` and `lstat`. The test for `lstat` verifies it does not follow symlinks
