### PR TITLE
Allow changing socket blocking state

### DIFF
--- a/src/shims/unix/fd.rs
+++ b/src/shims/unix/fd.rs
@@ -62,6 +62,20 @@ pub trait UnixFileDescription: FileDescription {
         throw_unsup_format!("cannot flock {}", self.name());
     }
 
+    /// Modifies device parameters.
+    /// `op` is the device-dependent operation code. It's either a `c_long` or `c_int`, depending on
+    /// the target and whether it uses glibc or musl.
+    /// `arg` is the optional third argument which exists depending on the operation code. It's either
+    /// an integer or a pointer.
+    fn ioctl<'tcx>(
+        &self,
+        _op: Scalar,
+        _arg: Option<&OpTy<'tcx>>,
+        _ecx: &mut MiriInterpCx<'tcx>,
+    ) -> InterpResult<'tcx, i32> {
+        throw_unsup_format!("cannot use ioctl on {}", self.name());
+    }
+
     /// Return which epoll events are currently active.
     fn epoll_active_events<'tcx>(&self) -> InterpResult<'tcx, EpollEvents> {
         throw_unsup_format!("{}: epoll does not support this file description", self.name());
@@ -127,6 +141,39 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // return `0` if flock is successful
         let result = result.map(|()| 0i32);
         interp_ok(Scalar::from_i32(this.try_unwrap_io_result(result)?))
+    }
+
+    fn ioctl(
+        &mut self,
+        fd: &OpTy<'tcx>,
+        op: &OpTy<'tcx>,
+        varargs: &[OpTy<'tcx>],
+    ) -> InterpResult<'tcx, Scalar> {
+        let this = self.eval_context_mut();
+
+        let fd = this.read_scalar(fd)?.to_i32()?;
+        let op = this.read_scalar(op)?;
+        // There is at most one relevant variadic argument.
+        // It exists depending on the device and the opcode and thus we can't
+        // use `check_min_vararg_count` here.
+        let arg = varargs.first();
+
+        let Some(fd) = this.machine.fds.get(fd) else {
+            return this.set_last_error_and_return_i32(LibcError("EBADF"));
+        };
+
+        // Handle common opcodes.
+        let fioclex = this.eval_libc("FIOCLEX");
+        let fionclex = this.eval_libc("FIONCLEX");
+        if op == fioclex || op == fionclex {
+            // Since we don't support `exec`, those are NOPs.
+            return interp_ok(Scalar::from_i32(0));
+        }
+
+        // Since some ioctl operations use the return value as an output parameter, we cannot strictly use the convention of
+        // zero indicating success and -1 indicating an error.
+        let return_value = fd.as_unix(this).ioctl(op, arg, this)?;
+        interp_ok(Scalar::from_i32(return_value))
     }
 
     fn fcntl(

--- a/src/shims/unix/foreign_items.rs
+++ b/src/shims/unix/foreign_items.rs
@@ -307,6 +307,12 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let result = this.flock(fd, op)?;
                 this.write_scalar(result, dest)?;
             }
+            "ioctl" => {
+                let ([fd, op], varargs) =
+                    this.check_shim_sig_variadic_lenient(abi, CanonAbi::C, link_name, args)?;
+                let result = this.ioctl(fd, op, varargs)?;
+                this.write_scalar(result, dest)?;
+            }
 
             // File and file system access
             "open" => {

--- a/src/shims/unix/macos/foreign_items.rs
+++ b/src/shims/unix/macos/foreign_items.rs
@@ -80,12 +80,6 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let result = this.realpath(path, resolved_path)?;
                 this.write_scalar(result, dest)?;
             }
-            "ioctl" => {
-                let ([fd_num, cmd], varargs) =
-                    this.check_shim_sig_variadic_lenient(abi, CanonAbi::C, link_name, args)?;
-                let result = this.ioctl(fd_num, cmd, varargs)?;
-                this.write_scalar(result, dest)?;
-            }
 
             // Environment related shims
             "_NSGetEnviron" => {
@@ -340,31 +334,5 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         };
 
         interp_ok(EmulateItemResult::NeedsReturn)
-    }
-
-    fn ioctl(
-        &mut self,
-        fd_num: &OpTy<'tcx>,
-        cmd: &OpTy<'tcx>,
-        _varargs: &[OpTy<'tcx>],
-    ) -> InterpResult<'tcx, Scalar> {
-        let this = self.eval_context_mut();
-
-        let fioclex = this.eval_libc_u64("FIOCLEX");
-
-        let fd_num = this.read_scalar(fd_num)?.to_i32()?;
-        let cmd = this.read_scalar(cmd)?.to_u64()?;
-
-        if cmd == fioclex {
-            // Since we don't support `exec`, this is a NOP. However, we want to
-            // return EBADF if the FD is invalid.
-            if this.machine.fds.is_fd_num(fd_num) {
-                interp_ok(Scalar::from_i32(0))
-            } else {
-                this.set_last_error_and_return_i32(LibcError("EBADF"))
-            }
-        } else {
-            throw_unsup_format!("ioctl: unsupported command {cmd:#x}");
-        }
     }
 }

--- a/src/shims/unix/socket.rs
+++ b/src/shims/unix/socket.rs
@@ -15,7 +15,8 @@ use rustc_target::spec::Os;
 
 use crate::concurrency::blocking_io::InterestReceiver;
 use crate::shims::files::{EvalContextExt as _, FdId, FileDescription, FileDescriptionRef};
-use crate::{OpTy, Scalar, *};
+use crate::shims::unix::UnixFileDescription;
+use crate::*;
 
 #[derive(Debug, PartialEq)]
 enum SocketFamily {
@@ -171,6 +172,10 @@ impl FileDescription for Socket {
         true
     }
 
+    fn as_unix<'tcx>(&self, _ecx: &MiriInterpCx<'tcx>) -> &dyn UnixFileDescription {
+        self
+    }
+
     fn get_flags<'tcx>(&self, ecx: &mut MiriInterpCx<'tcx>) -> InterpResult<'tcx, Scalar> {
         let mut flags = ecx.eval_libc_i32("O_RDWR");
 
@@ -183,10 +188,64 @@ impl FileDescription for Socket {
 
     fn set_flags<'tcx>(
         &self,
-        mut _flag: i32,
-        _ecx: &mut MiriInterpCx<'tcx>,
+        mut flag: i32,
+        ecx: &mut MiriInterpCx<'tcx>,
     ) -> InterpResult<'tcx, Scalar> {
-        throw_unsup_format!("fcntl: socket flags aren't supported")
+        let o_nonblock = ecx.eval_libc_i32("O_NONBLOCK");
+
+        // O_NONBLOCK flag can be set / unset by user.
+        if flag & o_nonblock == o_nonblock {
+            self.is_non_block.set(true);
+            flag &= !o_nonblock;
+        } else {
+            self.is_non_block.set(false);
+        }
+
+        // Throw error if there is any unsupported flag.
+        if flag != 0 {
+            throw_unsup_format!("fcntl: only O_NONBLOCK is supported for sockets")
+        }
+
+        interp_ok(Scalar::from_i32(0))
+    }
+}
+
+impl UnixFileDescription for Socket {
+    fn ioctl<'tcx>(
+        &self,
+        op: Scalar,
+        arg: Option<&OpTy<'tcx>>,
+        ecx: &mut MiriInterpCx<'tcx>,
+    ) -> InterpResult<'tcx, i32> {
+        assert!(ecx.machine.communicate(), "cannot have `Socket` with isolation enabled!");
+
+        let fionbio = ecx.eval_libc("FIONBIO");
+
+        if op == fionbio {
+            // On these OSes, Rust uses the ioctl, so we trust that it is reasonable and controls
+            // the same internal flag as fcntl.
+            if !matches!(ecx.tcx.sess.target.os, Os::Linux | Os::Android | Os::MacOs | Os::FreeBsd)
+            {
+                // FIONBIO cannot be used to change the blocking mode of a socket on solarish targets:
+                // <https://github.com/rust-lang/rust/commit/dda5c97675b4f5b1f6fdab64606c8a1f21021b0a>
+                // Since there might be more targets which do weird things with this option, we use
+                // an allowlist instead of just denying solarish targets.
+                throw_unsup_format!(
+                    "ioctl: setting FIONBIO on sockets is unsupported on target {}",
+                    ecx.tcx.sess.target.os
+                );
+            }
+
+            let Some(value_ptr) = arg else {
+                throw_ub_format!("ioctl: setting FIONBIO on sockets requires a third argument");
+            };
+            let value = ecx.deref_pointer_as(value_ptr, ecx.machine.layouts.i32)?;
+            let non_block = ecx.read_scalar(&value)?.to_i32()? != 0;
+            self.is_non_block.set(non_block);
+            return interp_ok(0);
+        }
+
+        throw_unsup_format!("ioctl: unsupported operation {op:#x} on socket");
     }
 }
 

--- a/tests/pass-dep/libc/libc-blocking-io-same-fd.rs
+++ b/tests/pass-dep/libc/libc-blocking-io-same-fd.rs
@@ -11,7 +11,7 @@ use libc_utils::*;
 // same fd at the same time.
 
 fn main() {
-    let (server_sockfd, addr) = net::make_listener_ipv4(0).unwrap();
+    let (server_sockfd, addr) = net::make_listener_ipv4().unwrap();
     let client_sockfd =
         unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
 

--- a/tests/pass-dep/libc/libc-socket-no-blocking.rs
+++ b/tests/pass-dep/libc/libc-socket-no-blocking.rs
@@ -1,4 +1,4 @@
-//@only-target: linux android freebsd solaris illumos # Currently we only support targets which can create non-blocking sockets using the `socket` syscall.
+//@ignore-target: windows
 //@compile-flags: -Zmiri-disable-isolation
 //@revisions: windows_host unix_host
 //@[unix_host] ignore-host: windows
@@ -18,9 +18,36 @@ use libc_utils::*;
 const TEST_BYTES: &[u8] = b"these are some test bytes!";
 
 fn main() {
+    test_fcntl_nonblock_opt();
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "solaris",
+        target_os = "illumos"
+    ))]
+    test_sock_nonblock_opt();
+    #[cfg(not(any(target_os = "solaris", target_os = "illumos")))]
+    test_ioctl_fionbio_op();
+
     test_accept_nonblock();
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "solaris",
+        target_os = "illumos"
+    ))]
     test_accept4_sock_nonblock_opt();
+    test_connect_nonblock();
     test_send_recv_nonblock();
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "solaris",
+        target_os = "illumos"
+    ))]
     test_send_recv_dontwait();
     test_write_read_nonblock();
 
@@ -28,15 +55,91 @@ fn main() {
     test_getpeername_ipv4_nonblock_no_peer();
 }
 
-/// Test that nonblocking TCP server sockets return [`io::ErrorKind::WouldBlock`] when trying
+/// Test that setting the O_NONBLOCK flag changes the blocking state of a socket.
+fn test_fcntl_nonblock_opt() {
+    let sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+
+    unsafe {
+        // Change socket to be non-blocking.
+        errno_check(libc::fcntl(sockfd, libc::F_SETFL, libc::O_NONBLOCK));
+    }
+
+    let flags = unsafe { errno_result(libc::fcntl(sockfd, libc::F_GETFL, 0)).unwrap() };
+    // Ensure that socket is really non-blocking.
+    assert_eq!(flags & libc::O_NONBLOCK, libc::O_NONBLOCK);
+
+    unsafe {
+        // Change socket back to be blocking.
+        errno_check(libc::fcntl(sockfd, libc::F_SETFL, 0));
+    }
+
+    let flags = unsafe { errno_result(libc::fcntl(sockfd, libc::F_GETFL, 0)).unwrap() };
+    // Ensure that socket is really blocking.
+    assert_eq!(flags & libc::O_NONBLOCK, 0);
+}
+
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "solaris",
+    target_os = "illumos"
+))]
+/// Test creating a non-blocking socket by using the SOCK_NONBLOCK option
+/// for the `socket` syscall.
+fn test_sock_nonblock_opt() {
+    let sockfd = unsafe {
+        errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM | libc::SOCK_NONBLOCK, 0))
+            .unwrap()
+    };
+
+    let flags = unsafe { errno_result(libc::fcntl(sockfd, libc::F_GETFL, 0)).unwrap() };
+    // Ensure that socket is really non-blocking.
+    assert_eq!(flags & libc::O_NONBLOCK, libc::O_NONBLOCK);
+}
+
+#[cfg(not(any(target_os = "solaris", target_os = "illumos")))]
+/// Test changing the blocking state of a socket using the `ioctl(fd, FIONBIO, ...)`
+/// syscall.
+fn test_ioctl_fionbio_op() {
+    let sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+
+    unsafe {
+        // Change socket to be non-blocking.
+        let mut value = 1 as libc::c_int;
+        errno_check(libc::ioctl(sockfd, libc::FIONBIO, &mut value));
+    }
+
+    let flags = unsafe { errno_result(libc::fcntl(sockfd, libc::F_GETFL, 0)).unwrap() };
+    // Ensure that socket is really non-blocking.
+    assert_eq!(flags & libc::O_NONBLOCK, libc::O_NONBLOCK);
+
+    unsafe {
+        // Change socket back to be blocking.
+        let mut value = 0 as libc::c_int;
+        errno_check(libc::ioctl(sockfd, libc::FIONBIO, &mut value));
+    }
+
+    let flags = unsafe { errno_result(libc::fcntl(sockfd, libc::F_GETFL, 0)).unwrap() };
+    // Ensure that socket is really blocking.
+    assert_eq!(flags & libc::O_NONBLOCK, 0);
+}
+
+/// Test that nonblocking TCP server sockets return [`ErrorKind::WouldBlock`] when trying
 /// to accept when no incoming connection exists. This also tests that nonblocking server sockets
 /// are still able to accept incoming connections should they already exist before the `accept` or
 /// `accept4` syscall is called.
 fn test_accept_nonblock() {
-    // Create a new non-blocking server socket.
-    let (server_sockfd, addr) = net::make_listener_ipv4(libc::SOCK_NONBLOCK).unwrap();
+    let (server_sockfd, addr) = net::make_listener_ipv4().unwrap();
     let client_sockfd =
         unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+
+    unsafe {
+        // Change server socket to be non-blocking.
+        errno_check(libc::fcntl(server_sockfd, libc::F_SETFL, libc::O_NONBLOCK));
+    }
 
     // This should fail as we don't have an incoming connection for this address.
     let err = net::accept_ipv4(server_sockfd).unwrap_err();
@@ -57,10 +160,17 @@ fn test_accept_nonblock() {
     server_thread.join().unwrap();
 }
 
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "solaris",
+    target_os = "illumos"
+))]
 /// Test that calling `accept4` with the SOCK_NONBLOCK flag produces
 /// a non-blocking peer socket.
 fn test_accept4_sock_nonblock_opt() {
-    let (server_sockfd, addr) = net::make_listener_ipv4(0).unwrap();
+    let (server_sockfd, addr) = net::make_listener_ipv4().unwrap();
     let client_sockfd =
         unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
 
@@ -90,14 +200,55 @@ fn test_accept4_sock_nonblock_opt() {
     server_thread.join().unwrap();
 }
 
+/// Test that connecting to a server socket works when the client
+/// socket is non-blocking before the `connect` call.
+fn test_connect_nonblock() {
+    let (server_sockfd, addr) = net::make_listener_ipv4().unwrap();
+    let client_sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+
+    unsafe {
+        // Change client socket to be non-blocking.
+        errno_check(libc::fcntl(client_sockfd, libc::F_SETFL, libc::O_NONBLOCK));
+    }
+
+    // Spawn the server thread.
+    let server_thread = thread::spawn(move || {
+        net::accept_ipv4(server_sockfd).unwrap();
+    });
+
+    // Yield to server thread to ensure that it's currently accepting.
+    thread::sleep(Duration::from_millis(10));
+
+    // Non-blocking connects always "fail" with EINPROGRESS.
+    let err = net::connect_ipv4(client_sockfd, addr).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::InProgress);
+
+    loop {
+        let result = net::sockname_ipv4(|storage, len| unsafe {
+            libc::getpeername(client_sockfd, storage, len)
+        });
+        match result {
+            Ok(_) => {
+                // The client is now connected.
+                break;
+            }
+            Err(err) if err.kind() == ErrorKind::NotConnected => {
+                // The client is still connecting.
+                thread::sleep(Duration::from_millis(10));
+            }
+            Err(err) => panic!("unexpected error whilst ensuring connection: {err}"),
+        }
+    }
+
+    server_thread.join().unwrap();
+}
+
 /// Test sending bytes into and receiving bytes from a connected stream without blocking.
 fn test_send_recv_nonblock() {
-    let (server_sockfd, addr) = net::make_listener_ipv4(0).unwrap();
-    // Create a new non-blocking client socket.
-    let client_sockfd = unsafe {
-        errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM | libc::SOCK_NONBLOCK, 0))
-            .unwrap()
-    };
+    let (server_sockfd, addr) = net::make_listener_ipv4().unwrap();
+    let client_sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
 
     // Spawn the server thread.
     let server_thread = thread::spawn(move || {
@@ -133,14 +284,14 @@ fn test_send_recv_nonblock() {
         assert_eq!(&buffer, TEST_BYTES);
     });
 
-    // Yield to server thread to ensure that it's currently accepting.
-    thread::sleep(Duration::from_millis(10));
+    net::connect_ipv4(client_sockfd, addr).unwrap();
 
-    // Non-blocking connects always "fail" with EINPROGRESS.
-    let err = net::connect_ipv4(client_sockfd, addr).unwrap_err();
-    assert_eq!(err.kind(), ErrorKind::InProgress);
+    unsafe {
+        // Change client socket to be non-blocking.
+        errno_check(libc::fcntl(client_sockfd, libc::F_SETFL, libc::O_NONBLOCK));
+    }
 
-    // We are connecting and the server socket is not writing.
+    // We are connected and the server socket is not writing.
 
     let mut buffer = [0; TEST_BYTES.len()];
     // Receiving from a socket when the peer is not writing is
@@ -201,11 +352,18 @@ fn test_send_recv_nonblock() {
     server_thread.join().unwrap();
 }
 
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "solaris",
+    target_os = "illumos"
+))]
 /// Test sending bytes into and receiving bytes from a connected stream without blocking.
 /// Instead of using non-blocking sockets, we test whether it works with blocking sockets
 /// when passing the `libc::MSG_DONTWAIT` flag to the send and receive calls.
 fn test_send_recv_dontwait() {
-    let (server_sockfd, addr) = net::make_listener_ipv4(0).unwrap();
+    let (server_sockfd, addr) = net::make_listener_ipv4().unwrap();
     let client_sockfd =
         unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
 
@@ -312,12 +470,9 @@ fn test_send_recv_dontwait() {
 
 /// Test writing bytes into and reading bytes from a connected stream without blocking.
 fn test_write_read_nonblock() {
-    let (server_sockfd, addr) = net::make_listener_ipv4(0).unwrap();
-    // Create a new non-blocking client socket.
-    let client_sockfd = unsafe {
-        errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM | libc::SOCK_NONBLOCK, 0))
-            .unwrap()
-    };
+    let (server_sockfd, addr) = net::make_listener_ipv4().unwrap();
+    let client_sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
 
     // Spawn the server thread.
     let server_thread = thread::spawn(move || {
@@ -347,14 +502,14 @@ fn test_write_read_nonblock() {
         assert_eq!(&buffer, TEST_BYTES);
     });
 
-    // Yield to server thread to ensure that it's currently accepting.
-    thread::sleep(Duration::from_millis(10));
+    net::connect_ipv4(client_sockfd, addr).unwrap();
 
-    // Non-blocking connects always "fail" with EINPROGRESS.
-    let err = net::connect_ipv4(client_sockfd, addr).unwrap_err();
-    assert_eq!(err.kind(), ErrorKind::InProgress);
+    unsafe {
+        // Change client socket to be non-blocking.
+        errno_check(libc::fcntl(client_sockfd, libc::F_SETFL, libc::O_NONBLOCK));
+    }
 
-    // We are connecting and the server socket is not writing.
+    // We are connected and the server socket is not writing.
 
     let mut buffer = [0; TEST_BYTES.len()];
     // Reading from a socket when the peer is not writing is
@@ -423,12 +578,14 @@ fn test_write_read_nonblock() {
 /// for a non-blocking IPv4 socket whose connection has been successfully
 /// established before calling the syscall.
 fn test_getpeername_ipv4_nonblock() {
-    let (server_sockfd, addr) = net::make_listener_ipv4(0).unwrap();
-    // Create a new non-blocking client socket.
-    let client_sockfd = unsafe {
-        errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM | libc::SOCK_NONBLOCK, 0))
-            .unwrap()
-    };
+    let (server_sockfd, addr) = net::make_listener_ipv4().unwrap();
+    let client_sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+
+    unsafe {
+        // Change client socket to be non-blocking.
+        errno_check(libc::fcntl(client_sockfd, libc::F_SETFL, libc::O_NONBLOCK));
+    }
 
     // Spawn the server thread.
     let server_thread = thread::spawn(move || {
@@ -471,11 +628,13 @@ fn test_getpeername_ipv4_nonblock() {
 /// for a non-blocking IPv4 socket which is stuck at
 /// connecting to the remote address.
 fn test_getpeername_ipv4_nonblock_no_peer() {
-    // Create a new non-blocking client socket.
-    let client_sockfd = unsafe {
-        errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM | libc::SOCK_NONBLOCK, 0))
-            .unwrap()
-    };
+    let client_sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+
+    unsafe {
+        // Change client socket to be non-blocking.
+        errno_check(libc::fcntl(client_sockfd, libc::F_SETFL, libc::O_NONBLOCK));
+    }
 
     // We cannot attempt to connect to a localhost address because
     // it could be the case that a socket from another test is

--- a/tests/pass-dep/libc/libc-socket.rs
+++ b/tests/pass-dep/libc/libc-socket.rs
@@ -16,7 +16,7 @@ use utils::check_nondet;
 const TEST_BYTES: &[u8] = b"these are some test bytes!";
 
 fn main() {
-    test_socket_close();
+    test_create_close();
     test_bind_ipv4();
     test_bind_ipv4_reuseaddr();
     test_set_reuseaddr_invalid_len();
@@ -48,11 +48,17 @@ fn main() {
     test_getpeername_ipv6();
 }
 
-fn test_socket_close() {
-    unsafe {
-        let sockfd = errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap();
-        errno_check(libc::close(sockfd));
-    }
+/// Test creating a socket and then closing it afterwards.
+fn test_create_close() {
+    let sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+
+    let flags = unsafe { errno_result(libc::fcntl(sockfd, libc::F_GETFL, 0)).unwrap() };
+
+    // Ensure that socket is initially blocking.
+    assert_eq!(flags & libc::O_NONBLOCK, 0);
+
+    unsafe { errno_check(libc::close(sockfd)) };
 }
 
 fn test_bind_ipv4() {
@@ -191,7 +197,7 @@ fn test_listen() {
 /// - Connecting when the server is already accepting
 /// - Accepting when there is already an incoming connection
 fn test_accept_connect() {
-    let (server_sockfd, addr) = net::make_listener_ipv4(0).unwrap();
+    let (server_sockfd, addr) = net::make_listener_ipv4().unwrap();
     let client_sockfd =
         unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
 
@@ -234,7 +240,7 @@ fn test_accept_connect() {
 /// We especially want to test that the peeking doesn't remove the bytes from
 /// the queue.
 fn test_send_peek_recv() {
-    let (server_sockfd, addr) = net::make_listener_ipv4(0).unwrap();
+    let (server_sockfd, addr) = net::make_listener_ipv4().unwrap();
     let client_sockfd =
         unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
 
@@ -291,7 +297,7 @@ fn test_send_peek_recv() {
 
 /// Test that we actually do partial sends and partial receives for sockets.
 fn test_partial_send_recv() {
-    let (server_sockfd, addr) = net::make_listener_ipv4(0).unwrap();
+    let (server_sockfd, addr) = net::make_listener_ipv4().unwrap();
     let client_sockfd =
         unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
 
@@ -338,7 +344,7 @@ fn test_partial_send_recv() {
 /// We want to test this because `write` and `read` should be the same as
 /// `send` and `recv` with zero flags.
 fn test_write_read() {
-    let (server_sockfd, addr) = net::make_listener_ipv4(0).unwrap();
+    let (server_sockfd, addr) = net::make_listener_ipv4().unwrap();
     let client_sockfd =
         unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
 
@@ -481,7 +487,7 @@ fn test_getsockname_ipv6() {
 /// For a connected socket, the `getpeername` syscall should
 /// return the same address as the socket was connected to.
 fn test_getpeername_ipv4() {
-    let (server_sockfd, addr) = net::make_listener_ipv4(0).unwrap();
+    let (server_sockfd, addr) = net::make_listener_ipv4().unwrap();
     let client_sockfd =
         unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
 
@@ -506,7 +512,7 @@ fn test_getpeername_ipv4() {
 /// For a connected socket, the `getpeername` syscall should
 /// return the same address as the socket was connected to.
 fn test_getpeername_ipv6() {
-    let (server_sockfd, addr) = net::make_listener_ipv6(0).unwrap();
+    let (server_sockfd, addr) = net::make_listener_ipv6().unwrap();
     let client_sockfd =
         unsafe { errno_result(libc::socket(libc::AF_INET6, libc::SOCK_STREAM, 0)).unwrap() };
 

--- a/tests/pass/shims/socket-no-blocking.rs
+++ b/tests/pass/shims/socket-no-blocking.rs
@@ -1,0 +1,92 @@
+//@ignore-target: windows # No libc socket on Windows
+//@compile-flags: -Zmiri-disable-isolation -Zmiri-fixed-schedule
+
+use std::io::{ErrorKind, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::thread;
+
+const TEST_BYTES: &[u8] = b"these are some test bytes!";
+
+fn main() {
+    test_accept_nonblock();
+    test_send_recv_nonblock();
+}
+
+/// Test that nonblocking TCP server sockets return [`ErrorKind::WouldBlock`] when trying
+/// to accept when no incoming connection exists. This also tests that nonblocking server sockets
+/// are still able to accept incoming connections should they already exist before [`TcpListener::accept`]
+/// is called.
+fn test_accept_nonblock() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    // Make server non-blocking.
+    listener.set_nonblocking(true).unwrap();
+    // Get local address with randomized port to know where
+    // we need to connect to.
+    let address = listener.local_addr().unwrap();
+
+    // Accepting when no incoming connecting exists should block.
+    let err = listener.accept().unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::WouldBlock);
+
+    // Start server thread.
+    let handle = thread::spawn(move || {
+        // Accepting when there is an existing incoming connection should
+        // succeed without blocking.
+
+        let (_stream, _peer_addr) = listener.accept().unwrap();
+    });
+
+    // The connect is blocking and thus we yield to the server thread.
+    let _stream = TcpStream::connect(address).unwrap();
+
+    handle.join().unwrap();
+}
+
+/// Test sending bytes into and receiving bytes from a connected stream without blocking.
+fn test_send_recv_nonblock() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    // Get local address with randomized port to know where
+    // we need to connect to.
+    let address = listener.local_addr().unwrap();
+
+    // Start server thread.
+    let handle = thread::spawn(move || {
+        let (mut stream, _addr) = listener.accept().unwrap();
+
+        // Yield back to client thread to ensure that the first read
+        // is before we write anything into the socket.
+        thread::yield_now();
+
+        stream.write_all(TEST_BYTES).unwrap();
+    });
+
+    // The connect is blocking and thus we yield to the server thread.
+    let mut stream = TcpStream::connect(address).unwrap();
+    // Make client non-blocking.
+    stream.set_nonblocking(true).unwrap();
+    let mut buffer = [0; TEST_BYTES.len()];
+    // Reading when no data was written should return WouldBlock.
+    let err = stream.read_exact(&mut buffer).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::WouldBlock);
+
+    // Try to read bytes from the peer socket without blocking.
+    // Since the peer socket might do partial writes, we might need to
+    // sleep multiple times until we read everything.
+
+    let mut bytes_read = 0;
+    while bytes_read != TEST_BYTES.len() {
+        match stream.read(&mut buffer[bytes_read..]) {
+            Ok(read) => bytes_read += read,
+            Err(err) if err.kind() == ErrorKind::WouldBlock => {
+                // Not all data is written into the stream, yield to the server thread
+                // to write more into the stream.
+                thread::yield_now();
+            }
+            Err(err) => panic!("unexpected error whilst reading: {err}"),
+        }
+    }
+
+    assert_eq!(&buffer, TEST_BYTES);
+
+    handle.join().unwrap();
+}

--- a/tests/utils/libc.rs
+++ b/tests/utils/libc.rs
@@ -257,11 +257,8 @@ pub mod net {
 
     /// Create an IPv4 TCP socket which listens on a random port at the localhost address.
     /// Returns the socket file descriptor and the actual socket address the socket is listening on.
-    pub fn make_listener_ipv4(
-        options: libc::c_int,
-    ) -> io::Result<(libc::c_int, libc::sockaddr_in)> {
-        let sockfd =
-            unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM | options, 0))? };
+    pub fn make_listener_ipv4() -> io::Result<(libc::c_int, libc::sockaddr_in)> {
+        let sockfd = unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0))? };
         // Turn address into socket address with a random free port.
         let addr = sock_addr_ipv4(IPV4_LOCALHOST, 0);
         unsafe {
@@ -285,11 +282,8 @@ pub mod net {
 
     /// Create an IPv6 TCP socket which listens on a random port at the localhost address.
     /// Returns the socket file descriptor and the actual socket address the socket is listening on.
-    pub fn make_listener_ipv6(
-        options: libc::c_int,
-    ) -> io::Result<(libc::c_int, libc::sockaddr_in6)> {
-        let sockfd =
-            unsafe { errno_result(libc::socket(libc::AF_INET6, libc::SOCK_STREAM | options, 0))? };
+    pub fn make_listener_ipv6() -> io::Result<(libc::c_int, libc::sockaddr_in6)> {
+        let sockfd = unsafe { errno_result(libc::socket(libc::AF_INET6, libc::SOCK_STREAM, 0))? };
         // Turn address into socket address with a random free port.
         let addr = sock_addr_ipv6(IPV6_LOCALHOST, 0);
         unsafe {


### PR DESCRIPTION
Hi,

This pull request adds the required functionality to change the network socket blocking state through `ioctl` (used by the standard library) and `fcntl`.

Since the `ioctl` shim now allows changing the socket blocking state through the standard library, there are now also some tests for testing non-blocking sockets using the standard library. However, we cannot test non-blocking connects this way, as we would need mio for that.

Is it worth adding mio as a test dependency for this in a future PR? Because we already test non-blocking connects using libc.

Also, because setting the blocking state of a socket through `fcntl` is supported on all targets, we can now also run the libc non-blocking socket tests on MacOS targets.