### PR TITLE
Implement `_mm512_permutex2var_epi64` shim

### DIFF
--- a/src/shims/x86/avx512.rs
+++ b/src/shims/x86/avx512.rs
@@ -3,7 +3,9 @@ use rustc_middle::ty::Ty;
 use rustc_span::Symbol;
 use rustc_target::callconv::FnAbi;
 
-use super::{packssdw, packsswb, packusdw, packuswb, permute, pmaddbw, pmaddwd, psadbw, pshufb};
+use super::{
+    packssdw, packsswb, packusdw, packuswb, permute, permute2, pmaddbw, pmaddwd, psadbw, pshufb,
+};
 use crate::*;
 
 impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
@@ -110,6 +112,13 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
 
                 permute(this, left, right, dest)?;
+            }
+            // Used to implement the _mm512_permutex2var_epi64 intrinsic.
+            "vpermi2var.q.512" => {
+                let [left, indices, right] =
+                    this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
+
+                permute2(this, left, indices, right, dest)?;
             }
             // Used to implement the _mm512_shuffle_epi8 intrinsic.
             "pshuf.b.512" => {

--- a/src/shims/x86/mod.rs
+++ b/src/shims/x86/mod.rs
@@ -1107,6 +1107,54 @@ fn permute<'tcx>(
     interp_ok(())
 }
 
+/// Shuffle elements from *two* source registers (`left` and `right`) using
+/// the corresponding index in `indices`, and store the results in `dest`.
+///
+/// For a vector with `N` lanes, the low `log2(N)` bits of each index select a
+/// lane within a source vector. Bit `log2(N)` selects the source vector (`0` =>
+/// `left`, `1` => `right`), and all higher bits are ignored.
+/// Equivalently, lane `i` of the result is copied from
+/// `src[indices[i] & (N - 1)]` where
+/// `src = if indices[i] & N == 0 { left } else { right }`.
+///
+/// <https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_permutex2var_epi64>
+fn permute2<'tcx>(
+    ecx: &mut crate::MiriInterpCx<'tcx>,
+    left: &OpTy<'tcx>,
+    indices: &OpTy<'tcx>,
+    right: &OpTy<'tcx>,
+    dest: &MPlaceTy<'tcx>,
+) -> InterpResult<'tcx, ()> {
+    let (left, left_len) = ecx.project_to_simd(left)?;
+    let (indices, indices_len) = ecx.project_to_simd(indices)?;
+    let (right, right_len) = ecx.project_to_simd(right)?;
+    let (dest, dest_len) = ecx.project_to_simd(dest)?;
+
+    assert_eq!(dest_len, left_len);
+    assert_eq!(dest_len, indices_len);
+    assert_eq!(dest_len, right_len);
+
+    // Use the low bits to select a lane within either input vector, and the next bit to
+    // choose between the two vectors.
+    assert!(dest_len.is_power_of_two());
+    let lane_mask = u128::from(dest_len).strict_sub(1);
+    let vector_select_bit = u128::from(dest_len);
+
+    for i in 0..dest_len {
+        let dest = ecx.project_index(&dest, i)?;
+        let index_place = ecx.project_index(&indices, i)?;
+        let index = ecx.read_scalar(&index_place)?.to_uint(index_place.layout.size)?;
+        // `lane_mask` is at most `dest_len - 1` which fits in a `u64`, so this cannot fail.
+        let lane = u64::try_from(index & lane_mask).unwrap();
+        let src = if index & vector_select_bit == 0 { &left } else { &right };
+        let element = ecx.project_index(src, lane)?;
+
+        ecx.copy_op(&element, &dest)?;
+    }
+
+    interp_ok(())
+}
+
 /// Multiplies packed 16-bit signed integer values, truncates the 32-bit
 /// product to the 18 most significant bits by right-shifting, and then
 /// divides the 18-bit value by 2 (rounding to nearest) by first adding

--- a/tests/pass/shims/x86/intrinsics-x86-avx512.rs
+++ b/tests/pass/shims/x86/intrinsics-x86-avx512.rs
@@ -243,6 +243,33 @@ unsafe fn test_avx512() {
     }
     test_mm512_permutexvar_epi64();
 
+    #[target_feature(enable = "avx512f")]
+    unsafe fn test_mm512_permutex2var_epi64() {
+        // a[i] = (i+1) * 10, b[i] = (i+1) * 100.
+        let a = _mm512_set_epi64(80, 70, 60, 50, 40, 30, 20, 10);
+        let b = _mm512_set_epi64(800, 700, 600, 500, 400, 300, 200, 100);
+
+        // All from `a`: identity (bit 3 clear).
+        let idx = _mm512_set_epi64(7, 6, 5, 4, 3, 2, 1, 0);
+        assert_eq_m512i(_mm512_permutex2var_epi64(a, idx, b), a);
+
+        // All from `b` (bit 3 set).
+        let idx = _mm512_set_epi64(15, 14, 13, 12, 11, 10, 9, 8);
+        assert_eq_m512i(_mm512_permutex2var_epi64(a, idx, b), b);
+
+        // Interleave: even elements from `a`, odd from `b`.
+        let idx = _mm512_set_epi64(15, 6, 13, 4, 11, 2, 9, 0);
+        let e = _mm512_set_epi64(800, 70, 600, 50, 400, 30, 200, 10);
+        assert_eq_m512i(_mm512_permutex2var_epi64(a, idx, b), e);
+
+        // Only the low 4 bits of each index are used: bits [2:0] pick the lane,
+        // bit 3 selects between `a` and `b`.
+        let idx = _mm512_set_epi64(0, -1, -128, i64::MIN, 15, 8, 128, i64::MAX);
+        let e = _mm512_set_epi64(10, 800, 10, 10, 800, 100, 10, 800);
+        assert_eq_m512i(_mm512_permutex2var_epi64(a, idx, b), e);
+    }
+    test_mm512_permutex2var_epi64();
+
     #[target_feature(enable = "avx512bw")]
     unsafe fn test_mm512_shuffle_epi8() {
         #[rustfmt::skip]


### PR DESCRIPTION
This implements the `_mm512_permutex2var_epi64` intrinsic, which is `vpermi2var.q.512`, which permutes 64-bit elements from two input vectors according to an index vector, producing a destination vector.