### PR TITLE
remove vec_unique.default.stderr

### DIFF
--- a/tests/pass/tree_borrows/vec_unique.default.stderr
+++ b/tests/pass/tree_borrows/vec_unique.default.stderr
@@ -1,6 +1,0 @@
-──────────────────────────────────────────────────
-Warning: this tree is indicative only. Some tags may have been hidden.
-0..   2
-| Act |    └─┬──<TAG=root of the allocation>
-| Res |      └────<TAG=base.as_ptr(), base.as_ptr(), raw_parts.0, reconstructed.as_ptr(), reconstructed.as_ptr()>
-──────────────────────────────────────────────────


### PR DESCRIPTION
This very small PR removes the file `tests/pass/tree_borrows/vec_unique.default.stderr`. It has no matching test and seems to be forgotten when the test was removed / changed.