### PR TITLE
Use `AtomicUsize` instead of `AtomicBool` to test weak atomic for targets lacking byte-sized atomic

### DIFF
--- a/tests/pass/atomic.rs
+++ b/tests/pass/atomic.rs
@@ -185,12 +185,12 @@ fn atomic_ptr() {
 }
 
 fn weak_sometimes_fails() {
-    let atomic = AtomicBool::new(false);
+    let atomic = AtomicUsize::new(0);
     let tries = 100;
     for _ in 0..tries {
         let cur = atomic.load(Relaxed);
-        // Try (weakly) to flip the flag.
-        if atomic.compare_exchange_weak(cur, !cur, Relaxed, Relaxed).is_err() {
+        // Try (weakly) to modify the flag.
+        if atomic.compare_exchange_weak(cur, cur + 1, Relaxed, Relaxed).is_err() {
             // We failed, so return and skip the panic.
             return;
         }


### PR DESCRIPTION
Fixes rust-lang/rust#155100