### PR TITLE
bump openssl-sys to support OpenSSL 4.0.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,9 +1013,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
The previously pinned version of openssl-sys is not compatible with OpenSSL 4.0.x.

- `openssl-sys`: 0.9.111 -> 0.9.114

Also see https://github.com/rust-lang/rust/issues/155397

r? @RalfJung