### PR TITLE
tree borrows (implicit writes): add support for #[rustc_no_writable]

### DIFF
--- a/src/borrow_tracker/tree_borrows/mod.rs
+++ b/src/borrow_tracker/tree_borrows/mod.rs
@@ -134,9 +134,11 @@ impl<'tcx> NewPermission {
         let ty_is_freeze = pointee.is_freeze(*cx.tcx, cx.typing_env());
         let is_protected = retag_kind == RetagKind::FnEntry;
 
-        // Check if the implicit writes feature is globally enabled, using the `-Zmiri-tree-borrows-implicit-writes` flag, and not locally disabled using the `#[rustc_no_writable]` attribute.
-        // For performance reasons, only performs the lookup if is_protected is true as implicit write checking only works for protected references.
-        let implicit_writes_enabled = if is_protected {
+        // Check if the implicit writes feature is globally enabled, using the
+        // `-Zmiri-tree-borrows-implicit-writes` flag, and not locally disabled using the
+        // `#[rustc_no_writable]` attribute. For performance reasons, only performs the lookup if
+        // is_protected is true as implicit writes are only performed for protected references.
+        let implicit_writes_enabled = is_protected && {
             let implicit_writes = cx
                 .machine
                 .borrow_tracker
@@ -147,10 +149,7 @@ impl<'tcx> NewPermission {
                 .get_tree_borrows_params()
                 .implicit_writes;
             let def_id = cx.frame().instance().def_id();
-            let no_writable = find_attr!(cx.tcx, def_id, RustcNoWritable);
-            implicit_writes && !no_writable
-        } else {
-            false
+            implicit_writes && !find_attr!(cx.tcx, def_id, RustcNoWritable)
         };
 
         if matches!(ref_mutability, Some(Mutability::Mut) | None if !ty_is_unpin) {

--- a/src/borrow_tracker/tree_borrows/mod.rs
+++ b/src/borrow_tracker/tree_borrows/mod.rs
@@ -1,4 +1,5 @@
 use rustc_abi::Size;
+use rustc_hir::find_attr;
 use rustc_middle::mir::{Mutability, RetagKind};
 use rustc_middle::ty::layout::HasTypingEnv;
 use rustc_middle::ty::{self, Ty};
@@ -133,16 +134,24 @@ impl<'tcx> NewPermission {
         let ty_is_freeze = pointee.is_freeze(*cx.tcx, cx.typing_env());
         let is_protected = retag_kind == RetagKind::FnEntry;
 
-        // Check if the implicit writes check has been enabled for this function using the `-Zmiri-tree-borrows-implicit-writes` flag
-        let implicit_writes = cx
-            .machine
-            .borrow_tracker
-            .as_ref()
-            .unwrap()
-            .borrow()
-            .borrow_tracker_method
-            .get_tree_borrows_params()
-            .implicit_writes;
+        // Check if the implicit writes feature is globally enabled, using the `-Zmiri-tree-borrows-implicit-writes` flag, and not locally disabled using the `#[rustc_no_writable]` attribute.
+        // For performance reasons, only performs the lookup if is_protected is true as implicit write checking only works for protected references.
+        let implicit_writes_enabled = if is_protected {
+            let implicit_writes = cx
+                .machine
+                .borrow_tracker
+                .as_ref()
+                .unwrap()
+                .borrow()
+                .borrow_tracker_method
+                .get_tree_borrows_params()
+                .implicit_writes;
+            let def_id = cx.frame().instance().def_id();
+            let no_writable = find_attr!(cx.tcx, def_id, RustcNoWritable);
+            implicit_writes && !no_writable
+        } else {
+            false
+        };
 
         if matches!(ref_mutability, Some(Mutability::Mut) | None if !ty_is_unpin) {
             // Mutable reference / Box to pinning type: retagging is a NOP.
@@ -175,7 +184,7 @@ impl<'tcx> NewPermission {
                     },
                 // Mutable references
                 Some(Mutability::Mut) => {
-                    if is_protected && implicit_writes && !matches!(part, Outside) {
+                    if implicit_writes_enabled && !matches!(part, Outside) {
                         // We cannot use `Unique` for the outside part.
                         Permission::new_unique()
                     } else if is_protected || frozen {
@@ -187,8 +196,8 @@ impl<'tcx> NewPermission {
                     }
                 }
                 // Boxes
-                None =>
-                    if is_protected && implicit_writes && !matches!(part, Outside) {
+                None => {
+                    if implicit_writes_enabled && !matches!(part, Outside) {
                         // Boxes are treated the same as mutable references.
                         Permission::new_unique()
                     } else if is_protected || frozen {
@@ -197,7 +206,8 @@ impl<'tcx> NewPermission {
                         Permission::new_reserved_frz()
                     } else {
                         Permission::new_reserved_im()
-                    },
+                    }
+                }
             }
         };
 

--- a/tests/pass/both_borrows/smallvec.rs
+++ b/tests/pass/both_borrows/smallvec.rs
@@ -2,8 +2,11 @@
 //! What makes it interesting as a test is that it relies on Stacked Borrow's "quirk"
 //! in a fundamental, hard-to-fix-without-full-trees way.
 
-//@revisions: stack tree
+//@revisions: stack tree tree_implicit_writes
 //@[tree]compile-flags: -Zmiri-tree-borrows
+//@[tree_implicit_writes]compile-flags: -Zmiri-tree-borrows -Zmiri-tree-borrows-implicit-writes
+
+#![feature(rustc_attrs)]
 
 use std::marker::PhantomData;
 use std::mem::{ManuallyDrop, MaybeUninit};
@@ -24,6 +27,7 @@ impl<T, const N: usize> RawSmallVec<T, N> {
         Self { inline: ManuallyDrop::new(inline) }
     }
 
+    #[rustc_no_writable]
     const fn as_mut_ptr_inline(&mut self) -> *mut T {
         &raw mut self.inline as *mut T
     }
@@ -77,6 +81,7 @@ impl<T, const N: usize> SmallVec<T, N> {
         size_of::<T>() == 0
     }
 
+    #[rustc_no_writable]
     pub const fn as_mut_ptr(&mut self) -> *mut T {
         if self.len.on_heap(Self::is_zst()) {
             // SAFETY: see above

--- a/tests/pass/box-custom-alloc.rs
+++ b/tests/pass/box-custom-alloc.rs
@@ -1,4 +1,5 @@
-//@revisions: stack tree
+//@revisions: stack tree tree_implicit_writes
+//@[tree_implicit_writes]compile-flags: -Zmiri-tree-borrows -Zmiri-tree-borrows-implicit-writes
 //@[tree]compile-flags: -Zmiri-tree-borrows
 #![feature(allocator_api)]
 

--- a/tests/pass/hashmap.rs
+++ b/tests/pass/hashmap.rs
@@ -1,4 +1,5 @@
-//@revisions: stack tree
+//@revisions: stack tree tree_implicit_writes
+//@[tree_implicit_writes]compile-flags: -Zmiri-tree-borrows -Zmiri-tree-borrows-implicit-writes
 //@[tree]compile-flags: -Zmiri-tree-borrows
 use std::collections::HashMap;
 use std::hash::BuildHasher;

--- a/tests/pass/slices.rs
+++ b/tests/pass/slices.rs
@@ -1,5 +1,6 @@
-//@revisions: stack tree
+//@revisions: stack tree tree_implicit_writes
 //@[tree]compile-flags: -Zmiri-tree-borrows
+//@[tree_implicit_writes]compile-flags: -Zmiri-tree-borrows -Zmiri-tree-borrows-implicit-writes
 //@compile-flags: -Zmiri-strict-provenance
 #![feature(slice_partition_dedup)]
 #![feature(layout_for_ptr)]

--- a/tests/pass/tree_borrows/copy-nonoverlapping.rs
+++ b/tests/pass/tree_borrows/copy-nonoverlapping.rs
@@ -1,4 +1,6 @@
-//@compile-flags: -Zmiri-tree-borrows
+//@revisions: tree tree_implicit_writes
+//@[tree]compile-flags: -Zmiri-tree-borrows
+//@[tree_implicit_writes]compile-flags: -Zmiri-tree-borrows -Zmiri-tree-borrows-implicit-writes
 
 // copy_nonoverlapping works regardless of the order in which we construct
 // the arguments.

--- a/tests/pass/tree_borrows/rustc_no_writable.rs
+++ b/tests/pass/tree_borrows/rustc_no_writable.rs
@@ -1,0 +1,19 @@
+// Tests that the `#[rustc_no_writable]` attribute disables implicit writes checking for the function it is applied to, so that `tests/fail/tree_borrows/implicit_writes/ptr_write.rs` would pass even with implicit writes enabled.
+//@compile-flags: -Zmiri-tree-borrows -Zmiri-tree-borrows-implicit-writes
+
+#![feature(rustc_attrs)]
+
+fn main() {
+    let mut x = 0u8;
+    let ptr = &raw mut x;
+    let res = dereference(&mut x, ptr);
+    assert_eq!(*res, 0);
+}
+
+#[rustc_no_writable]
+fn dereference<T>(x: T, y: *mut u8) -> T {
+    // miri inserts *no* implicit write here due to the attribute.
+    // Therefore we end up only reading from `x` and `y` which is fine.
+    let _ = unsafe { *y };
+    x
+}

--- a/tests/pass/vec.rs
+++ b/tests/pass/vec.rs
@@ -1,5 +1,6 @@
-//@revisions: stack tree
+//@revisions: stack tree tree_implicit_writes
 //@compile-flags: -Zmiri-strict-provenance
+//@[tree_implicit_writes]compile-flags: -Zmiri-tree-borrows -Zmiri-tree-borrows-implicit-writes
 //@[tree]compile-flags: -Zmiri-tree-borrows
 #![feature(iter_advance_by, iter_next_chunk)]
 

--- a/tests/pass/vec.tree_implicit_writes.stderr
+++ b/tests/pass/vec.tree_implicit_writes.stderr
@@ -1,0 +1,5 @@
+
+thread 'main' ($TID) panicked at tests/pass/vec.rs:LL:CC:
+explicit panic
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+note: in Miri, you may have to set `MIRIFLAGS=-Zmiri-env-forward=RUST_BACKTRACE` for the environment variable to have an effect


### PR DESCRIPTION
This PR enables support for the `#[rustc_no_writable]` attribute. If implicit writes checking in tree borrows is enabled, this attribute can be used to disable the checking on a per function basis.
A test case has been provided to demonstrate the usage and tests that it works as intended.