### PR TITLE
avoid underflow in std::Instant when computing times before program startup

### DIFF
--- a/src/shims/time.rs
+++ b/src/shims/time.rs
@@ -247,6 +247,13 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let qpc = i64::try_from(duration.as_nanos()).map_err(|_| {
             err_unsup_format!("programs running longer than 2^63 nanoseconds are not supported")
         })?;
+        // We are allowed to offset this by an arbitrary constant, which will correspond to the
+        // value of this clock at program start time. We use that freedom to work around
+        // <https://github.com/rust-lang/rust/issues/156142>, caused by std casting the result of
+        // this function to `u64`. We pick an offset of `i64::MAX/2` instead of `i64::MAX` to avoid
+        // being too close to overflow for callers that actually do use signed integers.
+        let qpc = qpc.strict_add(i64::MAX / 2);
+
         this.write_scalar(
             Scalar::from_i64(qpc),
             &this.deref_pointer_as(lpPerformanceCount_op, this.machine.layouts.i64)?,

--- a/tests/pass/shims/time-with-isolation.rs
+++ b/tests/pass/shims/time-with-isolation.rs
@@ -1,4 +1,12 @@
+#![feature(duration_constructors, thread_sleep_until)]
 use std::time::{Duration, Instant};
+
+fn test_underflow() {
+    // The time 1 day before the program started should be representable.
+    // (This used to underflow on Windows.)
+    let now = Instant::now();
+    let _earlier = now - Duration::from_days(1);
+}
 
 fn test_sleep() {
     // We sleep a *long* time here -- but the clock is virtual so the test should still pass quickly.
@@ -6,6 +14,14 @@ fn test_sleep() {
     std::thread::sleep(Duration::from_secs(3600));
     let after = Instant::now();
     assert!((after - before).as_secs() >= 3600);
+}
+
+fn test_sleep_until() {
+    let before = Instant::now();
+    let hunderd_millis_after_start = before + Duration::from_millis(100);
+    std::thread::sleep_until(hunderd_millis_after_start);
+    let after = Instant::now();
+    assert!((after - before).as_millis() >= 100);
 }
 
 /// Ensure that time passes even if we don't sleep (but just work).
@@ -48,8 +64,10 @@ fn test_deterministic() {
 }
 
 fn main() {
+    test_underflow();
     test_time_passes();
     test_block_for_one_second();
     test_sleep();
+    test_sleep_until();
     test_deterministic();
 }

--- a/tests/pass/shims/time.rs
+++ b/tests/pass/shims/time.rs
@@ -1,5 +1,5 @@
 //@compile-flags: -Zmiri-disable-isolation
-#![feature(thread_sleep_until)]
+#![feature(duration_constructors, thread_sleep_until)]
 
 use std::time::{Duration, Instant, SystemTime};
 
@@ -7,6 +7,13 @@ fn duration_sanity(diff: Duration) {
     // On my laptop, I observed times around 15-40ms. Add 10x lee-way both ways.
     assert!(diff.as_millis() > 1);
     assert!(diff.as_millis() < 1000); // macOS is very slow sometimes
+}
+
+fn test_underflow() {
+    // The time 1 day before the program started should be representable.
+    // (This used to underflow on Windows.)
+    let now = Instant::now();
+    let _earlier = now - Duration::from_days(1);
 }
 
 fn test_sleep() {
@@ -57,6 +64,7 @@ fn main() {
     assert_eq!(now2 - diff, now1);
     duration_sanity(diff);
 
+    test_underflow();
     test_sleep();
     test_sleep_until();
 }


### PR DESCRIPTION
This used to underflow on Windows because std treats the value as `u64`, i.e. it assumes that the value is far enough away from 0 that we can meaningfully subtract from it.

That seems like a questionable assumption TBH -- if this is time measured since the computer started, then `Instant::now() - Duration::from_days(1)` would overflow if called just after a reboot. See https://github.com/rust-lang/rust/issues/156142 for further details.