### PR TITLE
Remove `WSAESHUTDOWN` workaround for network socket writes

### DIFF
--- a/src/shims/unix/socket.rs
+++ b/src/shims/unix/socket.rs
@@ -1548,15 +1548,6 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // would be returned on UNIX-like systems. We thus remap this error to an EWOULDBLOCK.
                 interp_ok(Err(IoError::HostError(io::ErrorKind::WouldBlock.into())))
             }
-            Err(IoError::HostError(e))
-                if cfg!(windows)
-                    && matches!(e.raw_os_error(), Some(/* WSAESHUTDOWN error code */ 10058)) =>
-            {
-                // FIXME: This is a temporary workaround for handling WSAESHUTDOWN errors
-                // on Windows. A discussion on how those errors should be handled can be found here:
-                // <https://rust-lang.zulipchat.com/#narrow/channel/219381-t-libs/topic/WSAESHUTDOWN.20error.20on.20Windows/near/591883531>
-                interp_ok(Err(IoError::HostError(io::ErrorKind::BrokenPipe.into())))
-            }
             result => interp_ok(result),
         }
     }


### PR DESCRIPTION
With the merger of https://github.com/rust-lang/rust/pull/156063, we no longer need to have a workaround for mapping WSAESHUTDOWN error codes to `io::ErrorKind::BrokenPipe`. This is now part of the standard library.

The error kind mapping is not added to the `UNIX_IO_ERROR_TABLE` because `ERROR_NO_DATA` already maps to `io::ErrorKind::BrokenPipe`.