### PR TITLE
try to remove generic normalization from backtraces

### DIFF
--- a/tests/fail-dep/concurrency/libc_pthread_mutex_deadlock.stderr
+++ b/tests/fail-dep/concurrency/libc_pthread_mutex_deadlock.stderr
@@ -8,9 +8,9 @@ LL |         let ret = unsafe { libc::pthread_join(id, ptr::null_mut()) };
    = note: stack backtrace:
            0: std::sys::thread::PLATFORM::Thread::join
                at RUSTLIB/std/src/sys/thread/PLATFORM.rs:LL:CC
-           1: std::thread::lifecycle::JoinInner::join
+           1: std::thread::lifecycle::JoinInner::<'_, ()>::join
                at RUSTLIB/std/src/thread/lifecycle.rs:LL:CC
-           2: std::thread::JoinHandle::join
+           2: std::thread::JoinHandle::<()>::join
                at RUSTLIB/std/src/thread/join_handle.rs:LL:CC
            3: main
                at tests/fail-dep/concurrency/libc_pthread_mutex_deadlock.rs:LL:CC

--- a/tests/fail-dep/concurrency/libc_pthread_mutex_free_while_queued.stderr
+++ b/tests/fail-dep/concurrency/libc_pthread_mutex_free_while_queued.stderr
@@ -10,9 +10,9 @@ LL |                 self.1.deallocate(From::from(ptr.cast()), layout);
    = note: stack backtrace:
            0: <std::boxed::Box<Mutex> as std::ops::Drop>::drop
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
-           1: std::ptr::drop_glue))
+           1: std::ptr::drop_glue::<std::boxed::Box<Mutex>> - shim(Some(std::boxed::Box<Mutex>))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
-           2: std::mem::drop
+           2: std::mem::drop::<std::boxed::Box<Mutex>>
                at RUSTLIB/core/src/mem/mod.rs:LL:CC
            3: main::{closure#0}::{closure#2}
                at tests/fail-dep/concurrency/libc_pthread_mutex_free_while_queued.rs:LL:CC

--- a/tests/fail-dep/concurrency/libc_pthread_rwlock_write_read_deadlock.stderr
+++ b/tests/fail-dep/concurrency/libc_pthread_rwlock_write_read_deadlock.stderr
@@ -8,9 +8,9 @@ LL |         let ret = unsafe { libc::pthread_join(id, ptr::null_mut()) };
    = note: stack backtrace:
            0: std::sys::thread::PLATFORM::Thread::join
                at RUSTLIB/std/src/sys/thread/PLATFORM.rs:LL:CC
-           1: std::thread::lifecycle::JoinInner::join
+           1: std::thread::lifecycle::JoinInner::<'_, ()>::join
                at RUSTLIB/std/src/thread/lifecycle.rs:LL:CC
-           2: std::thread::JoinHandle::join
+           2: std::thread::JoinHandle::<()>::join
                at RUSTLIB/std/src/thread/join_handle.rs:LL:CC
            3: main
                at tests/fail-dep/concurrency/libc_pthread_rwlock_write_read_deadlock.rs:LL:CC

--- a/tests/fail-dep/concurrency/libc_pthread_rwlock_write_write_deadlock.stderr
+++ b/tests/fail-dep/concurrency/libc_pthread_rwlock_write_write_deadlock.stderr
@@ -8,9 +8,9 @@ LL |         let ret = unsafe { libc::pthread_join(id, ptr::null_mut()) };
    = note: stack backtrace:
            0: std::sys::thread::PLATFORM::Thread::join
                at RUSTLIB/std/src/sys/thread/PLATFORM.rs:LL:CC
-           1: std::thread::lifecycle::JoinInner::join
+           1: std::thread::lifecycle::JoinInner::<'_, ()>::join
                at RUSTLIB/std/src/thread/lifecycle.rs:LL:CC
-           2: std::thread::JoinHandle::join
+           2: std::thread::JoinHandle::<()>::join
                at RUSTLIB/std/src/thread/join_handle.rs:LL:CC
            3: main
                at tests/fail-dep/concurrency/libc_pthread_rwlock_write_write_deadlock.rs:LL:CC

--- a/tests/fail-dep/concurrency/windows_join_detached.stderr
+++ b/tests/fail-dep/concurrency/windows_join_detached.stderr
@@ -10,9 +10,9 @@ LL |         let rc = unsafe { c::WaitForSingleObject(self.handle.as_raw_handle(
    = note: stack backtrace:
            0: std::sys::thread::PLATFORM::Thread::join
                at RUSTLIB/std/src/sys/thread/PLATFORM.rs:LL:CC
-           1: std::thread::lifecycle::JoinInner::join
+           1: std::thread::lifecycle::JoinInner::<'_, ()>::join
                at RUSTLIB/std/src/thread/lifecycle.rs:LL:CC
-           2: std::thread::JoinHandle::join
+           2: std::thread::JoinHandle::<()>::join
                at RUSTLIB/std/src/thread/join_handle.rs:LL:CC
            3: main
                at tests/fail-dep/concurrency/windows_join_detached.rs:LL:CC

--- a/tests/fail-dep/concurrency/windows_join_main.stderr
+++ b/tests/fail-dep/concurrency/windows_join_main.stderr
@@ -8,9 +8,9 @@ LL |         let rc = unsafe { c::WaitForSingleObject(self.handle.as_raw_handle(
    = note: stack backtrace:
            0: std::sys::thread::PLATFORM::Thread::join
                at RUSTLIB/std/src/sys/thread/PLATFORM.rs:LL:CC
-           1: std::thread::lifecycle::JoinInner::join
+           1: std::thread::lifecycle::JoinInner::<'_, ()>::join
                at RUSTLIB/std/src/thread/lifecycle.rs:LL:CC
-           2: std::thread::JoinHandle::join
+           2: std::thread::JoinHandle::<()>::join
                at RUSTLIB/std/src/thread/join_handle.rs:LL:CC
            3: main
                at tests/fail-dep/concurrency/windows_join_main.rs:LL:CC

--- a/tests/fail-dep/concurrency/windows_join_self.stderr
+++ b/tests/fail-dep/concurrency/windows_join_self.stderr
@@ -8,9 +8,9 @@ LL |         let rc = unsafe { c::WaitForSingleObject(self.handle.as_raw_handle(
    = note: stack backtrace:
            0: std::sys::thread::PLATFORM::Thread::join
                at RUSTLIB/std/src/sys/thread/PLATFORM.rs:LL:CC
-           1: std::thread::lifecycle::JoinInner::join
+           1: std::thread::lifecycle::JoinInner::<'_, ()>::join
                at RUSTLIB/std/src/thread/lifecycle.rs:LL:CC
-           2: std::thread::JoinHandle::join
+           2: std::thread::JoinHandle::<()>::join
                at RUSTLIB/std/src/thread/join_handle.rs:LL:CC
            3: main
                at tests/fail-dep/concurrency/windows_join_self.rs:LL:CC

--- a/tests/fail-dep/libc/eventfd_block_read_twice.stderr
+++ b/tests/fail-dep/libc/eventfd_block_read_twice.stderr
@@ -8,9 +8,9 @@ LL |         let ret = unsafe { libc::pthread_join(id, ptr::null_mut()) };
    = note: stack backtrace:
            0: std::sys::thread::PLATFORM::Thread::join
                at RUSTLIB/std/src/sys/thread/PLATFORM.rs:LL:CC
-           1: std::thread::lifecycle::JoinInner::join
+           1: std::thread::lifecycle::JoinInner::<'_, ()>::join
                at RUSTLIB/std/src/thread/lifecycle.rs:LL:CC
-           2: std::thread::JoinHandle::join
+           2: std::thread::JoinHandle::<()>::join
                at RUSTLIB/std/src/thread/join_handle.rs:LL:CC
            3: main
                at tests/fail-dep/libc/eventfd_block_read_twice.rs:LL:CC

--- a/tests/fail-dep/libc/eventfd_block_write_twice.stderr
+++ b/tests/fail-dep/libc/eventfd_block_write_twice.stderr
@@ -8,9 +8,9 @@ LL |         let ret = unsafe { libc::pthread_join(id, ptr::null_mut()) };
    = note: stack backtrace:
            0: std::sys::thread::PLATFORM::Thread::join
                at RUSTLIB/std/src/sys/thread/PLATFORM.rs:LL:CC
-           1: std::thread::lifecycle::JoinInner::join
+           1: std::thread::lifecycle::JoinInner::<'_, ()>::join
                at RUSTLIB/std/src/thread/lifecycle.rs:LL:CC
-           2: std::thread::JoinHandle::join
+           2: std::thread::JoinHandle::<()>::join
                at RUSTLIB/std/src/thread/join_handle.rs:LL:CC
            3: main
                at tests/fail-dep/libc/eventfd_block_write_twice.rs:LL:CC

--- a/tests/fail-dep/libc/libc_epoll_block_two_thread.stderr
+++ b/tests/fail-dep/libc/libc_epoll_block_two_thread.stderr
@@ -8,9 +8,9 @@ LL |         let ret = unsafe { libc::pthread_join(id, ptr::null_mut()) };
    = note: stack backtrace:
            0: std::sys::thread::PLATFORM::Thread::join
                at RUSTLIB/std/src/sys/thread/PLATFORM.rs:LL:CC
-           1: std::thread::lifecycle::JoinInner::join
+           1: std::thread::lifecycle::JoinInner::<'_, ()>::join
                at RUSTLIB/std/src/thread/lifecycle.rs:LL:CC
-           2: std::thread::JoinHandle::join
+           2: std::thread::JoinHandle::<()>::join
                at RUSTLIB/std/src/thread/join_handle.rs:LL:CC
            3: main
                at tests/fail-dep/libc/libc_epoll_block_two_thread.rs:LL:CC

--- a/tests/fail-dep/libc/socketpair-close-while-blocked.stderr
+++ b/tests/fail-dep/libc/socketpair-close-while-blocked.stderr
@@ -8,9 +8,9 @@ LL |         let ret = unsafe { libc::pthread_join(id, ptr::null_mut()) };
    = note: stack backtrace:
            0: std::sys::thread::PLATFORM::Thread::join
                at RUSTLIB/std/src/sys/thread/PLATFORM.rs:LL:CC
-           1: std::thread::lifecycle::JoinInner::join
+           1: std::thread::lifecycle::JoinInner::<'_, ()>::join
                at RUSTLIB/std/src/thread/lifecycle.rs:LL:CC
-           2: std::thread::JoinHandle::join
+           2: std::thread::JoinHandle::<()>::join
                at RUSTLIB/std/src/thread/join_handle.rs:LL:CC
            3: main
                at tests/fail-dep/libc/socketpair-close-while-blocked.rs:LL:CC

--- a/tests/fail-dep/libc/socketpair_block_read_twice.stderr
+++ b/tests/fail-dep/libc/socketpair_block_read_twice.stderr
@@ -8,9 +8,9 @@ LL |         let ret = unsafe { libc::pthread_join(id, ptr::null_mut()) };
    = note: stack backtrace:
            0: std::sys::thread::PLATFORM::Thread::join
                at RUSTLIB/std/src/sys/thread/PLATFORM.rs:LL:CC
-           1: std::thread::lifecycle::JoinInner::join
+           1: std::thread::lifecycle::JoinInner::<'_, ()>::join
                at RUSTLIB/std/src/thread/lifecycle.rs:LL:CC
-           2: std::thread::JoinHandle::join
+           2: std::thread::JoinHandle::<()>::join
                at RUSTLIB/std/src/thread/join_handle.rs:LL:CC
            3: main
                at tests/fail-dep/libc/socketpair_block_read_twice.rs:LL:CC

--- a/tests/fail-dep/libc/socketpair_block_write_twice.stderr
+++ b/tests/fail-dep/libc/socketpair_block_write_twice.stderr
@@ -8,9 +8,9 @@ LL |         let ret = unsafe { libc::pthread_join(id, ptr::null_mut()) };
    = note: stack backtrace:
            0: std::sys::thread::PLATFORM::Thread::join
                at RUSTLIB/std/src/sys/thread/PLATFORM.rs:LL:CC
-           1: std::thread::lifecycle::JoinInner::join
+           1: std::thread::lifecycle::JoinInner::<'_, ()>::join
                at RUSTLIB/std/src/thread/lifecycle.rs:LL:CC
-           2: std::thread::JoinHandle::join
+           2: std::thread::JoinHandle::<()>::join
                at RUSTLIB/std/src/thread/join_handle.rs:LL:CC
            3: main
                at tests/fail-dep/libc/socketpair_block_write_twice.rs:LL:CC

--- a/tests/fail/alloc/alloc_error_handler.stderr
+++ b/tests/fail/alloc/alloc_error_handler.stderr
@@ -10,7 +10,7 @@ LL |         crate::process::abort()
    = note: stack backtrace:
            0: std::alloc::rust_oom::{closure#0}
                at RUSTLIB/std/src/alloc.rs:LL:CC
-           1: std::sys::backtrace::__rust_end_short_backtrace
+           1: std::sys::backtrace::__rust_end_short_backtrace::<{closure@std::alloc::rust_oom::{closure#0}}, !>
                at RUSTLIB/std/src/sys/backtrace.rs:LL:CC
            2: std::alloc::rust_oom
                at RUSTLIB/std/src/alloc.rs:LL:CC

--- a/tests/fail/alloc/global_system_mixup.stderr
+++ b/tests/fail/alloc/global_system_mixup.stderr
@@ -7,7 +7,7 @@ LL |         FREE();
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: stack backtrace:
-           0: std::sys::alloc::PLATFORM::dealloc
+           0: std::sys::alloc::PLATFORM::<impl std::alloc::GlobalAlloc for std::alloc::System>::dealloc
                at RUSTLIB/std/src/sys/alloc/PLATFORM.rs:LL:CC
            1: <std::alloc::System as std::alloc::Allocator>::deallocate
                at RUSTLIB/std/src/alloc.rs:LL:CC

--- a/tests/fail/alloc/stack_free.stderr
+++ b/tests/fail/alloc/stack_free.stderr
@@ -9,9 +9,9 @@ LL |                 self.1.deallocate(From::from(ptr.cast()), layout);
    = note: stack backtrace:
            0: <std::boxed::Box<i32> as std::ops::Drop>::drop
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
-           1: std::ptr::drop_glue))
+           1: std::ptr::drop_glue::<std::boxed::Box<i32>> - shim(Some(std::boxed::Box<i32>))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
-           2: std::mem::drop
+           2: std::mem::drop::<std::boxed::Box<i32>>
                at RUSTLIB/core/src/mem/mod.rs:LL:CC
            3: main
                at tests/fail/alloc/stack_free.rs:LL:CC

--- a/tests/fail/both_borrows/aliasing_mut4.tree.stderr
+++ b/tests/fail/both_borrows/aliasing_mut4.tree.stderr
@@ -20,11 +20,11 @@ help: the protected tag <TAG> was created here, in the initial state Frozen
 LL | fn safe(x: &i32, y: &mut Cell<i32>) {
    |         ^
    = note: stack backtrace:
-           0: std::mem::replace
+           0: std::mem::replace::<i32>
                at RUSTLIB/core/src/mem/mod.rs:LL:CC
-           1: std::cell::Cell::replace
+           1: std::cell::Cell::<i32>::replace
                at RUSTLIB/core/src/cell.rs:LL:CC
-           2: std::cell::Cell::set
+           2: std::cell::Cell::<i32>::set
                at RUSTLIB/core/src/cell.rs:LL:CC
            3: safe
                at tests/fail/both_borrows/aliasing_mut4.rs:LL:CC

--- a/tests/fail/both_borrows/buggy_split_at_mut.stack.stderr
+++ b/tests/fail/both_borrows/buggy_split_at_mut.stack.stderr
@@ -23,7 +23,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x10] by a Unique retag
 LL |                 from_raw_parts_mut(ptr.offset(mid as isize), len - mid),
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: stack backtrace:
-           0: safe::split_at_mut
+           0: safe::split_at_mut::<i32>
                at tests/fail/both_borrows/buggy_split_at_mut.rs:LL:CC
            1: main
                at tests/fail/both_borrows/buggy_split_at_mut.rs:LL:CC

--- a/tests/fail/both_borrows/drop_in_place_protector.stack.stderr
+++ b/tests/fail/both_borrows/drop_in_place_protector.stack.stderr
@@ -19,11 +19,11 @@ LL |         core::ptr::drop_in_place(x);
    = note: stack backtrace:
            0: <HasDrop as std::ops::Drop>::drop
                at tests/fail/both_borrows/drop_in_place_protector.rs:LL:CC
-           1: std::ptr::drop_glue - shim(Some(HasDrop))
+           1: std::ptr::drop_glue::<HasDrop> - shim(Some(HasDrop))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
-           2: std::ptr::drop_glue - shim(Some((HasDrop, u8)))
+           2: std::ptr::drop_glue::<(HasDrop, u8)> - shim(Some((HasDrop, u8)))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
-           3: std::ptr::drop_in_place
+           3: std::ptr::drop_in_place::<(HasDrop, u8)>
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
            4: main
                at tests/fail/both_borrows/drop_in_place_protector.rs:LL:CC

--- a/tests/fail/both_borrows/drop_in_place_protector.tree.stderr
+++ b/tests/fail/both_borrows/drop_in_place_protector.tree.stderr
@@ -22,11 +22,11 @@ LL |         core::ptr::drop_in_place(x);
    = note: stack backtrace:
            0: <HasDrop as std::ops::Drop>::drop
                at tests/fail/both_borrows/drop_in_place_protector.rs:LL:CC
-           1: std::ptr::drop_glue - shim(Some(HasDrop))
+           1: std::ptr::drop_glue::<HasDrop> - shim(Some(HasDrop))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
-           2: std::ptr::drop_glue - shim(Some((HasDrop, u8)))
+           2: std::ptr::drop_glue::<(HasDrop, u8)> - shim(Some((HasDrop, u8)))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
-           3: std::ptr::drop_in_place
+           3: std::ptr::drop_in_place::<(HasDrop, u8)>
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
            4: main
                at tests/fail/both_borrows/drop_in_place_protector.rs:LL:CC

--- a/tests/fail/both_borrows/newtype_pair_retagging.stack.stderr
+++ b/tests/fail/both_borrows/newtype_pair_retagging.stack.stderr
@@ -17,13 +17,13 @@ help: <TAG> is this argument
 LL | fn dealloc_while_running(_n: Newtype<'_>, dealloc: impl FnOnce()) {
    |                          ^^
    = note: stack backtrace:
-           0: std::boxed::Box::from_raw_in
+           0: std::boxed::Box::<i32>::from_raw_in
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
-           1: std::boxed::Box::from_raw
+           1: std::boxed::Box::<i32>::from_raw
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
            2: main::{closure#0}
                at tests/fail/both_borrows/newtype_pair_retagging.rs:LL:CC
-           3: dealloc_while_running
+           3: dealloc_while_running::<{closure@tests/fail/both_borrows/newtype_pair_retagging.rs:LL:CC}>
                at tests/fail/both_borrows/newtype_pair_retagging.rs:LL:CC
            4: main
                at tests/fail/both_borrows/newtype_pair_retagging.rs:LL:CC

--- a/tests/fail/both_borrows/newtype_pair_retagging.tree.stderr
+++ b/tests/fail/both_borrows/newtype_pair_retagging.tree.stderr
@@ -28,13 +28,13 @@ LL |             || drop(Box::from_raw(ptr)),
    = note: stack backtrace:
            0: <std::boxed::Box<i32> as std::ops::Drop>::drop
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
-           1: std::ptr::drop_glue))
+           1: std::ptr::drop_glue::<std::boxed::Box<i32>> - shim(Some(std::boxed::Box<i32>))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
-           2: std::mem::drop
+           2: std::mem::drop::<std::boxed::Box<i32>>
                at RUSTLIB/core/src/mem/mod.rs:LL:CC
            3: main::{closure#0}
                at tests/fail/both_borrows/newtype_pair_retagging.rs:LL:CC
-           4: dealloc_while_running
+           4: dealloc_while_running::<{closure@tests/fail/both_borrows/newtype_pair_retagging.rs:LL:CC}>
                at tests/fail/both_borrows/newtype_pair_retagging.rs:LL:CC
            5: main
                at tests/fail/both_borrows/newtype_pair_retagging.rs:LL:CC

--- a/tests/fail/both_borrows/newtype_retagging.stack.stderr
+++ b/tests/fail/both_borrows/newtype_retagging.stack.stderr
@@ -17,13 +17,13 @@ help: <TAG> is this argument
 LL | fn dealloc_while_running(_n: Newtype<'_>, dealloc: impl FnOnce()) {
    |                          ^^
    = note: stack backtrace:
-           0: std::boxed::Box::from_raw_in
+           0: std::boxed::Box::<i32>::from_raw_in
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
-           1: std::boxed::Box::from_raw
+           1: std::boxed::Box::<i32>::from_raw
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
            2: main::{closure#0}
                at tests/fail/both_borrows/newtype_retagging.rs:LL:CC
-           3: dealloc_while_running
+           3: dealloc_while_running::<{closure@tests/fail/both_borrows/newtype_retagging.rs:LL:CC}>
                at tests/fail/both_borrows/newtype_retagging.rs:LL:CC
            4: main
                at tests/fail/both_borrows/newtype_retagging.rs:LL:CC

--- a/tests/fail/both_borrows/newtype_retagging.tree.stderr
+++ b/tests/fail/both_borrows/newtype_retagging.tree.stderr
@@ -28,13 +28,13 @@ LL |             || drop(Box::from_raw(ptr)),
    = note: stack backtrace:
            0: <std::boxed::Box<i32> as std::ops::Drop>::drop
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
-           1: std::ptr::drop_glue))
+           1: std::ptr::drop_glue::<std::boxed::Box<i32>> - shim(Some(std::boxed::Box<i32>))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
-           2: std::mem::drop
+           2: std::mem::drop::<std::boxed::Box<i32>>
                at RUSTLIB/core/src/mem/mod.rs:LL:CC
            3: main::{closure#0}
                at tests/fail/both_borrows/newtype_retagging.rs:LL:CC
-           4: dealloc_while_running
+           4: dealloc_while_running::<{closure@tests/fail/both_borrows/newtype_retagging.rs:LL:CC}>
                at tests/fail/both_borrows/newtype_retagging.rs:LL:CC
            5: main
                at tests/fail/both_borrows/newtype_retagging.rs:LL:CC

--- a/tests/fail/coroutine-pinned-moved.stderr
+++ b/tests/fail/coroutine-pinned-moved.stderr
@@ -21,7 +21,7 @@ LL |     }; // *deallocate* coroutine_iterator
                at tests/fail/coroutine-pinned-moved.rs:LL:CC
            1: <CoroutineIteratorAdapter<{static coroutine@tests/fail/coroutine-pinned-moved.rs:LL:CC}> as std::iter::Iterator>::next
                at tests/fail/coroutine-pinned-moved.rs:LL:CC
-           2: std::boxed::iter::next
+           2: std::boxed::iter::<impl std::iter::Iterator for std::boxed::Box<CoroutineIteratorAdapter<{static coroutine@tests/fail/coroutine-pinned-moved.rs:LL:CC}>>>::next
                at RUSTLIB/alloc/src/boxed/iter.rs:LL:CC
            3: main
                at tests/fail/coroutine-pinned-moved.rs:LL:CC

--- a/tests/fail/memleak_rc.stderr
+++ b/tests/fail/memleak_rc.stderr
@@ -5,7 +5,7 @@ LL |                 Box::leak(Box::new(RcInner { strong: Cell::new(1), weak: Ce
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: stack backtrace:
-           0: std::rc::Rc::new
+           0: std::rc::Rc::<std::cell::RefCell<std::option::Option<Dummy>>>::new
                at RUSTLIB/alloc/src/rc.rs:LL:CC
            1: main
                at tests/fail/memleak_rc.rs:LL:CC

--- a/tests/fail/panic/bad_unwind.stderr
+++ b/tests/fail/panic/bad_unwind.stderr
@@ -14,11 +14,11 @@ LL |     std::panic::catch_unwind(|| unwind()).unwrap_err();
    = note: stack backtrace:
            0: main::{closure#0}
                at tests/fail/panic/bad_unwind.rs:LL:CC
-           1: std::panicking::catch_unwind::do_call
+           1: std::panicking::catch_unwind::do_call::<{closure@tests/fail/panic/bad_unwind.rs:LL:CC}, ()>
                at RUSTLIB/std/src/panicking.rs:LL:CC
-           2: std::panicking::catch_unwind
+           2: std::panicking::catch_unwind::<(), {closure@tests/fail/panic/bad_unwind.rs:LL:CC}>
                at RUSTLIB/std/src/panicking.rs:LL:CC
-           3: std::panic::catch_unwind
+           3: std::panic::catch_unwind::<{closure@tests/fail/panic/bad_unwind.rs:LL:CC}, ()>
                at RUSTLIB/std/src/panic.rs:LL:CC
            4: main
                at tests/fail/panic/bad_unwind.rs:LL:CC

--- a/tests/fail/panic/panic_abort1.stderr
+++ b/tests/fail/panic/panic_abort1.stderr
@@ -20,7 +20,7 @@ LL |     crate::process::abort();
                at RUSTLIB/std/src/panicking.rs:LL:CC
            4: std::panicking::panic_handler::{closure#0}
                at RUSTLIB/std/src/panicking.rs:LL:CC
-           5: std::sys::backtrace::__rust_end_short_backtrace
+           5: std::sys::backtrace::__rust_end_short_backtrace::<{closure@std::panicking::panic_handler::{closure#0}}, !>
                at RUSTLIB/std/src/sys/backtrace.rs:LL:CC
            6: std::panicking::panic_handler
                at RUSTLIB/std/src/panicking.rs:LL:CC

--- a/tests/fail/panic/panic_abort2.stderr
+++ b/tests/fail/panic/panic_abort2.stderr
@@ -20,7 +20,7 @@ LL |     crate::process::abort();
                at RUSTLIB/std/src/panicking.rs:LL:CC
            4: std::panicking::panic_handler::{closure#0}
                at RUSTLIB/std/src/panicking.rs:LL:CC
-           5: std::sys::backtrace::__rust_end_short_backtrace
+           5: std::sys::backtrace::__rust_end_short_backtrace::<{closure@std::panicking::panic_handler::{closure#0}}, !>
                at RUSTLIB/std/src/sys/backtrace.rs:LL:CC
            6: std::panicking::panic_handler
                at RUSTLIB/std/src/panicking.rs:LL:CC

--- a/tests/fail/panic/panic_abort3.stderr
+++ b/tests/fail/panic/panic_abort3.stderr
@@ -20,7 +20,7 @@ LL |     crate::process::abort();
                at RUSTLIB/std/src/panicking.rs:LL:CC
            4: std::panicking::panic_handler::{closure#0}
                at RUSTLIB/std/src/panicking.rs:LL:CC
-           5: std::sys::backtrace::__rust_end_short_backtrace
+           5: std::sys::backtrace::__rust_end_short_backtrace::<{closure@std::panicking::panic_handler::{closure#0}}, !>
                at RUSTLIB/std/src/sys/backtrace.rs:LL:CC
            6: std::panicking::panic_handler
                at RUSTLIB/std/src/panicking.rs:LL:CC

--- a/tests/fail/panic/panic_abort4.stderr
+++ b/tests/fail/panic/panic_abort4.stderr
@@ -20,7 +20,7 @@ LL |     crate::process::abort();
                at RUSTLIB/std/src/panicking.rs:LL:CC
            4: std::panicking::panic_handler::{closure#0}
                at RUSTLIB/std/src/panicking.rs:LL:CC
-           5: std::sys::backtrace::__rust_end_short_backtrace
+           5: std::sys::backtrace::__rust_end_short_backtrace::<{closure@std::panicking::panic_handler::{closure#0}}, !>
                at RUSTLIB/std/src/sys/backtrace.rs:LL:CC
            6: std::panicking::panic_handler
                at RUSTLIB/std/src/panicking.rs:LL:CC

--- a/tests/fail/shims/fs/isolated_file.stderr
+++ b/tests/fail/shims/fs/isolated_file.stderr
@@ -9,25 +9,25 @@ LL |         let fd = cvt_r(|| unsafe { open64(path.as_ptr(), flags, opts.mode a
    = note: stack backtrace:
            0: std::sys::fs::PLATFORM::File::open_c::{closure#0}
                at RUSTLIB/std/src/sys/fs/PLATFORM.rs:LL:CC
-           1: std::sys::pal::PLATFORM::cvt_r
+           1: std::sys::pal::PLATFORM::cvt_r::<i32, {closure@std::sys::fs::PLATFORM::File::open_c::{closure#0}}>
                at RUSTLIB/std/src/sys/pal/PLATFORM/mod.rs:LL:CC
            2: std::sys::fs::PLATFORM::File::open_c
                at RUSTLIB/std/src/sys/fs/PLATFORM.rs:LL:CC
            3: std::sys::fs::PLATFORM::File::open::{closure#0}
                at RUSTLIB/std/src/sys/fs/PLATFORM.rs:LL:CC
-           4: std::sys::helpers::small_c_string::run_with_cstr_stack
+           4: std::sys::helpers::small_c_string::run_with_cstr_stack::<std::sys::fs::PLATFORM::File>
                at RUSTLIB/std/src/sys/helpers/small_c_string.rs:LL:CC
-           5: std::sys::helpers::small_c_string::run_with_cstr
+           5: std::sys::helpers::small_c_string::run_with_cstr::<std::sys::fs::PLATFORM::File>
                at RUSTLIB/std/src/sys/helpers/small_c_string.rs:LL:CC
-           6: std::sys::helpers::small_c_string::run_path_with_cstr
+           6: std::sys::helpers::small_c_string::run_path_with_cstr::<std::sys::fs::PLATFORM::File>
                at RUSTLIB/std/src/sys/helpers/small_c_string.rs:LL:CC
            7: std::sys::fs::PLATFORM::File::open
                at RUSTLIB/std/src/sys/fs/PLATFORM.rs:LL:CC
            8: std::fs::OpenOptions::_open
                at RUSTLIB/std/src/fs.rs:LL:CC
-           9: std::fs::OpenOptions::open
+           9: std::fs::OpenOptions::open::<&std::path::Path>
                at RUSTLIB/std/src/fs.rs:LL:CC
-           10: std::fs::File::open
+           10: std::fs::File::open::<&str>
                at RUSTLIB/std/src/fs.rs:LL:CC
            11: main
                at tests/fail/shims/fs/isolated_file.rs:LL:CC

--- a/tests/fail/stacked_borrows/deallocate_against_protector1.stderr
+++ b/tests/fail/stacked_borrows/deallocate_against_protector1.stderr
@@ -9,9 +9,9 @@ LL |                 self.1.deallocate(From::from(ptr.cast()), layout);
    = note: stack backtrace:
            0: <std::boxed::Box<i32> as std::ops::Drop>::drop
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
-           1: std::ptr::drop_glue))
+           1: std::ptr::drop_glue::<std::boxed::Box<i32>> - shim(Some(std::boxed::Box<i32>))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
-           2: std::mem::drop
+           2: std::mem::drop::<std::boxed::Box<i32>>
                at RUSTLIB/core/src/mem/mod.rs:LL:CC
            3: main::{closure#0}
                at tests/fail/stacked_borrows/deallocate_against_protector1.rs:LL:CC

--- a/tests/fail/stacked_borrows/drop_in_place_retag.stderr
+++ b/tests/fail/stacked_borrows/drop_in_place_retag.stderr
@@ -12,7 +12,7 @@ help: <TAG> was created by a SharedReadOnly retag at offsets [0x0..0x1]
 LL |         let x = core::ptr::addr_of!(x);
    |                 ^^^^^^^^^^^^^^^^^^^^^^
    = note: stack backtrace:
-           0: std::ptr::drop_in_place
+           0: std::ptr::drop_in_place::<u8>
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
            1: main
                at tests/fail/stacked_borrows/drop_in_place_retag.rs:LL:CC

--- a/tests/fail/tail_calls/cc-mismatch.stderr
+++ b/tests/fail/tail_calls/cc-mismatch.stderr
@@ -9,29 +9,29 @@ LL |     extern "rust-call" fn call_once(self, args: Args) -> Self::Output;
    = note: stack backtrace:
            0: <fn() as std::ops::FnOnce<()>>::call_once - shim(fn())
                at RUSTLIB/core/src/ops/function.rs:LL:CC
-           1: std::sys::backtrace::__rust_begin_short_backtrace
+           1: std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>
                at RUSTLIB/std/src/sys/backtrace.rs:LL:CC
-           2: std::rt::lang_start::{closure#0}
+           2: std::rt::lang_start::<()>::{closure#0}
                at RUSTLIB/std/src/rt.rs:LL:CC
-           3: std::ops::function::impls::call_once
+           3: std::ops::function::impls::<impl std::ops::FnOnce<()> for &dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe>::call_once
                at RUSTLIB/core/src/ops/function.rs:LL:CC
-           4: std::panicking::catch_unwind::do_call
+           4: std::panicking::catch_unwind::do_call::<&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe, i32>
                at RUSTLIB/std/src/panicking.rs:LL:CC
-           5: std::panicking::catch_unwind
+           5: std::panicking::catch_unwind::<i32, &dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe>
                at RUSTLIB/std/src/panicking.rs:LL:CC
-           6: std::panic::catch_unwind
+           6: std::panic::catch_unwind::<&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe, i32>
                at RUSTLIB/std/src/panic.rs:LL:CC
            7: std::rt::lang_start_internal::{closure#0}
                at RUSTLIB/std/src/rt.rs:LL:CC
-           8: std::panicking::catch_unwind::do_call
+           8: std::panicking::catch_unwind::do_call::<{closure@std::rt::lang_start_internal::{closure#0}}, isize>
                at RUSTLIB/std/src/panicking.rs:LL:CC
-           9: std::panicking::catch_unwind
+           9: std::panicking::catch_unwind::<isize, {closure@std::rt::lang_start_internal::{closure#0}}>
                at RUSTLIB/std/src/panicking.rs:LL:CC
-           10: std::panic::catch_unwind
+           10: std::panic::catch_unwind::<{closure@std::rt::lang_start_internal::{closure#0}}, isize>
                at RUSTLIB/std/src/panic.rs:LL:CC
            11: std::rt::lang_start_internal
                at RUSTLIB/std/src/rt.rs:LL:CC
-           12: std::rt::lang_start
+           12: std::rt::lang_start::<()>
                at RUSTLIB/std/src/rt.rs:LL:CC
 
 error: aborting due to 1 previous error

--- a/tests/fail/tls_macro_leak.stderr
+++ b/tests/fail/tls_macro_leak.stderr
@@ -7,9 +7,9 @@ LL |             cell.set(Some(Box::leak(Box::new(123))));
    = note: stack backtrace:
            0: main::{closure#0}::{closure#0}
                at tests/fail/tls_macro_leak.rs:LL:CC
-           1: std::thread::LocalKey::<std::cell::Cell<std::option::Option<&i32>>>::try_with
+           1: std::thread::LocalKey::<std::cell::Cell<std::option::Option<&i32>>>::try_with::<{closure@tests/fail/tls_macro_leak.rs:LL:CC}, ()>
                at RUSTLIB/std/src/thread/local.rs:LL:CC
-           2: std::thread::LocalKey::<std::cell::Cell<std::option::Option<&i32>>>::with
+           2: std::thread::LocalKey::<std::cell::Cell<std::option::Option<&i32>>>::with::<{closure@tests/fail/tls_macro_leak.rs:LL:CC}, ()>
                at RUSTLIB/std/src/thread/local.rs:LL:CC
            3: main::{closure#0}
                at tests/fail/tls_macro_leak.rs:LL:CC

--- a/tests/fail/tree_borrows/implicit_writes/ptr_write.stderr
+++ b/tests/fail/tree_borrows/implicit_writes/ptr_write.stderr
@@ -20,7 +20,7 @@ help: the protected tag <TAG> was created here, in the initial state Reserved
 LL | fn dereference<T>(x: T, y: *mut u8) -> T {
    |                   ^
    = note: stack backtrace:
-           0: dereference
+           0: dereference::<&mut u8>
                at tests/fail/tree_borrows/implicit_writes/ptr_write.rs:LL:CC
            1: main
                at tests/fail/tree_borrows/implicit_writes/ptr_write.rs:LL:CC

--- a/tests/fail/tree_borrows/implicit_writes/ptr_write_box.stderr
+++ b/tests/fail/tree_borrows/implicit_writes/ptr_write_box.stderr
@@ -20,7 +20,7 @@ help: the protected tag <TAG> was created here, in the initial state Reserved
 LL | fn dereference<T>(x: T, y: *mut u8) -> T {
    |                   ^
    = note: stack backtrace:
-           0: dereference
+           0: dereference::<std::boxed::Box<u8>>
                at tests/fail/tree_borrows/implicit_writes/ptr_write_box.rs:LL:CC
            1: main
                at tests/fail/tree_borrows/implicit_writes/ptr_write_box.rs:LL:CC

--- a/tests/fail/tree_borrows/implicit_writes/ptr_write_unsafe_cell.stderr
+++ b/tests/fail/tree_borrows/implicit_writes/ptr_write_unsafe_cell.stderr
@@ -20,7 +20,7 @@ help: the protected tag <TAG> was created here, in the initial state Reserved
 LL | fn dereference<T>(x: T, y: *mut u8) -> T {
    |                   ^
    = note: stack backtrace:
-           0: dereference
+           0: dereference::<&mut std::cell::UnsafeCell<u8>>
                at tests/fail/tree_borrows/implicit_writes/ptr_write_unsafe_cell.rs:LL:CC
            1: main
                at tests/fail/tree_borrows/implicit_writes/ptr_write_unsafe_cell.rs:LL:CC

--- a/tests/fail/tree_borrows/strongly-protected.stderr
+++ b/tests/fail/tree_borrows/strongly-protected.stderr
@@ -21,9 +21,9 @@ LL | fn inner(x: &mut i32, f: fn(*mut i32)) {
    = note: stack backtrace:
            0: <std::boxed::Box<i32> as std::ops::Drop>::drop
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
-           1: std::ptr::drop_glue))
+           1: std::ptr::drop_glue::<std::boxed::Box<i32>> - shim(Some(std::boxed::Box<i32>))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
-           2: std::mem::drop
+           2: std::mem::drop::<std::boxed::Box<i32>>
                at RUSTLIB/core/src/mem/mod.rs:LL:CC
            3: main::{closure#0}
                at tests/fail/tree_borrows/strongly-protected.rs:LL:CC

--- a/tests/fail/tree_borrows/wildcard/strongly_protected_wildcard.stderr
+++ b/tests/fail/tree_borrows/wildcard/strongly_protected_wildcard.stderr
@@ -21,9 +21,9 @@ LL | fn inner(x: &mut i32, f: fn(usize)) {
    = note: stack backtrace:
            0: <std::boxed::Box<i32> as std::ops::Drop>::drop
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
-           1: std::ptr::drop_glue))
+           1: std::ptr::drop_glue::<std::boxed::Box<i32>> - shim(Some(std::boxed::Box<i32>))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
-           2: std::mem::drop
+           2: std::mem::drop::<std::boxed::Box<i32>>
                at RUSTLIB/core/src/mem/mod.rs:LL:CC
            3: main::{closure#0}
                at tests/fail/tree_borrows/wildcard/strongly_protected_wildcard.rs:LL:CC

--- a/tests/fail/unaligned_pointers/drop_in_place.stderr
+++ b/tests/fail/unaligned_pointers/drop_in_place.stderr
@@ -7,7 +7,7 @@ LL |     unsafe { drop_glue(&mut *to_drop) }
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: stack backtrace:
-           0: std::ptr::drop_in_place
+           0: std::ptr::drop_in_place::<PartialDrop>
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
            1: main
                at tests/fail/unaligned_pointers/drop_in_place.rs:LL:CC

--- a/tests/fail/unaligned_pointers/reference_to_packed.stderr
+++ b/tests/fail/unaligned_pointers/reference_to_packed.stderr
@@ -7,7 +7,7 @@ LL |     mem::transmute(x)
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: stack backtrace:
-           0: raw_to_ref
+           0: raw_to_ref::<'_, i32>
                at tests/fail/unaligned_pointers/reference_to_packed.rs:LL:CC
            1: main
                at tests/fail/unaligned_pointers/reference_to_packed.rs:LL:CC

--- a/tests/fail/uninit/uninit_alloc_diagnostic.stderr
+++ b/tests/fail/uninit/uninit_alloc_diagnostic.stderr
@@ -9,7 +9,7 @@ LL |         let mut order = unsafe { compare_bytes(left, right, len) as isize }
    = note: stack backtrace:
            0: <u8 as core::slice::cmp::SliceOrd>::compare
                at RUSTLIB/core/src/slice/cmp.rs:LL:CC
-           1: core::slice::cmp::cmp
+           1: core::slice::cmp::<impl std::cmp::Ord for [u8]>::cmp
                at RUSTLIB/core/src/slice/cmp.rs:LL:CC
            2: main
                at tests/fail/uninit/uninit_alloc_diagnostic.rs:LL:CC

--- a/tests/fail/uninit/uninit_alloc_diagnostic_with_provenance.stderr
+++ b/tests/fail/uninit/uninit_alloc_diagnostic_with_provenance.stderr
@@ -9,7 +9,7 @@ LL |         let mut order = unsafe { compare_bytes(left, right, len) as isize }
    = note: stack backtrace:
            0: <u8 as core::slice::cmp::SliceOrd>::compare
                at RUSTLIB/core/src/slice/cmp.rs:LL:CC
-           1: core::slice::cmp::cmp
+           1: core::slice::cmp::<impl std::cmp::Ord for [u8]>::cmp
                at RUSTLIB/core/src/slice/cmp.rs:LL:CC
            2: main
                at tests/fail/uninit/uninit_alloc_diagnostic_with_provenance.rs:LL:CC

--- a/tests/genmc/fail/atomics/atomic_ptr_double_free.stderr
+++ b/tests/genmc/fail/atomics/atomic_ptr_double_free.stderr
@@ -25,7 +25,7 @@ LL |     dealloc(ptr as *mut u8, Layout::new::<u64>())
                at tests/genmc/fail/atomics/atomic_ptr_double_free.rs:LL:CC
            2: <std::boxed::Box<{closure@tests/genmc/fail/atomics/atomic_ptr_double_free.rs:LL:CC}> as std::ops::FnOnce<()>>::call_once
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
-           3: genmc::spawn_pthread_closure::thread_func
+           3: genmc::spawn_pthread_closure::thread_func::<{closure@tests/genmc/fail/atomics/atomic_ptr_double_free.rs:LL:CC}>
                at tests/genmc/fail/atomics/../../../utils/genmc.rs:LL:CC
 note: the last function in that backtrace got called indirectly due to this code
   --> tests/genmc/fail/atomics/../../../utils/genmc.rs:LL:CC

--- a/tests/genmc/fail/data_race/atomic_ptr_alloc_race.dealloc.stderr
+++ b/tests/genmc/fail/data_race/atomic_ptr_alloc_race.dealloc.stderr
@@ -13,7 +13,7 @@ LL |                         dealloc(b as *mut u8, Layout::new::<u64>());
                at tests/genmc/fail/data_race/atomic_ptr_alloc_race.rs:LL:CC
            1: <std::boxed::Box<{closure@tests/genmc/fail/data_race/atomic_ptr_alloc_race.rs:LL:CC}> as std::ops::FnOnce<()>>::call_once
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
-           2: genmc::spawn_pthread_closure::thread_func
+           2: genmc::spawn_pthread_closure::thread_func::<{closure@tests/genmc/fail/data_race/atomic_ptr_alloc_race.rs:LL:CC}>
                at tests/genmc/fail/data_race/../../../utils/genmc.rs:LL:CC
 note: the last function in that backtrace got called indirectly due to this code
   --> tests/genmc/fail/data_race/../../../utils/genmc.rs:LL:CC

--- a/tests/genmc/fail/data_race/atomic_ptr_alloc_race.write.stderr
+++ b/tests/genmc/fail/data_race/atomic_ptr_alloc_race.write.stderr
@@ -13,7 +13,7 @@ LL |                         *b = 42;
                at tests/genmc/fail/data_race/atomic_ptr_alloc_race.rs:LL:CC
            1: <std::boxed::Box<{closure@tests/genmc/fail/data_race/atomic_ptr_alloc_race.rs:LL:CC}> as std::ops::FnOnce<()>>::call_once
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
-           2: genmc::spawn_pthread_closure::thread_func
+           2: genmc::spawn_pthread_closure::thread_func::<{closure@tests/genmc/fail/data_race/atomic_ptr_alloc_race.rs:LL:CC}>
                at tests/genmc/fail/data_race/../../../utils/genmc.rs:LL:CC
 note: the last function in that backtrace got called indirectly due to this code
   --> tests/genmc/fail/data_race/../../../utils/genmc.rs:LL:CC

--- a/tests/genmc/fail/data_race/atomic_ptr_dealloc_write_race.stderr
+++ b/tests/genmc/fail/data_race/atomic_ptr_dealloc_write_race.stderr
@@ -23,7 +23,7 @@ LL |             }),
                at tests/genmc/fail/data_race/atomic_ptr_dealloc_write_race.rs:LL:CC
            1: <std::boxed::Box<{closure@tests/genmc/fail/data_race/atomic_ptr_dealloc_write_race.rs:LL:CC}> as std::ops::FnOnce<()>>::call_once
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
-           2: genmc::spawn_pthread_closure::thread_func
+           2: genmc::spawn_pthread_closure::thread_func::<{closure@tests/genmc/fail/data_race/atomic_ptr_dealloc_write_race.rs:LL:CC}>
                at tests/genmc/fail/data_race/../../../utils/genmc.rs:LL:CC
 note: the last function in that backtrace got called indirectly due to this code
   --> tests/genmc/fail/data_race/../../../utils/genmc.rs:LL:CC

--- a/tests/genmc/fail/data_race/atomic_ptr_write_dealloc_race.stderr
+++ b/tests/genmc/fail/data_race/atomic_ptr_write_dealloc_race.stderr
@@ -13,7 +13,7 @@ LL |             }),
                at tests/genmc/fail/data_race/atomic_ptr_write_dealloc_race.rs:LL:CC
            1: <std::boxed::Box<{closure@tests/genmc/fail/data_race/atomic_ptr_write_dealloc_race.rs:LL:CC}> as std::ops::FnOnce<()>>::call_once
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
-           2: genmc::spawn_pthread_closure::thread_func
+           2: genmc::spawn_pthread_closure::thread_func::<{closure@tests/genmc/fail/data_race/atomic_ptr_write_dealloc_race.rs:LL:CC}>
                at tests/genmc/fail/data_race/../../../utils/genmc.rs:LL:CC
 note: the last function in that backtrace got called indirectly due to this code
   --> tests/genmc/fail/data_race/../../../utils/genmc.rs:LL:CC

--- a/tests/genmc/fail/data_race/mpu2_rels_rlx.stderr
+++ b/tests/genmc/fail/data_race/mpu2_rels_rlx.stderr
@@ -13,7 +13,7 @@ LL |                 X = 2;
                at tests/genmc/fail/data_race/mpu2_rels_rlx.rs:LL:CC
            1: <std::boxed::Box<{closure@tests/genmc/fail/data_race/mpu2_rels_rlx.rs:LL:CC}> as std::ops::FnOnce<()>>::call_once
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
-           2: genmc::spawn_pthread_closure::thread_func
+           2: genmc::spawn_pthread_closure::thread_func::<{closure@tests/genmc/fail/data_race/mpu2_rels_rlx.rs:LL:CC}>
                at tests/genmc/fail/data_race/../../../utils/genmc.rs:LL:CC
 note: the last function in that backtrace got called indirectly due to this code
   --> tests/genmc/fail/data_race/../../../utils/genmc.rs:LL:CC

--- a/tests/genmc/fail/data_race/weak_orderings.rel_rlx.stderr
+++ b/tests/genmc/fail/data_race/weak_orderings.rel_rlx.stderr
@@ -13,7 +13,7 @@ LL |                 X = 2;
                at tests/genmc/fail/data_race/weak_orderings.rs:LL:CC
            1: <std::boxed::Box<{closure@tests/genmc/fail/data_race/weak_orderings.rs:LL:CC}> as std::ops::FnOnce<()>>::call_once
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
-           2: genmc::spawn_pthread_closure::thread_func
+           2: genmc::spawn_pthread_closure::thread_func::<{closure@tests/genmc/fail/data_race/weak_orderings.rs:LL:CC}>
                at tests/genmc/fail/data_race/../../../utils/genmc.rs:LL:CC
 note: the last function in that backtrace got called indirectly due to this code
   --> tests/genmc/fail/data_race/../../../utils/genmc.rs:LL:CC

--- a/tests/genmc/fail/data_race/weak_orderings.rlx_acq.stderr
+++ b/tests/genmc/fail/data_race/weak_orderings.rlx_acq.stderr
@@ -13,7 +13,7 @@ LL |                 X = 2;
                at tests/genmc/fail/data_race/weak_orderings.rs:LL:CC
            1: <std::boxed::Box<{closure@tests/genmc/fail/data_race/weak_orderings.rs:LL:CC}> as std::ops::FnOnce<()>>::call_once
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
-           2: genmc::spawn_pthread_closure::thread_func
+           2: genmc::spawn_pthread_closure::thread_func::<{closure@tests/genmc/fail/data_race/weak_orderings.rs:LL:CC}>
                at tests/genmc/fail/data_race/../../../utils/genmc.rs:LL:CC
 note: the last function in that backtrace got called indirectly due to this code
   --> tests/genmc/fail/data_race/../../../utils/genmc.rs:LL:CC

--- a/tests/genmc/fail/data_race/weak_orderings.rlx_rlx.stderr
+++ b/tests/genmc/fail/data_race/weak_orderings.rlx_rlx.stderr
@@ -13,7 +13,7 @@ LL |                 X = 2;
                at tests/genmc/fail/data_race/weak_orderings.rs:LL:CC
            1: <std::boxed::Box<{closure@tests/genmc/fail/data_race/weak_orderings.rs:LL:CC}> as std::ops::FnOnce<()>>::call_once
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
-           2: genmc::spawn_pthread_closure::thread_func
+           2: genmc::spawn_pthread_closure::thread_func::<{closure@tests/genmc/fail/data_race/weak_orderings.rs:LL:CC}>
                at tests/genmc/fail/data_race/../../../utils/genmc.rs:LL:CC
 note: the last function in that backtrace got called indirectly due to this code
   --> tests/genmc/fail/data_race/../../../utils/genmc.rs:LL:CC

--- a/tests/genmc/fail/shims/mutex_diff_thread_unlock.stderr
+++ b/tests/genmc/fail/shims/mutex_diff_thread_unlock.stderr
@@ -11,11 +11,11 @@ LL |             self.lock.inner.unlock();
    = note: stack backtrace:
            0: <std::sync::MutexGuard<'_, u64> as std::ops::Drop>::drop
                at RUSTLIB/std/src/sync/poison/mutex.rs:LL:CC
-           1: std::ptr::drop_glue))
+           1: std::ptr::drop_glue::<std::sync::MutexGuard<'_, u64>> - shim(Some(std::sync::MutexGuard<'_, u64>))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
-           2: std::ptr::drop_glue))
+           2: std::ptr::drop_glue::<EvilSend<std::sync::MutexGuard<'_, u64>>> - shim(Some(EvilSend<std::sync::MutexGuard<'_, u64>>))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
-           3: std::mem::drop
+           3: std::mem::drop::<EvilSend<std::sync::MutexGuard<'_, u64>>>
                at RUSTLIB/core/src/mem/mod.rs:LL:CC
            4: miri_start::{closure#0}
                at tests/genmc/fail/shims/mutex_diff_thread_unlock.rs:LL:CC

--- a/tests/genmc/fail/shims/mutex_double_unlock.stderr
+++ b/tests/genmc/fail/shims/mutex_double_unlock.stderr
@@ -10,9 +10,9 @@ LL |             self.lock.inner.unlock();
    = note: stack backtrace:
            0: <std::sync::MutexGuard<'_, u64> as std::ops::Drop>::drop
                at RUSTLIB/std/src/sync/poison/mutex.rs:LL:CC
-           1: std::ptr::drop_glue))
+           1: std::ptr::drop_glue::<std::sync::MutexGuard<'_, u64>> - shim(Some(std::sync::MutexGuard<'_, u64>))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
-           2: std::mem::drop
+           2: std::mem::drop::<std::sync::MutexGuard<'_, u64>>
                at RUSTLIB/core/src/mem/mod.rs:LL:CC
            3: miri_start
                at tests/genmc/fail/shims/mutex_double_unlock.rs:LL:CC

--- a/tests/genmc/fail/simple/alloc_large.multiple.stderr
+++ b/tests/genmc/fail/simple/alloc_large.multiple.stderr
@@ -11,11 +11,11 @@ LL |             AllocInit::Uninitialized => alloc.allocate(layout),
                at RUSTLIB/alloc/src/raw_vec/mod.rs:LL:CC
            1: alloc::raw_vec::RawVecInner::with_capacity_in
                at RUSTLIB/alloc/src/raw_vec/mod.rs:LL:CC
-           2: alloc::raw_vec::RawVec::with_capacity_in
+           2: alloc::raw_vec::RawVec::<u8>::with_capacity_in
                at RUSTLIB/alloc/src/raw_vec/mod.rs:LL:CC
-           3: std::vec::Vec::with_capacity_in
+           3: std::vec::Vec::<u8>::with_capacity_in
                at RUSTLIB/alloc/src/vec/mod.rs:LL:CC
-           4: std::vec::Vec::with_capacity
+           4: std::vec::Vec::<u8>::with_capacity
                at RUSTLIB/alloc/src/vec/mod.rs:LL:CC
            5: miri_start
                at tests/genmc/fail/simple/alloc_large.rs:LL:CC

--- a/tests/genmc/fail/simple/alloc_large.single.stderr
+++ b/tests/genmc/fail/simple/alloc_large.single.stderr
@@ -11,11 +11,11 @@ LL |             AllocInit::Uninitialized => alloc.allocate(layout),
                at RUSTLIB/alloc/src/raw_vec/mod.rs:LL:CC
            1: alloc::raw_vec::RawVecInner::with_capacity_in
                at RUSTLIB/alloc/src/raw_vec/mod.rs:LL:CC
-           2: alloc::raw_vec::RawVec::with_capacity_in
+           2: alloc::raw_vec::RawVec::<u8>::with_capacity_in
                at RUSTLIB/alloc/src/raw_vec/mod.rs:LL:CC
-           3: std::vec::Vec::with_capacity_in
+           3: std::vec::Vec::<u8>::with_capacity_in
                at RUSTLIB/alloc/src/vec/mod.rs:LL:CC
-           4: std::vec::Vec::with_capacity
+           4: std::vec::Vec::<u8>::with_capacity
                at RUSTLIB/alloc/src/vec/mod.rs:LL:CC
            5: miri_start
                at tests/genmc/fail/simple/alloc_large.rs:LL:CC

--- a/tests/genmc/pass/atomics/cas_failure_ord_racy_key_init.stderr
+++ b/tests/genmc/pass/atomics/cas_failure_ord_racy_key_init.stderr
@@ -13,7 +13,7 @@ LL |     match KEY.compare_exchange(KEY_SENTVAL, key, Release, Acquire) {
                at tests/genmc/pass/atomics/cas_failure_ord_racy_key_init.rs:LL:CC
            2: <std::boxed::Box<{closure@tests/genmc/pass/atomics/cas_failure_ord_racy_key_init.rs:LL:CC}> as std::ops::FnOnce<()>>::call_once
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
-           3: genmc::spawn_pthread_closure::thread_func
+           3: genmc::spawn_pthread_closure::thread_func::<{closure@tests/genmc/pass/atomics/cas_failure_ord_racy_key_init.rs:LL:CC}>
                at tests/genmc/pass/atomics/../../../utils/genmc.rs:LL:CC
 note: the last function in that backtrace got called indirectly due to this code
   --> tests/genmc/pass/atomics/../../../utils/genmc.rs:LL:CC

--- a/tests/pass-dep/libc/libc-socket-no-blocking.windows_host.stderr
+++ b/tests/pass-dep/libc/libc-socket-no-blocking.windows_host.stderr
@@ -10,9 +10,9 @@ LL |         libc::getsockname(client_sockfd, storage, len)
    = note: stack backtrace:
            0: test_getsockname_ipv4_connect_nonblock::{closure#0}
                at tests/pass-dep/libc/libc-socket-no-blocking.rs:LL:CC
-           1: libc_utils::net::sockname
+           1: libc_utils::net::sockname::<{closure@tests/pass-dep/libc/libc-socket-no-blocking.rs:LL:CC}>
                at tests/pass-dep/libc/../../utils/libc.rs:LL:CC
-           2: libc_utils::net::sockname_ipv4
+           2: libc_utils::net::sockname_ipv4::<{closure@tests/pass-dep/libc/libc-socket-no-blocking.rs:LL:CC}>
                at tests/pass-dep/libc/../../utils/libc.rs:LL:CC
            3: test_getsockname_ipv4_connect_nonblock
                at tests/pass-dep/libc/libc-socket-no-blocking.rs:LL:CC

--- a/tests/pass/alloc-access-tracking.stderr
+++ b/tests/pass/alloc-access-tracking.stderr
@@ -25,7 +25,7 @@ LL |                 self.1.deallocate(From::from(ptr.cast()), layout);
    = note: stack backtrace:
            0: <std::boxed::Box<std::mem::MaybeUninit<[u8; 123]>> as std::ops::Drop>::drop
                at RUSTLIB/alloc/src/boxed.rs:LL:CC
-           1: std::ptr::drop_glue))
+           1: std::ptr::drop_glue::<std::boxed::Box<std::mem::MaybeUninit<[u8; 123]>>> - shim(Some(std::boxed::Box<std::mem::MaybeUninit<[u8; 123]>>))
                at RUSTLIB/core/src/ptr/mod.rs:LL:CC
            2: main
                at tests/pass/alloc-access-tracking.rs:LL:CC

--- a/tests/pass/backtrace/backtrace-global-alloc.stderr
+++ b/tests/pass/backtrace/backtrace-global-alloc.stderr
@@ -2,27 +2,27 @@
              at tests/pass/backtrace/backtrace-global-alloc.rs:LL:CC
    1: <fn() as std::ops::FnOnce<()>>::call_once - shim(fn())
              at RUSTLIB/core/src/ops/function.rs:LL:CC
-   2: std::sys::backtrace::__rust_begin_short_backtrace
+   2: std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>
              at RUSTLIB/std/src/sys/backtrace.rs:LL:CC
-   3: std::rt::lang_start::{closure#0}
+   3: std::rt::lang_start::<()>::{closure#0}
              at RUSTLIB/std/src/rt.rs:LL:CC
-   4: std::ops::function::impls::call_once
+   4: std::ops::function::impls::<impl std::ops::FnOnce<()> for &dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe>::call_once
              at RUSTLIB/core/src/ops/function.rs:LL:CC
-   5: std::panicking::catch_unwind::do_call
+   5: std::panicking::catch_unwind::do_call::<&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe, i32>
              at RUSTLIB/std/src/panicking.rs:LL:CC
-   6: std::panicking::catch_unwind
+   6: std::panicking::catch_unwind::<i32, &dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe>
              at RUSTLIB/std/src/panicking.rs:LL:CC
-   7: std::panic::catch_unwind
+   7: std::panic::catch_unwind::<&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe, i32>
              at RUSTLIB/std/src/panic.rs:LL:CC
    8: std::rt::lang_start_internal::{closure#0}
              at RUSTLIB/std/src/rt.rs:LL:CC
-   9: std::panicking::catch_unwind::do_call
+   9: std::panicking::catch_unwind::do_call::<{closure@std::rt::lang_start_internal::{closure#0}}, isize>
              at RUSTLIB/std/src/panicking.rs:LL:CC
-  10: std::panicking::catch_unwind
+  10: std::panicking::catch_unwind::<isize, {closure@std::rt::lang_start_internal::{closure#0}}>
              at RUSTLIB/std/src/panicking.rs:LL:CC
-  11: std::panic::catch_unwind
+  11: std::panic::catch_unwind::<{closure@std::rt::lang_start_internal::{closure#0}}, isize>
              at RUSTLIB/std/src/panic.rs:LL:CC
   12: std::rt::lang_start_internal
              at RUSTLIB/std/src/rt.rs:LL:CC
-  13: std::rt::lang_start
+  13: std::rt::lang_start::<()>
              at RUSTLIB/std/src/rt.rs:LL:CC

--- a/tests/pass/backtrace/backtrace-std.stderr
+++ b/tests/pass/backtrace/backtrace-std.stderr
@@ -2,7 +2,7 @@
              at tests/pass/backtrace/backtrace-std.rs:LL:CC
    1: func_c
              at tests/pass/backtrace/backtrace-std.rs:LL:CC
-   2: func_b
+   2: func_b::<u8>
              at tests/pass/backtrace/backtrace-std.rs:LL:CC
    3: func_a
              at tests/pass/backtrace/backtrace-std.rs:LL:CC
@@ -10,27 +10,27 @@
              at tests/pass/backtrace/backtrace-std.rs:LL:CC
    5: <fn() as std::ops::FnOnce<()>>::call_once - shim(fn())
              at RUSTLIB/core/src/ops/function.rs:LL:CC
-   6: std::sys::backtrace::__rust_begin_short_backtrace
+   6: std::sys::backtrace::__rust_begin_short_backtrace::<fn(), ()>
              at RUSTLIB/std/src/sys/backtrace.rs:LL:CC
-   7: std::rt::lang_start::{closure#0}
+   7: std::rt::lang_start::<()>::{closure#0}
              at RUSTLIB/std/src/rt.rs:LL:CC
-   8: std::ops::function::impls::call_once
+   8: std::ops::function::impls::<impl std::ops::FnOnce<()> for &dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe>::call_once
              at RUSTLIB/core/src/ops/function.rs:LL:CC
-   9: std::panicking::catch_unwind::do_call
+   9: std::panicking::catch_unwind::do_call::<&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe, i32>
              at RUSTLIB/std/src/panicking.rs:LL:CC
-  10: std::panicking::catch_unwind
+  10: std::panicking::catch_unwind::<i32, &dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe>
              at RUSTLIB/std/src/panicking.rs:LL:CC
-  11: std::panic::catch_unwind
+  11: std::panic::catch_unwind::<&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe, i32>
              at RUSTLIB/std/src/panic.rs:LL:CC
   12: std::rt::lang_start_internal::{closure#0}
              at RUSTLIB/std/src/rt.rs:LL:CC
-  13: std::panicking::catch_unwind::do_call
+  13: std::panicking::catch_unwind::do_call::<{closure@std::rt::lang_start_internal::{closure#0}}, isize>
              at RUSTLIB/std/src/panicking.rs:LL:CC
-  14: std::panicking::catch_unwind
+  14: std::panicking::catch_unwind::<isize, {closure@std::rt::lang_start_internal::{closure#0}}>
              at RUSTLIB/std/src/panicking.rs:LL:CC
-  15: std::panic::catch_unwind
+  15: std::panic::catch_unwind::<{closure@std::rt::lang_start_internal::{closure#0}}, isize>
              at RUSTLIB/std/src/panic.rs:LL:CC
   16: std::rt::lang_start_internal
              at RUSTLIB/std/src/rt.rs:LL:CC
-  17: std::rt::lang_start
+  17: std::rt::lang_start::<()>
              at RUSTLIB/std/src/rt.rs:LL:CC

--- a/tests/pass/open_a_file_in_proc.stderr
+++ b/tests/pass/open_a_file_in_proc.stderr
@@ -7,25 +7,25 @@ LL |         let fd = cvt_r(|| unsafe { open64(path.as_ptr(), flags, opts.mode a
    = note: stack backtrace:
            0: std::sys::fs::PLATFORM::File::open_c::{closure#0}
                at RUSTLIB/std/src/sys/fs/PLATFORM.rs:LL:CC
-           1: std::sys::pal::PLATFORM::cvt_r
+           1: std::sys::pal::PLATFORM::cvt_r::<i32, {closure@std::sys::fs::PLATFORM::File::open_c::{closure#0}}>
                at RUSTLIB/std/src/sys/pal/PLATFORM/mod.rs:LL:CC
            2: std::sys::fs::PLATFORM::File::open_c
                at RUSTLIB/std/src/sys/fs/PLATFORM.rs:LL:CC
            3: std::sys::fs::PLATFORM::File::open::{closure#0}
                at RUSTLIB/std/src/sys/fs/PLATFORM.rs:LL:CC
-           4: std::sys::helpers::small_c_string::run_with_cstr_stack
+           4: std::sys::helpers::small_c_string::run_with_cstr_stack::<std::sys::fs::PLATFORM::File>
                at RUSTLIB/std/src/sys/helpers/small_c_string.rs:LL:CC
-           5: std::sys::helpers::small_c_string::run_with_cstr
+           5: std::sys::helpers::small_c_string::run_with_cstr::<std::sys::fs::PLATFORM::File>
                at RUSTLIB/std/src/sys/helpers/small_c_string.rs:LL:CC
-           6: std::sys::helpers::small_c_string::run_path_with_cstr
+           6: std::sys::helpers::small_c_string::run_path_with_cstr::<std::sys::fs::PLATFORM::File>
                at RUSTLIB/std/src/sys/helpers/small_c_string.rs:LL:CC
            7: std::sys::fs::PLATFORM::File::open
                at RUSTLIB/std/src/sys/fs/PLATFORM.rs:LL:CC
            8: std::fs::OpenOptions::_open
                at RUSTLIB/std/src/fs.rs:LL:CC
-           9: std::fs::OpenOptions::open
+           9: std::fs::OpenOptions::open::<&std::path::Path>
                at RUSTLIB/std/src/fs.rs:LL:CC
-           10: std::fs::File::open
+           10: std::fs::File::open::<&str>
                at RUSTLIB/std/src/fs.rs:LL:CC
            11: main
                at tests/pass/open_a_file_in_proc.rs:LL:CC

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -267,8 +267,6 @@ regexes! {
     "<[0-9]+="                       => "<TAG=",
     // normalize width of Tree Borrows diagnostic borders (which otherwise leak borrow tag info)
     "(─{50})─+"                      => "$1",
-    // erase generics in backtraces
-    "([0-9]+: .*)::<.*>"             => "$1",
     // erase long hexadecimals
     r"0x[0-9a-fA-F]+[0-9a-fA-F]{2,2}" => "$$HEX",
     // erase specific alignments


### PR DESCRIPTION
I forgot why we do this, but it leads to some very strange results like
```
           0: <std::sync::MutexGuard<'_, u64> as std::ops::Drop>::drop
               at RUSTLIB/std/src/sync/poison/mutex.rs:LL:CC
           1: std::ptr::drop_glue))
               at RUSTLIB/core/src/ptr/mod.rs:LL:CC
           2: std::ptr::drop_glue))
               at RUSTLIB/core/src/ptr/mod.rs:LL:CC
```