### PR TITLE
cargo: Remove deprecated package authors field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Miri Team"]
 description = "An experimental interpreter for Rust MIR (core driver)."
 license = "MIT OR Apache-2.0"
 name = "miri"

--- a/bench-cargo-miri/mse/Cargo.toml
+++ b/bench-cargo-miri/mse/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "mse"
 version = "0.1.0"
-authors = ["Ralf Jung <post@ralfj.de>"]
 edition = "2018"
 
 [dependencies]

--- a/bench-cargo-miri/serde1/Cargo.toml
+++ b/bench-cargo-miri/serde1/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "cargo-miri-test"
 version = "0.1.0"
-authors = ["Oliver Schneider <git-spam-no-reply9815368754983@oli-obk.de>"]
 edition = "2018"
 
 [dependencies]

--- a/bench-cargo-miri/serde2/Cargo.toml
+++ b/bench-cargo-miri/serde2/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "cargo-miri-test"
 version = "0.1.0"
-authors = ["Oliver Schneider <git-spam-no-reply9815368754983@oli-obk.de>"]
 edition = "2018"
 
 [dependencies]

--- a/cargo-miri/Cargo.toml
+++ b/cargo-miri/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Miri Team"]
 description = "An experimental interpreter for Rust MIR (cargo wrapper)."
 license = "MIT OR Apache-2.0"
 name = "cargo-miri"

--- a/genmc-sys/Cargo.toml
+++ b/genmc-sys/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Miri Team"]
 license = "MIT OR Apache-2.0"
 name = "genmc-sys"
 version = "0.1.0"

--- a/miri-script/Cargo.toml
+++ b/miri-script/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Miri Team"]
 description = "Helpers for miri maintenance"
 license = "MIT OR Apache-2.0"
 name = "miri-script"

--- a/test-cargo-miri/Cargo.toml
+++ b/test-cargo-miri/Cargo.toml
@@ -5,7 +5,6 @@ exclude = ["no-std-smoke"] # it wants to be panic="abort"
 [package]
 name = "cargo-miri-test"
 version = "0.1.0"
-authors = ["Miri Team"]
 edition = "2024"
 
 [dependencies]

--- a/test-cargo-miri/exported-symbol-dep/Cargo.toml
+++ b/test-cargo-miri/exported-symbol-dep/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
 name = "exported_symbol_dep"
 version = "0.1.0"
-authors = ["Miri Team"]
 edition = "2018"

--- a/test-cargo-miri/exported-symbol/Cargo.toml
+++ b/test-cargo-miri/exported-symbol/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "exported_symbol"
 version = "0.1.0"
-authors = ["Miri Team"]
 edition = "2018"
 
 [dependencies]

--- a/test-cargo-miri/issue-1567/Cargo.toml
+++ b/test-cargo-miri/issue-1567/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "issue_1567"
 version = "0.1.0"
-authors = ["Miri Team"]
 edition = "2018"
 
 [lib]

--- a/test-cargo-miri/issue-1691/Cargo.toml
+++ b/test-cargo-miri/issue-1691/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "issue_1691"
 version = "0.1.0"
-authors = ["Miri Team"]
 edition = "2018"
 
 [lib]

--- a/test-cargo-miri/issue-1705/Cargo.toml
+++ b/test-cargo-miri/issue-1705/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "issue_1705"
 version = "0.1.0"
-authors = ["Miri Team"]
 edition = "2018"
 
 [lib]

--- a/test-cargo-miri/issue-rust-86261/Cargo.toml
+++ b/test-cargo-miri/issue-rust-86261/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
 name = "issue_rust_86261"
 version = "0.1.0"
-authors = ["Miri Team"]
 edition = "2018"

--- a/test-cargo-miri/proc-macro-crate/Cargo.toml
+++ b/test-cargo-miri/proc-macro-crate/Cargo.toml
@@ -2,7 +2,6 @@
 # regression test for issue 1760
 name = "proc_macro_crate"
 version = "0.1.0"
-authors = ["Miri Team"]
 edition = "2018"
 
 [lib]

--- a/test-cargo-miri/subcrate/Cargo.toml
+++ b/test-cargo-miri/subcrate/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "subcrate"
 version = "0.1.0"
-authors = ["Miri Team"]
 # This is deliberately *not* on the 2024 edition to ensure doctests keep working
 # on old editions.
 edition = "2018"

--- a/tests/deps/Cargo.toml
+++ b/tests/deps/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Miri Team"]
 description = "dependencies that unit tests can have"
 license = "MIT OR Apache-2.0"
 name = "miri-test-deps"


### PR DESCRIPTION
`package.authors` is deprecated: https://github.com/rust-lang/cargo/pull/15068