### PR TITLE
default all unknown weak extern statics to null

### DIFF
--- a/src/machine.rs
+++ b/src/machine.rs
@@ -17,7 +17,7 @@ use rustc_data_structures::either::Either;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 #[allow(unused)]
 use rustc_data_structures::static_assert_size;
-use rustc_hir::attrs::InlineAttr;
+use rustc_hir::attrs::{InlineAttr, Linkage};
 use rustc_log::tracing;
 use rustc_middle::middle::codegen_fn_attrs::TargetFeatureKind;
 use rustc_middle::mir;
@@ -573,6 +573,8 @@ pub struct MiriMachine<'tcx> {
 
     /// Mapping extern static names to their pointer.
     pub(crate) extern_statics: FxHashMap<Symbol, StrictPointer>,
+    /// A pointer to the allocation we provide for non-existent weak symbols.
+    pub(crate) missing_weak_symbol: Option<StrictPointer>,
 
     /// The random number generator used for resolving non-determinism.
     /// Needs to be queried by ptr_to_int, hence needs interior mutability.
@@ -742,6 +744,7 @@ impl<'tcx> MiriMachine<'tcx> {
             .expect("Couldn't create poll instance");
         let alloc_addresses =
             RefCell::new(alloc_addresses::GlobalStateInner::new(config, stack_addr, tcx));
+
         MiriMachine {
             tcx,
             borrow_tracker,
@@ -770,6 +773,7 @@ impl<'tcx> MiriMachine<'tcx> {
             backtrace_style: config.backtrace_style,
             user_relevant_crates,
             extern_statics: FxHashMap::default(),
+            missing_weak_symbol: None,
             rng: RefCell::new(rng),
             allocator: (!config.native_lib.is_empty())
                 .then(|| Rc::new(RefCell::new(crate::alloc::isolated_alloc::IsolatedAlloc::new()))),
@@ -1014,6 +1018,7 @@ impl VisitProvenance for MiriMachine<'_> {
             argv,
             cmd_line,
             extern_statics,
+            missing_weak_symbol,
             dirs,
             borrow_tracker,
             data_race,
@@ -1077,6 +1082,7 @@ impl VisitProvenance for MiriMachine<'_> {
         argc.visit_provenance(visit);
         argv.visit_provenance(visit);
         cmd_line.visit_provenance(visit);
+        missing_weak_symbol.visit_provenance(visit);
         for ptr in extern_statics.values() {
             ptr.visit_provenance(visit);
         }
@@ -1376,6 +1382,10 @@ impl<'tcx> Machine<'tcx> for MiriMachine<'tcx> {
         def_id: DefId,
     ) -> InterpResult<'tcx, StrictPointer> {
         let link_name = Symbol::intern(ecx.tcx.symbol_name(Instance::mono(*ecx.tcx, def_id)).name);
+        let def_ty = ecx.tcx.type_of(def_id).instantiate_identity().skip_norm_wip();
+        let extern_decl_layout =
+            ecx.tcx.layout_of(ecx.typing_env().as_query_input(def_ty)).unwrap();
+
         if let Some(&ptr) = ecx.machine.extern_statics.get(&link_name) {
             // Various parts of the engine rely on `get_alloc_info` for size and alignment
             // information. That uses the type information of this static.
@@ -1384,9 +1394,6 @@ impl<'tcx> Machine<'tcx> for MiriMachine<'tcx> {
                 panic!("extern_statics cannot contain wildcards")
             };
             let info = ecx.get_alloc_info(alloc_id);
-            let def_ty = ecx.tcx.type_of(def_id).instantiate_identity().skip_norm_wip();
-            let extern_decl_layout =
-                ecx.tcx.layout_of(ecx.typing_env().as_query_input(def_ty)).unwrap();
             if extern_decl_layout.size != info.size || extern_decl_layout.align.abi != info.align {
                 throw_unsup_format!(
                     "extern static `{link_name}` has been declared as `{krate}::{name}` \
@@ -1402,8 +1409,26 @@ impl<'tcx> Machine<'tcx> for MiriMachine<'tcx> {
                 )
             }
             interp_ok(ptr)
+        } else if ecx.tcx.codegen_fn_attrs(def_id).import_linkage == Some(Linkage::ExternalWeak) {
+            // Symbols with weak linkage default to null if they are not defined. However we can't
+            // create new allocations here. On the plus side we know rustc rejects non-ptr-sized
+            // weak statics so we can just use a single global "null" allocation for all of them.
+            // The memory we are assigning this address to is anyway somewhat "fake", it's an
+            // indirection introduced by how Rust represents external symbols with linkage (see
+            // <https://github.com/rust-lang/rust/issues/156468>). So we can just specify that such
+            // memory does not have unique addresses, despite being technically a `static`.
+            assert_eq!(
+                extern_decl_layout.size,
+                ecx.tcx.data_layout.pointer_size(),
+                "non-pointer-sized weak static"
+            );
+            interp_ok(
+                ecx.machine
+                    .missing_weak_symbol
+                    .expect("`missing_weak_symbol` should have been initialized"),
+            )
         } else {
-            throw_unsup_format!("extern static `{link_name}` is not supported by Miri",)
+            throw_unsup_format!("extern static `{link_name}` is not supported by Miri")
         }
     }
 

--- a/src/shims/extern_static.rs
+++ b/src/shims/extern_static.rs
@@ -16,18 +16,6 @@ impl<'tcx> MiriMachine<'tcx> {
         interp_ok(())
     }
 
-    /// Zero-initialized pointer-sized extern statics are pretty common.
-    /// Most of them are for weak symbols, which we all set to null (indicating that the
-    /// symbol is not supported, and triggering fallback code which ends up calling
-    /// some other shim that we do support).
-    fn null_ptr_extern_statics(ecx: &mut MiriInterpCx<'tcx>, names: &[&str]) -> InterpResult<'tcx> {
-        for name in names {
-            let val = ImmTy::from_int(0, ecx.machine.layouts.usize);
-            Self::alloc_extern_static(ecx, name, val)?;
-        }
-        interp_ok(())
-    }
-
     /// Extern statics that are initialized with function pointers to the symbols of the same name.
     fn weak_symbol_extern_statics(
         ecx: &mut MiriInterpCx<'tcx>,
@@ -53,17 +41,9 @@ impl<'tcx> MiriMachine<'tcx> {
 
         match &ecx.tcx.sess.target.os {
             Os::Linux => {
-                Self::null_ptr_extern_statics(
-                    ecx,
-                    &["__cxa_thread_atexit_impl", "__clock_gettime64", "__clock_nanosleep_time64"],
-                )?;
-                Self::weak_symbol_extern_statics(ecx, &["getrandom", "gettid", "statx"])?;
-            }
-            Os::FreeBsd => {
-                Self::null_ptr_extern_statics(ecx, &["__cxa_thread_atexit_impl"])?;
+                Self::weak_symbol_extern_statics(ecx, &["getrandom", "gettid", "statx", "strlen"])?;
             }
             Os::Android => {
-                Self::null_ptr_extern_statics(ecx, &["bsd_signal"])?;
                 Self::weak_symbol_extern_statics(ecx, &["signal", "getrandom", "gettid"])?;
             }
             Os::Windows => {
@@ -75,8 +55,14 @@ impl<'tcx> MiriMachine<'tcx> {
             Os::Illumos | Os::Solaris => {
                 Self::weak_symbol_extern_statics(ecx, &["pthread_setname_np"])?;
             }
-            _ => {} // No "extern statics" supported on this target
+            _ => {} // No "extern statics" supported on this target.
         }
+
+        // Also initialize `missing_weak_symbol`.
+        let place = ecx.allocate(ecx.machine.layouts.usize, MiriMemoryKind::ExternStatic.into())?;
+        ecx.write_null(&place)?;
+        ecx.machine.missing_weak_symbol = Some(place.ptr().into_pointer_or_addr().unwrap());
+
         interp_ok(())
     }
 }

--- a/src/shims/unix/foreign_items.rs
+++ b/src/shims/unix/foreign_items.rs
@@ -19,8 +19,8 @@ use crate::{shim_sig, *};
 
 pub fn is_dyn_sym(name: &str, target_os: &Os) -> bool {
     match name {
-        // Used for tests.
-        "isatty" => true,
+        // Used for (std and Miri) tests.
+        "strlen" => true,
         // `signal` is set up as a weak symbol in `init_extern_statics` (on Android) so we might as
         // well allow it in `dlsym`.
         "signal" => true,

--- a/tests/pass-dep/libc/libc-misc.rs
+++ b/tests/pass-dep/libc/libc-misc.rs
@@ -66,12 +66,10 @@ fn test_dlsym() {
     let addr = unsafe { libc::dlsym(libc::RTLD_DEFAULT, c"notasymbol".as_ptr()) };
     assert!(addr as usize == 0);
 
-    let addr = unsafe { libc::dlsym(libc::RTLD_DEFAULT, c"isatty".as_ptr()) };
+    let addr = unsafe { libc::dlsym(libc::RTLD_DEFAULT, c"strlen".as_ptr()) };
     assert!(addr as usize != 0);
-    let isatty: extern "C" fn(i32) -> i32 = unsafe { transmute(addr) };
-    assert_eq!(isatty(999), 0);
-    let errno = std::io::Error::last_os_error().raw_os_error().unwrap();
-    assert_eq!(errno, libc::EBADF);
+    let strlen: extern "C" fn(*const libc::c_char) -> libc::size_t = unsafe { transmute(addr) };
+    assert_eq!(strlen(c"1234".as_ptr()), 4);
 
     let addr = unsafe { libc::dlsym(libc::RTLD_DEFAULT, c"environ".as_ptr()) };
     assert!(addr as usize != 0);

--- a/tests/pass/weak-linkage-missing.rs
+++ b/tests/pass/weak-linkage-missing.rs
@@ -1,0 +1,10 @@
+#![feature(linkage)]
+
+unsafe extern "C" {
+    #[linkage = "extern_weak"]
+    static test_symbol_that_does_not_exist: Option<unsafe extern "C" fn()>;
+}
+
+fn main() {
+    unsafe { assert!(test_symbol_that_does_not_exist.is_none()) };
+}


### PR DESCRIPTION
Unfortunately we can't easily create a zero-filled allocation on-demand when encountering a weak extern. So instead we pre-allocate a ptr-sized null-filled allocation, and then make all ptr-sized weak externs aliases of that allocation. (Non-ptr-sized weak externs are just not supported for now.)

@bjorn3 does that seem like a plausible implementation strategy or is it silly?
In particular I wonder if LLVM is allowed to assume that different weak extern statics resolve to different addresses.