### PR TITLE
try_errnum_to_io_error: better support for unix targets on unix hosts

### DIFF
--- a/src/shims/io_error.rs
+++ b/src/shims/io_error.rs
@@ -246,8 +246,8 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         this.read_scalar(&errno_place)
     }
 
-    /// This function tries to produce the most similar OS error from the `std::io::ErrorKind`
-    /// as a platform-specific errnum.
+    /// This function converts host errors to target errors. It tries to produce the most similar OS
+    /// error from the `std::io::ErrorKind` as a platform-specific errnum.
     fn io_error_to_errnum(&self, err: std::io::Error) -> InterpResult<'tcx, Scalar> {
         let this = self.eval_context_ref();
         let target = &this.tcx.sess.target;
@@ -274,27 +274,46 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         }
     }
 
-    /// The inverse of `io_error_to_errnum`.
+    /// The inverse of `io_error_to_errnum`: it converts target errors to host errors.
+    /// This is done in a best-effort way.
     #[expect(clippy::needless_return)]
     fn try_errnum_to_io_error(
         &self,
-        errnum: Scalar,
-    ) -> InterpResult<'tcx, Option<std::io::ErrorKind>> {
+        target_errnum: Scalar,
+    ) -> InterpResult<'tcx, Option<io::Error>> {
         let this = self.eval_context_ref();
         let target = &this.tcx.sess.target;
         if target.families.iter().any(|f| f == "unix") {
-            let errnum = errnum.to_i32()?;
+            let target_errnum = target_errnum.to_i32()?;
+            // If the host is also unix, we try to translate the errno directly.
+            // That lets us use `Error::from_raw_os_error`, which has a much better `Display`
+            // impl than what we get by going through `ErrorKind`.
+            #[cfg(unix)]
+            {
+                // For now, we only add the constants we need to make `std` tests happy.
+                const ERRNOS: &[(&str, libc::c_int)] = &[
+                    ("ENOENT", libc::ENOENT),
+                    ("ENOTDIR", libc::ENOTDIR),
+                    ("ENOTSOCK", libc::ENOTSOCK),
+                ];
+                for &(name, errno) in ERRNOS {
+                    if target_errnum == this.eval_libc_i32(name) {
+                        return interp_ok(Some(io::Error::from_raw_os_error(errno)));
+                    }
+                }
+            }
+            // For other hosts or other constants, we fall back to translating via `ErrorKind`.
             for &(name, kind) in UNIX_IO_ERROR_TABLE {
-                if errnum == this.eval_libc_i32(name) {
-                    return interp_ok(Some(kind));
+                if target_errnum == this.eval_libc_i32(name) {
+                    return interp_ok(Some(kind.into()));
                 }
             }
             return interp_ok(None);
         } else if target.families.iter().any(|f| f == "windows") {
-            let errnum = errnum.to_u32()?;
+            let target_errnum = target_errnum.to_u32()?;
             for &(name, kind) in WINDOWS_IO_ERROR_TABLE {
-                if errnum == this.eval_windows("c", name).to_u32()? {
-                    return interp_ok(Some(kind));
+                if target_errnum == this.eval_windows("c", name).to_u32()? {
+                    return interp_ok(Some(kind.into()));
                 }
             }
             return interp_ok(None);


### PR DESCRIPTION
Creating an `io::Error` from an `ErrorKind` and from a raw OS error produces internally very different values. Calling `kind()` on them behaves pretty much the same, but calling `to_string()` on them behaves very differently.  The only purpose of Miri's `try_errnum_to_io_error` is to help in implementing `strerror_r`, so `to_string()` is what we ultimately call about.

To opportunistically improve the quality of the error strings we produce if host and target both happen to be Unix, add a code path that directly translates target errnos to host errnos, side-stepping `ErrorKind` entirely. It's a bit of a hack but very locally contained, and it lets us pass a few more std tests.