### PR TITLE
Handle short reads and writes for TCP sockets

### DIFF
--- a/src/shims/unix/socket.rs
+++ b/src/shims/unix/socket.rs
@@ -1470,8 +1470,6 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
         // This is a *non-blocking* write.
         let result = this.write_to_host(stream, length, buffer_ptr)?;
-        // FIXME: When the host does a short write, we should emit an epoll edge -- at least for targets for which tokio assumes no short writes:
-        // <https://github.com/tokio-rs/tokio/blob/6c03e03898d71eca976ee1ad8481cf112ae722ba/tokio/src/io/poll_evented.rs#L240>
         match result {
             Err(IoError::HostError(e))
                 if matches!(e.kind(), io::ErrorKind::NotConnected | io::ErrorKind::WouldBlock) =>
@@ -1483,6 +1481,45 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // On Windows hosts, `send` can return WSAENOTCONN where EAGAIN or EWOULDBLOCK
                 // would be returned on UNIX-like systems. We thus remap this error to an EWOULDBLOCK.
                 interp_ok(Err(IoError::HostError(io::ErrorKind::WouldBlock.into())))
+            }
+            Ok(bytes_written) if bytes_written < length => {
+                // We had a short write. On Unix hosts using the `epoll` and `kqueue` backends, a
+                // short write means that the write buffer is full. We update the readiness
+                // accordingly, which means that next time we see "writable" we will report an epoll
+                // edge. Some applications (e.g. tokio) rely on this behavior; see
+                // <https://github.com/tokio-rs/tokio/blob/HEAD/tokio/src/io/poll_evented.rs#L244-L264>.
+                if cfg!(any(
+                    // epoll
+                    target_os = "android",
+                    target_os = "illumos",
+                    target_os = "linux",
+                    target_os = "redox",
+                    // kqueue
+                    target_os = "dragonfly",
+                    target_os = "freebsd",
+                    target_os = "ios",
+                    target_os = "macos",
+                    target_os = "netbsd",
+                    target_os = "openbsd",
+                    target_os = "tvos",
+                    target_os = "visionos",
+                    target_os = "watchos",
+                )) {
+                    socket.io_readiness.borrow_mut().writable = false;
+                    this.update_epoll_active_events(socket.clone(), /* force_edge */ false)?;
+                } else {
+                    // On hosts which don't use the `epoll` or `kqueue` backends, a short write
+                    // doesn't imply a full write buffer. However, the target we are emulating might
+                    // guarantee this behavior. To prevent applications from being stuck on such
+                    // targets waiting on a new readiness event, we emit a new edge which still
+                    // contains a writable readiness. This should trick the applications into trying
+                    // another write which would then return EWOULDBLOCK should it really be full.
+                    // This results in an unrealistic execution but we don't have another way of
+                    // finding out whether the write buffer is full. The "default case" of linux
+                    // host and linux target isn't affected by this.
+                    this.update_epoll_active_events(socket.clone(), /* force_edge */ true)?;
+                }
+                interp_ok(result)
             }
             result => interp_ok(result),
         }
@@ -1556,8 +1593,6 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             length,
             buffer_ptr,
         )?;
-        // FIXME: When the host does a short read, we should emit an epoll edge -- at least for targets for which tokio assumes no short reads:
-        // <https://github.com/tokio-rs/tokio/blob/6c03e03898d71eca976ee1ad8481cf112ae722ba/tokio/src/io/poll_evented.rs#L182>
         match result {
             Err(IoError::HostError(e))
                 if matches!(e.kind(), io::ErrorKind::NotConnected | io::ErrorKind::WouldBlock) =>
@@ -1569,6 +1604,47 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // On Windows hosts, `recv` can return WSAENOTCONN where EAGAIN or EWOULDBLOCK
                 // would be returned on UNIX-like systems. We thus remap this error to an EWOULDBLOCK.
                 interp_ok(Err(IoError::HostError(io::ErrorKind::WouldBlock.into())))
+            }
+            Ok(bytes_read) if bytes_read < length && bytes_read > 0 => {
+                // We had a short read. (Note that reading 0 bytes is guaranteed to indicate EOF,
+                // and can never happen spuriously, so we have to exclude that case.) On Unix hosts
+                // using the `epoll` and `kqueue` backends, a short read means that the read buffer
+                // is empty. We update the readiness accordingly, which means that next time we see
+                // "readable" we will report an epoll edge. Some applications (e.g. tokio) rely on
+                // this behavior; see
+                // <https://github.com/tokio-rs/tokio/blob/HEAD/tokio/src/io/poll_evented.rs#L190-L210>
+                if cfg!(any(
+                    // epoll
+                    target_os = "android",
+                    target_os = "illumos",
+                    target_os = "linux",
+                    target_os = "redox",
+                    // kqueue
+                    target_os = "dragonfly",
+                    target_os = "freebsd",
+                    target_os = "ios",
+                    target_os = "macos",
+                    target_os = "netbsd",
+                    target_os = "openbsd",
+                    target_os = "tvos",
+                    target_os = "visionos",
+                    target_os = "watchos",
+                )) {
+                    socket.io_readiness.borrow_mut().readable = false;
+                    this.update_epoll_active_events(socket.clone(), /* force_edge */ false)?;
+                } else {
+                    // On hosts which don't use the `epoll` or `kqueue` backends, a short read
+                    // doesn't imply an empty read buffer. However, the target we are emulating
+                    // might guarantee this behavior. To prevent applications from being stuck on
+                    // such targets waiting on a new readiness event, we emit a new edge which still
+                    // contains a readable readiness. This should trick the applications into trying
+                    // another read which would then return EWOULDBLOCK should it really be empty.
+                    // This results in an unrealistic execution but we don't have another way of
+                    // finding out whether the read buffer is empty. The "default case" of linux
+                    // host and linux target isn't affected by this.
+                    this.update_epoll_active_events(socket.clone(), /* force_edge */ true)?;
+                }
+                interp_ok(result)
             }
             result => interp_ok(result),
         }

--- a/tests/pass-dep/libc/libc-socket-no-blocking-epoll.rs
+++ b/tests/pass-dep/libc/libc-socket-no-blocking-epoll.rs
@@ -1,8 +1,5 @@
 //@only-target: linux android illumos
 //@compile-flags: -Zmiri-disable-isolation
-//@revisions: windows_host unix_host
-//@[unix_host] ignore-host: windows
-//@[windows_host] only-host: windows
 
 #![feature(io_error_inprogress)]
 
@@ -23,11 +20,12 @@ fn main() {
     test_accept_nonblock();
     test_connect_nonblock_err();
     test_recv_nonblock();
-    #[cfg(not(windows_hosts))]
     test_send_nonblock();
     test_shutdown_read_write();
     test_shutdown_read();
     test_shutdown_write();
+    test_readiness_after_short_read();
+    test_readiness_after_short_write();
 }
 
 /// Test that connecting to a server socket works when the client
@@ -256,11 +254,6 @@ fn test_recv_nonblock() {
 /// Once the buffer is filled we wait for the epoll WRITABLE
 /// readiness instead of busy waiting until we can
 /// write again.
-///
-/// **Note**: This can only be tested on UNIX hosts because
-/// the socket write buffers dynamically grow for localhost
-/// connections on Windows.
-#[cfg(not(windows_hosts))]
 fn test_send_nonblock() {
     let (server_sockfd, addr) = net::make_listener_ipv4().unwrap();
     let client_sockfd =
@@ -290,15 +283,22 @@ fn test_send_nonblock() {
     let fill_buf = [1u8; 32_000];
     let mut total_written = 0usize;
     loop {
-        // Ensure the socket is still writable.
-        assert_eq!(current_epoll_readiness::<8>(client_sockfd, EPOLLOUT | EPOLLET), EPOLLOUT);
-
         let result = unsafe {
             errno_result(libc::send(client_sockfd, fill_buf.as_ptr().cast(), fill_buf.len(), 0))
         };
 
         match result {
-            Ok(written) => total_written += written as usize,
+            Ok(written) => {
+                total_written += written as usize;
+                if written as usize == fill_buf.len() {
+                    // When we didn't have a short write we should still be able to write more.
+                    // Ensure the socket is still writable.
+                    assert_eq!(
+                        current_epoll_readiness::<8>(client_sockfd, EPOLLOUT | EPOLLET),
+                        EPOLLOUT
+                    );
+                }
+            }
             Err(err) if err.kind() == ErrorKind::WouldBlock => break,
             Err(err) => panic!("unexpected error whilst filling up buffer: {err}"),
         }
@@ -420,4 +420,169 @@ fn test_shutdown_write() {
     check_epoll_wait::<8>(epfd, &[Ev { events: EPOLLRDHUP, data: client_sockfd }], -1);
 
     server_thread.join().unwrap();
+}
+
+/// Test that Miri correctly removes the readable readiness or emits a new edge after a short read.
+fn test_readiness_after_short_read() {
+    let (server_sockfd, addr) = net::make_listener_ipv4().unwrap();
+    let client_sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+    let epfd = errno_result(unsafe { libc::epoll_create1(0) }).unwrap();
+
+    // Spawn the server thread.
+    let server_thread = thread::spawn(move || {
+        let (peerfd, _) = net::accept_ipv4(server_sockfd).unwrap();
+
+        // Write `TEST_BYTES` into the stream.
+        libc_utils::write_all(peerfd, TEST_BYTES).unwrap();
+
+        // Return the peer socket file descriptor such that we can use
+        // it after joining the server thread.
+        peerfd
+    });
+
+    net::connect_ipv4(client_sockfd, addr).unwrap();
+
+    unsafe {
+        // Change client socket to be non-blocking.
+        errno_check(libc::fcntl(client_sockfd, libc::F_SETFL, libc::O_NONBLOCK));
+    }
+
+    // Add client socket with readable interest to epoll.
+    epoll_ctl_add(epfd, client_sockfd, EPOLLET | EPOLLIN).unwrap();
+
+    // Wait until the socket becomes readable.
+    check_epoll_wait::<8>(epfd, &[Ev { events: EPOLLIN, data: client_sockfd }], -1);
+
+    let mut buffer = [0u8; 1024];
+
+    // We want to read in chunks of 16 bytes. To ensure we get a short read, `TEST_BYTES.len()`
+    // must not be dividable by 16.
+    assert!(TEST_BYTES.len() % 16 != 0);
+
+    let mut total_bytes_read = 0;
+    // Read everything from the socket until we get a short read.
+    // We don't want to provide `TEST_BYTES.len()` as `count` because then we won't trigger
+    // a short read.
+    loop {
+        let bytes_read = unsafe {
+            errno_result(libc::read(
+                client_sockfd,
+                buffer.as_mut_ptr().byte_add(total_bytes_read).cast(),
+                // Read a chunk of 16 bytes.
+                16,
+            ))
+            .unwrap()
+        };
+
+        total_bytes_read += bytes_read as usize;
+        if bytes_read < 16 {
+            // We had a short read; we thus assume the read buffer is empty.
+            break;
+        }
+    }
+    assert_eq!(total_bytes_read, TEST_BYTES.len());
+
+    // We had a short read because `buffer` is bigger than `TEST_BYTES`.
+
+    // The read buffer is now empty. We thus write again `TEST_BYTES` into the peer socket.
+    let peerfd = server_thread.join().unwrap();
+    libc_utils::write_all(peerfd, TEST_BYTES).unwrap();
+
+    // Wait until the client socket becomes readable again.
+    // If this blocks indefinitely, Miri lost track of the proper status of this socket.
+    check_epoll_wait::<8>(epfd, &[Ev { events: EPOLLIN, data: client_sockfd }], -1);
+
+    // Now we can read the 2nd chunk of data.
+    unsafe {
+        libc_utils::read_exact_generic(
+            buffer.as_mut_ptr().cast(),
+            TEST_BYTES.len(),
+            libc_utils::NoRetry,
+            |buf, count| libc::read(client_sockfd, buf, count),
+        )
+        .unwrap()
+    };
+}
+
+/// Test that Miri correctly removes the writable readiness or emits a new edge after a short write.
+fn test_readiness_after_short_write() {
+    let (server_sockfd, addr) = net::make_listener_ipv4().unwrap();
+    let client_sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+    let epfd = errno_result(unsafe { libc::epoll_create1(0) }).unwrap();
+
+    // Spawn the server thread.
+    let server_thread = thread::spawn(move || {
+        let (peerfd, _) = net::accept_ipv4(server_sockfd).unwrap();
+        // Return the peer socket file descriptor such that we can use
+        // it after joining the server thread.
+        peerfd
+    });
+
+    net::connect_ipv4(client_sockfd, addr).unwrap();
+
+    unsafe {
+        // Change client socket to be non-blocking.
+        errno_check(libc::fcntl(client_sockfd, libc::F_SETFL, libc::O_NONBLOCK));
+    }
+
+    // The peer socket is a blocking socket.
+    let peerfd = server_thread.join().unwrap();
+
+    // Add client socket with writable interest to epoll.
+    epoll_ctl_add(epfd, client_sockfd, EPOLLET | EPOLLOUT).unwrap();
+
+    // Wait until the socket becomes writable.
+    check_epoll_wait::<8>(epfd, &[Ev { events: EPOLLOUT, data: client_sockfd }], -1);
+
+    // We now want to fill the write buffer of the socket by repeatedly writing
+    // `buffer` into it. The last write should then be a short write.
+    // We assume/hope that the write buffer length is not divisible by 1039.
+    let buffer = [123u8; 1039];
+
+    let mut total_bytes_written = 0;
+    loop {
+        let result = unsafe {
+            errno_result(libc::write(client_sockfd, buffer.as_ptr().cast(), buffer.len()))
+        };
+
+        match result {
+            Ok(bytes_written) => {
+                total_bytes_written += bytes_written as usize;
+                if (bytes_written as usize) < buffer.len() {
+                    // We had a short write; we thus assume the write buffer is full.
+                    break;
+                }
+            }
+            Err(err) if err.kind() == ErrorKind::WouldBlock => {
+                // Windows and Apple hosts behave weirdly when attempting to fill up the write buffer.
+                // Instead of doing a short write to completely fill the buffer, they can return an
+                // EWOULDBLOCK when the next write wouldn't fit into the buffer.
+                // When we get such an error, we also assume the write buffer is full.
+                break;
+            }
+            Err(err) => panic!("unexpected error whilst filling up buffer: {err}"),
+        }
+    }
+
+    // By reading half of the written bytes on the peer socket, the client socket
+    // should become writable again.
+    let mut read_buffer = Vec::<u8>::with_capacity(total_bytes_written / 2);
+    unsafe {
+        libc_utils::read_exact_generic(
+            read_buffer.as_mut_ptr().cast(),
+            total_bytes_written / 2,
+            libc_utils::NoRetry,
+            |buf, count| libc::read(peerfd, buf, count),
+        )
+        .unwrap()
+    };
+
+    // Wait until the socket becomes writable again.
+    // If this blocks indefinitely, Miri lost track of the proper status of this socket.
+    check_epoll_wait::<8>(epfd, &[Ev { events: EPOLLOUT, data: client_sockfd }], -1);
+
+    // We should again be able to write into the socket.
+    libc_utils::write_all(client_sockfd, &buffer).unwrap();
 }

--- a/tests/pass-dep/tokio/socket.rs
+++ b/tests/pass-dep/tokio/socket.rs
@@ -1,7 +1,7 @@
 //@only-target: linux # We only support tokio on Linux
 //@compile-flags: -Zmiri-disable-isolation
 
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{self, AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 
 const TEST_BYTES: &[u8] = b"these are some test bytes!";
@@ -10,6 +10,7 @@ const TEST_BYTES: &[u8] = b"these are some test bytes!";
 async fn main() {
     test_accept_and_connect().await;
     test_read_write().await;
+    test_echo_server().await;
 }
 
 /// Test connecting and accepting a connection.
@@ -53,4 +54,42 @@ async fn test_read_write() {
     assert_eq!(&buffer, TEST_BYTES);
 
     stream.write_all(TEST_BYTES).await.unwrap();
+}
+
+// Test that copying every socket input directly into it's output works.
+// By this, we test whether Miri correctly removes read readiness when we
+// have a short read (meaning the buffer is empty).
+// This test case is heavily inspired by the `tcp_echo` test case of the tokio
+// test suite.
+async fn test_echo_server() {
+    const ITER: usize = 4;
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    // Spawn the client thread.
+    tokio::spawn(async move {
+        let mut stream = TcpStream::connect(&addr).await.unwrap();
+
+        for _ in 0..ITER {
+            // Write some bytes into the socket.
+            stream.write_all(TEST_BYTES).await.unwrap();
+            // Expect to read the same bytes again.
+            let mut buf = [0; TEST_BYTES.len()];
+            stream.read_exact(&mut buf).await.unwrap();
+            assert_eq!(&buf[..], TEST_BYTES);
+        }
+
+        tx.send(()).unwrap();
+    });
+
+    let (mut stream, _) = listener.accept().await.unwrap();
+    let (mut rd, mut wr) = stream.split();
+
+    let n = io::copy(&mut rd, &mut wr).await.unwrap() as usize;
+    assert_eq!(n, ITER * TEST_BYTES.len());
+
+    rx.await.unwrap();
 }


### PR DESCRIPTION
Hi,

As mentioned in rust-lang/miri#5005, this pull request adds handling for short reads and writes on TCP sockets. 
Because short reads/writes imply an empty/full buffer on Unix hosts, we need to remove the readiness in those cases. On Windows hosts, we need to forcefully emit a new readiness event to prevent applications relying on this behavior from being stuck forever.

The `tcp_echo` test would not finish with the current implementation, thus I adjusted this test case and added it here, to ensure that it finishes with the new handling.