### PR TITLE
feat: Implement linkat syscall for hardlink support

### DIFF
--- a/src/shims/unix/foreign_items.rs
+++ b/src/shims/unix/foreign_items.rs
@@ -396,6 +396,16 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let result = this.symlink(target, linkpath)?;
                 this.write_scalar(result, dest)?;
             }
+            "linkat" => {
+                let [oldfd, oldpath, newfd, newpath, flags] = this.check_shim_sig(
+                    shim_sig!(extern "C" fn(i32, *const _, i32, *const _, i32) -> i32),
+                    link_name,
+                    abi,
+                    args,
+                )?;
+                let result = this.linkat(oldfd, oldpath, newfd, newpath, flags)?;
+                this.write_scalar(result, dest)?;
+            }
             "fstat" => {
                 let [fd, buf] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
                 let result = this.fstat(fd, buf)?;

--- a/src/shims/unix/fs.rs
+++ b/src/shims/unix/fs.rs
@@ -584,6 +584,62 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         interp_ok(Scalar::from_i32(this.try_unwrap_io_result(result)?))
     }
 
+    fn linkat(
+        &mut self,
+        oldfd_op: &OpTy<'tcx>,
+        oldpath_op: &OpTy<'tcx>,
+        newfd_op: &OpTy<'tcx>,
+        newpath_op: &OpTy<'tcx>,
+        flags_op: &OpTy<'tcx>,
+    ) -> InterpResult<'tcx, Scalar> {
+        let this = self.eval_context_mut();
+
+        // Load all arguments
+        let flags = this.read_scalar(flags_op)?.to_i32()?;
+        let oldfd = this.read_scalar(oldfd_op)?.to_i32()?;
+        let newfd = this.read_scalar(newfd_op)?.to_i32()?;
+        let oldpath_ptr = this.read_pointer(oldpath_op)?;
+        let newpath_ptr = this.read_pointer(newpath_op)?;
+
+        // Reject if isolation is enabled.
+        if let IsolatedOp::Reject(reject_with) = this.machine.isolated_op {
+            this.reject_in_isolation("`linkat`", reject_with)?;
+            return this.set_errno_and_return_neg1_i32(ErrorKind::PermissionDenied);
+        }
+
+        // Read flags- only support 0
+        if flags != 0 {
+            throw_unsup_format!("unsupported linkat flags {:#x}", flags);
+        }
+
+        // Read file descriptors
+        let at_fdcwd = this.eval_libc_i32("AT_FDCWD");
+
+        // Resolve oldpath
+        let oldpath = if oldfd == at_fdcwd {
+            if oldpath_ptr == Pointer::null() {
+                return this.set_errno_and_return_neg1_i32(ErrorKind::InvalidInput);
+            }
+            this.read_path_from_c_str(oldpath_ptr)?.into_owned()
+        } else {
+            // We don't support linkat with a real fd yet
+            return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
+        };
+
+        // Resolve newpath
+        let newpath = if newfd == at_fdcwd {
+            if newpath_ptr == Pointer::null() {
+                return this.set_errno_and_return_neg1_i32(ErrorKind::InvalidInput);
+            }
+            this.read_path_from_c_str(newpath_ptr)?.into_owned()
+        } else {
+            return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
+        };
+
+        let result = fs::hard_link(&oldpath, &newpath).map(|()| 0);
+        interp_ok(Scalar::from_i32(this.try_unwrap_io_result(result)?))
+    }
+
     fn stat(&mut self, path_op: &OpTy<'tcx>, buf_op: &OpTy<'tcx>) -> InterpResult<'tcx, Scalar> {
         let this = self.eval_context_mut();
 

--- a/src/shims/unix/fs.rs
+++ b/src/shims/unix/fs.rs
@@ -601,40 +601,37 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let oldpath_ptr = this.read_pointer(oldpath_op)?;
         let newpath_ptr = this.read_pointer(newpath_op)?;
 
+        // Relevant libc constants
+        let at_fdcwd = this.eval_libc_i32("AT_FDCWD");
+
         // Reject if isolation is enabled.
         if let IsolatedOp::Reject(reject_with) = this.machine.isolated_op {
             this.reject_in_isolation("`linkat`", reject_with)?;
             return this.set_errno_and_return_neg1_i32(ErrorKind::PermissionDenied);
         }
 
-        // Read flags- only support 0
+        // Read flags - only support 0.
         if flags != 0 {
             throw_unsup_format!("unsupported linkat flags {:#x}", flags);
         }
 
-        // Read file descriptors
-        let at_fdcwd = this.eval_libc_i32("AT_FDCWD");
-
         // Resolve oldpath
-        let oldpath = if oldfd == at_fdcwd {
-            if oldpath_ptr == Pointer::null() {
-                return this.set_errno_and_return_neg1_i32(ErrorKind::InvalidInput);
-            }
-            this.read_path_from_c_str(oldpath_ptr)?.into_owned()
-        } else {
-            // We don't support linkat with a real fd yet
-            return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
-        };
+        if oldfd != at_fdcwd {
+            throw_unsup_format!("linkat with `olddirfd` not equal to `AT_FDCWD` is not supported");
+        }
+        if oldpath_ptr == Pointer::null() {
+            return this.set_errno_and_return_neg1_i32(LibcError("EFAULT"));
+        }
+        let oldpath = this.read_path_from_c_str(oldpath_ptr)?.into_owned();
 
         // Resolve newpath
-        let newpath = if newfd == at_fdcwd {
-            if newpath_ptr == Pointer::null() {
-                return this.set_errno_and_return_neg1_i32(ErrorKind::InvalidInput);
-            }
-            this.read_path_from_c_str(newpath_ptr)?.into_owned()
-        } else {
-            return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
-        };
+        if newfd != at_fdcwd {
+            throw_unsup_format!("linkat with `newdirfd` not equal to `AT_FDCWD` is not supported");
+        }
+        if newpath_ptr == Pointer::null() {
+            return this.set_errno_and_return_neg1_i32(LibcError("EFAULT"));
+        }
+        let newpath = this.read_path_from_c_str(newpath_ptr)?.into_owned();
 
         let result = fs::hard_link(&oldpath, &newpath).map(|()| 0);
         interp_ok(Scalar::from_i32(this.try_unwrap_io_result(result)?))

--- a/tests/pass-dep/libc/libc-fs.rs
+++ b/tests/pass-dep/libc/libc-fs.rs
@@ -2,8 +2,8 @@
 //@compile-flags: -Zmiri-disable-isolation
 
 use std::ffi::{CStr, CString, OsString};
-use std::fs::{File, canonicalize, create_dir, remove_dir, remove_file};
-use std::io::{Error, ErrorKind, Read, Write};
+use std::fs::{self, File, canonicalize, create_dir, remove_dir, remove_file};
+use std::io::{Error, ErrorKind, Write};
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
@@ -22,7 +22,6 @@ fn main() {
     test_dup_stdout_stderr();
     test_canonicalize_too_long();
     test_rename();
-    test_linkat();
     test_ftruncate::<libc::off_t>(libc::ftruncate);
     #[cfg(target_os = "linux")]
     test_ftruncate::<libc::off64_t>(libc::ftruncate64);
@@ -69,11 +68,12 @@ fn main() {
     #[cfg(not(target_os = "solaris"))]
     test_pwritev();
     test_pwrite();
+    test_linkat();
 }
 
 #[cfg(target_os = "linux")]
 #[track_caller]
-fn assert_statx_matches_metadata(stx: &libc::statx, meta: &std::fs::Metadata, expected_size: u64) {
+fn assert_statx_matches_metadata(stx: &libc::statx, meta: &fs::Metadata, expected_size: u64) {
     use std::os::unix::fs::MetadataExt;
     let mask = stx.stx_mask;
 
@@ -153,7 +153,7 @@ fn test_statx_on_file_path() {
         assert_eq!(ret, 0, "statx failed: {}", std::io::Error::last_os_error());
 
         let stx = stx.assume_init();
-        let meta = std::fs::metadata(&path).unwrap();
+        let meta = fs::metadata(&path).unwrap();
         assert_statx_matches_metadata(&stx, &meta, bytes.len() as u64);
     }
 
@@ -1167,15 +1167,10 @@ fn test_linkat() {
         ));
     }
 
-    // Verify that the hard link works
-    // Modifications to one are visible through the other
-    let mut file = std::fs::File::create(&source).unwrap();
-    file.write_all(b"hello world").unwrap();
-    drop(file);
-
-    let mut file = std::fs::File::open(&link).unwrap();
-    let mut contents = Vec::new();
-    file.read_to_end(&mut contents).unwrap();
+    // Verify that the hard link works:
+    // Modifications to one are visible through the other.
+    fs::write(&source, b"hello world").unwrap();
+    let contents = fs::read(&link).unwrap();
     assert_eq!(contents, b"hello world");
 
     // Cleanup

--- a/tests/pass-dep/libc/libc-fs.rs
+++ b/tests/pass-dep/libc/libc-fs.rs
@@ -3,7 +3,7 @@
 
 use std::ffi::{CStr, CString, OsString};
 use std::fs::{File, canonicalize, create_dir, remove_dir, remove_file};
-use std::io::{Error, ErrorKind, Write};
+use std::io::{Error, ErrorKind, Read, Write};
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
@@ -22,6 +22,7 @@ fn main() {
     test_dup_stdout_stderr();
     test_canonicalize_too_long();
     test_rename();
+    test_linkat();
     test_ftruncate::<libc::off_t>(libc::ftruncate);
     #[cfg(target_os = "linux")]
     test_ftruncate::<libc::off64_t>(libc::ftruncate64);
@@ -1146,4 +1147,38 @@ fn test_pwrite() {
 
     // The write should start at the provided byte offset.
     assert_eq!(&write_buffer[0..bytes_written], &read_buffer[OFFSET..(bytes_written + OFFSET)]);
+}
+
+fn test_linkat() {
+    let source = utils::prepare_with_content("miri_test_libc_linkat_source.txt", b"hello");
+    let link = utils::prepare("miri_test_libc_linkat_link.txt");
+
+    let c_source = CString::new(source.as_os_str().as_bytes()).expect("CString::new failed");
+    let c_link = CString::new(link.as_os_str().as_bytes()).expect("CString::new failed");
+
+    // Call linkat
+    unsafe {
+        libc_utils::errno_check(libc::linkat(
+            libc::AT_FDCWD,
+            c_source.as_ptr(),
+            libc::AT_FDCWD,
+            c_link.as_ptr(),
+            0,
+        ));
+    }
+
+    // Verify that the hard link works
+    // Modifications to one are visible through the other
+    let mut file = std::fs::File::create(&source).unwrap();
+    file.write_all(b"hello world").unwrap();
+    drop(file);
+
+    let mut file = std::fs::File::open(&link).unwrap();
+    let mut contents = Vec::new();
+    file.read_to_end(&mut contents).unwrap();
+    assert_eq!(contents, b"hello world");
+
+    // Cleanup
+    remove_file(&source).unwrap();
+    remove_file(&link).unwrap();
 }

--- a/tests/pass/shims/fs.rs
+++ b/tests/pass/shims/fs.rs
@@ -34,17 +34,18 @@ fn main() {
     test_file_set_len();
     test_file_sync();
     test_rename();
-    #[cfg(all(unix, not(target_os = "android")))]
-    test_hard_link();
     // Windows file handling is very incomplete.
     if cfg!(not(windows)) {
         test_directory();
         test_canonicalize();
-        #[cfg(unix)]
-        test_pread_pwrite();
         #[cfg(not(target_os = "solaris"))]
         test_flock();
+        #[cfg(not(target_os = "android"))]
+        test_hard_link();
+
         test_readv_writev();
+        #[cfg(unix)]
+        test_pread_pwrite();
         #[cfg(all(unix, not(any(target_os = "solaris", target_os = "android"))))]
         test_preadv_pwritev();
     }
@@ -514,20 +515,28 @@ fn test_preadv_pwritev() {
     assert_eq!(written_bytes.as_slice(), &write_buffer[0..bytes_written]);
 }
 
-#[cfg(unix)]
-// We do not support the link syscall on Android
-#[cfg(all(unix, not(target_os = "android")))]
+// std uses `libc::link` on Android which we do not support.
+#[cfg(not(target_os = "android"))]
 fn test_hard_link() {
-    use std::os::unix::fs::MetadataExt;
     let source = utils::prepare_with_content("miri_test_fs_hard_link_source.txt", b"hello");
     let link = utils::prepare("miri_test_fs_hard_link_link.txt");
 
     fs::hard_link(&source, &link).unwrap();
 
-    // Verify both files have same inode
-    let source_meta = std::fs::metadata(&source).unwrap();
-    let link_meta = std::fs::metadata(&link).unwrap();
-    assert_eq!(source_meta.ino(), link_meta.ino());
+    // Verify that the hard link works:
+    // Modifications to one are visible through the other.
+    fs::write(&source, b"hello world").unwrap();
+    let contents = fs::read(&link).unwrap();
+    assert_eq!(contents, b"hello world");
+
+    // Only on Unix: verify both files have same inode
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let source_meta = std::fs::metadata(&source).unwrap();
+        let link_meta = std::fs::metadata(&link).unwrap();
+        assert_eq!(source_meta.ino(), link_meta.ino());
+    }
 
     // Test error: link already exists
     assert_eq!(ErrorKind::AlreadyExists, fs::hard_link(&source, &link).unwrap_err().kind());

--- a/tests/pass/shims/fs.rs
+++ b/tests/pass/shims/fs.rs
@@ -34,6 +34,8 @@ fn main() {
     test_file_set_len();
     test_file_sync();
     test_rename();
+    #[cfg(all(unix, not(target_os = "android")))]
+    test_hard_link();
     // Windows file handling is very incomplete.
     if cfg!(not(windows)) {
         test_directory();
@@ -510,4 +512,27 @@ fn test_preadv_pwritev() {
     let mut written_bytes = vec![0u8; bytes_written];
     f.read_exact(&mut written_bytes).unwrap();
     assert_eq!(written_bytes.as_slice(), &write_buffer[0..bytes_written]);
+}
+
+#[cfg(unix)]
+// We do not support the link syscall on Android
+#[cfg(all(unix, not(target_os = "android")))]
+fn test_hard_link() {
+    use std::os::unix::fs::MetadataExt;
+    let source = utils::prepare_with_content("miri_test_fs_hard_link_source.txt", b"hello");
+    let link = utils::prepare("miri_test_fs_hard_link_link.txt");
+
+    fs::hard_link(&source, &link).unwrap();
+
+    // Verify both files have same inode
+    let source_meta = std::fs::metadata(&source).unwrap();
+    let link_meta = std::fs::metadata(&link).unwrap();
+    assert_eq!(source_meta.ino(), link_meta.ino());
+
+    // Test error: link already exists
+    assert_eq!(ErrorKind::AlreadyExists, fs::hard_link(&source, &link).unwrap_err().kind());
+
+    // Cleanup after test
+    remove_file(&source).unwrap();
+    remove_file(&link).unwrap();
 }


### PR DESCRIPTION
## Summary
Implements the `linkat` syscall to enable creating hard links in Miri, addressing issue rust-lang/miri#5017.

Rust's `std::fs::hard_link()` internally calls:
`linkat(AT_FDCWD, oldpath, AT_FDCWD, newpath, 0)`
implemented exactly this behavior:
- oldfd = AT_FDCWD (-100) - interpret oldpath relative to cwd
- newfd = AT_FDCWD (-100) - interpret newpath relative to cwd  
- flags = 0 - no special flags (the only flag std passes)
For non-standard usage (nonzero flags, real file descriptors), we return appropriate errors:
- EINVAL for nonzero flags
- EBADF for non-AT_FDCWD file descriptors





