### PR TITLE
Support TTL and TCP nodelay socket options

### DIFF
--- a/src/shims/unix/socket.rs
+++ b/src/shims/unix/socket.rs
@@ -895,6 +895,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let socket = this.read_scalar(socket)?.to_i32()?;
         let level = this.read_scalar(level)?.to_i32()?;
         let option_name = this.read_scalar(option_name)?.to_i32()?;
+        let option_value_ptr = this.read_pointer(option_value)?;
         let socklen_layout = this.libc_ty_layout("socklen_t");
         let option_len = this.read_scalar(option_len)?.to_int(socklen_layout.size)?;
 
@@ -903,7 +904,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return this.set_last_error_and_return_i32(LibcError("EBADF"));
         };
 
-        let Some(_socket) = fd.downcast::<Socket>() else {
+        let Some(socket) = fd.downcast::<Socket>() else {
             // Man page specifies to return ENOTSOCK if `fd` is not a socket.
             return this.set_last_error_and_return_i32(LibcError("ENOTSOCK"));
         };
@@ -921,7 +922,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                         return this.set_last_error_and_return_i32(LibcError("EINVAL"));
                     }
                     let option_value =
-                        this.deref_pointer_as(option_value, this.machine.layouts.i32)?;
+                        this.ptr_to_mplace(option_value_ptr, this.machine.layouts.i32);
                     let _val = this.read_scalar(&option_value)?.to_i32()?;
                     // We entirely ignore this value since we do not support signals anyway.
 
@@ -934,7 +935,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     // Option value should be C-int which is usually 4 bytes.
                     return this.set_last_error_and_return_i32(LibcError("EINVAL"));
                 }
-                let option_value = this.deref_pointer_as(option_value, this.machine.layouts.i32)?;
+                let option_value = this.ptr_to_mplace(option_value_ptr, this.machine.layouts.i32);
                 let _val = this.read_scalar(&option_value)?.to_i32()?;
                 // We entirely ignore this: std always sets REUSEADDR for us, and in the end it's more of a
                 // hint to bypass some arbitrary timeout anyway.
@@ -944,10 +945,72 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     "setsockopt: option {option_name:#x} is unsupported for level SOL_SOCKET",
                 );
             }
+        } else if level == this.eval_libc_i32("IPPROTO_IP") {
+            let opt_ip_ttl = this.eval_libc_i32("IP_TTL");
+
+            if option_name == opt_ip_ttl {
+                if option_len != 4 {
+                    // Option value should be C-uint which is usually 4 bytes.
+                    return this.set_last_error_and_return_i32(LibcError("EINVAL"));
+                }
+                let option_value = this.ptr_to_mplace(option_value_ptr, this.machine.layouts.u32);
+                let ttl = this.read_scalar(&option_value)?.to_u32()?;
+
+                let result = match &*socket.state.borrow() {
+                    SocketState::Initial | SocketState::Bound(_) =>
+                        throw_unsup_format!(
+                            "setsockopt: setting option IP_TTL on level IPPROTO_IP is only supported \
+                            on connected and listening sockets"
+                        ),
+                    SocketState::Listening(listener) => listener.set_ttl(ttl),
+                    SocketState::Connecting(stream) | SocketState::Connected(stream) =>
+                        stream.set_ttl(ttl),
+                };
+
+                return match result {
+                    Ok(_) => interp_ok(Scalar::from_i32(0)),
+                    Err(e) => this.set_last_error_and_return_i32(e),
+                };
+            } else {
+                throw_unsup_format!(
+                    "setsockopt: option {option_name:#x} is unsupported for level IPPROTO_IP",
+                );
+            }
+        } else if level == this.eval_libc_i32("IPPROTO_TCP") {
+            let opt_tcp_nodelay = this.eval_libc_i32("TCP_NODELAY");
+
+            if option_name == opt_tcp_nodelay {
+                if option_len != 4 {
+                    // Option value should be C-int which is usually 4 bytes.
+                    return this.set_last_error_and_return_i32(LibcError("EINVAL"));
+                }
+                let option_value = this.ptr_to_mplace(option_value_ptr, this.machine.layouts.i32);
+                let nodelay = this.read_scalar(&option_value)?.to_i32()? != 0;
+
+                let result = match &*socket.state.borrow() {
+                    SocketState::Initial | SocketState::Bound(_) | SocketState::Listening(_) =>
+                        throw_unsup_format!(
+                            "setsockopt: setting option TCP_NODELAY on level IPPROTO_TCP is only supported \
+                            on connected sockets"
+                        ),
+                    SocketState::Connecting(stream) | SocketState::Connected(stream) =>
+                        stream.set_nodelay(nodelay),
+                };
+
+                return match result {
+                    Ok(_) => interp_ok(Scalar::from_i32(0)),
+                    Err(e) => this.set_last_error_and_return_i32(e),
+                };
+            } else {
+                throw_unsup_format!(
+                    "setsockopt: option {option_name:#x} is unsupported for level IPPROTO_TCP"
+                );
+            }
         }
 
         throw_unsup_format!(
-            "setsockopt: level {level:#x} is unsupported, only SOL_SOCKET is allowed"
+            "setsockopt: level {level:#x} is unsupported, only SOL_SOCKET, IPPROTO_IP \
+            and IPPROTO_TCP are allowed"
         );
     }
 
@@ -1065,9 +1128,38 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     "getsockopt: option {option_name:#x} is unsupported for level IPPROTO_IP",
                 );
             }
+        } else if level == this.eval_libc_i32("IPPROTO_TCP") {
+            let opt_tcp_nodelay = this.eval_libc_i32("TCP_NODELAY");
+
+            if option_name == opt_tcp_nodelay {
+                let nodelay = match &*socket.state.borrow() {
+                    SocketState::Initial | SocketState::Bound(_) | SocketState::Listening(_) =>
+                        throw_unsup_format!(
+                            "getsockopt: reading option TCP_NODELAY on level IPPROTO_TCP is only supported \
+                            on connected sockets"
+                        ),
+                    SocketState::Connecting(stream) | SocketState::Connected(stream) =>
+                        stream.nodelay(),
+                };
+
+                let nodelay = match nodelay {
+                    Ok(nodelay) => nodelay,
+                    Err(e) => return this.set_last_error_and_return_i32(e),
+                };
+
+                // Allocate new buffer on the stack with the `i32` layout.
+                let value_buffer = this.allocate(this.machine.layouts.i32, MemoryKind::Stack)?;
+                this.write_int(i32::from(nodelay), &value_buffer)?;
+                value_buffer
+            } else {
+                throw_unsup_format!(
+                    "getsockopt: option {option_name:#x} is unsupported for level IPPROTO_TCP"
+                );
+            }
         } else {
             throw_unsup_format!(
-                "getsockopt: level {level:#x} is unsupported, only SOL_SOCKET is allowed"
+                "getsockopt: level {level:#x} is unsupported, only SOL_SOCKET, IPPROTO_IP \
+                and IPPROTO_TCP are allowed"
             )
         };
 

--- a/tests/pass-dep/libc/libc-socket.rs
+++ b/tests/pass-dep/libc/libc-socket.rs
@@ -425,10 +425,8 @@ fn test_getsockname_ipv4_connect() {
     let client_sockfd =
         unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
 
-    // Spawn the server thread.
-    let server_thread = thread::spawn(move || net::accept_ipv4(server_sockfd).unwrap());
-
     net::connect_ipv4(client_sockfd, addr).unwrap();
+    net::accept_ipv4(server_sockfd).unwrap();
 
     let (_, sock_addr) = net::sockname_ipv4(|storage, len| unsafe {
         libc::getsockname(client_sockfd, storage, len)
@@ -443,8 +441,6 @@ fn test_getsockname_ipv4_connect() {
     assert_eq!(addr.sin_family, sock_addr.sin_family);
     assert_ne!(addr.sin_addr.s_addr, sock_addr.sin_addr.s_addr);
     assert!(sock_addr.sin_port > 0);
-
-    server_thread.join().unwrap();
 }
 
 /// Test the `getsockname` syscall on an IPv6 socket which is bound.
@@ -485,10 +481,8 @@ fn test_getpeername_ipv4() {
     let client_sockfd =
         unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
 
-    // Spawn the server thread.
-    let server_thread = thread::spawn(move || net::accept_ipv4(server_sockfd).unwrap());
-
     net::connect_ipv4(client_sockfd, addr).unwrap();
+    net::accept_ipv4(server_sockfd).unwrap();
 
     let (_, peer_addr) = net::sockname_ipv4(|storage, len| unsafe {
         libc::getpeername(client_sockfd, storage, len)
@@ -498,8 +492,6 @@ fn test_getpeername_ipv4() {
     assert_eq!(addr.sin_family, peer_addr.sin_family);
     assert_eq!(addr.sin_port, peer_addr.sin_port);
     assert_eq!(addr.sin_addr.s_addr, peer_addr.sin_addr.s_addr);
-
-    server_thread.join().unwrap();
 }
 
 /// Test the `getpeername` syscall on an IPv6 socket.
@@ -510,10 +502,8 @@ fn test_getpeername_ipv6() {
     let client_sockfd =
         unsafe { errno_result(libc::socket(libc::AF_INET6, libc::SOCK_STREAM, 0)).unwrap() };
 
-    // Spawn the server thread.
-    let server_thread = thread::spawn(move || net::accept_ipv6(server_sockfd).unwrap());
-
     net::connect_ipv6(client_sockfd, addr).unwrap();
+    net::accept_ipv6(server_sockfd).unwrap();
 
     let (_, peer_addr) = net::sockname_ipv6(|storage, len| unsafe {
         libc::getpeername(client_sockfd, storage, len)
@@ -525,8 +515,6 @@ fn test_getpeername_ipv6() {
     assert_eq!(addr.sin6_flowinfo, peer_addr.sin6_flowinfo);
     assert_eq!(addr.sin6_scope_id, peer_addr.sin6_scope_id);
     assert_eq!(addr.sin6_addr.s6_addr, peer_addr.sin6_addr.s6_addr);
-
-    server_thread.join().unwrap();
 }
 
 /// Test shutting down TCP streams.

--- a/tests/pass/shims/socket.rs
+++ b/tests/pass/shims/socket.rs
@@ -27,21 +27,15 @@ fn test_create_ipv6_listener() {
     let _listener_ipv6 = TcpListener::bind("[::1]:0").unwrap();
 }
 
-/// Try to connect to a TCP listener running in a separate thread and
-/// accepting connections.
+/// Try to connect to a TCP listener and accepting connections.
 fn test_accept_and_connect() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     // Get local address with randomized port to know where
     // we need to connect to.
     let address = listener.local_addr().unwrap();
 
-    let handle = thread::spawn(move || {
-        let (_stream, _addr) = listener.accept().unwrap();
-    });
-
     let _stream = TcpStream::connect(address).unwrap();
-
-    handle.join().unwrap();
+    let (_other_stream, _addr) = listener.accept().unwrap();
 }
 
 /// Test reading and writing into two connected sockets and ensuring
@@ -165,16 +159,11 @@ fn test_sockopt_nodelay() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let address = listener.local_addr().unwrap();
 
-    // Start server thread.
-    let handle = thread::spawn(move || {
-        listener.accept().unwrap();
-    });
-
     let stream = TcpStream::connect(address).unwrap();
+    let _other_end = listener.accept().unwrap();
+
     stream.set_nodelay(true).unwrap();
     assert_eq!(stream.nodelay().unwrap(), true);
     stream.set_nodelay(false).unwrap();
     assert_eq!(stream.nodelay().unwrap(), false);
-
-    handle.join().unwrap();
 }

--- a/tests/pass/shims/socket.rs
+++ b/tests/pass/shims/socket.rs
@@ -16,6 +16,7 @@ fn main() {
     test_peer_addr();
     test_shutdown();
     test_sockopt_ttl();
+    test_sockopt_nodelay();
 }
 
 fn test_create_ipv4_listener() {
@@ -119,8 +120,6 @@ fn test_peer_addr() {
 /// Test shutting down TCP streams.
 fn test_shutdown() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-    // Get local address with randomized port to know where
-    // we need to connect to.
     let address = listener.local_addr().unwrap();
 
     // Start server thread.
@@ -157,7 +156,25 @@ fn test_shutdown() {
 /// Test setting and reading the TTL socket option.
 fn test_sockopt_ttl() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-    listener.ttl().unwrap();
+    listener.set_ttl(16).unwrap();
+    assert_eq!(listener.ttl().unwrap(), 16);
+}
 
-    // TODO: Once we support setting the TTL we should also test it here.
+/// Test setting and reading the TCP nodelay socket option.
+fn test_sockopt_nodelay() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+
+    // Start server thread.
+    let handle = thread::spawn(move || {
+        listener.accept().unwrap();
+    });
+
+    let stream = TcpStream::connect(address).unwrap();
+    stream.set_nodelay(true).unwrap();
+    assert_eq!(stream.nodelay().unwrap(), true);
+    stream.set_nodelay(false).unwrap();
+    assert_eq!(stream.nodelay().unwrap(), false);
+
+    handle.join().unwrap();
 }


### PR DESCRIPTION
Hi,

This pull request adds support for setting the TTL socket option and for getting and setting the TCP nodelay socket option.
Those are the last socket options which mio supports out of the box. 

The standard library also supports:
- `TcpStream::set_read_timeout`
- `TcpStream::set_write_timeout`
- `TcpStream::read_timeout`
- `TcpStream::write_timeout`

Which we need to implement manually on top of mio. I'd suggest we just provide a timeout to the `block_thread_for_io` calls of `block_for_recv` and `block_for_send` (and a bit of extra care to account for spurious wake ups). 