### PR TITLE
CI: fix passing --feature flags to `./miri test` invocation

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -63,10 +63,9 @@ function run_tests {
 
   ## ui test suite
   if [ -n "${GC_STRESS-}" ]; then
-    time MIRIFLAGS="${MIRIFLAGS-} -Zmiri-provenance-gc=1" ./miri test $TARGET_FLAG
-  else
-    time ./miri test $FEATURES $TARGET_FLAG
+    MIRIFLAGS_EXTRA="-Zmiri-provenance-gc=1"
   fi
+  time MIRIFLAGS="${MIRIFLAGS-} ${MIRIFLAGS_EXTRA-}" ./miri test $FEATURES $TARGET_FLAG
 
   ## advanced tests
   if [ -n "${MIR_OPT-}" ]; then

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -219,7 +219,7 @@ fn run_tests(
         config.program.args.push("-Zmiri-disable-stacked-borrows".into());
     }
 
-    eprintln!("   Compiler: {}", config.program.display());
+    println!("   Compiler: {}", config.program.display());
     ui_test::run_tests_generic(
         // Only run one test suite. In the future we can add all test suites to one `Vec` and run
         // them all at once, making best use of systems with high parallelism.
@@ -303,7 +303,7 @@ fn ui(
     tmpdir: &Path,
 ) -> Result<()> {
     let msg = format!("## Running ui tests in {path} for {target}");
-    eprintln!("{}", msg.green().bold());
+    println!("{}", msg.green().bold());
 
     let with_dependencies = match with_dependencies {
         WithDependencies => true,


### PR DESCRIPTION
I apparently screwed this up the last time I touched this code. Maybe we should rewrite it in Rust...