### PR TITLE
Fix `connect` of blocking TCP sockets always returning `ENOTCONN` on error

### DIFF
--- a/src/shims/unix/socket.rs
+++ b/src/shims/unix/socket.rs
@@ -45,6 +45,13 @@ enum SocketState {
     /// For a socket created using the `connect` syscall, this is
     /// only reachable from the [`SocketState::Connecting`] state.
     Connected(TcpStream),
+    /// The SO_ERROR socket option has been set after calling
+    /// the `connect` syscall, indicating that the connection
+    /// attempt failed. By the POSIX specification, a socket is
+    /// is an unspecified state after a failed connection attempt
+    /// and thus nothing (except destroying the socket) should be
+    /// supported when a socket is in this state.
+    ConnectionFailed(TcpStream),
 }
 
 #[derive(Debug)]
@@ -77,7 +84,10 @@ impl FileDescription for Socket {
 
         if matches!(
             &*self.state.borrow(),
-            SocketState::Listening(_) | SocketState::Connecting(_) | SocketState::Connected(_)
+            SocketState::Listening(_)
+                | SocketState::Connecting(_)
+                | SocketState::Connected(_)
+                | SocketState::ConnectionFailed(_)
         ) {
             // There exists an associated host socket so we need to deregister it
             // from the blocking I/O manager.
@@ -373,6 +383,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         };
 
         assert!(this.machine.communicate(), "cannot have `Socket` with isolation enabled!");
+        this.ensure_not_failed(&socket, "bind")?;
 
         let mut state = socket.state.borrow_mut();
 
@@ -411,6 +422,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     "bind: socket is already bound and binding a socket \
                     multiple times is unsupported"
                 ),
+            SocketState::ConnectionFailed(_) => unreachable!(),
         }
 
         interp_ok(Scalar::from_i32(0))
@@ -434,6 +446,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         };
 
         assert!(this.machine.communicate(), "cannot have `Socket` with isolation enabled!");
+        this.ensure_not_failed(&socket, "listen")?;
 
         let mut state = socket.state.borrow_mut();
 
@@ -460,6 +473,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             SocketState::Connecting(_) | SocketState::Connected(_) => {
                 throw_unsup_format!("listen: listening on a connected socket is unsupported")
             }
+            SocketState::ConnectionFailed(_) => unreachable!(),
         }
 
         interp_ok(Scalar::from_i32(0))
@@ -495,6 +509,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         };
 
         assert!(this.machine.communicate(), "cannot have `Socket` with isolation enabled!");
+        this.ensure_not_failed(&socket, "accept4")?;
 
         if !matches!(*socket.state.borrow(), SocketState::Listening(_)) {
             throw_unsup_format!(
@@ -589,6 +604,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         };
 
         assert!(this.machine.communicate(), "cannot have `Socket` with isolation enabled!");
+        this.ensure_not_failed(&socket, "connect")?;
 
         match &*socket.state.borrow() {
             SocketState::Initial => { /* fall-through to below */ }
@@ -632,15 +648,20 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             let dest = dest.clone();
 
             this.ensure_connected(
-                socket,
+                socket.clone(),
                 /* should_wait */ true,
                 "connect",
                 callback!(
                     @capture<'tcx> {
+                        socket: FileDescriptionRef<Socket>,
                         dest: MPlaceTy<'tcx>
                     } |this, result: Result<(), ()>| {
                         if result.is_err() {
-                            this.set_last_error_and_return(LibcError("ENOTCONN"), &dest)
+                            // An error occurred whilst connecting. We know
+                            // that it has been consumed by `ensure_connected`
+                            // and is now stored in `socket.error`.
+                            let err = socket.error.take().unwrap();
+                            this.set_last_error_and_return(err, &dest)
                         } else {
                             this.write_scalar(Scalar::from_i32(0), &dest)
                         }
@@ -964,6 +985,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     SocketState::Listening(listener) => listener.set_ttl(ttl),
                     SocketState::Connecting(stream) | SocketState::Connected(stream) =>
                         stream.set_ttl(ttl),
+                    SocketState::ConnectionFailed(_) => unreachable!(),
                 };
 
                 return match result {
@@ -994,6 +1016,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                         ),
                     SocketState::Connecting(stream) | SocketState::Connected(stream) =>
                         stream.set_nodelay(nodelay),
+                    SocketState::ConnectionFailed(_) => unreachable!(),
                 };
 
                 return match result {
@@ -1064,17 +1087,16 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             let opt_so_error = this.eval_libc_i32("SO_ERROR");
 
             if option_name == opt_so_error {
-                // Because `TcpStream::take_error()` and `TcpListener::take_error()` consume the latest async
-                // error, we know that our stored `socket.error` is outdated when `TcpStream::take_error()`/
-                // `TcpListener::take_error()` returns `Ok(Some(...))`.
-                // If they return `Ok(None)`, then we fall back to the stored `socket.error`.
-                let error = match &*socket.state.borrow() {
-                    SocketState::Initial | SocketState::Bound(_) => socket.error.take(),
-                    SocketState::Listening(listener) =>
-                        listener.take_error().unwrap_or(socket.error.take()),
-                    SocketState::Connecting(stream) | SocketState::Connected(stream) =>
-                        stream.take_error().unwrap_or(socket.error.take()),
+                // Reading SO_ERROR should always return the latest async error. Because our stored
+                // `socket.error` could be outdated, we attempt to update it here.
+                this.update_last_error(&socket);
+
+                let return_value = match socket.error.take() {
+                    Some(err) => this.io_error_to_errnum(err)?.to_i32()?,
+                    // If there is no error, we return 0 as the option value.
+                    None => 0,
                 };
+
                 // Clear our own stored error -- it was either `take`n above or it is outdated.
                 socket.error.replace(None);
 
@@ -1082,12 +1104,6 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // I/O and epoll readiness of the socket.
                 socket.io_readiness.borrow_mut().error = false;
                 this.update_epoll_active_events(socket, /* force_edge */ false)?;
-
-                let return_value = match error {
-                    Some(err) => this.io_error_to_errnum(err)?.to_i32()?,
-                    // If there is no error, we write 0 into the option value buffer.
-                    None => 0,
-                };
 
                 // Allocate new buffer on the stack with the `i32` layout.
                 let value_buffer = this.allocate(this.machine.layouts.i32, MemoryKind::Stack)?;
@@ -1111,6 +1127,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     SocketState::Listening(listener) => listener.ttl(),
                     SocketState::Connecting(stream) | SocketState::Connected(stream) =>
                         stream.ttl(),
+                    SocketState::ConnectionFailed(_) => unreachable!(),
                 };
 
                 let ttl = match ttl {
@@ -1139,6 +1156,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                         ),
                     SocketState::Connecting(stream) | SocketState::Connected(stream) =>
                         stream.nodelay(),
+                    SocketState::ConnectionFailed(_) => unreachable!(),
                 };
 
                 let nodelay = match nodelay {
@@ -1211,6 +1229,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         };
 
         assert!(this.machine.communicate(), "cannot have `Socket` with isolation enabled!");
+        this.ensure_not_failed(&socket, "getsockname")?;
 
         let state = socket.state.borrow();
 
@@ -1254,6 +1273,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             // For non-bound sockets the POSIX manual says the returned address is unspecified.
             // Often this is 0.0.0.0:0 and thus we set it to this value.
             SocketState::Initial => SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)),
+            SocketState::ConnectionFailed(_) => unreachable!(),
         };
 
         this.write_socket_address(&address, address_ptr, address_len_ptr, "getsockname")
@@ -1343,6 +1363,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         };
 
         assert!(this.machine.communicate(), "cannot have `Socket` with isolation enabled!");
+        this.ensure_not_failed(&socket, "shutdown")?;
 
         let state = socket.state.borrow();
 
@@ -1744,9 +1765,12 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     // Execute the provided callback function when the socket is either in
     // [`SocketState::Connected`] or an error occurred.
     /// If the socket is currently neither in the [`SocketState::Connecting`] nor
-    /// the [`SocketState::Connecting`] state, an ENOTCONN error is returned.
-    /// When the callback function is called with `Ok(_)`, then we're guaranteed
+    /// the [`SocketState::Connecting`] state, [`Err`] is returned.
+    /// When the callback function is called with [`Ok`], then we're guaranteed
     /// that the socket is in the [`SocketState::Connected`] state.
+    ///
+    /// This method internally calls `ensure_not_failed` and thus an unsupported
+    /// error is thrown should `socket` be in [`SocketState::ConnectionFailed`].
     ///
     /// This function can optionally also block until either an error occurred or
     /// the socket reached the [`SocketState::Connected`] state.
@@ -1768,6 +1792,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             }
             _ => {
                 drop(state);
+                this.ensure_not_failed(&socket, foreign_name)?;
                 return action.call(this, Err(()));
             }
         };
@@ -1805,9 +1830,9 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                     // The thread woke up because it's ready, indicating a writeable or error event.
 
-                    let mut state = socket.state.borrow_mut();
-                    let stream = match &*state {
-                        SocketState::Connecting(stream) => stream,
+                    let state = socket.state.borrow();
+                    match &*state {
+                        SocketState::Connecting(_) => { /* fall-through to below */ },
                         SocketState::Connected(_) => {
                             drop(state);
                             // This can happen because we blocked the thread:
@@ -1820,25 +1845,19 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                             // Since this thread just got rescheduled, it could be that another
                             // thread realized that the connection failed and we're thus in
                             // an "invalid state".
+                            this.ensure_not_failed(&socket, foreign_name)?;
                             return action.call(this, Err(()))
                         }
                     };
 
-                    // Manually check whether there were any errors since calling `connect`.
-                    if let Ok(Some(err)) = stream.take_error() {
-                        // There was an error during connecting and thus we
-                        // return ENOTCONN. It's the program's responsibility
-                        // to read SO_ERROR itself.
+                    drop(state);
 
-                        // Store the error such that we can return it when
-                        // `getsockopt(SOL_SOCKET, SO_ERROR, ...)` is called on the socket.
-                        socket.error.replace(Some(err));
+                    // Set `socket.error` if `socket` currently has an error.
+                    this.update_last_error(&socket);
 
-                        // Go back to initial state since the only way of getting into the
-                        // `Connecting` state is from the `Initial` state and at this point
-                        // we know that the connection won't be established anymore.
-                        *state = SocketState::Initial;
-                        drop(state);
+                    if socket.error.borrow().is_some() {
+                        // There was an error during connecting.
+                        // It's the program's responsibility to read SO_ERROR itself.
                         return action.call(this, Err(()))
                     }
 
@@ -1860,6 +1879,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     // The connection is established.
 
                     // Temporarily use dummy state to take ownership of the stream.
+                    let mut state = socket.state.borrow_mut();
                     let SocketState::Connecting(stream) = std::mem::replace(&mut*state, SocketState::Initial) else {
                         // At the start of the function we ensured that we're currently connecting.
                         unreachable!()
@@ -1870,6 +1890,64 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 }
             ),
         )
+    }
+
+    /// Ensure that `socket` is not in the [`SocketState::ConnectionFailed`] state.
+    /// If `socket` is currently in [`SocketState::ConnectionFailed`], an unsupported
+    /// error is thrown.
+    fn ensure_not_failed(
+        &self,
+        socket: &FileDescriptionRef<Socket>,
+        foreign_name: &'static str,
+    ) -> InterpResult<'tcx> {
+        if let SocketState::ConnectionFailed(_) = &*socket.state.borrow() {
+            throw_unsup_format!(
+                "{foreign_name}: sockets are in an unspecified state after a failed `connect`; \
+                any operation on such a socket is thus unsupported"
+            );
+        } else {
+            interp_ok(())
+        }
+    }
+
+    /// Check whether the underlying host socket of `socket` contains an error.
+    /// If there is an error, we store it in `socket.error`.
+    ///
+    /// Should `socket` be in the [`SocketState::Connecting`] state whilst there is
+    /// an error on the host socket, we transition into the [`SocketState::ConnectionFailed`]
+    /// state because we know that `socket` can no longer successfully establish a
+    /// connection.
+    fn update_last_error(&self, socket: &FileDescriptionRef<Socket>) {
+        let mut state = socket.state.borrow_mut();
+
+        let new_error = match &*state {
+            SocketState::Listening(listener) =>
+                listener.take_error().expect("Reading SO_ERROR should not fail"),
+            SocketState::Connecting(stream) | SocketState::Connected(stream) =>
+                stream.take_error().expect("Reading SO_ERROR should not fail"),
+            SocketState::Initial | SocketState::Bound(_) | SocketState::ConnectionFailed(_) => None,
+        };
+
+        let Some(new_error) = new_error else { return };
+
+        // Store the error such that we can return it when
+        // `getsockopt(SOL_SOCKET, SO_ERROR, ...)` is called on the socket.
+        socket.error.replace(Some(new_error));
+
+        if matches!(&*state, SocketState::Connecting(_)) {
+            // After reading an error on a connecting socket, we know that
+            // the connection won't be established anymore. By the POSIX
+            // specification, the socket is now in an unspecified state.
+            // We thus change the socket state to `ConnectionFailed`.
+
+            // Temporarily use dummy state to take ownership of the stream.
+            let SocketState::Connecting(stream) =
+                std::mem::replace(&mut *state, SocketState::Initial)
+            else {
+                unreachable!()
+            };
+            *state = SocketState::ConnectionFailed(stream);
+        }
     }
 }
 
@@ -1884,7 +1962,9 @@ impl SourceFileDescription for Socket {
         let mut state = self.state.borrow_mut();
         match &mut *state {
             SocketState::Listening(listener) => f(listener),
-            SocketState::Connecting(stream) | SocketState::Connected(stream) => f(stream),
+            SocketState::Connecting(stream)
+            | SocketState::Connected(stream)
+            | SocketState::ConnectionFailed(stream) => f(stream),
             // We never try adding a socket which is not backed by a real socket to the poll registry.
             _ => unreachable!(),
         }

--- a/tests/fail-dep/libc/socket-connect-after-failed-connection.rs
+++ b/tests/fail-dep/libc/socket-connect-after-failed-connection.rs
@@ -1,0 +1,68 @@
+//@only-target: linux android illumos
+//@compile-flags: -Zmiri-disable-isolation
+
+#![feature(io_error_inprogress)]
+
+#[path = "../../utils/libc.rs"]
+mod libc_utils;
+
+use std::io::ErrorKind;
+
+use libc_utils::epoll::*;
+use libc_utils::*;
+
+/// Test calling `connect` after the first `connect` failed.
+fn main() {
+    let client_sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+    let epfd = errno_result(unsafe { libc::epoll_create1(0) }).unwrap();
+
+    unsafe {
+        // Change client socket to be non-blocking.
+        errno_check(libc::fcntl(client_sockfd, libc::F_SETFL, libc::O_NONBLOCK));
+    }
+
+    // We cannot attempt to connect to a localhost address because
+    // it could be the case that a socket from another test is
+    // currently listening on `localhost:12321` because we bind to
+    // random ports everywhere. For `127.0.1.1` we know that it's a loopback
+    // address and thus exists but because it's not the standard loopback
+    // address we also assume that nothing is bound to it.
+    // The port `12321` is just a random non-zero port because Windows
+    // and Apple hosts return EADDRNOTAVAIL when attempting to connect to
+    // a zero port.
+    let addr = net::sock_addr_ipv4([127, 0, 1, 1], 12321);
+
+    // Non-blocking connect should fail with EINPROGRESS.
+    let err = net::connect_ipv4(client_sockfd, addr).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::InProgress);
+
+    // Add interest for client socket.
+    epoll_ctl_add(epfd, client_sockfd, EPOLLOUT | EPOLLET | libc::EPOLLERR).unwrap();
+
+    // Wait until the socket has an error.
+    check_epoll_wait::<8>(
+        epfd,
+        &[Ev { events: libc::EPOLLERR | EPOLLOUT | EPOLLHUP, data: client_sockfd }],
+        -1,
+    );
+
+    let errno =
+        net::getsockopt::<libc::c_int>(client_sockfd, libc::SOL_SOCKET, libc::SO_ERROR).unwrap();
+    // Depending on the host we receive different error kinds. Thus, we only check
+    // that it's a nonzero error code.
+    assert!(errno != 0);
+
+    // Ensure that error readiness is cleared after reading SO_ERROR.
+    let readiness = current_epoll_readiness::<8>(client_sockfd, EPOLLET | EPOLLOUT | EPOLLERR);
+    assert!(readiness & EPOLLERR == 0);
+
+    unsafe {
+        //~vERROR: sockets are in an unspecified state after a failed `connect`
+        libc::connect(
+            client_sockfd,
+            (&addr as *const libc::sockaddr_in).cast(),
+            size_of::<libc::sockaddr_in>() as libc::socklen_t,
+        )
+    };
+}

--- a/tests/fail-dep/libc/socket-connect-after-failed-connection.stderr
+++ b/tests/fail-dep/libc/socket-connect-after-failed-connection.stderr
@@ -1,0 +1,16 @@
+error: unsupported operation: connect: sockets are in an unspecified state after a failed `connect`; any operation on such a socket is thus unsupported
+  --> tests/fail-dep/libc/socket-connect-after-failed-connection.rs:LL:CC
+   |
+LL | /         libc::connect(
+LL | |             client_sockfd,
+LL | |             (&addr as *const libc::sockaddr_in).cast(),
+LL | |             size_of::<libc::sockaddr_in>() as libc::socklen_t,
+LL | |         )
+   | |_________^ unsupported operation occurred here
+   |
+   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/tests/pass-dep/libc/libc-socket.rs
+++ b/tests/pass-dep/libc/libc-socket.rs
@@ -35,6 +35,7 @@ fn main() {
     test_listen();
 
     test_accept_connect();
+    test_connect_error();
     test_send_peek_recv();
     test_write_read();
     test_readv();
@@ -256,6 +257,27 @@ fn test_accept_connect() {
     net::connect_ipv4(client_sockfd, addr).unwrap();
 
     server_thread.join().unwrap();
+}
+
+/// Test connecting to an address where nothing is listening and ensure the error matches what
+/// the standard library expects.
+fn test_connect_error() {
+    let client_sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+
+    // Connecting to a zero port fails on all host platforms.
+    let addr = net::sock_addr_ipv4(net::IPV4_LOCALHOST, 0);
+
+    let err = net::connect_ipv4(client_sockfd, addr).unwrap_err();
+    // Ensure that we fail for the same reasons as the standard library expects.
+    assert!(matches!(
+        err.kind(),
+        ErrorKind::ConnectionRefused
+            | ErrorKind::InvalidInput
+            | ErrorKind::AddrInUse
+            | ErrorKind::AddrNotAvailable
+            | ErrorKind::NetworkUnreachable
+    ));
 }
 
 /// Test sending bytes into a connected stream and then peeking and receiving


### PR DESCRIPTION
This pull request fixes that failed blocking connects always return ENOTCONN instead of the actual error. 
The problem was that we also stored the result of `TcpStream::take_error` for blocking sockets instead of just returning this error.