### PR TITLE
Fix last remnants of TB's Active -> Unique renaming

### DIFF
--- a/src/borrow_tracker/tree_borrows/diagnostics.rs
+++ b/src/borrow_tracker/tree_borrows/diagnostics.rs
@@ -456,7 +456,7 @@ struct DisplayFmtWrapper {
 /// will show each permission line as
 /// ```text
 /// 0.. 1.. 2.. 3.. 4.. 5
-/// [Act|Res|Frz|Dis|___]
+/// [Unq|Res|Frz|Dis|___]
 /// ```
 struct DisplayFmtPermission {
     /// Text that starts the permission block.
@@ -467,7 +467,7 @@ struct DisplayFmtPermission {
     close: S,
     /// Text to show when a permission is not initialized.
     /// Should have the same width as a `Permission`'s `.short_name()`, i.e.
-    /// 3 if using the `Res/Act/Frz/Dis` notation.
+    /// 3 if using the `Res/Unq/Frz/Dis` notation.
     uninit: S,
     /// Text to separate the `start` and `end` values of a range.
     range_sep: S,
@@ -525,7 +525,7 @@ struct DisplayFmtPadding {
 /// ```
 /// will show states as
 /// ```text
-///  Act
+///  Unq
 /// ?Res
 /// ____
 /// ```
@@ -549,8 +549,8 @@ struct DisplayFmt {
 }
 impl DisplayFmt {
     /// Print the permission with the format
-    /// ` Res`/` Re*`/` Act`/` Frz`/` Dis` for accessed locations
-    /// and `?Res`/`?Re*`/`?Act`/`?Frz`/`?Dis` for unaccessed locations.
+    /// ` Res`/` Re*`/` Unq`/` Frz`/` Dis` for accessed locations
+    /// and `?Res`/`?Re*`/`?Unq`/`?Frz`/`?Dis` for unaccessed locations.
     fn print_perm(&self, perm: Option<LocationState>) -> String {
         if let Some(perm) = perm {
             format!(
@@ -801,7 +801,7 @@ impl DisplayRepr {
         ) {
             let mut line = String::new();
             // Format the permissions on each range.
-            // Looks like `| Act| Res| Res| Act|`.
+            // Looks like `| Unq| Res| Res| Unq|`.
             line.push_str(fmt.perm.open);
             for (i, (perm, &pad)) in tree.rperm.iter().zip(padding.iter()).enumerate() {
                 if i > 0 {

--- a/src/borrow_tracker/tree_borrows/perms.rs
+++ b/src/borrow_tracker/tree_borrows/perms.rs
@@ -462,7 +462,7 @@ pub mod diagnostics {
                 ReservedFrz { conflicted: false } => "Res ",
                 ReservedFrz { conflicted: true } => "ResC",
                 ReservedIM => "ReIM",
-                Unique => "Act ",
+                Unique => "Unq ",
                 Frozen => "Frz ",
                 Disabled => "Dis ",
             }

--- a/tests/fail/tree_borrows/cell-inside-struct.tree.stderr
+++ b/tests/fail/tree_borrows/cell-inside-struct.tree.stderr
@@ -1,7 +1,7 @@
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   4..   8
-| Act | Act |    └─┬──<TAG=root of the allocation>
+| Unq | Unq |    └─┬──<TAG=root of the allocation>
 | Frz |?Cel |      └────<TAG=a>
 ──────────────────────────────────────────────────
 error: Undefined Behavior: write access through <TAG> (a) at ALLOC[0x0] is forbidden

--- a/tests/fail/tree_borrows/cell-inside-struct.tree_implicit_writes.stderr
+++ b/tests/fail/tree_borrows/cell-inside-struct.tree_implicit_writes.stderr
@@ -1,7 +1,7 @@
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   4..   8
-| Act | Act |    └─┬──<TAG=root of the allocation>
+| Unq | Unq |    └─┬──<TAG=root of the allocation>
 | Frz |?Cel |      └────<TAG=a>
 ──────────────────────────────────────────────────
 error: Undefined Behavior: write access through <TAG> (a) at ALLOC[0x0] is forbidden

--- a/tests/fail/tree_borrows/reserved/cell-protected-write.stderr
+++ b/tests/fail/tree_borrows/reserved/cell-protected-write.stderr
@@ -1,7 +1,7 @@
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   1
-| Act |    └─┬──<TAG=root of the allocation>
+| Unq |    └─┬──<TAG=root of the allocation>
 | ReIM|      └─┬──<TAG=base>
 | ReIM|        ├─┬──<TAG=x>
 | ReIM|        │ └─┬──<TAG=caller:x>

--- a/tests/fail/tree_borrows/reserved/int-protected-write.stderr
+++ b/tests/fail/tree_borrows/reserved/int-protected-write.stderr
@@ -1,7 +1,7 @@
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   1
-| Act |    └─┬──<TAG=root of the allocation>
+| Unq |    └─┬──<TAG=root of the allocation>
 | Res |      └─┬──<TAG=n>
 | Res |        ├─┬──<TAG=x>
 | Res |        │ └─┬──<TAG=caller:x>

--- a/tests/pass/tree_borrows/cell-alternate-writes.tree.stderr
+++ b/tests/pass/tree_borrows/cell-alternate-writes.tree.stderr
@@ -1,7 +1,7 @@
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   1
-| Act |    └─┬──<TAG=root of the allocation>
+| Unq |    └─┬──<TAG=root of the allocation>
 | ReIM|      └─┬──<TAG=data>
 |?Cel |        ├────<TAG=x>
 |?Cel |        └────<TAG=y>
@@ -9,8 +9,8 @@ Warning: this tree is indicative only. Some tags may have been hidden.
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   1
-| Act |    └─┬──<TAG=root of the allocation>
-| Act |      └─┬──<TAG=data>
+| Unq |    └─┬──<TAG=root of the allocation>
+| Unq |      └─┬──<TAG=data>
 | Cel |        ├────<TAG=x>
 | Cel |        └────<TAG=y>
 ──────────────────────────────────────────────────

--- a/tests/pass/tree_borrows/cell-alternate-writes.tree_implicit_writes.stderr
+++ b/tests/pass/tree_borrows/cell-alternate-writes.tree_implicit_writes.stderr
@@ -1,7 +1,7 @@
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   1
-| Act |    └─┬──<TAG=root of the allocation>
+| Unq |    └─┬──<TAG=root of the allocation>
 | ReIM|      └─┬──<TAG=data>
 |?Cel |        ├────<TAG=x>
 |?Cel |        └────<TAG=y>
@@ -9,8 +9,8 @@ Warning: this tree is indicative only. Some tags may have been hidden.
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   1
-| Act |    └─┬──<TAG=root of the allocation>
-| Act |      └─┬──<TAG=data>
+| Unq |    └─┬──<TAG=root of the allocation>
+| Unq |      └─┬──<TAG=data>
 | Cel |        ├────<TAG=x>
 | Cel |        └────<TAG=y>
 ──────────────────────────────────────────────────

--- a/tests/pass/tree_borrows/cell-inside-box.tree.stderr
+++ b/tests/pass/tree_borrows/cell-inside-box.tree.stderr
@@ -1,7 +1,7 @@
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   4
-| Act |    └─┬──<TAG=root of the allocation>
-| Act |      └─┬──<TAG=ptr1>
+| Unq |    └─┬──<TAG=root of the allocation>
+| Unq |      └─┬──<TAG=ptr1>
 | ReIM|        └────<TAG=ptr2>
 ──────────────────────────────────────────────────

--- a/tests/pass/tree_borrows/cell-inside-box.tree_implicit_writes.stderr
+++ b/tests/pass/tree_borrows/cell-inside-box.tree_implicit_writes.stderr
@@ -1,7 +1,7 @@
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   4
-| Act |    └─┬──<TAG=root of the allocation>
-| Act |      └─┬──<TAG=ptr1>
+| Unq |    └─┬──<TAG=root of the allocation>
+| Unq |      └─┬──<TAG=ptr1>
 | ReIM|        └────<TAG=ptr2>
 ──────────────────────────────────────────────────

--- a/tests/pass/tree_borrows/cell-inside-struct.tree.stderr
+++ b/tests/pass/tree_borrows/cell-inside-struct.tree.stderr
@@ -1,6 +1,6 @@
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   8
-| Act |    └─┬──<TAG=root of the allocation>
+| Unq |    └─┬──<TAG=root of the allocation>
 |?Cel |      └────<TAG=a>
 ──────────────────────────────────────────────────

--- a/tests/pass/tree_borrows/cell-inside-struct.tree_implicit_writes.stderr
+++ b/tests/pass/tree_borrows/cell-inside-struct.tree_implicit_writes.stderr
@@ -1,6 +1,6 @@
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   8
-| Act |    └─┬──<TAG=root of the allocation>
+| Unq |    └─┬──<TAG=root of the allocation>
 |?Cel |      └────<TAG=a>
 ──────────────────────────────────────────────────

--- a/tests/pass/tree_borrows/end-of-protector.tree.stderr
+++ b/tests/pass/tree_borrows/end-of-protector.tree.stderr
@@ -1,14 +1,14 @@
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   1
-| Act |    └─┬──<TAG=root of the allocation>
+| Unq |    └─┬──<TAG=root of the allocation>
 | Res |      └─┬──<TAG=data>
 | Res |        └────<TAG=x>
 ──────────────────────────────────────────────────
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   1
-| Act |    └─┬──<TAG=root of the allocation>
+| Unq |    └─┬──<TAG=root of the allocation>
 | Res |      └─┬──<TAG=data>
 | Res |        └─┬──<TAG=x>
 | Res |          └─┬──<TAG=caller:x>
@@ -17,7 +17,7 @@ Warning: this tree is indicative only. Some tags may have been hidden.
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   1
-| Act |    └─┬──<TAG=root of the allocation>
+| Unq |    └─┬──<TAG=root of the allocation>
 | Res |      └─┬──<TAG=data>
 | Res |        ├─┬──<TAG=x>
 | Res |        │ └─┬──<TAG=caller:x>
@@ -27,10 +27,10 @@ Warning: this tree is indicative only. Some tags may have been hidden.
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   1
-| Act |    └─┬──<TAG=root of the allocation>
-| Act |      └─┬──<TAG=data>
+| Unq |    └─┬──<TAG=root of the allocation>
+| Unq |      └─┬──<TAG=data>
 | Dis |        ├─┬──<TAG=x>
 | Dis |        │ └─┬──<TAG=caller:x>
 | Dis |        │   └────<TAG=callee:x>
-| Act |        └────<TAG=y>
+| Unq |        └────<TAG=y>
 ──────────────────────────────────────────────────

--- a/tests/pass/tree_borrows/end-of-protector.tree_implicit_writes.stderr
+++ b/tests/pass/tree_borrows/end-of-protector.tree_implicit_writes.stderr
@@ -1,24 +1,24 @@
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   1
-| Act |    └─┬──<TAG=root of the allocation>
+| Unq |    └─┬──<TAG=root of the allocation>
 | Res |      └─┬──<TAG=data>
 | Res |        └────<TAG=x>
 ──────────────────────────────────────────────────
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   1
-| Act |    └─┬──<TAG=root of the allocation>
-| Act |      └─┬──<TAG=data>
-| Act |        └─┬──<TAG=x>
-| Act |          └─┬──<TAG=caller:x>
-| Act |            └────<TAG=callee:x> Strongly protected
+| Unq |    └─┬──<TAG=root of the allocation>
+| Unq |      └─┬──<TAG=data>
+| Unq |        └─┬──<TAG=x>
+| Unq |          └─┬──<TAG=caller:x>
+| Unq |            └────<TAG=callee:x> Strongly protected
 ──────────────────────────────────────────────────
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   1
-| Act |    └─┬──<TAG=root of the allocation>
-| Act |      └─┬──<TAG=data>
+| Unq |    └─┬──<TAG=root of the allocation>
+| Unq |      └─┬──<TAG=data>
 | Frz |        ├─┬──<TAG=x>
 | Frz |        │ └─┬──<TAG=caller:x>
 | Frz |        │   └────<TAG=callee:x>
@@ -27,10 +27,10 @@ Warning: this tree is indicative only. Some tags may have been hidden.
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   1
-| Act |    └─┬──<TAG=root of the allocation>
-| Act |      └─┬──<TAG=data>
+| Unq |    └─┬──<TAG=root of the allocation>
+| Unq |      └─┬──<TAG=data>
 | Dis |        ├─┬──<TAG=x>
 | Dis |        │ └─┬──<TAG=caller:x>
 | Dis |        │   └────<TAG=callee:x>
-| Act |        └────<TAG=y>
+| Unq |        └────<TAG=y>
 ──────────────────────────────────────────────────

--- a/tests/pass/tree_borrows/formatting.stderr
+++ b/tests/pass/tree_borrows/formatting.stderr
@@ -1,17 +1,17 @@
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   1..   2..  10..  11.. 100.. 101..1000..1001..1024
-| Act | Act | Act | Act | Act | Act | Act | Act | Act |    └─┬──<TAG=root of the allocation>
-| Res | Act | Res | Act | Res | Act | Res | Act | Res |      └─┬──<TAG=data, data>
-|-----| Act |-----|?Dis |-----|?Dis |-----|?Dis |-----|        ├────<TAG=data[1]>
-|-----|-----|-----| Act |-----|?Dis |-----|?Dis |-----|        ├────<TAG=data[10]>
+| Unq | Unq | Unq | Unq | Unq | Unq | Unq | Unq | Unq |    └─┬──<TAG=root of the allocation>
+| Res | Unq | Res | Unq | Res | Unq | Res | Unq | Res |      └─┬──<TAG=data, data>
+|-----| Unq |-----|?Dis |-----|?Dis |-----|?Dis |-----|        ├────<TAG=data[1]>
+|-----|-----|-----| Unq |-----|?Dis |-----|?Dis |-----|        ├────<TAG=data[10]>
 |-----|-----|-----|-----|-----| Frz |-----|?Dis |-----|        ├────<TAG=data[100]>
-|-----|-----|-----|-----|-----|-----|-----| Act |-----|        └────<TAG=data[1000]>
+|-----|-----|-----|-----|-----|-----|-----| Unq |-----|        └────<TAG=data[1000]>
 ──────────────────────────────────────────────────
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   1
-| Act |    └─┬──<TAG=root of the allocation>
+| Unq |    └─┬──<TAG=root of the allocation>
 | Frz |      └─┬──<TAG=x>
 | Frz |        ├─┬──<TAG=xa>
 | Frz |        │ ├────<TAG=xaa>

--- a/tests/pass/tree_borrows/implicit-writes-permissions.stderr
+++ b/tests/pass/tree_borrows/implicit-writes-permissions.stderr
@@ -1,7 +1,7 @@
 ──────────────────────────────────────────────
 0..   1
-| Act |    └─┬──<TAG=root of the allocation>
-| Act |      └─┬──<TAG>
-| Act |        └─┬──<TAG>
-| Act |          └────<TAG> Strongly protected
+| Unq |    └─┬──<TAG=root of the allocation>
+| Unq |      └─┬──<TAG>
+| Unq |        └─┬──<TAG>
+| Unq |          └────<TAG> Strongly protected
 ──────────────────────────────────────────────

--- a/tests/pass/tree_borrows/reborrow-is-read.tree.stderr
+++ b/tests/pass/tree_borrows/reborrow-is-read.tree.stderr
@@ -1,15 +1,15 @@
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   1
-| Act |    └─┬──<TAG=root of the allocation>
-| Act |      └─┬──<TAG=parent>
-| Act |        └────<TAG=x>
+| Unq |    └─┬──<TAG=root of the allocation>
+| Unq |      └─┬──<TAG=parent>
+| Unq |        └────<TAG=x>
 ──────────────────────────────────────────────────
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   1
-| Act |    └─┬──<TAG=root of the allocation>
-| Act |      └─┬──<TAG=parent>
+| Unq |    └─┬──<TAG=root of the allocation>
+| Unq |      └─┬──<TAG=parent>
 | Frz |        ├────<TAG=x>
 | Res |        └────<TAG=y>
 ──────────────────────────────────────────────────

--- a/tests/pass/tree_borrows/reborrow-is-read.tree_implicit_writes.stderr
+++ b/tests/pass/tree_borrows/reborrow-is-read.tree_implicit_writes.stderr
@@ -1,15 +1,15 @@
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   1
-| Act |    └─┬──<TAG=root of the allocation>
-| Act |      └─┬──<TAG=parent>
-| Act |        └────<TAG=x>
+| Unq |    └─┬──<TAG=root of the allocation>
+| Unq |      └─┬──<TAG=parent>
+| Unq |        └────<TAG=x>
 ──────────────────────────────────────────────────
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   1
-| Act |    └─┬──<TAG=root of the allocation>
-| Act |      └─┬──<TAG=parent>
+| Unq |    └─┬──<TAG=root of the allocation>
+| Unq |      └─┬──<TAG=parent>
 | Frz |        ├────<TAG=x>
 | Res |        └────<TAG=y>
 ──────────────────────────────────────────────────

--- a/tests/pass/tree_borrows/reserved.stderr
+++ b/tests/pass/tree_borrows/reserved.stderr
@@ -2,7 +2,7 @@
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   1
-| Act |    └─┬──<TAG=root of the allocation>
+| Unq |    └─┬──<TAG=root of the allocation>
 | ReIM|      └─┬──<TAG=base>
 | ReIM|        ├─┬──<TAG=x>
 | ReIM|        │ └─┬──<TAG=caller:x>
@@ -13,7 +13,7 @@ Warning: this tree is indicative only. Some tags may have been hidden.
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   8
-| Act |    └─┬──<TAG=root of the allocation>
+| Unq |    └─┬──<TAG=root of the allocation>
 | ReIM|      └─┬──<TAG=base>
 | ReIM|        ├────<TAG=x>
 | ReIM|        └────<TAG=y>
@@ -22,16 +22,16 @@ Warning: this tree is indicative only. Some tags may have been hidden.
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   8
-| Act |    └─┬──<TAG=root of the allocation>
-| Act |      └─┬──<TAG=base>
+| Unq |    └─┬──<TAG=root of the allocation>
+| Unq |      └─┬──<TAG=base>
 | ReIM|        ├────<TAG=x>
-| Act |        └────<TAG=y>
+| Unq |        └────<TAG=y>
 ──────────────────────────────────────────────────
 [protected] Foreign Read: Res -> Frz
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   1
-| Act |    └─┬──<TAG=root of the allocation>
+| Unq |    └─┬──<TAG=root of the allocation>
 | Res |      └─┬──<TAG=base>
 | Res |        ├─┬──<TAG=x>
 | Res |        │ └─┬──<TAG=caller:x>
@@ -42,7 +42,7 @@ Warning: this tree is indicative only. Some tags may have been hidden.
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   1
-| Act |    └─┬──<TAG=root of the allocation>
+| Unq |    └─┬──<TAG=root of the allocation>
 | Res |      └─┬──<TAG=base>
 | Res |        ├────<TAG=x>
 | Res |        └────<TAG=y>
@@ -51,8 +51,8 @@ Warning: this tree is indicative only. Some tags may have been hidden.
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   1
-| Act |    └─┬──<TAG=root of the allocation>
-| Act |      └─┬──<TAG=base>
+| Unq |    └─┬──<TAG=root of the allocation>
+| Unq |      └─┬──<TAG=base>
 | Dis |        ├────<TAG=x>
-| Act |        └────<TAG=y>
+| Unq |        └────<TAG=y>
 ──────────────────────────────────────────────────

--- a/tests/pass/tree_borrows/wildcard/formatting.stderr
+++ b/tests/pass/tree_borrows/wildcard/formatting.stderr
@@ -1,7 +1,7 @@
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   1
-| Act |    └─┬──<TAG=root of the allocation>
+| Unq |    └─┬──<TAG=root of the allocation>
 | Frz |      └─┬──<TAG=x>
 | Frz |        ├────<TAG=xa>
 | Frz |        └────<TAG=xb> (exposed)


### PR DESCRIPTION
Seems like we forgot this in rust-lang/miri#4595 