### PR TITLE
Add Linux copy_file_range shim

### DIFF
--- a/src/shims/extern_static.rs
+++ b/src/shims/extern_static.rs
@@ -41,7 +41,10 @@ impl<'tcx> MiriMachine<'tcx> {
 
         match &ecx.tcx.sess.target.os {
             Os::Linux => {
-                Self::weak_symbol_extern_statics(ecx, &["getrandom", "gettid", "statx", "strlen"])?;
+                Self::weak_symbol_extern_statics(
+                    ecx,
+                    &["copy_file_range", "getrandom", "gettid", "statx", "strlen"],
+                )?;
             }
             Os::Android => {
                 Self::weak_symbol_extern_statics(

--- a/src/shims/unix/fs.rs
+++ b/src/shims/unix/fs.rs
@@ -395,6 +395,185 @@ trait EvalContextExtPrivate<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
 impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
 pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
+    fn copy_file_range(
+        &mut self,
+        fd_in_op: &OpTy<'tcx>,
+        off_in_op: &OpTy<'tcx>,
+        fd_out_op: &OpTy<'tcx>,
+        off_out_op: &OpTy<'tcx>,
+        len_op: &OpTy<'tcx>,
+        flags_op: &OpTy<'tcx>,
+        dest: &MPlaceTy<'tcx>,
+    ) -> InterpResult<'tcx> {
+        let this = self.eval_context_mut();
+
+        let fd_in = this.read_scalar(fd_in_op)?.to_i32()?;
+        let fd_out = this.read_scalar(fd_out_op)?.to_i32()?;
+        let len = this.read_target_usize(len_op)?;
+        let flags = this.read_scalar(flags_op)?.to_u32()?;
+
+        if flags != 0 {
+            return this.set_last_error_and_return(LibcError("EINVAL"), dest);
+        }
+
+        let Some(fd_in) = this.machine.fds.get(fd_in) else {
+            return this.set_last_error_and_return(LibcError("EBADF"), dest);
+        };
+        let Some(fd_out) = this.machine.fds.get(fd_out) else {
+            return this.set_last_error_and_return(LibcError("EBADF"), dest);
+        };
+        let Some(file_in) = fd_in.downcast::<FileHandle>() else {
+            return this.set_last_error_and_return(LibcError("EINVAL"), dest);
+        };
+        let Some(file_out) = fd_out.downcast::<FileHandle>() else {
+            return this.set_last_error_and_return(LibcError("EINVAL"), dest);
+        };
+        if file_in == file_out {
+            return this.set_last_error_and_return(LibcError("EINVAL"), dest);
+        }
+        if !file_out.writable {
+            return this.set_last_error_and_return(LibcError("EBADF"), dest);
+        }
+
+        let loff_t = this.libc_ty_layout("loff_t");
+        let off_in_ptr = this.read_pointer(off_in_op)?;
+        let off_out_ptr = this.read_pointer(off_out_op)?;
+        let mut off_in = if this.ptr_is_null(off_in_ptr)? {
+            None
+        } else {
+            let place = this.deref_pointer_as(off_in_op, loff_t)?;
+            let offset = this.read_scalar(&place)?.to_i64()?;
+            if offset < 0 {
+                return this.set_last_error_and_return(LibcError("EINVAL"), dest);
+            }
+            Some((place, u64::try_from(offset).unwrap()))
+        };
+        let mut off_out = if this.ptr_is_null(off_out_ptr)? {
+            None
+        } else {
+            let place = this.deref_pointer_as(off_out_op, loff_t)?;
+            let offset = this.read_scalar(&place)?.to_i64()?;
+            if offset < 0 {
+                return this.set_last_error_and_return(LibcError("EINVAL"), dest);
+            }
+            Some((place, u64::try_from(offset).unwrap()))
+        };
+
+        // The kernel is permitted to perform a partial copy. Keep the host allocation bounded;
+        // std will keep calling this shim until EOF or an error is reached.
+        let count = len
+            .min(u64::try_from(this.target_isize_max()).unwrap())
+            .min(u64::try_from(isize::MAX).unwrap())
+            .min(1024 * 1024);
+        let count = usize::try_from(count).unwrap();
+        if count == 0 {
+            this.write_null(dest)?;
+            return interp_ok(());
+        }
+
+        let communicate = this.machine.communicate();
+        assert!(communicate, "isolation should have prevented even opening a file");
+
+        let mut src = &file_in.file;
+        let mut dst = &file_out.file;
+        let src_start = if off_in.is_none() {
+            match src.stream_position() {
+                Ok(pos) => Some(pos),
+                Err(err) => return this.set_last_error_and_return(err, dest),
+            }
+        } else {
+            None
+        };
+        let dst_start = if off_out.is_none() {
+            match dst.stream_position() {
+                Ok(pos) => Some(pos),
+                Err(err) => return this.set_last_error_and_return(err, dest),
+            }
+        } else {
+            None
+        };
+
+        let mut bytes = vec![0; count];
+        let read_result = if let Some((_, offset)) = off_in {
+            let cur = match src.stream_position() {
+                Ok(pos) => pos,
+                Err(err) => return this.set_last_error_and_return(err, dest),
+            };
+            let result = src.seek(SeekFrom::Start(offset)).and_then(|_| src.read(&mut bytes));
+            src.seek(SeekFrom::Start(cur))
+                .expect("failed to restore file position, this shouldn't be possible");
+            result
+        } else {
+            src.read(&mut bytes)
+        };
+        let read_size = match read_result {
+            Ok(read_size) => read_size,
+            Err(err) => return this.set_last_error_and_return(err, dest),
+        };
+        if read_size == 0 {
+            this.write_null(dest)?;
+            return interp_ok(());
+        }
+
+        let write_result = if let Some((_, offset)) = off_out {
+            let cur = match dst.stream_position() {
+                Ok(pos) => pos,
+                Err(err) => {
+                    if let Some(src_start) = src_start {
+                        src.seek(SeekFrom::Start(src_start))
+                            .expect("failed to restore file position, this shouldn't be possible");
+                    }
+                    return this.set_last_error_and_return(err, dest);
+                }
+            };
+            let result =
+                dst.seek(SeekFrom::Start(offset)).and_then(|_| dst.write(&bytes[..read_size]));
+            dst.seek(SeekFrom::Start(cur))
+                .expect("failed to restore file position, this shouldn't be possible");
+            result
+        } else {
+            dst.write(&bytes[..read_size])
+        };
+        let write_size = match write_result {
+            Ok(write_size) => write_size,
+            Err(err) => {
+                if let Some(src_start) = src_start {
+                    src.seek(SeekFrom::Start(src_start))
+                        .expect("failed to restore file position, this shouldn't be possible");
+                }
+                if let Some(dst_start) = dst_start {
+                    dst.seek(SeekFrom::Start(dst_start))
+                        .expect("failed to restore file position, this shouldn't be possible");
+                }
+                return this.set_last_error_and_return(err, dest);
+            }
+        };
+        if let Some(src_start) = src_start {
+            let copied = u64::try_from(write_size).unwrap();
+            if write_size < read_size {
+                src.seek(SeekFrom::Start(src_start.strict_add(copied)))
+                    .expect("failed to restore file position, this shouldn't be possible");
+            }
+        }
+        if let Some((place, offset)) = off_in.as_mut() {
+            let Some(new_offset) = offset.checked_add(u64::try_from(write_size).unwrap()) else {
+                return this.set_last_error_and_return(LibcError("EOVERFLOW"), dest);
+            };
+            *offset = new_offset;
+            this.write_int(*offset, place)?;
+        }
+        if let Some((place, offset)) = off_out.as_mut() {
+            let Some(new_offset) = offset.checked_add(u64::try_from(write_size).unwrap()) else {
+                return this.set_last_error_and_return(LibcError("EOVERFLOW"), dest);
+            };
+            *offset = new_offset;
+            this.write_int(*offset, place)?;
+        }
+
+        this.write_int(u64::try_from(write_size).unwrap(), dest)?;
+        interp_ok(())
+    }
+
     fn open(
         &mut self,
         path_raw: &OpTy<'tcx>,

--- a/src/shims/unix/fs.rs
+++ b/src/shims/unix/fs.rs
@@ -446,7 +446,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             if offset < 0 {
                 return this.set_last_error_and_return(LibcError("EINVAL"), dest);
             }
-            Some((place, u64::try_from(offset).unwrap()))
+            Some((place, offset))
         };
         let mut off_out = if this.ptr_is_null(off_out_ptr)? {
             None
@@ -456,7 +456,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             if offset < 0 {
                 return this.set_last_error_and_return(LibcError("EINVAL"), dest);
             }
-            Some((place, u64::try_from(offset).unwrap()))
+            Some((place, offset))
         };
 
         // The kernel is permitted to perform a partial copy. Keep the host allocation bounded;
@@ -494,12 +494,14 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         };
 
         let mut bytes = vec![0; count];
-        let read_result = if let Some((_, offset)) = off_in {
+        let read_result = if let Some((_, offset)) = off_in.as_ref() {
             let cur = match src.stream_position() {
                 Ok(pos) => pos,
                 Err(err) => return this.set_last_error_and_return(err, dest),
             };
-            let result = src.seek(SeekFrom::Start(offset)).and_then(|_| src.read(&mut bytes));
+            let result = src
+                .seek(SeekFrom::Start(u64::try_from(*offset).unwrap()))
+                .and_then(|_| src.read(&mut bytes));
             src.seek(SeekFrom::Start(cur))
                 .expect("failed to restore file position, this shouldn't be possible");
             result
@@ -514,8 +516,22 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             this.write_null(dest)?;
             return interp_ok(());
         }
+        if let Some((_, offset)) = off_in.as_ref() {
+            if offset.checked_add(i64::try_from(read_size).unwrap()).is_none() {
+                return this.set_last_error_and_return(LibcError("EOVERFLOW"), dest);
+            }
+        }
+        if let Some((_, offset)) = off_out.as_ref() {
+            if offset.checked_add(i64::try_from(read_size).unwrap()).is_none() {
+                if let Some(src_start) = src_start {
+                    src.seek(SeekFrom::Start(src_start))
+                        .expect("failed to restore file position, this shouldn't be possible");
+                }
+                return this.set_last_error_and_return(LibcError("EOVERFLOW"), dest);
+            }
+        }
 
-        let write_result = if let Some((_, offset)) = off_out {
+        let write_result = if let Some((_, offset)) = off_out.as_ref() {
             let cur = match dst.stream_position() {
                 Ok(pos) => pos,
                 Err(err) => {
@@ -526,8 +542,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     return this.set_last_error_and_return(err, dest);
                 }
             };
-            let result =
-                dst.seek(SeekFrom::Start(offset)).and_then(|_| dst.write(&bytes[..read_size]));
+            let result = dst
+                .seek(SeekFrom::Start(u64::try_from(*offset).unwrap()))
+                .and_then(|_| dst.write(&bytes[..read_size]));
             dst.seek(SeekFrom::Start(cur))
                 .expect("failed to restore file position, this shouldn't be possible");
             result
@@ -556,14 +573,14 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             }
         }
         if let Some((place, offset)) = off_in.as_mut() {
-            let Some(new_offset) = offset.checked_add(u64::try_from(write_size).unwrap()) else {
+            let Some(new_offset) = offset.checked_add(i64::try_from(write_size).unwrap()) else {
                 return this.set_last_error_and_return(LibcError("EOVERFLOW"), dest);
             };
             *offset = new_offset;
             this.write_int(*offset, place)?;
         }
         if let Some((place, offset)) = off_out.as_mut() {
-            let Some(new_offset) = offset.checked_add(u64::try_from(write_size).unwrap()) else {
+            let Some(new_offset) = offset.checked_add(i64::try_from(write_size).unwrap()) else {
                 return this.set_last_error_and_return(LibcError("EOVERFLOW"), dest);
             };
             *offset = new_offset;

--- a/src/shims/unix/linux/foreign_items.rs
+++ b/src/shims/unix/linux/foreign_items.rs
@@ -19,7 +19,7 @@ use crate::*;
 const TASK_COMM_LEN: u64 = 16;
 
 pub fn is_dyn_sym(name: &str) -> bool {
-    matches!(name, "gettid" | "statx")
+    matches!(name, "copy_file_range" | "gettid" | "statx")
 }
 
 impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
@@ -113,6 +113,24 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 let result = this.posix_fallocate(fd, offset, len)?;
                 this.write_scalar(result, dest)?;
+            }
+            "copy_file_range" => {
+                let [fd_in, off_in, fd_out, off_out, len, flags] = this.check_shim_sig(
+                    shim_sig!(
+                        extern "C" fn(
+                            i32,
+                            *mut _,
+                            i32,
+                            *mut _,
+                            libc::size_t,
+                            libc::c_uint,
+                        ) -> libc::ssize_t
+                    ),
+                    link_name,
+                    abi,
+                    args,
+                )?;
+                this.copy_file_range(fd_in, off_in, fd_out, off_out, len, flags, dest)?;
             }
             "readdir64" => {
                 let [dirp] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
@@ -241,7 +259,6 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 this.write_int(SIGRTMAX, dest)?;
             }
-
             // Incomplete shims that we "stub out" just to get pre-main initialization code to work.
             // These shims are enabled only when the caller is in the standard library.
             "pthread_getattr_np" if this.frame_in_std() => {

--- a/src/shims/unix/linux_like/syscall.rs
+++ b/src/shims/unix/linux_like/syscall.rs
@@ -5,6 +5,7 @@ use rustc_target::callconv::FnAbi;
 
 use crate::shims::sig::check_min_vararg_count;
 use crate::shims::unix::env::EvalContextExt;
+use crate::shims::unix::fs::EvalContextExt as _;
 use crate::shims::unix::linux_like::eventfd::EvalContextExt as _;
 use crate::shims::unix::linux_like::sync::futex;
 use crate::shims::unix::socket::EvalContextExt as _;
@@ -28,6 +29,7 @@ pub fn syscall<'tcx>(
     let sys_eventfd2 = ecx.eval_libc("SYS_eventfd2").to_target_usize(ecx)?;
     let sys_gettid = ecx.eval_libc("SYS_gettid").to_target_usize(ecx)?;
     let sys_accept4 = ecx.eval_libc("SYS_accept4").to_target_usize(ecx)?;
+    let sys_copy_file_range = ecx.eval_libc("SYS_copy_file_range").to_target_usize(ecx)?;
 
     match ecx.read_target_usize(op)? {
         // `libc::syscall(NR_GETRANDOM, buf.as_mut_ptr(), buf.len(), GRND_NONBLOCK)`
@@ -66,6 +68,11 @@ pub fn syscall<'tcx>(
             let [socket, address, address_len, flags] =
                 check_min_vararg_count("syscall(SYS_accept4, ...)", varargs)?;
             ecx.accept4(socket, address, address_len, Some(flags), dest)?;
+        }
+        num if num == sys_copy_file_range => {
+            let [fd_in, off_in, fd_out, off_out, len, flags] =
+                check_min_vararg_count("syscall(SYS_copy_file_range, ...)", varargs)?;
+            ecx.copy_file_range(fd_in, off_in, fd_out, off_out, len, flags, dest)?;
         }
         num => {
             throw_unsup_format!("syscall: unsupported syscall number {num}");

--- a/tests/pass-dep/libc/libc-fs.rs
+++ b/tests/pass-dep/libc/libc-fs.rs
@@ -144,6 +144,27 @@ fn test_copy_file_range() {
     syscall_dst.sync_all().unwrap();
     assert_eq!(std::fs::read(&syscall_dst_path).unwrap(), bytes);
 
+    let overflow_dst_path =
+        utils::prepare("miri_test_libc_copy_file_range_overflow_destination.txt");
+    let overflow_dst = File::create(&overflow_dst_path).unwrap();
+    let mut overflow_off_out: libc::loff_t = i64::MAX as libc::loff_t;
+    unsafe {
+        assert_eq!(libc::lseek(src.as_raw_fd(), 0, libc::SEEK_SET), 0);
+        let ret = libc::copy_file_range(
+            src.as_raw_fd(),
+            ptr::null_mut(),
+            overflow_dst.as_raw_fd(),
+            &mut overflow_off_out,
+            1,
+            0,
+        );
+        assert_eq!(ret, -1);
+        assert_eq!(libc::lseek(src.as_raw_fd(), 0, libc::SEEK_CUR), 0);
+    }
+    assert_eq!(Error::last_os_error().raw_os_error(), Some(libc::EOVERFLOW));
+    assert_eq!(overflow_off_out, i64::MAX as libc::loff_t);
+    assert_eq!(std::fs::read(&overflow_dst_path).unwrap(), b"");
+
     unsafe {
         let ret = libc::copy_file_range(-1, ptr::null_mut(), -1, ptr::null_mut(), 1, 0);
         assert_eq!(ret, -1);
@@ -154,6 +175,7 @@ fn test_copy_file_range() {
     remove_file(&dst_path).unwrap();
     remove_file(&explicit_dst_path).unwrap();
     remove_file(&syscall_dst_path).unwrap();
+    remove_file(&overflow_dst_path).unwrap();
 }
 
 #[cfg(target_os = "linux")]

--- a/tests/pass-dep/libc/libc-fs.rs
+++ b/tests/pass-dep/libc/libc-fs.rs
@@ -44,6 +44,8 @@ fn main() {
     test_posix_fallocate::<libc::off64_t>(libc::posix_fallocate64);
     #[cfg(target_os = "linux")]
     test_sync_file_range();
+    #[cfg(target_os = "linux")]
+    test_copy_file_range();
     test_fstat();
     test_stat();
     test_lstat();
@@ -72,6 +74,86 @@ fn main() {
     test_pwritev();
     test_pwrite();
     test_linkat();
+}
+
+#[cfg(target_os = "linux")]
+fn test_copy_file_range() {
+    use std::ptr;
+
+    let bytes = b"abcdef";
+    let src_path = utils::prepare_with_content("miri_test_libc_copy_file_range_source.txt", bytes);
+    let dst_path = utils::prepare("miri_test_libc_copy_file_range_destination.txt");
+    let src = File::open(&src_path).unwrap();
+    let dst = File::create(&dst_path).unwrap();
+
+    unsafe {
+        let ret = libc::copy_file_range(
+            src.as_raw_fd(),
+            ptr::null_mut(),
+            dst.as_raw_fd(),
+            ptr::null_mut(),
+            bytes.len(),
+            0,
+        );
+        assert_eq!(ret, bytes.len() as libc::ssize_t);
+    }
+    dst.sync_all().unwrap();
+    assert_eq!(std::fs::read(&dst_path).unwrap(), bytes);
+
+    let explicit_dst_path =
+        utils::prepare("miri_test_libc_copy_file_range_explicit_destination.txt");
+    let explicit_dst = File::create(&explicit_dst_path).unwrap();
+    let mut off_in: libc::loff_t = 2;
+    let mut off_out: libc::loff_t = 1;
+
+    unsafe {
+        let ret = libc::copy_file_range(
+            src.as_raw_fd(),
+            &mut off_in,
+            explicit_dst.as_raw_fd(),
+            &mut off_out,
+            3,
+            0,
+        );
+        assert_eq!(ret, 3);
+    }
+    assert_eq!(off_in, 5);
+    assert_eq!(off_out, 4);
+    assert_eq!(
+        unsafe { libc::lseek(src.as_raw_fd(), 0, libc::SEEK_CUR) },
+        bytes.len() as libc::off_t
+    );
+    explicit_dst.sync_all().unwrap();
+    assert_eq!(std::fs::read(&explicit_dst_path).unwrap(), b"\0cde");
+
+    let syscall_dst_path = utils::prepare("miri_test_libc_copy_file_range_syscall_destination.txt");
+    let syscall_dst = File::create(&syscall_dst_path).unwrap();
+    unsafe {
+        assert_eq!(libc::lseek(src.as_raw_fd(), 0, libc::SEEK_SET), 0);
+        let ret = libc::syscall(
+            libc::SYS_copy_file_range,
+            src.as_raw_fd(),
+            ptr::null_mut::<libc::loff_t>(),
+            syscall_dst.as_raw_fd(),
+            ptr::null_mut::<libc::loff_t>(),
+            bytes.len(),
+            0,
+        );
+        assert_eq!(ret, bytes.len() as libc::c_long);
+    }
+    syscall_dst.sync_all().unwrap();
+    assert_eq!(std::fs::read(&syscall_dst_path).unwrap(), bytes);
+
+    unsafe {
+        let ret = libc::copy_file_range(-1, ptr::null_mut(), -1, ptr::null_mut(), 1, 0);
+        assert_eq!(ret, -1);
+    }
+    assert_eq!(Error::last_os_error().raw_os_error(), Some(libc::EBADF));
+
+    remove_file(&src_path).unwrap();
+    remove_file(&dst_path).unwrap();
+    remove_file(&explicit_dst_path).unwrap();
+    remove_file(&syscall_dst_path).unwrap();
 }
 
 #[cfg(target_os = "linux")]

--- a/tests/pass/shims/fs-copy.rs
+++ b/tests/pass/shims/fs-copy.rs
@@ -1,0 +1,27 @@
+//@compile-flags: -Zmiri-disable-isolation
+//@only-target: linux
+//@ignore-host: windows
+
+use std::fs;
+
+#[path = "../../utils/mod.rs"]
+mod utils;
+
+fn main() {
+    let bytes = b"Hello, copied World!\n";
+    let src = utils::prepare_with_content("miri_test_fs_copy_source.txt", bytes);
+    let dst = utils::prepare("miri_test_fs_copy_destination.txt");
+
+    let copied = fs::copy(&src, &dst).unwrap();
+    assert_eq!(copied, bytes.len() as u64);
+    assert_eq!(fs::read(&dst).unwrap(), bytes);
+
+    let new_bytes = b"short";
+    fs::write(&src, new_bytes).unwrap();
+    let copied = fs::copy(&src, &dst).unwrap();
+    assert_eq!(copied, new_bytes.len() as u64);
+    assert_eq!(fs::read(&dst).unwrap(), new_bytes);
+
+    fs::remove_file(&src).unwrap();
+    fs::remove_file(&dst).unwrap();
+}


### PR DESCRIPTION
Refs: https://github.com/rust-lang/miri/issues/4183#issuecomment-4413693178


> At least on Linux the main required shim for this seems to be "copy_file_range". That would be the first step.

Friendly invite @RalfJung to review.

https://codebrowser.dev/linux/linux/fs/read_write.c.html#1648


Some places I'm aware for `fn copy_file_range`'s limitation:

1. `fn copy_file_range` currently rejects same `file_in` and `file_out`, but linux does not reject “same file” by itself. It rejects “same file with overlapping source/destination ranges.” 

In https://man7.org/linux/man-pages/man2/copy_file_range.2.html:
>        fd_in and fd_out can refer to the same file.  If they refer to the
>       same file, then the source and target ranges are not allowed to
>       overlap.
>
>       The flags argument is provided to allow for future extensions and
>       currently must be set to 0.

But in this PR:

```rust
        if file_in == file_out {
            return this.set_last_error_and_return(LibcError("EINVAL"), dest);
        }
```


