### PR TITLE
libc shim fixes

### DIFF
--- a/src/shims/unix/fs.rs
+++ b/src/shims/unix/fs.rs
@@ -750,7 +750,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // However, `statx` is allowed to return information that was not requested or to not
         // return information that was requested. This `mask` represents the information we can
         // actually provide for any target.
-        let mut mask = this.eval_libc_u32("STATX_TYPE") | this.eval_libc_u32("STATX_SIZE");
+        let mut mask = this.eval_libc_u32("STATX_TYPE")
+            | this.eval_libc_u32("STATX_MODE")
+            | this.eval_libc_u32("STATX_SIZE");
 
         // Check which pieces of metadata we acquired, and set the appropriate flags in the mask.
         if metadata.ino.is_some() {

--- a/src/shims/unix/fs.rs
+++ b/src/shims/unix/fs.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 use std::ffi::OsString;
 use std::fs::{self, DirBuilder, File, FileType, OpenOptions, TryLockError};
 use std::io::{self, ErrorKind, Read, Seek, SeekFrom, Write};
-use std::path::{self, Path, PathBuf};
+use std::path::{self, Path};
 use std::time::SystemTime;
 
 use rustc_abi::Size;
@@ -1652,13 +1652,8 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             // Write the modified template back to the passed in pointer to maintain POSIX semantics.
             this.write_bytes_ptr(template_ptr, template_bytes.iter().copied())?;
 
-            // To actually open the file, turn this into a host OsString.
-            let p = bytes_to_os_str(template_bytes)?.to_os_string();
-
-            let possibly_unique = std::env::temp_dir().join::<PathBuf>(p.into());
-
-            let file = fopts.open(possibly_unique);
-
+            // See if we can create and open this file.
+            let file = fopts.open(bytes_to_os_str(template_bytes)?);
             match file {
                 Ok(f) => {
                     let fd = this.machine.fds.insert_new(FileHandle { file: f, writable: true });

--- a/src/shims/unix/linux_like/eventfd.rs
+++ b/src/shims/unix/linux_like/eventfd.rs
@@ -97,8 +97,9 @@ impl FileDescription for EventFd {
     ) -> InterpResult<'tcx> {
         // We're treating the buffer as a `u64`.
         let ty = ecx.machine.layouts.u64;
-        // Check the size of slice, and return error only if the size of the slice < 8.
-        if len < ty.layout.size.bytes_usize() {
+        // Check the size of slice, and return error if the size is wrong. The docs say we only
+        // error when the size is too small, but Linux seems to also error when the size is too big.
+        if len != ty.layout.size.bytes_usize() {
             return finish.call(ecx, Err(ErrorKind::InvalidInput.into()));
         }
 

--- a/tests/pass-dep/libc/libc-affinity.rs
+++ b/tests/pass-dep/libc/libc-affinity.rs
@@ -1,7 +1,5 @@
 //@only-target: linux freebsd # these are Linux/FreeBSD-specific APIs
 //@compile-flags: -Zmiri-disable-isolation -Zmiri-num-cpus=4
-#![feature(io_error_more)]
-#![feature(pointer_is_aligned_to)]
 
 use std::mem::{size_of, size_of_val};
 

--- a/tests/pass-dep/libc/libc-epoll-blocking.rs
+++ b/tests/pass-dep/libc/libc-epoll-blocking.rs
@@ -89,7 +89,7 @@ fn test_notification_after_timeout() {
     check_epoll_wait::<1>(epfd, &[Ev { events: libc::EPOLLIN | libc::EPOLLOUT, data: fds[0] }], 10);
 }
 
-// This test shows a data_race before epoll had vector clocks added.
+// This test shows a data race before epoll had vector clocks added.
 fn test_epoll_race() {
     // Create an epoll instance.
     let epfd = errno_result(unsafe { libc::epoll_create1(0) }).unwrap();
@@ -99,7 +99,7 @@ fn test_epoll_race() {
     let fd = errno_result(unsafe { libc::eventfd(0, flags) }).unwrap();
 
     // Register eventfd with the epoll instance.
-    epoll_ctl_add(epfd, fd, libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET).unwrap();
+    epoll_ctl_add(epfd, fd, libc::EPOLLIN | libc::EPOLLET).unwrap();
 
     static mut VAL: u8 = 0;
     let thread1 = thread::spawn(move || {
@@ -109,13 +109,10 @@ fn test_epoll_race() {
         write_all(fd, &1_u64.to_ne_bytes()).unwrap();
     });
     thread::yield_now();
-    // epoll_wait for the event to happen.
-    check_epoll_wait::<8>(epfd, &[Ev { events: (libc::EPOLLIN | libc::EPOLLOUT), data: fd }], -1);
+    // epoll_wait for EPOLLIN.
+    check_epoll_wait::<8>(epfd, &[Ev { events: libc::EPOLLIN, data: fd }], -1);
     // Read from the static mut variable.
-    #[allow(static_mut_refs)]
-    unsafe {
-        assert_eq!(VAL, 1)
-    };
+    assert_eq!(unsafe { VAL }, 1);
     thread1.join().unwrap();
 }
 

--- a/tests/pass-dep/libc/libc-eventfd.rs
+++ b/tests/pass-dep/libc/libc-eventfd.rs
@@ -5,7 +5,10 @@
 // FIXME(static_mut_refs): Do not allow `static_mut_refs` lint
 #![allow(static_mut_refs)]
 
-use std::thread;
+use std::{io, thread};
+
+#[path = "../../utils/libc.rs"]
+mod libc_utils;
 
 fn main() {
     test_read_write();
@@ -19,15 +22,16 @@ fn main() {
     test_two_threads_blocked_on_eventfd();
 }
 
-fn read_bytes<const N: usize>(fd: i32, buf: &mut [u8; N]) -> i32 {
-    let res: i32 = unsafe { libc::read(fd, buf.as_mut_ptr().cast(), N).try_into().unwrap() };
-    return res;
+// We want to do individual read/write calls here so we avoid read_exact/write_all.
+
+fn read_bytes<const N: usize>(fd: i32, buf: &mut [u8; N]) -> io::Result<usize> {
+    libc_utils::errno_result(unsafe { libc::read(fd, buf.as_mut_ptr().cast(), N) })
+        .map(|len| len.try_into().unwrap())
 }
 
-fn write_bytes<const N: usize>(fd: i32, data: [u8; N]) -> i32 {
-    let res: i32 =
-        unsafe { libc::write(fd, data.as_ptr() as *const libc::c_void, N).try_into().unwrap() };
-    return res;
+fn write_bytes<const N: usize>(fd: i32, data: [u8; N]) -> io::Result<usize> {
+    libc_utils::errno_result(unsafe { libc::write(fd, data.as_ptr() as *const libc::c_void, N) })
+        .map(|len| len.try_into().unwrap())
 }
 
 fn test_read_write() {
@@ -35,64 +39,60 @@ fn test_read_write() {
     let fd = unsafe { libc::eventfd(0, flags) };
     let sized_8_data: [u8; 8] = 1_u64.to_ne_bytes();
     // Write 1 to the counter.
-    let res = write_bytes(fd, sized_8_data);
+    let res = write_bytes(fd, sized_8_data).unwrap();
+    assert_eq!(res, 8);
+    // Write 0 to the counter,
+    let res = write_bytes(fd, [0u8; 8]).unwrap();
     assert_eq!(res, 8);
 
     // Read 1 from the counter.
     let mut buf: [u8; 8] = [0; 8];
-    let res = read_bytes(fd, &mut buf);
+    let res = read_bytes(fd, &mut buf).unwrap();
     // Read returns number of bytes has been read, which is always 8.
     assert_eq!(res, 8);
     // Check the value of counter read.
-    let counter = u64::from_ne_bytes(buf);
-    assert_eq!(counter, 1);
+    assert_eq!(u64::from_ne_bytes(buf), 1);
 
-    // After read, the counter is currently 0, read counter 0 should fail with return
-    // value -1.
+    // After read, the counter is currently 0, read counter 0 should fail with EAGAIN.
     let mut buf: [u8; 8] = [0; 8];
-    let res = read_bytes(fd, &mut buf);
-    let e = std::io::Error::last_os_error();
-    assert_eq!(e.raw_os_error(), Some(libc::EAGAIN));
-    assert_eq!(res, -1);
+    let err = read_bytes(fd, &mut buf).unwrap_err();
+    assert_eq!(err.raw_os_error(), Some(libc::EAGAIN));
 
-    // Write with supplied buffer bigger than 8 bytes should be allowed.
-    let sized_9_data: [u8; 9];
-    if cfg!(target_endian = "big") {
-        // Adjust the data based on the endianness of host system.
-        sized_9_data = [0, 0, 0, 0, 0, 0, 0, 1, 0];
-    } else {
-        sized_9_data = [1, 0, 0, 0, 0, 0, 0, 0, 0];
-    }
-    let res = write_bytes(fd, sized_9_data);
-    assert_eq!(res, 8);
+    // Write with supplied buffer bigger than 8 bytes should be allowed according to the docs,
+    // but tests on real systems indicate that it fails.
+    let sized_9_data = [0u8; 9];
+    let err = write_bytes(fd, sized_9_data).unwrap_err();
+    assert_eq!(err.raw_os_error(), Some(libc::EINVAL));
 
     // Read with supplied buffer smaller than 8 bytes should fail with return
     // value -1.
     let mut buf: [u8; 7] = [1; 7];
-    let res = read_bytes(fd, &mut buf);
-    let e = std::io::Error::last_os_error();
-    assert_eq!(e.raw_os_error(), Some(libc::EINVAL));
-    assert_eq!(res, -1);
+    let err = read_bytes(fd, &mut buf).unwrap_err();
+    assert_eq!(err.raw_os_error(), Some(libc::EINVAL));
 
     // Write with supplied buffer smaller than 8 bytes should fail with return
     // value -1.
     let size_7_data: [u8; 7] = [1; 7];
-    let res = write_bytes(fd, size_7_data);
-    let e = std::io::Error::last_os_error();
-    assert_eq!(e.raw_os_error(), Some(libc::EINVAL));
-    assert_eq!(res, -1);
+    let err = write_bytes(fd, size_7_data).unwrap_err();
+    assert_eq!(err.raw_os_error(), Some(libc::EINVAL));
+
+    // Do two valid writes so we have something to read for the next test.
+    let res = write_bytes(fd, sized_8_data).unwrap();
+    assert_eq!(res, 8);
+    let res = write_bytes(fd, sized_8_data).unwrap();
+    assert_eq!(res, 8);
 
     // Read with supplied buffer bigger than 8 bytes should be allowed.
     let mut buf: [u8; 9] = [1; 9];
-    let res = read_bytes(fd, &mut buf);
+    let res = read_bytes(fd, &mut buf).unwrap();
     assert_eq!(res, 8);
+    let buf: &[u8; 8] = (&buf[..8]).try_into().unwrap();
+    assert_eq!(u64::from_ne_bytes(*buf), 2);
 
     // Write u64::MAX should fail.
     let u64_max_bytes: [u8; 8] = [255; 8];
-    let res = write_bytes(fd, u64_max_bytes);
-    let e = std::io::Error::last_os_error();
-    assert_eq!(e.raw_os_error(), Some(libc::EINVAL));
-    assert_eq!(res, -1);
+    let err = write_bytes(fd, u64_max_bytes).unwrap_err();
+    assert_eq!(err.raw_os_error(), Some(libc::EINVAL));
 }
 
 fn test_race() {
@@ -101,7 +101,7 @@ fn test_race() {
     let fd = unsafe { libc::eventfd(0, flags) };
     let thread1 = thread::spawn(move || {
         let mut buf: [u8; 8] = [0; 8];
-        let res = read_bytes(fd, &mut buf);
+        let res = read_bytes(fd, &mut buf).unwrap();
         // read returns number of bytes has been read, which is always 8.
         assert_eq!(res, 8);
         let counter = u64::from_ne_bytes(buf);
@@ -110,7 +110,7 @@ fn test_race() {
     });
     unsafe { VAL = 1 };
     let data: [u8; 8] = 1_u64.to_ne_bytes();
-    let res = write_bytes(fd, data);
+    let res = write_bytes(fd, data).unwrap();
     // write returns number of bytes written, which is always 8.
     assert_eq!(res, 8);
     thread::yield_now();
@@ -135,7 +135,7 @@ fn test_blocking_read() {
     let thread1 = thread::spawn(move || {
         let mut buf: [u8; 8] = [0; 8];
         // This will block.
-        let res = read_bytes(fd, &mut buf);
+        let res = read_bytes(fd, &mut buf).unwrap();
         // read returns number of bytes has been read, which is always 8.
         assert_eq!(res, 8);
         let counter = u64::from_ne_bytes(buf);
@@ -145,7 +145,7 @@ fn test_blocking_read() {
     // Pass control to thread1 so it can block on eventfd `read`.
     thread::yield_now();
     // Write 1 to the counter to unblock thread1.
-    let res = write_bytes(fd, sized_8_data);
+    let res = write_bytes(fd, sized_8_data).unwrap();
     assert_eq!(res, 8);
     thread1.join().unwrap();
 }
@@ -176,7 +176,7 @@ fn test_blocking_write() {
     // Pass control to thread1 so it can block on eventfd `write`.
     thread::yield_now();
     // This will unblock previously blocked eventfd read.
-    let res = read_bytes(fd, &mut buf);
+    let res = read_bytes(fd, &mut buf).unwrap();
     // read returns number of bytes has been read, which is always 8.
     assert_eq!(res, 8);
     let counter = u64::from_ne_bytes(buf);
@@ -222,7 +222,7 @@ fn test_two_threads_blocked_on_eventfd() {
     let thread3 = thread::spawn(move || {
         let mut buf: [u8; 8] = [0; 8];
         // This will unblock previously blocked eventfd read.
-        let res = read_bytes(fd, &mut buf);
+        let res = read_bytes(fd, &mut buf).unwrap();
         // read returns number of bytes has been read, which is always 8.
         assert_eq!(res, 8);
         let counter = u64::from_ne_bytes(buf);

--- a/tests/pass-dep/libc/libc-fs-permissions.rs
+++ b/tests/pass-dep/libc/libc-fs-permissions.rs
@@ -2,9 +2,6 @@
 //@ignore-host: windows # needs unix PermissionExt
 //@compile-flags: -Zmiri-disable-isolation
 
-#![feature(io_error_more)]
-#![feature(io_error_uncategorized)]
-
 use std::ffi::{CStr, CString};
 use std::mem::MaybeUninit;
 use std::os::unix::ffi::OsStrExt;

--- a/tests/pass-dep/libc/libc-fs.rs
+++ b/tests/pass-dep/libc/libc-fs.rs
@@ -362,7 +362,7 @@ fn test_posix_mkstemp() {
     assert!(fd > 0);
     let osstr = OsStr::from_bytes(slice.to_bytes());
     let path: &Path = osstr.as_ref();
-    let name = path.file_name().unwrap().to_string_lossy();
+    let name = path.to_string_lossy();
     assert!(name.ne("fooXXXXXX"));
     assert!(name.starts_with("foo"));
     assert_eq!(name.len(), 9);
@@ -372,6 +372,9 @@ fn test_posix_mkstemp() {
     );
     let file = unsafe { File::from_raw_fd(fd) };
     assert!(file.set_len(0).is_ok());
+    // Cleanup. Also checks that the filename actually exists.
+    drop(file);
+    remove_file(path).unwrap();
 
     let invalid_templates = vec!["foo", "barXX", "XXXXXXbaz", "whatXXXXXXever", "X"];
     for t in invalid_templates {

--- a/tests/pass-dep/libc/libc-fs.rs
+++ b/tests/pass-dep/libc/libc-fs.rs
@@ -1,9 +1,6 @@
 //@ignore-target: windows # no libc
 //@compile-flags: -Zmiri-disable-isolation
 
-#![feature(io_error_more)]
-#![feature(io_error_uncategorized)]
-
 use std::ffi::{CStr, CString, OsString};
 use std::fs::{File, canonicalize, remove_file};
 use std::io::{Error, ErrorKind, Write};

--- a/tests/pass-dep/libc/libc-fs.rs
+++ b/tests/pass-dep/libc/libc-fs.rs
@@ -64,10 +64,12 @@ fn assert_statx_matches_metadata(stx: &libc::statx, meta: &std::fs::Metadata, ex
     let mask = stx.stx_mask;
 
     // Guaranteed by the shim on any Linux target.
-    assert!(mask & libc::STATX_TYPE != 0);
     assert!(mask & libc::STATX_SIZE != 0);
     assert_eq!(stx.stx_size, expected_size);
-    assert_eq!((stx.stx_mode as u32) & libc::S_IFMT, libc::S_IFREG);
+    assert!(mask & libc::STATX_TYPE != 0);
+    assert_eq!((stx.stx_mode as libc::mode_t) & libc::S_IFMT, libc::S_IFREG);
+    assert!(mask & libc::STATX_MODE != 0);
+    assert_ne!((stx.stx_mode as libc::mode_t) & !libc::S_IFMT, 0);
 
     // Host-dependent enrichment: only assert when the mask says the field is real.
     if mask & libc::STATX_INO != 0 {
@@ -85,9 +87,6 @@ fn assert_statx_matches_metadata(stx: &libc::statx, meta: &std::fs::Metadata, ex
     if mask & libc::STATX_BLOCKS != 0 {
         assert_eq!(stx.stx_blocks, meta.blocks());
     }
-
-    // We don't support non-S_IFMT bits in stx_mode.
-    assert_eq!(mask & libc::STATX_MODE, 0);
 
     // Do not assert stx_blksize and stx_dev_* : there are no mask bits for them.
 }
@@ -174,18 +173,21 @@ fn test_statx_empty_path_on_pipe() {
 
         let statx_buf = statx_buf.assume_init();
 
-        assert_ne!(statx_buf.stx_mask & libc::STATX_TYPE, 0);
         assert_ne!(statx_buf.stx_mask & libc::STATX_SIZE, 0);
-        assert_eq!(statx_buf.stx_mask & libc::STATX_MODE, 0);
-        assert_eq!((statx_buf.stx_mode as libc::mode_t) & libc::S_IFMT, libc::S_IFIFO);
         assert_eq!(statx_buf.stx_size, 0);
+        assert_ne!(statx_buf.stx_mask & libc::STATX_TYPE, 0);
+        assert_eq!((statx_buf.stx_mode as libc::mode_t) & libc::S_IFMT, libc::S_IFIFO);
+        assert_ne!(statx_buf.stx_mask & libc::STATX_MODE, 0);
+        assert_ne!((statx_buf.stx_mode as libc::mode_t) & !libc::S_IFMT, 0);
 
-        // Synthetic metadata must not advertise host-only fields.
-        assert_eq!(statx_buf.stx_mask & libc::STATX_INO, 0);
-        assert_eq!(statx_buf.stx_mask & libc::STATX_NLINK, 0);
-        assert_eq!(statx_buf.stx_mask & libc::STATX_UID, 0);
-        assert_eq!(statx_buf.stx_mask & libc::STATX_GID, 0);
-        assert_eq!(statx_buf.stx_mask & libc::STATX_BLOCKS, 0);
+        if cfg!(miri) {
+            // Synthetic metadata must not advertise host-only fields.
+            assert_eq!(statx_buf.stx_mask & libc::STATX_INO, 0);
+            assert_eq!(statx_buf.stx_mask & libc::STATX_NLINK, 0);
+            assert_eq!(statx_buf.stx_mask & libc::STATX_UID, 0);
+            assert_eq!(statx_buf.stx_mask & libc::STATX_GID, 0);
+            assert_eq!(statx_buf.stx_mask & libc::STATX_BLOCKS, 0);
+        }
 
         errno_check(libc::close(fds[0]));
         errno_check(libc::close(fds[1]));
@@ -322,13 +324,16 @@ fn test_ftruncate<T: From<i32>>(
 
 #[cfg(target_os = "linux")]
 fn test_o_tmpfile_flag() {
+    if !cfg!(miri) {
+        return; // checks miri-specific behavior
+    }
+
     use std::fs::{OpenOptions, create_dir};
     use std::os::unix::fs::OpenOptionsExt;
     let dir_path = utils::prepare_dir("miri_test_fs_dir");
     create_dir(&dir_path).unwrap();
     // test that the `O_TMPFILE` custom flag gracefully errors instead of stopping execution
     assert_eq!(
-        Some(libc::EOPNOTSUPP),
         OpenOptions::new()
             .read(true)
             .write(true)
@@ -336,6 +341,7 @@ fn test_o_tmpfile_flag() {
             .open(dir_path)
             .unwrap_err()
             .raw_os_error(),
+        Some(libc::EOPNOTSUPP),
     );
 }
 

--- a/tests/pass-dep/libc/libc-misc.rs
+++ b/tests/pass-dep/libc/libc-misc.rs
@@ -1,7 +1,5 @@
 //@ignore-target: windows # only very limited libc on Windows
 //@compile-flags: -Zmiri-disable-isolation
-#![feature(io_error_more)]
-#![feature(pointer_is_aligned_to)]
 
 use std::mem::transmute;
 

--- a/tests/pass-dep/libc/libc-time.rs
+++ b/tests/pass-dep/libc/libc-time.rs
@@ -66,7 +66,7 @@ fn test_posix_gettimeofday() {
     assert!(tv.tv_sec > 0);
     assert!(tv.tv_usec >= 0); // Theoretically this could be 0.
 
-    // Test that non-null tz returns an error.
+    // Test that non-null tz returns an error (because we don't support it).
     let mut tz = mem::MaybeUninit::<libc::timezone>::uninit();
     let tz_ptr = tz.as_mut_ptr();
     let is_error = unsafe { libc::gettimeofday(tp.as_mut_ptr(), tz_ptr.cast()) };


### PR DESCRIPTION
Fixes some problems I found while running these tests on the host: 
- eventfd writes with a larger-than-8-bytes buffer actually should fail with EINVAL, notwithstanding what the docs say
- an epoll-blocking test was blocking for `IN | OUT` but the socket is always `OUT`; we should block for just `IN`
- statx should always return the MODE
- mkstemp should not prefix the path with `/tmp`