### PR TITLE
as_mut_ptr test update description

### DIFF
--- a/tests/fail/tree_borrows/implicit_writes/as_mut_ptr.rs
+++ b/tests/fail/tree_borrows/implicit_writes/as_mut_ptr.rs
@@ -1,5 +1,4 @@
-// This code no longer works using implicit writes in tree borrows.
-// This code tests that. The passing version is in `pass/tree_borrows/implicit_writes/as_mut_ptr.rs`.
+// This code works in Tree Borrows without implicit writes, but is expected to fail with implicit writes.
 //@compile-flags: -Zmiri-tree-borrows -Zmiri-tree-borrows-implicit-writes
 
 fn main() {


### PR DESCRIPTION
Updates the description in the `tests/fail/tree_borrows/implicit_writes/as_mut_ptr.rs` test. The referenced file no longer exists.