### PR TITLE
Perform host I/O poll before foreign item invocation

### DIFF
--- a/src/concurrency/blocking_io.rs
+++ b/src/concurrency/blocking_io.rs
@@ -154,15 +154,9 @@ impl BlockingIoManager {
     }
 
     /// Poll for new I/O events from the OS or wait until the timeout expired.
-    ///
-    /// - If the timeout is [`Some`] and contains [`Duration::ZERO`], the poll doesn't block and just
-    ///   reads all events since the last poll.
-    /// - If the timeout is [`Some`] and contains a non-zero duration, it blocks at most for the
-    ///   specified duration.
-    /// - If the timeout is [`None`] the poll blocks indefinitely until an event occurs.
-    ///
+    /// The timeout semantics are the same as described in [`Poll::poll`].
     /// The events also immediately get processed: threads get unblocked, and epoll readiness gets updated.
-    pub fn poll<'tcx>(
+    fn poll<'tcx>(
         ecx: &mut MiriInterpCx<'tcx>,
         timeout: Option<Duration>,
     ) -> InterpResult<'tcx, Result<(), io::Error>> {
@@ -344,6 +338,9 @@ pub trait EvalContextExt<'tcx>: MiriInterpCxExt<'tcx> {
     /// readiness gets set for the source even when the requested interest
     /// might not be fulfilled.
     ///
+    /// The callback function will immediately be executed with [`UnblockKind::Ready`]
+    /// when `interest` is already fulfilled for `source_fd`.
+    ///
     /// There can also be spurious wake-ups by the OS and thus it's the callers
     /// responsibility to verify that the requested I/O interests are
     /// really ready and to block again if they're not.
@@ -372,6 +369,29 @@ pub trait EvalContextExt<'tcx>: MiriInterpCxExt<'tcx> {
             // until the readiness is fulfilled and execute the callback then.
             this.block_thread(BlockReason::IO, deadline, callback);
             interp_ok(())
+        }
+    }
+
+    /// Poll for I/O events until either an I/O event happened or the timeout expired.
+    ///
+    /// - If the timeout is [`Some`] and contains [`Duration::ZERO`], the poll doesn't block and just
+    ///   reads all events since the last poll.
+    /// - If the timeout is [`Some`] and contains a non-zero duration, it blocks at most for the
+    ///   specified duration.
+    /// - If the timeout is [`None`] the poll blocks indefinitely until an event occurs.
+    ///
+    /// Unblocks all threads which are blocked on I/O and whose I/O interests
+    /// are currently fulfilled.
+    fn poll_and_unblock(&mut self, timeout: Option<Duration>) -> InterpResult<'tcx> {
+        let this = self.eval_context_mut();
+
+        match BlockingIoManager::poll(this, timeout)? {
+            Ok(_) => interp_ok(()),
+            // We can ignore errors originating from interrupts; that's just a spurious wakeup.
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => interp_ok(()),
+            // For other errors we panic. On Linux and BSD hosts this should only be
+            // reachable when a system resource error (e.g. ENOMEM or ENOSPC) occurred.
+            Err(e) => panic!("unexpected error while polling: {e}"),
         }
     }
 }

--- a/src/concurrency/thread.rs
+++ b/src/concurrency/thread.rs
@@ -1,9 +1,9 @@
 //! Implements threads.
 
+use std::mem;
 use std::sync::atomic::Ordering::Relaxed;
 use std::task::Poll;
 use std::time::{Duration, SystemTime};
-use std::{io, mem};
 
 use rand::RngExt;
 use rand::seq::IteratorRandom;
@@ -698,8 +698,11 @@ trait EvalContextPrivExt<'tcx>: MiriInterpCxExt<'tcx> {
         // or timeouts to take care of.
 
         if this.machine.communicate() {
-            // When isolation is disabled we need to check for events for
-            // threads which are blocked on host I/O.
+            // When isolation is disabled we need to check for events for threads
+            // which are blocked on host I/O. Unlike the `poll_and_unblock` before
+            // any foreign item, the call here is needed to ensure that threads which
+            // are blocked on host I/O are woken up even if no shimmed functions are
+            // executed afterwards.
             // We do this before running any other threads such that the threads
             // which received events are available for scheduling afterwards.
 
@@ -790,24 +793,6 @@ trait EvalContextPrivExt<'tcx>: MiriInterpCxExt<'tcx> {
             ThreadState::Blocked { reason: BlockReason::Epoll { epfd }, .. } =>
                 this.has_epoll_host_interests(epfd),
             _ => false,
-        }
-    }
-
-    /// Poll for I/O events until either an I/O event happened or the timeout expired.
-    /// The different timeout values are described in [`BlockingIoManager::poll`].
-    ///
-    /// Unblocks all threads which are blocked on I/O and whose I/O interests
-    /// are currently fulfilled.
-    fn poll_and_unblock(&mut self, timeout: Option<Duration>) -> InterpResult<'tcx> {
-        let this = self.eval_context_mut();
-
-        match BlockingIoManager::poll(this, timeout)? {
-            Ok(_) => interp_ok(()),
-            // We can ignore errors originating from interrupts; that's just a spurious wakeup.
-            Err(e) if e.kind() == io::ErrorKind::Interrupted => interp_ok(()),
-            // For other errors we panic. On Linux and BSD hosts this should only be
-            // reachable when a system resource error (e.g. ENOMEM or ENOSPC) occurred.
-            Err(e) => panic!("unexpected error while polling: {e}"),
         }
     }
 

--- a/src/shims/unix/foreign_items.rs
+++ b/src/shims/unix/foreign_items.rs
@@ -1,5 +1,6 @@
 use std::ffi::OsStr;
 use std::str;
+use std::time::Duration;
 
 use rustc_abi::{CanonAbi, Size};
 use rustc_middle::ty::Ty;
@@ -107,6 +108,16 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         dest: &MPlaceTy<'tcx>,
     ) -> InterpResult<'tcx, EmulateItemResult> {
         let this = self.eval_context_mut();
+
+        if this.machine.communicate() {
+            // When isolation is disabled we need to check for new host I/O events before
+            // running any shimmed function. This is needed to ensure that the shim we
+            // execute has up-to-date information about host readiness (as reflected
+            // e.g. by epoll) even if the current thread never yields.
+
+            // Perform a non-blocking poll for newly available I/O events from the OS.
+            this.poll_and_unblock(Some(Duration::ZERO))?;
+        }
 
         // See `fn emulate_foreign_item_inner` in `shims/foreign_items.rs` for the general pattern.
         match link_name.as_str() {

--- a/tests/pass-dep/libc/libc-socket-no-blocking-epoll.rs
+++ b/tests/pass-dep/libc/libc-socket-no-blocking-epoll.rs
@@ -523,11 +523,6 @@ fn test_readiness_after_short_peek() {
     // Write some bytes into the peer socket.
     libc_utils::write_all(peerfd, TEST_BYTES).unwrap();
 
-    // FIXME: Changes in host I/O readiness are only processed when entering the scheduler.
-    // Ensure that we process the effects if the `write_all` by yielding the current (only) thread.
-    // <https://github.com/rust-lang/miri/issues/5047>
-    thread::yield_now();
-
     // `buffer` is intentionally bigger than `TEST_BYTES.len()` to trigger a short peek.
     let mut buffer = [0; 128];
     let bytes_read = unsafe {
@@ -540,9 +535,6 @@ fn test_readiness_after_short_peek() {
         .unwrap()
     } as usize;
     assert_eq!(bytes_read, TEST_BYTES.len());
-
-    // FIXME(#5047): same as above.
-    thread::yield_now();
 
     // Ensure that the readable readiness is still set.
     assert_eq!(current_epoll_readiness::<8>(client_sockfd, EPOLLIN | EPOLLET), EPOLLIN);


### PR DESCRIPTION
Hi,

This pull request fixes that the host I/O readiness events are only processed when a thread yields. As discussed in the linked issue, we now also call `poll_and_unblock` before invoking any foreign item. By this, we ensure that the latest host I/O events are processed before any function is called which might rely on those updated events.

This also has the consequence that we no longer need to enter the scheduler for zero timeout blocks.

Closes rust-lang/miri#5047.