### PR TITLE
Shim the LoongArch CRC intrinsics

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -150,11 +150,10 @@ case $HOST_TARGET in
   i686-unknown-linux-gnu)
     # Host
     MIR_OPT=1 MANY_SEEDS=64 TEST_BENCH=1 CARGO_MIRI_ENV=1 run_tests
-    # Fully, but not officially, supported tier 2
+    # Not officially supported tier 2
     MANY_SEEDS=16 TEST_TARGET=aarch64-linux-android run_tests
-    # Partially supported targets (tier 2)
-    BASIC="empty_main integer heap_alloc libc-mem vec string btreemap" # ensures we have the basics: pre-main code, system allocator
-    UNIX="hello panic/panic panic/unwind concurrency/simple atomic libc-mem libc-misc libc-random env num_cpus" # the things that are very similar across all Unixes, and hence easily supported there
+    MANY_SEEDS=16 TEST_TARGET=loongarch64-unknown-linux-gnu run_tests
+    # Partially supported targets (no_std, tier 2)
     TEST_TARGET=wasm32-unknown-unknown run_tests_minimal no_std empty_main wasm # this target doesn't really have std
     TEST_TARGET=thumbv7em-none-eabihf  run_tests_minimal no_std
     ;;

--- a/src/shims/aarch64.rs
+++ b/src/shims/aarch64.rs
@@ -196,10 +196,9 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     _ => unreachable!(),
                 };
 
-                let [left, right] =
-                    this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
-                let left = this.read_scalar(left)?;
-                let right = this.read_scalar(right)?;
+                let [crc, data] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
+                let crc = this.read_scalar(crc)?;
+                let data = this.read_scalar(data)?;
 
                 // The CRC accumulator is always u32. The data argument is u32 for
                 // b/h/w variants and u64 for the x variant, per the LLVM intrinsic
@@ -207,9 +206,8 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/IR/IntrinsicsAArch64.td
                 // If the higher bits are non-zero, `compute_crc32` will panic. We should probably
                 // raise a proper error instead, but outside stdarch nobody can trigger this anyway.
-                let crc = left.to_u32()?;
-                let data =
-                    if bit_size == 64 { right.to_u64()? } else { u64::from(right.to_u32()?) };
+                let crc = crc.to_u32()?;
+                let data = if bit_size == 64 { data.to_u64()? } else { u64::from(data.to_u32()?) };
 
                 let result = compute_crc32(crc, data, bit_size, polynomial);
                 this.write_scalar(Scalar::from_u32(result), dest)?;

--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -857,6 +857,14 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     this, link_name, abi, args, dest,
                 );
             }
+            name if name.starts_with("llvm.loongarch.")
+                && matches!(this.tcx.sess.target.arch, Arch::LoongArch32 | Arch::LoongArch64)
+                && this.tcx.sess.target.endian == Endian::Little =>
+            {
+                return shims::loongarch::EvalContextExt::emulate_loongarch_intrinsic(
+                    this, link_name, abi, args, dest,
+                );
+            }
 
             // Fallback to shims in submodules.
             _ => {

--- a/src/shims/loongarch.rs
+++ b/src/shims/loongarch.rs
@@ -1,0 +1,70 @@
+use rustc_abi::CanonAbi;
+use rustc_middle::ty::Ty;
+use rustc_span::Symbol;
+use rustc_target::callconv::FnAbi;
+
+use crate::shims::math::compute_crc32;
+use crate::*;
+
+impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
+pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
+    fn emulate_loongarch_intrinsic(
+        &mut self,
+        link_name: Symbol,
+        abi: &FnAbi<'tcx, Ty<'tcx>>,
+        args: &[OpTy<'tcx>],
+        dest: &MPlaceTy<'tcx>,
+    ) -> InterpResult<'tcx, EmulateItemResult> {
+        let this = self.eval_context_mut();
+        // Prefix should have already been checked.
+        let unprefixed_name = link_name.as_str().strip_prefix("llvm.loongarch.").unwrap();
+        match unprefixed_name {
+            // Used to implement the crc.w.{b,h,w,d}.w and crcc.w.{b,h,w,d}.w functions.
+            // https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html#crc-check-instructions
+            // These are only available on LA64, not on LA32, and are part of
+            // the LA64 1.0 baseline and therefore always available and don't
+            // require a target feature to be enabled.
+            "crc.w.b.w" | "crc.w.h.w" | "crc.w.w.w" | "crc.w.d.w" | "crcc.w.b.w" | "crcc.w.h.w"
+            | "crcc.w.w.w" | "crcc.w.d.w"
+                if this.tcx.pointer_size().bits() == 64 =>
+            {
+                // The polynomial constants below include the leading 1 bit
+                // (e.g. 0x104C11DB7 instead of 0x04C11DB7) which the the
+                // polynomial division algorithm requires.
+                // Note that Loongson's documentation mentions the numbers
+                // 0xEDB88320 for IEEE802.3 and 0x82F63B78 for Castagnoli,
+                // which is because their docs put the least significant bit
+                // first.
+                let (bit_size, polynomial): (u32, u128) = match unprefixed_name {
+                    "crc.w.b.w" => (8, 0x104C11DB7),
+                    "crc.w.h.w" => (16, 0x104C11DB7),
+                    "crc.w.w.w" => (32, 0x104C11DB7),
+                    "crc.w.d.w" => (64, 0x104C11DB7),
+                    "crcc.w.b.w" => (8, 0x11EDC6F41),
+                    "crcc.w.h.w" => (16, 0x11EDC6F41),
+                    "crcc.w.w.w" => (32, 0x11EDC6F41),
+                    "crcc.w.d.w" => (64, 0x11EDC6F41),
+                    _ => unreachable!(),
+                };
+
+                let [data, crc] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
+                let data = this.read_scalar(data)?;
+                let crc = this.read_scalar(crc)?;
+
+                // The CRC accumulator is always i32. The data argument is i32 for
+                // b/h/w variants and i64 for the d variant, per the LLVM intrinsic
+                // definitions.
+                // https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/IR/IntrinsicsLoongArch.td
+                // If the higher bits are non-zero, `compute_crc32` will panic. We should probably
+                // raise a proper error instead, but outside stdarch nobody can trigger this anyway.
+                let crc = crc.to_u32()?;
+                let data = if bit_size == 64 { data.to_u64()? } else { u64::from(data.to_u32()?) };
+
+                let result = compute_crc32(crc, data, bit_size, polynomial);
+                this.write_scalar(Scalar::from_u32(result), dest)?;
+            }
+            _ => return interp_ok(EmulateItemResult::NotSupported),
+        }
+        interp_ok(EmulateItemResult::NeedsReturn)
+    }
+}

--- a/src/shims/mod.rs
+++ b/src/shims/mod.rs
@@ -4,6 +4,7 @@ mod aarch64;
 mod alloc;
 mod backtrace;
 mod files;
+mod loongarch;
 mod math;
 #[cfg(all(feature = "native-lib", unix))]
 pub mod native_lib;

--- a/tests/pass/shims/loongarch/intrinsics-loongarch64-crc.rs
+++ b/tests/pass/shims/loongarch/intrinsics-loongarch64-crc.rs
@@ -1,0 +1,54 @@
+// We're testing loongarch64-specific intrinsics
+//@only-target: loongarch64
+#![feature(stdarch_loongarch)]
+
+use std::arch::loongarch64::*;
+
+fn main() {
+    test_crc_ieee();
+    test_crc_castagnoli();
+}
+
+fn test_crc_ieee() {
+    // crc.w.b.w: 8-bit input
+    assert_eq!(crc_w_b_w(0x01, 0x00000000), 0x77073096);
+    assert_eq!(crc_w_b_w(0x61, 0xffffffff_u32 as i32), 0x174841bc);
+    assert_eq!(crc_w_b_w(0x2a, 0x2aa1e72b), 0x772d9171);
+
+    // crc.w.h.w: 16-bit input
+    assert_eq!(crc_w_h_w(0x0001, 0x00000000), 0x191b3141);
+    assert_eq!(crc_w_h_w(0x1234, 0xffffffff_u32 as i32), 0xf6b56fbf_u32 as i32);
+    assert_eq!(crc_w_h_w(0x022b, 0x8ecec3b5_u32 as i32), 0x03a1db7c);
+
+    // crc.w.w.w: 32-bit input
+    assert_eq!(crc_w_w_w(0x00000001, 0x00000000), 0xb8bc6765_u32 as i32);
+    assert_eq!(crc_w_w_w(0x12345678, 0xffffffff_u32 as i32), 0x5092782d);
+    assert_eq!(crc_w_w_w(0x00845fed, 0xae2912c8_u32 as i32), 0xc5690dd4_u32 as i32);
+
+    // crc.w.d.w: 64-bit input
+    assert_eq!(crc_w_d_w(0x0000000000000001, 0x00000000), 0xccaa009e_u32 as i32);
+    assert_eq!(crc_w_d_w(0x123456789abcdef0, 0xffffffff_u32 as i32), 0xe6ddf8b5_u32 as i32);
+    assert_eq!(crc_w_d_w(0xc0febeefdadafefe_u64 as i64, 0x0badeafe), 0x61a45fba);
+}
+
+fn test_crc_castagnoli() {
+    // crcc.w.b.w: 8-bit input
+    assert_eq!(crcc_w_b_w(0x01, 0x00000000), 0xf26b8303_u32 as i32);
+    assert_eq!(crcc_w_b_w(0x61, 0xffffffff_u32 as i32), 0x3e2fbccf);
+    assert_eq!(crcc_w_b_w(0x2a, 0x2aa1e72b), 0xf24122e4_u32 as i32);
+
+    // crcc.w.h.w: 16-bit input
+    assert_eq!(crcc_w_h_w(0x0001, 0x00000000), 0x13a29877);
+    assert_eq!(crcc_w_h_w(0x1234, 0xffffffff_u32 as i32), 0xf13f4cea_u32 as i32);
+    assert_eq!(crcc_w_h_w(0x022b, 0x8ecec3b5_u32 as i32), 0x013bb2fb);
+
+    // crcc.w.w.w: 32-bit input
+    assert_eq!(crcc_w_w_w(0x00000001, 0x00000000), 0xdd45aab8_u32 as i32);
+    assert_eq!(crcc_w_w_w(0x12345678, 0xffffffff_u32 as i32), 0x4dece20c);
+    assert_eq!(crcc_w_w_w(0x00845fed, 0xae2912c8_u32 as i32), 0xffae2ed1_u32 as i32);
+
+    // crcc.w.d.w: 64-bit input
+    assert_eq!(crcc_w_d_w(0x0000000000000001, 0x00000000), 0x493c7d27);
+    assert_eq!(crcc_w_d_w(0x123456789abcdef0, 0xffffffff_u32 as i32), 0xd95b664b_u32 as i32);
+    assert_eq!(crcc_w_d_w(0xc0febeefdadafefe_u64 as i64, 0x0badeafe), 0x5b44f54f);
+}


### PR DESCRIPTION
I'm adding support for using these in zlib-rs, and @folkertdev suggested implementing them in Miri (https://github.com/trifectatechfoundation/zlib-rs/pull/511#discussion_r3294439704). The LoongArch CRC intrinsics are extremely similar to those found on AArch64, with the main difference that the argument order is swapped.

Here's the test in Miri and on actual hardware:

```
$ ./miri run tests/pass/shims/loongarch/intrinsics-loongarch64-crc.rs
$ cargo +miri build -Zroot-dir=/home/aelin/miri --manifest-path /home/aelin/miri/./Cargo.toml --all-targets
    Finished `dev` profile [optimized + debuginfo] target(s) in 0.14s
$ cargo +miri build -Zroot-dir=/home/aelin/miri --manifest-path /home/aelin/miri/cargo-miri/Cargo.toml --all-targets
    Finished `dev` profile [optimized + debuginfo] target(s) in 0.07s
$ cargo miri setup
$ /home/aelin/miri/target/debug/miri --edition 2021 --sysroot /home/aelin/.cache/miri tests/pass/shims/loongarch/intrinsics-loongarch64-crc.rs

$ rustc tests/pass/shims/loongarch/intrinsics-loongarch64-crc.rs -o /tmp/meow && /tmp/meow

$ uname -a
Linux seraphine 7.1.0-rc4-0-stable #1-Alpine SMP PREEMPT_DYNAMIC 2026-05-23 17:58:11 loongarch64 Linux
$ cat /proc/cpuinfo | grep Model -m 1
Model Name		: Loongson-3B6000
```

i.e. it behaves the same on real hardware and in Miri.

The implementation is based on the ACLE code with only very slight adjustments; the test is also basically the same one.

Helpful links for reviewing:
* Architecture manual: https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html#crc-check-instructions
* stdarch PR which aligns Rust's intrinsics with Clang's: https://github.com/rust-lang/stdarch/pull/2136
* Clang's intrinsics: https://github.com/llvm/llvm-project/blob/main/clang/lib/Headers/larchintrin.h#L58-L104
* LLVM's intrinsic definitions: https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/IR/IntrinsicsLoongArch.td#L78-L94 (note they all take `i32` or `i64` parameters)