### PR TITLE
Minimal support for `mmap` protections, `mprotect`, `madvise`

### DIFF
--- a/src/shims/unix/foreign_items.rs
+++ b/src/shims/unix/foreign_items.rs
@@ -816,16 +816,44 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             }
 
             "mmap" => {
-                let [addr, length, prot, flags, fd, offset] =
-                    this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
+                let [addr, length, prot, flags, fd, offset] = this.check_shim_sig(
+                    shim_sig!(extern "C" fn(*mut _, usize, i32, i32, i32, libc::off_t) -> *mut _),
+                    link_name,
+                    abi,
+                    args,
+                )?;
                 let offset = this.read_scalar(offset)?.to_int(this.libc_ty_layout("off_t").size)?;
                 let ptr = this.mmap(addr, length, prot, flags, fd, offset)?;
                 this.write_scalar(ptr, dest)?;
             }
             "munmap" => {
-                let [addr, length] =
-                    this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
+                let [addr, length] = this.check_shim_sig(
+                    shim_sig!(extern "C" fn(*mut _, usize) -> i32),
+                    link_name,
+                    abi,
+                    args,
+                )?;
                 let result = this.munmap(addr, length)?;
+                this.write_scalar(result, dest)?;
+            }
+            "mprotect" => {
+                let [addr, length, prot] = this.check_shim_sig(
+                    shim_sig!(extern "C" fn(*mut _, usize, i32) -> i32),
+                    link_name,
+                    abi,
+                    args,
+                )?;
+                let result = this.mprotect(addr, length, prot)?;
+                this.write_scalar(result, dest)?;
+            }
+            "madvise" => {
+                let [addr, length, advice] = this.check_shim_sig(
+                    shim_sig!(extern "C" fn(*mut _, usize, i32) -> i32),
+                    link_name,
+                    abi,
+                    args,
+                )?;
+                let result = this.madvise(addr, length, advice)?;
                 this.write_scalar(result, dest)?;
             }
 
@@ -1386,7 +1414,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let [_, _] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
                 this.write_null(dest)?;
             }
-            "sigaction" | "mprotect" if this.frame_in_std() => {
+            "sigaction" if this.frame_in_std() => {
                 let [_, _, _] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
                 this.write_null(dest)?;
             }

--- a/src/shims/unix/mem.rs
+++ b/src/shims/unix/mem.rs
@@ -53,9 +53,6 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return interp_ok(Scalar::from_maybe_pointer(Pointer::without_provenance(addr), this));
         }
 
-        let prot_read = this.eval_libc_i32("PROT_READ");
-        let prot_write = this.eval_libc_i32("PROT_WRITE");
-
         // First, we do some basic argument validation as required by mmap
         if (flags & (map_private | map_shared)).count_ones() != 1 {
             this.set_last_error(LibcError("EINVAL"))?;
@@ -80,13 +77,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             );
         }
 
-        // Miri doesn't support protections other than PROT_READ|PROT_WRITE.
-        if prot != prot_read | prot_write {
-            throw_unsup_format!(
-                "Miri does not support calls to mmap with protections other than \
-                 PROT_READ|PROT_WRITE",
-            );
-        }
+        verify_prot(this, prot)?;
 
         // Miri does not support shared mappings, or any of the other extensions that for example
         // Linux has added to the flags arguments.
@@ -103,14 +94,10 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         }
 
         let align = this.machine.page_align();
-        let Some(map_length) = length.checked_next_multiple_of(this.machine.page_size) else {
+        let Some(map_length) = round_up_to_page_size(this, length) else {
             this.set_last_error(LibcError("EINVAL"))?;
             return interp_ok(this.eval_libc("MAP_FAILED"));
         };
-        if map_length > this.target_usize_max() {
-            this.set_last_error(LibcError("EINVAL"))?;
-            return interp_ok(this.eval_libc("MAP_FAILED"));
-        }
 
         let ptr = this.allocate_ptr(
             Size::from_bytes(map_length),
@@ -135,13 +122,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return this.set_errno_and_return_neg1_i32(LibcError("EINVAL"));
         }
 
-        let Some(length) = length.checked_next_multiple_of(this.machine.page_size) else {
+        let Some(length) = round_up_to_page_size(this, length) else {
             return this.set_errno_and_return_neg1_i32(LibcError("EINVAL"));
         };
-        if length > this.target_usize_max() {
-            this.set_last_error(LibcError("EINVAL"))?;
-            return interp_ok(this.eval_libc("MAP_FAILED"));
-        }
 
         let length = Size::from_bytes(length);
         this.deallocate_ptr(
@@ -152,4 +135,106 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
         interp_ok(Scalar::from_i32(0))
     }
+
+    fn mprotect(
+        &mut self,
+        addr: &OpTy<'tcx>,
+        length: &OpTy<'tcx>,
+        prot: &OpTy<'tcx>,
+    ) -> InterpResult<'tcx, Scalar> {
+        let this = self.eval_context_mut();
+
+        let addr = this.read_pointer(addr)?;
+        let length = this.read_target_usize(length)?;
+        let prot = this.read_scalar(prot)?.to_i32()?;
+
+        // addr must be a multiple of the page size.
+        if !addr.addr().bytes().is_multiple_of(this.machine.page_size) {
+            return this.set_errno_and_return_neg1_i32(LibcError("EINVAL"));
+        }
+
+        verify_prot(this, prot)?;
+
+        // The pages from `[addr, addr + length)` must be mapped, so length definitely must not overflow.
+        let Some(length) = round_up_to_page_size(this, length) else {
+            return this.set_errno_and_return_neg1_i32(LibcError("ENOMEM"));
+        };
+        // Ensure this is actually allocated memory we can access.
+        this.check_ptr_access(addr, Size::from_bytes(length), CheckInAllocMsg::MemoryAccess)
+            .map_err_kind(|_| err_ub_format!("`mprotect` called on out-of-bounds memory"))?;
+
+        // If the memory comes from memory the Rust program has allocated with mmap, we only support
+        // `PROT_READ|PROT_WRITE`, so this `mprotect` is a no-op. If the memory was mmaped by the
+        // runtime (e.g. if it's the stack, executable memory, or static memory), POSIX also allows
+        // us to remap it. In those cases, such a call to `PROT_READ|PROT_WRITE` might actually change the permissions,
+        // but treating them as the new permissions is still UB. Therefore, we just pretend that we
+        // did the permission change by returning success, and will still reject if you try to use
+        // it with the "new" permissions.
+        interp_ok(Scalar::from_i32(0))
+    }
+
+    fn madvise(
+        &mut self,
+        addr: &OpTy<'tcx>,
+        length: &OpTy<'tcx>,
+        advice: &OpTy<'tcx>,
+    ) -> InterpResult<'tcx, Scalar> {
+        let this = self.eval_context_mut();
+
+        let addr = this.read_pointer(addr)?;
+        let length = this.read_target_usize(length)?;
+        let advise = this.read_scalar(advice)?.to_i32()?;
+
+        // addr must be a multiple of the page size.
+        if !addr.addr().bytes().is_multiple_of(this.machine.page_size) {
+            return this.set_errno_and_return_neg1_i32(LibcError("EINVAL"));
+        }
+
+        // advise must be supported.
+        let madv_normal = this.eval_libc_i32("MADV_NORMAL");
+        let madv_random = this.eval_libc_i32("MADV_RANDOM");
+        let madv_sequential = this.eval_libc_i32("MADV_SEQUENTIAL");
+        let madv_willneed = this.eval_libc_i32("MADV_WILLNEED");
+        if advise != madv_normal
+            && advise != madv_random
+            && advise != madv_sequential
+            && advise != madv_willneed
+        {
+            throw_unsup_format!(
+                "Miri does not support calls to madvise with advice other than MADV_NORMAL, MADV_RANDOM, MADV_SEQUENTIAL, or MADV_WILLNEED",
+            );
+        }
+
+        // The pages from `[addr, addr + length)` must be mapped, so length definitely must not overflow.
+        let Some(length) = round_up_to_page_size(this, length) else {
+            return this.set_errno_and_return_neg1_i32(LibcError("ENOMEM"));
+        };
+        // Ensure this is actually allocated memory we can access.
+        this.check_ptr_access(addr, Size::from_bytes(length), CheckInAllocMsg::MemoryAccess)
+            .map_err_kind(|_| err_ub_format!("`madvise` called on out-of-bounds memory"))?;
+
+        // All advises we support are no-ops.
+        interp_ok(Scalar::from_i32(0))
+    }
+}
+
+fn round_up_to_page_size(this: &MiriInterpCx<'_>, length: u64) -> Option<u64> {
+    length
+        .checked_next_multiple_of(this.machine.page_size)
+        .filter(|length| *length <= this.target_isize_max().try_into().unwrap())
+}
+
+fn verify_prot<'tcx>(this: &mut MiriInterpCx<'tcx>, prot: i32) -> InterpResult<'tcx> {
+    let prot_read = this.eval_libc_i32("PROT_READ");
+    let prot_write = this.eval_libc_i32("PROT_WRITE");
+
+    // Miri doesn't support protections other than PROT_READ|PROT_WRITE.
+    if prot != prot_read | prot_write {
+        throw_unsup_format!(
+            "Miri does not support calls to mmap/mprotect with protections other than \
+             PROT_READ|PROT_WRITE",
+        );
+    }
+
+    interp_ok(())
 }

--- a/tests/fail-dep/libc/madvise_out_of_bounds.rs
+++ b/tests/fail-dep/libc/madvise_out_of_bounds.rs
@@ -1,0 +1,20 @@
+//@compile-flags: -Zmiri-disable-isolation
+//@ignore-target: windows # No mmap on Windows
+//@normalize-stderr-test: "only .*? bytes" -> "only SIZE bytes"
+
+fn main() {
+    unsafe {
+        let page_size = page_size::get();
+        let ptr = libc::mmap(
+            std::ptr::null_mut(),
+            page_size,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+            -1,
+            0,
+        );
+        assert!(!ptr.is_null());
+
+        libc::madvise(ptr, page_size + 1, libc::MADV_NORMAL); //~ ERROR: `madvise` called on out-of-bounds memory
+    }
+}

--- a/tests/fail-dep/libc/madvise_out_of_bounds.stderr
+++ b/tests/fail-dep/libc/madvise_out_of_bounds.stderr
@@ -1,0 +1,13 @@
+error: Undefined Behavior: `madvise` called on out-of-bounds memory
+  --> tests/fail-dep/libc/madvise_out_of_bounds.rs:LL:CC
+   |
+LL |         libc::madvise(ptr, page_size + 1, libc::MADV_NORMAL);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/tests/fail-dep/libc/mprotect_out_of_bounds.rs
+++ b/tests/fail-dep/libc/mprotect_out_of_bounds.rs
@@ -1,0 +1,20 @@
+//@compile-flags: -Zmiri-disable-isolation
+//@ignore-target: windows # No mmap on Windows
+//@normalize-stderr-test: "only .*? bytes" -> "only SIZE bytes"
+
+fn main() {
+    unsafe {
+        let page_size = page_size::get();
+        let ptr = libc::mmap(
+            std::ptr::null_mut(),
+            page_size,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+            -1,
+            0,
+        );
+        assert!(!ptr.is_null());
+
+        libc::mprotect(ptr, page_size + 1, libc::PROT_READ | libc::PROT_WRITE); //~ ERROR: `mprotect` called on out-of-bounds memory
+    }
+}

--- a/tests/fail-dep/libc/mprotect_out_of_bounds.stderr
+++ b/tests/fail-dep/libc/mprotect_out_of_bounds.stderr
@@ -1,0 +1,13 @@
+error: Undefined Behavior: `mprotect` called on out-of-bounds memory
+  --> tests/fail-dep/libc/mprotect_out_of_bounds.rs:LL:CC
+   |
+LL |         libc::mprotect(ptr, page_size + 1, libc::PROT_READ | libc::PROT_WRITE);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/tests/pass-dep/libc/mmap.rs
+++ b/tests/pass-dep/libc/mmap.rs
@@ -94,6 +94,78 @@ fn test_mmap<Offset: Default>(
     assert_eq!(Error::last_os_error().raw_os_error().unwrap(), libc::EINVAL);
 }
 
+fn test_mprotect() {
+    let page_size = page_size::get();
+    let ptr = unsafe {
+        libc::mmap(
+            ptr::null_mut(),
+            4 * page_size,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+            -1,
+            Default::default(),
+        )
+    };
+    assert!(!ptr.is_null());
+
+    // Protect part of it redundantly.
+    let res = unsafe {
+        libc::mprotect(ptr.byte_add(2 * page_size), 42, libc::PROT_READ | libc::PROT_WRITE)
+    };
+    assert_eq!(res, 0i32);
+
+    // Protect everything redundantly.
+    let res = unsafe { libc::mprotect(ptr, 4 * page_size, libc::PROT_READ | libc::PROT_WRITE) };
+    assert_eq!(res, 0i32);
+
+    // We report an error when the address is not a multiple of the page size.
+    let res =
+        unsafe { libc::mprotect(ptr.byte_add(11), page_size, libc::PROT_READ | libc::PROT_WRITE) };
+    assert_eq!(res, -1);
+    assert_eq!(Error::last_os_error().raw_os_error().unwrap(), libc::EINVAL);
+
+    // We report an error if the length cannot be rounded up to a multiple of the page size.
+    let res = unsafe { libc::mprotect(ptr, usize::MAX - 1, libc::PROT_READ | libc::PROT_WRITE) };
+    assert_eq!(res, -1);
+    assert_eq!(Error::last_os_error().raw_os_error().unwrap(), libc::ENOMEM);
+}
+
+fn test_madvise() {
+    let page_size = page_size::get();
+    let ptr = unsafe {
+        libc::mmap(
+            ptr::null_mut(),
+            4 * page_size,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+            -1,
+            Default::default(),
+        )
+    };
+    assert!(!ptr.is_null());
+
+    for advice in [libc::MADV_NORMAL, libc::MADV_RANDOM, libc::MADV_SEQUENTIAL, libc::MADV_WILLNEED]
+    {
+        // Advise part of it redundantly.
+        let res = unsafe { libc::madvise(ptr.byte_add(2 * page_size), 42, advice) };
+        assert_eq!(res, 0i32);
+
+        // Protect everything redundantly.
+        let res = unsafe { libc::madvise(ptr, 4 * page_size, advice) };
+        assert_eq!(res, 0i32);
+    }
+
+    // We report an error when the address is not a multiple of the page size.
+    let res = unsafe { libc::madvise(ptr.byte_add(11), page_size, libc::MADV_NORMAL) };
+    assert_eq!(res, -1);
+    assert_eq!(Error::last_os_error().raw_os_error().unwrap(), libc::EINVAL);
+
+    // We report an error if the length cannot be rounded up to a multiple of the page size.
+    let res = unsafe { libc::madvise(ptr, usize::MAX - 1, libc::MADV_NORMAL) };
+    assert_eq!(res, -1);
+    assert_eq!(Error::last_os_error().raw_os_error().unwrap(), libc::ENOMEM);
+}
+
 #[cfg(target_os = "linux")]
 fn test_mremap() {
     let page_size = page_size::get();
@@ -145,6 +217,8 @@ fn main() {
     test_mmap(libc::mmap);
     #[cfg(target_os = "linux")]
     test_mmap(libc::mmap64);
+    test_mprotect();
+    test_madvise();
     #[cfg(target_os = "linux")]
     test_mremap();
 }


### PR DESCRIPTION
This very partially address rust-lang/miri#3605.

A common patterns in memory allocators is to use `mmap` with `PROT_NONE` to reserve a big chunk of address space, and then selectively commit it by changing the protections with `mprotect` (and hinting how it will be used with `madvise`).

A minimal way to support is to ignore protections in `mmap`. This incorrectly allows programs that access memory in a way not consistent with the protections, but the kernel reliably rejects them anyway, so running it without miri will reliably discover this error. `mprotect` can then be trivially implemented as a no-op.

I also started a prototype implementation of properly modelling protections. The borrow trackers already have Permission tags which could be co-opted for that I think (I don't think the model cares whether a borrow is disabled due to Rust rules or whether the kernel disabled the memory). An `mmap` with protections other than read/write could then be implemented as a new allocation that sets the initial permission accordingly, and not blindly to Unique. `mprotect` is a bit more tricky due to the partial nature and because it essentially yanks out permissions from underneath previously valid references. My initial idea to model permission downgrades was to forcefully change everything in the stack/tree of items to the new permission, but it might break some assumptions the algorithm makes. So I've decided to just propose this minimum implementation and see whether there's interest in the first place :)

On the other hand, supporting `madvise` is trivial, as it is mostly advisory. There are flags that have observable effects on file mappings, but file mappings are not supported by miri to begin with. So the shim doesn't need to do anything - we could do more argument validation, but again, that's not really the error you need miri for.