### PR TITLE
enforce noalias on custom allocator Box by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,10 @@ to Miri failing to detect cases of undefined behavior in a program.
   track interior mutable data on the level of references instead of on the
   byte-level as is done by default.  Therefore, with this flag, Tree
   Borrows will be more permissive.
+* `-Zmiri-tree-borrows-relax-custom-allocator-uniqueness` disables uniqueness assumptions for
+  `Box<T, A>` where `A` is not `Global`. The exact aliasing rules for such custom allocators are
+  still up in the air, and by default Miri is conservative and rejects some allocator
+  implementations that incur relevant aliasing between the allocation and the allocator.
 * `-Zmiri-force-page-size=<num>` overrides the default page size for an architecture, in multiples of 1k.
   `4` is default for most targets. This value should always be a power of 2 and nonzero.
 

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -526,6 +526,8 @@ fn main() -> ExitCode {
                 Some(BorrowTrackerMethod::TreeBorrows(TreeBorrowsParams {
                     precise_interior_mut: true,
                     implicit_writes: false,
+                    // We default this to "unique" for now to keep the design space open.
+                    box_custom_allocator_unique: true,
                 }));
         } else if arg == "-Zmiri-tree-borrows-no-precise-interior-mut" {
             match &mut miri_config.borrow_tracker {
@@ -545,6 +547,16 @@ fn main() -> ExitCode {
                 _ =>
                     fatal_error!(
                         "`-Zmiri-tree-borrows` is required before `-Zmiri-tree-borrows-implicit-writes`"
+                    ),
+            };
+        } else if arg == "-Zmiri-tree-borrows-relax-custom-allocator-uniqueness" {
+            match &mut miri_config.borrow_tracker {
+                Some(BorrowTrackerMethod::TreeBorrows(params)) => {
+                    params.box_custom_allocator_unique = false;
+                }
+                _ =>
+                    fatal_error!(
+                        "`-Zmiri-tree-borrows` is required before `-Zmiri-tree-borrows-relax-custom-allocator-uniqueness`"
                     ),
             };
         } else if arg == "-Zmiri-disable-data-race-detector" {

--- a/src/borrow_tracker/mod.rs
+++ b/src/borrow_tracker/mod.rs
@@ -226,9 +226,12 @@ pub enum BorrowTrackerMethod {
 /// Parameters that Tree Borrows can take.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct TreeBorrowsParams {
+    /// Controls whether we track `UnsafeCell` with byte precision.
     pub precise_interior_mut: bool,
     /// Controls whether `&mut` function arguments are immediately activated with an implicit write.
     pub implicit_writes: bool,
+    /// Controls whether `Box` with custom allocator is considered unique.
+    pub box_custom_allocator_unique: bool,
 }
 
 impl BorrowTrackerMethod {
@@ -236,6 +239,7 @@ impl BorrowTrackerMethod {
         RefCell::new(GlobalStateInner::new(self, config.tracked_pointer_tags.clone()))
     }
 
+    #[track_caller]
     pub fn get_tree_borrows_params(self) -> TreeBorrowsParams {
         match self {
             BorrowTrackerMethod::TreeBorrows(params) => params,

--- a/src/borrow_tracker/stacked_borrows/mod.rs
+++ b/src/borrow_tracker/stacked_borrows/mod.rs
@@ -869,12 +869,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             RetagMode::None => return interp_ok(None), // no retagging
         };
         let new_perm = if ty.is_box() {
-            if ty.is_box_global(*this.tcx) {
-                NewPermission::from_box_ty(val.layout.ty, mode, this)
-            } else {
-                // Boxes with local allocator are not retagged.
-                return interp_ok(None);
-            }
+            NewPermission::from_box_ty(val.layout.ty, mode, this)
         } else {
             NewPermission::from_ref_ty(val.layout.ty, mode, this)
         };

--- a/src/borrow_tracker/tree_borrows/mod.rs
+++ b/src/borrow_tracker/tree_borrows/mod.rs
@@ -127,7 +127,7 @@ impl<'tcx> NewPermission {
         pointee: Ty<'tcx>,
         ref_mutability: Option<Mutability>,
         mode: RetagMode,
-        cx: &crate::MiriInterpCx<'tcx>,
+        cx: &MiriInterpCx<'tcx>,
     ) -> Option<Self> {
         if mode == RetagMode::None {
             return None;
@@ -143,15 +143,7 @@ impl<'tcx> NewPermission {
         // `#[rustc_no_writable]` attribute. For performance reasons, only performs the lookup if
         // is_protected is true as implicit writes are only performed for protected references.
         let implicit_writes_enabled = is_protected && {
-            let implicit_writes = cx
-                .machine
-                .borrow_tracker
-                .as_ref()
-                .unwrap()
-                .borrow()
-                .borrow_tracker_method
-                .get_tree_borrows_params()
-                .implicit_writes;
+            let implicit_writes = cx.get_tree_borrows_params().implicit_writes;
             let def_id = cx.frame().instance().def_id();
             implicit_writes && !find_attr!(cx.tcx, def_id, RustcNoWritable)
         };
@@ -234,6 +226,14 @@ impl<'tcx> NewPermission {
 /// the implementation of NewPermission.
 impl<'tcx> EvalContextPrivExt<'tcx> for crate::MiriInterpCx<'tcx> {}
 trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
+    #[track_caller]
+    #[inline]
+    fn get_tree_borrows_params(&self) -> TreeBorrowsParams {
+        let this = self.eval_context_ref();
+        let borrow_tracker = this.machine.borrow_tracker.as_ref().unwrap().borrow();
+        borrow_tracker.borrow_tracker_method.get_tree_borrows_params()
+    }
+
     /// Returns the provenance that should be used henceforth.
     fn tb_reborrow(
         &mut self,
@@ -326,15 +326,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         }
 
         let protected = new_perm.protector.is_some();
-        let precise_interior_mut = this
-            .machine
-            .borrow_tracker
-            .as_mut()
-            .unwrap()
-            .get_mut()
-            .borrow_tracker_method
-            .get_tree_borrows_params()
-            .precise_interior_mut;
+        let precise_interior_mut = this.get_tree_borrows_params().precise_interior_mut;
 
         // Compute initial "inside" permissions.
         let loc_state = |frozen: bool| -> LocationState {
@@ -487,20 +479,23 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     ) -> InterpResult<'tcx, Option<ImmTy<'tcx>>> {
         let this = self.eval_context_mut();
         let new_perm = match *ty.kind() {
-            _ if ty.is_box_global(*this.tcx) => {
-                // The `None` marks this as a Box.
-                NewPermission::new(ty.builtin_deref(true).unwrap(), None, mode, this)
-            }
             ty::Ref(_, pointee, mutability) =>
                 NewPermission::new(pointee, Some(mutability), mode, this),
+            _ if ty.is_box() => {
+                let box_custom_allocator_unique =
+                    this.get_tree_borrows_params().box_custom_allocator_unique;
+                if box_custom_allocator_unique || ty.is_box_global(*this.tcx) {
+                    // The `None` marks this as a Box.
+                    NewPermission::new(ty.builtin_deref(true).unwrap(), None, mode, this)
+                } else {
+                    // No retagging for boxes with custom allocators.
+                    None
+                }
+            }
 
             ty::RawPtr(..) => {
                 assert!(mode == RetagMode::Raw);
                 // We don't give new tags to raw pointers.
-                None
-            }
-            _ if ty.is_box() => {
-                // No retagging for boxes with local allocators.
                 None
             }
             _ => panic!("tb_retag_ptr_value: invalid type {ty}"),

--- a/tests/fail/async-shared-mutable.rs
+++ b/tests/fail/async-shared-mutable.rs
@@ -3,7 +3,7 @@
 //! `UnsafePinned` must include the effects of `UnsafeCell`.
 //@revisions: stack tree
 //@[tree]compile-flags: -Zmiri-tree-borrows
-//@normalize-stderr-test: "\[0x[a-fx\d.]+\]" -> "[OFFSET]"
+//@normalize-stderr-test: "\[0x[a-fx\d.]+\]" -> "[RANGE]"
 
 use core::future::Future;
 use core::pin::{Pin, pin};

--- a/tests/fail/async-shared-mutable.stack.stderr
+++ b/tests/fail/async-shared-mutable.stack.stderr
@@ -1,12 +1,12 @@
-error: Undefined Behavior: attempting a write access using <TAG> at ALLOC[OFFSET], but that tag does not exist in the borrow stack for this location
+error: Undefined Behavior: attempting a write access using <TAG> at ALLOC[RANGE], but that tag does not exist in the borrow stack for this location
   --> tests/fail/async-shared-mutable.rs:LL:CC
    |
 LL |             *x = 1;
-   |             ^^^^^^ this error occurs as part of an access at ALLOC[OFFSET]
+   |             ^^^^^^ this error occurs as part of an access at ALLOC[RANGE]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
-help: <TAG> was created by a Unique retag at offsets [OFFSET]
+help: <TAG> was created by a Unique retag at offsets [RANGE]
   --> tests/fail/async-shared-mutable.rs:LL:CC
    |
 LL | /         core::future::poll_fn(move |_| {
@@ -15,7 +15,7 @@ LL | |             Poll::<()>::Pending
 LL | |         })
 LL | |         .await
    | |______________^
-help: <TAG> was later invalidated at offsets [OFFSET] by a SharedReadOnly retag
+help: <TAG> was later invalidated at offsets [RANGE] by a SharedReadOnly retag
   --> tests/fail/async-shared-mutable.rs:LL:CC
    |
 LL |     let _: Pin<&_> = f.as_ref(); // Or: `f.as_mut().into_ref()`.

--- a/tests/fail/async-shared-mutable.tree.stderr
+++ b/tests/fail/async-shared-mutable.tree.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: write access through <TAG> at ALLOC[OFFSET] is forbidden
+error: Undefined Behavior: write access through <TAG> at ALLOC[RANGE] is forbidden
   --> tests/fail/async-shared-mutable.rs:LL:CC
    |
 LL |             *x = 1;
@@ -16,13 +16,13 @@ LL | |             Poll::<()>::Pending
 LL | |         })
 LL | |         .await
    | |______________^
-help: the accessed tag <TAG> later transitioned to Unique due to a child write access at offsets [OFFSET]
+help: the accessed tag <TAG> later transitioned to Unique due to a child write access at offsets [RANGE]
   --> tests/fail/async-shared-mutable.rs:LL:CC
    |
 LL |             *x = 1;
    |             ^^^^^^
    = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
-help: the accessed tag <TAG> later transitioned to Frozen due to a reborrow (acting as a foreign read access) at offsets [OFFSET]
+help: the accessed tag <TAG> later transitioned to Frozen due to a reborrow (acting as a foreign read access) at offsets [RANGE]
   --> tests/fail/async-shared-mutable.rs:LL:CC
    |
 LL |     let _: Pin<&_> = f.as_ref(); // Or: `f.as_mut().into_ref()`.

--- a/tests/fail/both_borrows/box-custom-alloc-aliasing.rs
+++ b/tests/fail/both_borrows/box-custom-alloc-aliasing.rs
@@ -1,10 +1,9 @@
-//! Regression test for <https://github.com/rust-lang/miri/issues/3341>:
-//! If `Box` has a local allocator, then it can't be `noalias` as the allocator
-//! may want to access allocator state based on the data pointer.
-//! Ensure that the `-Zmiri-tree-borrows-relax-custom-allocator-uniqueness` flag makes us
-//! accept such code.
+//! Test related to <https://github.com/rust-lang/miri/issues/3341>:
+//! `Box` with custom allocators are still `noalias`, leading to UB.
 
-//@compile-flags: -Zmiri-tree-borrows -Zmiri-tree-borrows-relax-custom-allocator-uniqueness -Zmiri-tree-borrows-implicit-writes
+//@revisions: stack tree
+//@[tree]compile-flags: -Zmiri-tree-borrows
+//@normalize-stderr-test: "\[0x[a-fx\d.]+\]" -> "[RANGE]"
 #![feature(allocator_api)]
 
 use std::alloc::{AllocError, Allocator, Layout};
@@ -52,6 +51,7 @@ impl MyBin {
         // We access this via raw pointers so that the error span is in this file.
         let top_ptr = (&raw const self.top) as *mut usize;
         let top = top_ptr.read();
+        //~[tree]^ERROR: /read access .* is forbidden/
         top_ptr.write(top);
     }
 }
@@ -97,6 +97,7 @@ unsafe impl Allocator for MyAllocator {
         // That is fundamentally the source of the aliasing trouble in this example.
         let their_bin = ptr.as_ptr().map_addr(|addr| addr & !127).cast::<MyBin>();
         let thread_id = ptr::read(ptr::addr_of!((*their_bin).thread_id));
+        //~[stack]^ERROR: tag does not exist in the borrow stack
         if self.thread_id == thread_id {
             unsafe { (*their_bin).push(ptr) };
         } else {

--- a/tests/fail/both_borrows/box-custom-alloc-aliasing.stack.stderr
+++ b/tests/fail/both_borrows/box-custom-alloc-aliasing.stack.stderr
@@ -1,0 +1,37 @@
+error: Undefined Behavior: attempting a read access using <TAG> at ALLOC[RANGE], but that tag does not exist in the borrow stack for this location
+  --> tests/fail/both_borrows/box-custom-alloc-aliasing.rs:LL:CC
+   |
+LL |         let thread_id = ptr::read(ptr::addr_of!((*their_bin).thread_id));
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this error occurs as part of an access at ALLOC[RANGE]
+   |
+   = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
+   = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
+help: <TAG> was created by a Unique retag at offsets [RANGE]
+  --> tests/fail/both_borrows/box-custom-alloc-aliasing.rs:LL:CC
+   |
+LL |     (Box::new_in([t], a) as Box<[T], A>).into_vec()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: stack backtrace:
+           0: <MyAllocator as std::alloc::Allocator>::deallocate
+               at tests/fail/both_borrows/box-custom-alloc-aliasing.rs:LL:CC
+           1: <&MyAllocator as std::alloc::Allocator>::deallocate
+               at RUSTLIB/core/src/alloc/mod.rs:LL:CC
+           2: alloc::raw_vec::RawVecInner::<&MyAllocator>::deallocate
+               at RUSTLIB/alloc/src/raw_vec/mod.rs:LL:CC
+           3: <alloc::raw_vec::RawVec<usize, &MyAllocator> as std::ops::Drop>::drop
+               at RUSTLIB/alloc/src/raw_vec/mod.rs:LL:CC
+           4: std::ptr::drop_glue::<alloc::raw_vec::RawVec<usize, &MyAllocator>> - shim(Some(alloc::raw_vec::RawVec<usize, &MyAllocator>))
+               at RUSTLIB/core/src/ptr/mod.rs:LL:CC
+           5: std::ptr::drop_glue::<std::vec::Vec<usize, &MyAllocator>> - shim(Some(std::vec::Vec<usize, &MyAllocator>))
+               at RUSTLIB/core/src/ptr/mod.rs:LL:CC
+           6: std::ptr::drop_glue::<(std::vec::Vec<usize, &MyAllocator>, std::vec::Vec<usize, &MyAllocator>)> - shim(Some((std::vec::Vec<usize, &MyAllocator>, std::vec::Vec<usize, &MyAllocator>)))
+               at RUSTLIB/core/src/ptr/mod.rs:LL:CC
+           7: std::mem::drop::<(std::vec::Vec<usize, &MyAllocator>, std::vec::Vec<usize, &MyAllocator>)>
+               at RUSTLIB/core/src/mem/mod.rs:LL:CC
+           8: main
+               at tests/fail/both_borrows/box-custom-alloc-aliasing.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/tests/fail/both_borrows/box-custom-alloc-aliasing.tree.stderr
+++ b/tests/fail/both_borrows/box-custom-alloc-aliasing.tree.stderr
@@ -1,0 +1,52 @@
+error: Undefined Behavior: read access through <TAG> at ALLOC[RANGE] is forbidden
+  --> tests/fail/both_borrows/box-custom-alloc-aliasing.rs:LL:CC
+   |
+LL |         let top = top_ptr.read();
+   |                   ^^^^^^^^^^^^^^ Undefined Behavior occurred here
+   |
+   = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
+   = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/tree-borrows.md for further information
+   = help: the accessed tag <TAG> is a child of the conflicting tag <TAG>
+   = help: the conflicting tag <TAG> has state Disabled which forbids this child read access
+help: the accessed tag <TAG> was created here
+  --> tests/fail/both_borrows/box-custom-alloc-aliasing.rs:LL:CC
+   |
+LL |     unsafe fn push(&self, ptr: NonNull<u8>) {
+   |                    ^^^^^
+help: the conflicting tag <TAG> was created here, in the initial state Reserved
+  --> tests/fail/both_borrows/box-custom-alloc-aliasing.rs:LL:CC
+   |
+LL |     (Box::new_in([t], a) as Box<[T], A>).into_vec()
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: the conflicting tag <TAG> later transitioned to Disabled due to a foreign write access at offsets [RANGE]
+  --> tests/fail/both_borrows/box-custom-alloc-aliasing.rs:LL:CC
+   |
+LL |         self.top.set(top + 1);
+   |         ^^^^^^^^^^^^^^^^^^^^^
+   = help: this transition corresponds to a loss of read and write permissions
+   = note: stack backtrace:
+           0: MyBin::push
+               at tests/fail/both_borrows/box-custom-alloc-aliasing.rs:LL:CC
+           1: <MyAllocator as std::alloc::Allocator>::deallocate
+               at tests/fail/both_borrows/box-custom-alloc-aliasing.rs:LL:CC
+           2: <&MyAllocator as std::alloc::Allocator>::deallocate
+               at RUSTLIB/core/src/alloc/mod.rs:LL:CC
+           3: alloc::raw_vec::RawVecInner::<&MyAllocator>::deallocate
+               at RUSTLIB/alloc/src/raw_vec/mod.rs:LL:CC
+           4: <alloc::raw_vec::RawVec<usize, &MyAllocator> as std::ops::Drop>::drop
+               at RUSTLIB/alloc/src/raw_vec/mod.rs:LL:CC
+           5: std::ptr::drop_glue::<alloc::raw_vec::RawVec<usize, &MyAllocator>> - shim(Some(alloc::raw_vec::RawVec<usize, &MyAllocator>))
+               at RUSTLIB/core/src/ptr/mod.rs:LL:CC
+           6: std::ptr::drop_glue::<std::vec::Vec<usize, &MyAllocator>> - shim(Some(std::vec::Vec<usize, &MyAllocator>))
+               at RUSTLIB/core/src/ptr/mod.rs:LL:CC
+           7: std::ptr::drop_glue::<(std::vec::Vec<usize, &MyAllocator>, std::vec::Vec<usize, &MyAllocator>)> - shim(Some((std::vec::Vec<usize, &MyAllocator>, std::vec::Vec<usize, &MyAllocator>)))
+               at RUSTLIB/core/src/ptr/mod.rs:LL:CC
+           8: std::mem::drop::<(std::vec::Vec<usize, &MyAllocator>, std::vec::Vec<usize, &MyAllocator>)>
+               at RUSTLIB/core/src/mem/mod.rs:LL:CC
+           9: main
+               at tests/fail/both_borrows/box-custom-alloc-aliasing.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
As requested by @nia-e, let's use the more conservative semantics for now. Also add a flag to disable noalias on custom allocator Boxes. That flag wins the price for the longest flag: `-Zmiri-tree-borrows-relax-custom-allocator-uniqueness`. I am open to suggestions for shorter names. :)

In Stacked Borrows we just always enforce full uniqueness. It's meant to be the strict model anyway.