### PR TITLE
add shim for `neon.pmull64`

### DIFF
--- a/src/shims/aarch64.rs
+++ b/src/shims/aarch64.rs
@@ -214,6 +214,30 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let result = compute_crc32(crc, data, bit_size, polynomial);
                 this.write_scalar(Scalar::from_u32(result), dest)?;
             }
+            // Polynomial multiply long (64-bit x 64-bit -> 128-bit).
+            //
+            // This is the same as "carryless" multiplication, see
+            // <https://en.wikipedia.org/wiki/Carry-less_product#Multiplication_of_polynomials>.
+            //
+            // Used to implement the vmull_p64 and vmull_high_p64 functions.
+            // https://developer.arm.com/architectures/instruction-sets/intrinsics/vmull_p64
+            "neon.pmull64" => {
+                // LLVM and GCC group pmull with the AES intrinsics.
+                // Also see <https://gcc.gnu.org/pipermail/gcc-patches/2023-February/612088.html>.
+                this.expect_target_feature_for_intrinsic(link_name, "aes")?;
+
+                let [left, right] =
+                    this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
+                let left = this.read_scalar(left)?.to_u64()?;
+                let right = this.read_scalar(right)?.to_u64()?;
+
+                let result = left.widening_carryless_mul(right);
+
+                // dest is int8x16_t, transmute to u128 for the write.
+                let dest = dest.transmute(this.machine.layouts.u128, this)?;
+                this.write_scalar(Scalar::from_u128(result), &dest)?;
+            }
+
             _ => return interp_ok(EmulateItemResult::NotSupported),
         }
         interp_ok(EmulateItemResult::NeedsReturn)

--- a/tests/pass/shims/aarch64/intrinsics-aarch64-aes.rs
+++ b/tests/pass/shims/aarch64/intrinsics-aarch64-aes.rs
@@ -1,0 +1,45 @@
+// We're testing aarch64 AES target specific features.
+//@only-target: aarch64
+//@compile-flags: -C target-feature=+neon,+aes
+
+use std::arch::aarch64::*;
+use std::arch::is_aarch64_feature_detected;
+
+fn main() {
+    assert!(is_aarch64_feature_detected!("neon"));
+    assert!(is_aarch64_feature_detected!("aes"));
+
+    unsafe {
+        test_vmull_p64();
+        test_vmull_high_p64();
+    }
+}
+
+#[target_feature(enable = "neon,aes")]
+unsafe fn test_vmull_p64() {
+    assert_eq!(vmull_p64(0, 0), 0);
+    assert_eq!(vmull_p64(0, 0xffffffffffffffff), 0);
+    assert_eq!(vmull_p64(1, 1), 1);
+    assert_eq!(vmull_p64(1, 0x8000000000000000), 0x8000000000000000);
+
+    assert_eq!(vmull_p64(0b11, 0b11), 0b101);
+
+    // Check with the same inputs that are used in the x86_64 pclmulqdq test.
+    assert_eq!(
+        vmull_p64(0x7fffffffffffffff, 0xdd358416f52ecd34),
+        (2704901987789626761u128 << 64) | 13036940098130298092u128,
+    );
+}
+
+#[target_feature(enable = "neon,aes")]
+unsafe fn test_vmull_high_p64() {
+    // The lower (first) element is ignored.
+    let a = vcombine_p64(vcreate_p64(123), vcreate_p64(0b11));
+    let b = vcombine_p64(vcreate_p64(456), vcreate_p64(0b11));
+    assert_eq!(vmull_high_p64(a, b), 0b101);
+
+    // Check with the same inputs that are used in the x86_64 pclmulqdq test.
+    let a = vcombine_p64(vcreate_p64(0), vcreate_p64(0x7fffffffffffffff));
+    let b = vcombine_p64(vcreate_p64(0), vcreate_p64(0xdd358416f52ecd34));
+    assert_eq!(vmull_high_p64(a, b), (2704901987789626761u128 << 64) | 13036940098130298092u128);
+}


### PR DESCRIPTION
the aarch64 variant of x86's `pclmulqdq`, using carryless_mul for polynomial multiplication in GF(2). This intrinsic is useful for the crc32 algorithm.

The test has been validated on real hardware.