### PR TITLE
Add support for level-triggered epoll

### DIFF
--- a/src/shims/unix/linux_like/epoll.rs
+++ b/src/shims/unix/linux_like/epoll.rs
@@ -1,7 +1,6 @@
 use std::cell::RefCell;
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, VecDeque};
 use std::io;
-use std::ops::Bound;
 use std::time::Duration;
 
 use rustc_abi::FieldIdx;
@@ -23,7 +22,9 @@ pub struct Epoll {
     interest_list: RefCell<BTreeMap<EpollEventKey, EpollEventInterest>>,
     /// The subset of interests that is currently considered "ready". Stored separately so we
     /// can access it more efficiently.
-    ready_set: RefCell<BTreeSet<EpollEventKey>>,
+    /// This is implemented as a queue so that for level-triggered epoll, all events eventually
+    /// get returned from `epoll_wait`. The queue does not contain any duplicates.
+    ready_events: RefCell<VecDeque<EpollEventKey>>,
     /// The queue of threads blocked on this epoll instance.
     queue: RefCell<VecDeque<ThreadId>>,
 }
@@ -46,6 +47,9 @@ pub struct EpollEventInterest {
     relevant_events: u32,
     /// The currently active events for this file descriptor.
     active_events: u32,
+    /// Boolean whether this is an edge-triggered interest.
+    /// When [`false`] it's a level-triggered interest instead.
+    is_edge_triggered: bool,
     /// The vector clock for wakeups.
     clock: VClock,
     /// User-defined data associated with this interest.
@@ -203,12 +207,8 @@ impl EpollInterestTable {
                     .extract_if(range_for_id(id), |_, _| true)
                     // Consume the iterator.
                     .for_each(drop);
-                epoll
-                    .ready_set
-                    .borrow_mut()
-                    .extract_if(range_for_id(id), |_| true)
-                    // Consume the iterator.
-                    .for_each(drop);
+                // Remove the ready events for this file description.
+                epoll.ready_events.borrow_mut().retain(|(fd_id, _)| fd_id != &id);
             }
         }
     }
@@ -303,6 +303,13 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 this.read_scalar(&this.project_field(&event, FieldIdx::ZERO)?)?.to_u32()?;
             let data = this.read_scalar(&this.project_field(&event, FieldIdx::ONE)?)?.to_u64()?;
 
+            let is_edge_triggered = if events & epollet == epollet {
+                events &= !epollet;
+                true
+            } else {
+                false
+            };
+
             // Unset the flag we support to discover if any unsupported flags are used.
             let mut flags = events;
             // epoll_wait(2) will always wait for epollhup and epollerr; it is not
@@ -311,12 +318,6 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             events |= epollhup;
             events |= epollerr;
 
-            if events & epollet != epollet {
-                // We only support edge-triggered notification for now.
-                throw_unsup_format!("epoll_ctl: epollet flag must be included.");
-            } else {
-                flags &= !epollet;
-            }
             if flags & epollin == epollin {
                 flags &= !epollin;
             }
@@ -350,6 +351,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 }
                 let new_interest = EpollEventInterest {
                     relevant_events: events,
+                    is_edge_triggered,
                     data,
                     active_events: 0,
                     clock: VClock::default(),
@@ -364,6 +366,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     return this.set_errno_and_return_neg1_i32(LibcError("ENOENT"));
                 };
                 interest.relevant_events = events;
+                interest.is_edge_triggered = is_edge_triggered;
                 interest.data = data;
             }
 
@@ -391,7 +394,11 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // We did not have interest in this.
                 return this.set_errno_and_return_neg1_i32(LibcError("ENOENT"));
             };
-            epfd.ready_set.borrow_mut().remove(&epoll_key);
+            // Remove the ready event for this key, should one exist.
+            let mut ready_events = epfd.ready_events.borrow_mut();
+            if let Some(idx) = ready_events.iter().position(|k| k == &epoll_key) {
+                ready_events.remove(idx);
+            }
             // If this was the last interest in this FD, remove us from the global list
             // of who is interested in this FD.
             if interest_list.range(range_for_id(id)).next().is_none() {
@@ -469,7 +476,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return this.set_errno_and_return_neg1(LibcError("EBADF"), dest);
         };
 
-        if timeout == 0 || !epfd.ready_set.borrow().is_empty() {
+        if timeout == 0 || !epfd.ready_events.borrow().is_empty() {
             // If the timeout is 0 or there is a ready event, we can return immediately.
             return_ready_list(&epfd, dest, &event, this)?;
         } else {
@@ -590,18 +597,29 @@ fn update_readiness<'tcx>(
         &mut dyn FnMut(EpollEventKey, &mut EpollEventInterest) -> InterpResult<'tcx>,
     ) -> InterpResult<'tcx>,
 ) -> InterpResult<'tcx> {
-    let mut ready_set = epoll.ready_set.borrow_mut();
+    let mut ready_events = epoll.ready_events.borrow_mut();
     for_each_interest(&mut |key, interest| {
         // Update the ready events tracked in this interest.
         let new_readiness = interest.relevant_events & active_events;
         let prev_readiness = std::mem::replace(&mut interest.active_events, new_readiness);
         if new_readiness == 0 {
             // Un-trigger this, there's nothing left to report here.
-            ready_set.remove(&key);
+            if let Some(idx) = ready_events.iter().position(|k| k == &key) {
+                ready_events.remove(idx);
+            }
         } else if force_edge || new_readiness != prev_readiness & new_readiness {
-            // Either we force an "edge" to be detected, or there's a bit set in `new`
-            // that was not set in `prev`. In both cases, this is ready now.
-            ready_set.insert(key);
+            // Either we force an "edge" to be detected or there's a bit set in `new_readiness`
+            // that was not set in `prev_readiness`. In both cases, this is ready now.
+
+            // We need to ensure that this event is not already part of the
+            // `ready_events` queue before enqueueing:
+            // <https://github.com/torvalds/linux/blob/HEAD/fs/eventpoll.c#L1292-L1296>
+            if !ready_events.contains(&key) {
+                ready_events.push_back(key);
+            }
+
+            // No matter whether this is newly ready or just re-triggered,
+            // the `epoll_wait` fetching this event should sync with the current thread.
             ecx.release_clock(|clock| {
                 interest.clock.join(clock);
             })?;
@@ -609,12 +627,12 @@ fn update_readiness<'tcx>(
         interp_ok(())
     })?;
     // While there are events ready to be delivered, wake up a thread to receive them.
-    while !ready_set.is_empty()
+    while !ready_events.is_empty()
         && let Some(thread_id) = epoll.queue.borrow_mut().pop_front()
     {
-        drop(ready_set); // release the "lock" so the unblocked thread can have it
+        drop(ready_events); // release the "lock" so the unblocked thread can have it
         ecx.unblock_thread(thread_id, BlockReason::Epoll { epfd: epoll.clone() })?;
-        ready_set = epoll.ready_set.borrow_mut();
+        ready_events = epoll.ready_events.borrow_mut();
     }
 
     interp_ok(())
@@ -629,7 +647,7 @@ fn return_ready_list<'tcx>(
     ecx: &mut MiriInterpCx<'tcx>,
 ) -> InterpResult<'tcx, i32> {
     let mut interest_list = epfd.interest_list.borrow_mut();
-    let mut ready_set = epfd.ready_set.borrow_mut();
+    let mut ready_events = epfd.ready_events.borrow_mut();
     let mut num_of_events: i32 = 0;
     let mut array_iter = ecx.project_array_fields(events)?;
 
@@ -644,27 +662,29 @@ fn return_ready_list<'tcx>(
         }
     }
 
-    // While there is a slot to store another event, and an event to store, deliver that event.
-    // We can't use an iterator over `ready_set` as we want to remove elements as we go,
-    // so we track the most recently delivered event to find the next one. We track it as a lower
-    // bound that we can pass to `BTreeSet::range`.
-    let mut event_lower_bound = Bound::Unbounded;
-    while let Some(slot) = array_iter.next(ecx)?
-        && let Some(&key) = ready_set.range((event_lower_bound, Bound::Unbounded)).next()
+    // We will fill at most the first `ready_events_len` slots of the array.
+    // Bounding the iterator this way ensures that we can re-add events
+    // to the end of the queue during the loop without having them show up in the array.
+    let ready_events_len = u64::try_from(ready_events.len()).unwrap();
+    while let Some((idx, slot)) = array_iter.next(ecx)?
+        && idx < ready_events_len
+        && let Some(key) = ready_events.pop_front()
     {
         let interest = interest_list.get_mut(&key).expect("non-existent event in ready set");
         // Deliver event to caller.
         ecx.write_int_fields_named(
             &[("events", interest.active_events.into()), ("u64", interest.data.into())],
-            &slot.1,
+            &slot,
         )?;
         num_of_events = num_of_events.strict_add(1);
         // Synchronize receiving thread with the event of interest.
         ecx.acquire_clock(&interest.clock)?;
-        // This was an edge-triggered event, so remove it from the ready set.
-        ready_set.remove(&key);
-        // Go find the next event.
-        event_lower_bound = Bound::Excluded(key);
+        if !interest.is_edge_triggered {
+            // This is a level-triggered interest, so we need to re-add the event
+            // at the end of the ready queue:
+            // <https://github.com/torvalds/linux/blob/HEAD/fs/eventpoll.c#L1835-L1847>
+            ready_events.push_back(key);
+        }
     }
     ecx.write_int(num_of_events, dest)?;
     interp_ok(num_of_events)

--- a/tests/pass-dep/libc/libc-epoll-blocking.rs
+++ b/tests/pass-dep/libc/libc-epoll-blocking.rs
@@ -1,6 +1,7 @@
 //@only-target: linux android illumos
 // test_epoll_block_then_unblock and test_epoll_race depend on a deterministic schedule.
 //@compile-flags: -Zmiri-deterministic-concurrency
+//@revisions: edge_triggered level_triggered
 
 use std::convert::TryInto;
 use std::thread;
@@ -9,6 +10,10 @@ use std::thread;
 mod libc_utils;
 use libc_utils::epoll::*;
 use libc_utils::*;
+
+/// When the `edge_triggered` revision is active, this is EPOLLET, otherwise
+/// it's zero which means we perform level-triggered epolls.
+const EPOLLET_OR_ZERO: libc::c_int = if cfg!(edge_triggered) { EPOLLET } else { 0 };
 
 // This is a set of testcases for blocking epoll.
 
@@ -21,7 +26,9 @@ fn main() {
     multiple_events_wake_multiple_threads();
 }
 
-// This test allows epoll_wait to block, then unblock without notification.
+// This test allows edge-triggered epoll_wait to block and then unblock
+// without notification because the timeout expired.
+// The level-triggered epoll_wait should not block.
 fn test_epoll_block_without_notification() {
     // Create an epoll instance.
     let epfd = errno_result(unsafe { libc::epoll_create1(0) }).unwrap();
@@ -31,16 +38,24 @@ fn test_epoll_block_without_notification() {
     let fd = errno_result(unsafe { libc::eventfd(0, flags) }).unwrap();
 
     // Register eventfd with epoll.
-    epoll_ctl_add(epfd, fd, libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET).unwrap();
+    epoll_ctl_add(epfd, fd, EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
 
     // epoll_wait to clear notification.
-    check_epoll_wait::<1>(epfd, &[Ev { events: libc::EPOLLOUT, data: fd }], 0);
+    check_epoll_wait::<8>(epfd, &[Ev { events: EPOLLOUT, data: fd }], -1);
 
-    // This epoll wait blocks, and timeout without notification.
-    check_epoll_wait::<1>(epfd, &[], 5);
+    if cfg!(edge_triggered) {
+        // This epoll wait blocks, and timeout without notification.
+        check_epoll_wait::<1>(epfd, &[], 5);
+    } else {
+        // In level-triggered mode we should receive the same events
+        // as before without timing out.
+        check_epoll_wait::<8>(epfd, &[Ev { events: EPOLLOUT, data: fd }], -1);
+    }
 }
 
-// This test triggers notification and unblocks the epoll_wait before timeout.
+// This test triggers notification and unblocks the edge-triggered epoll_wait
+// before the timeout exceeds.
+// The level-triggered epoll_wait should not block.
 fn test_epoll_block_then_unblock() {
     // Create an epoll instance.
     let epfd = errno_result(unsafe { libc::epoll_create1(0) }).unwrap();
@@ -50,21 +65,33 @@ fn test_epoll_block_then_unblock() {
     errno_check(unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) });
 
     // Register one side of the socketpair with epoll.
-    epoll_ctl_add(epfd, fds[0], libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET).unwrap();
+    epoll_ctl_add(epfd, fds[0], EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
 
     // epoll_wait to clear notification.
-    check_epoll_wait::<1>(epfd, &[Ev { events: libc::EPOLLOUT, data: fds[0] }], 0);
+    check_epoll_wait::<2>(epfd, &[Ev { events: EPOLLOUT, data: fds[0] }], -1);
 
-    // epoll_wait before triggering notification so it will block then get unblocked before timeout.
     let thread1 = thread::spawn(move || {
         thread::yield_now();
+        // Due to deterministic concurrency, we'll only get here when the other thread blocks.
         write_all(fds[1], b"abcde").unwrap();
     });
-    check_epoll_wait::<1>(epfd, &[Ev { events: libc::EPOLLIN | libc::EPOLLOUT, data: fds[0] }], 10);
+
+    if cfg!(edge_triggered) {
+        // Edge-triggered epoll will block until the write succeeds and the buffer
+        // becomes readable. This is because we already read the writable edge
+        // before so at the time of calling `epoll_wait` there is no active readiness.
+        check_epoll_wait::<2>(epfd, &[Ev { events: EPOLLIN | EPOLLOUT, data: fds[0] }], 10);
+    } else {
+        // Level-triggered epoll won't wait for the write to succeed because
+        // _some_ readiness is already set (in this case the EPOLLOUT).
+        check_epoll_wait::<2>(epfd, &[Ev { events: EPOLLOUT, data: fds[0] }], -1);
+    }
+
     thread1.join().unwrap();
 }
 
-// This test triggers a notification after epoll_wait times out.
+// This test triggers a notification after epoll_wait times out in edge-triggered mode.
+// In level-triggered the epoll_wait should not time out.
 fn test_notification_after_timeout() {
     // Create an epoll instance.
     let epfd = errno_result(unsafe { libc::epoll_create1(0) }).unwrap();
@@ -74,19 +101,26 @@ fn test_notification_after_timeout() {
     errno_check(unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) });
 
     // Register one side of the socketpair with epoll.
-    epoll_ctl_add(epfd, fds[0], libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET).unwrap();
+    epoll_ctl_add(epfd, fds[0], EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
 
     // epoll_wait to clear notification.
-    check_epoll_wait::<1>(epfd, &[Ev { events: libc::EPOLLOUT, data: fds[0] }], 0);
+    check_epoll_wait::<2>(epfd, &[Ev { events: EPOLLOUT, data: fds[0] }], -1);
 
-    // epoll_wait timeouts without notification.
-    check_epoll_wait::<1>(epfd, &[], 10);
+    if cfg!(edge_triggered) {
+        // Edge-triggered epoll wait times out without notification because
+        // we just processed the edge.
+        check_epoll_wait::<1>(epfd, &[], 10);
+    } else {
+        // Level-triggered epoll just returns the same events as before
+        // without blocking.
+        check_epoll_wait::<2>(epfd, &[Ev { events: EPOLLOUT, data: fds[0] }], -1);
+    }
 
     // Trigger epoll notification after timeout.
     write_all(fds[1], b"abcde").unwrap();
 
     // Check the result of the notification.
-    check_epoll_wait::<1>(epfd, &[Ev { events: libc::EPOLLIN | libc::EPOLLOUT, data: fds[0] }], 10);
+    check_epoll_wait::<2>(epfd, &[Ev { events: EPOLLIN | EPOLLOUT, data: fds[0] }], 10);
 }
 
 // This test shows a data race before epoll had vector clocks added.
@@ -99,7 +133,7 @@ fn test_epoll_race() {
     let fd = errno_result(unsafe { libc::eventfd(0, flags) }).unwrap();
 
     // Register eventfd with the epoll instance.
-    epoll_ctl_add(epfd, fd, libc::EPOLLIN | libc::EPOLLET).unwrap();
+    epoll_ctl_add(epfd, fd, EPOLLIN | EPOLLET_OR_ZERO).unwrap();
 
     static mut VAL: u8 = 0;
     let thread1 = thread::spawn(move || {
@@ -110,7 +144,7 @@ fn test_epoll_race() {
     });
     thread::yield_now();
     // epoll_wait for EPOLLIN.
-    check_epoll_wait::<8>(epfd, &[Ev { events: libc::EPOLLIN, data: fd }], -1);
+    check_epoll_wait::<8>(epfd, &[Ev { events: EPOLLIN, data: fd }], -1);
     // Read from the static mut variable.
     assert_eq!(unsafe { VAL }, 1);
     thread1.join().unwrap();
@@ -131,18 +165,14 @@ fn wakeup_on_new_interest() {
 
     // Block a thread on the epoll instance.
     let t = std::thread::spawn(move || {
-        check_epoll_wait::<8>(
-            epfd,
-            &[Ev { events: libc::EPOLLIN | libc::EPOLLOUT, data: fds[1] }],
-            -1,
-        );
+        check_epoll_wait::<8>(epfd, &[Ev { events: EPOLLIN | EPOLLOUT, data: fds[1] }], -1);
     });
     // Ensure the thread is blocked.
     std::thread::yield_now();
 
-    // Register fd[1] with EPOLLIN|EPOLLOUT|EPOLLET|EPOLLRDHUP
-    epoll_ctl_add(epfd, fds[1], libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET | libc::EPOLLRDHUP)
-        .unwrap();
+    // Register fd[1] with EPOLLIN|EPOLLOUT|EPOLLRDHUP (and EPOLLET if we're in the
+    // `edge_triggered` revision).
+    epoll_ctl_add(epfd, fds[1], EPOLLIN | EPOLLOUT | EPOLLRDHUP | EPOLLET_OR_ZERO).unwrap();
 
     // This should wake up the thread.
     t.join().unwrap();
@@ -161,12 +191,11 @@ fn multiple_events_wake_multiple_threads() {
     let fd2 = errno_result(unsafe { libc::dup(fd1) }).unwrap();
 
     // Register both with epoll.
-    epoll_ctl_add(epfd, fd1, libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET).unwrap();
-    epoll_ctl_add(epfd, fd2, libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET).unwrap();
+    epoll_ctl_add(epfd, fd1, EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
+    epoll_ctl_add(epfd, fd2, EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
 
     // Consume the initial events.
-    let expected =
-        [Ev { events: libc::EPOLLOUT, data: fd1 }, Ev { events: libc::EPOLLOUT, data: fd2 }];
+    let expected = [Ev { events: EPOLLOUT, data: fd1 }, Ev { events: EPOLLOUT, data: fd2 }];
     check_epoll_wait::<8>(epfd, &expected, -1);
 
     // Block two threads on the epoll, both wanting to get just one event.
@@ -191,6 +220,7 @@ fn multiple_events_wake_multiple_threads() {
     // Both threads should have been woken up so that both events can be consumed.
     let e1 = t1.join().unwrap();
     let e2 = t2.join().unwrap();
-    // Ensure that across the two threads we got both events.
+
+    // In both modes we should get both events across the two threads.
     assert!(expected == [e1, e2] || expected == [e2, e1]);
 }

--- a/tests/pass-dep/libc/libc-epoll-no-blocking.rs
+++ b/tests/pass-dep/libc/libc-epoll-no-blocking.rs
@@ -1,11 +1,14 @@
 //@only-target: linux android illumos
-
-use std::convert::TryInto;
+//@revisions: edge_triggered level_triggered
 
 #[path = "../../utils/libc.rs"]
 mod libc_utils;
 use libc_utils::epoll::*;
 use libc_utils::*;
+
+/// When the `edge_triggered` revision is active, this is EPOLLET, otherwise
+/// it's zero which means we perform level-triggered epolls.
+const EPOLLET_OR_ZERO: libc::c_int = if cfg!(edge_triggered) { EPOLLET } else { 0 };
 
 fn main() {
     test_epoll_socketpair();
@@ -27,25 +30,11 @@ fn main() {
     test_ready_list_fetching_logic();
     test_epoll_ctl_epfd_equal_fd();
     test_epoll_ctl_notification();
+    test_epoll_mixed_modes();
+    test_epoll_registered_mode_switch();
     test_issue_3858();
     test_issue_4374();
     test_issue_4374_reads();
-}
-
-#[track_caller]
-fn check_epoll_wait<const N: usize>(epfd: i32, expected_notifications: &[(u32, u64)]) {
-    let epoll_event = libc::epoll_event { events: 0, u64: 0 };
-    let mut array: [libc::epoll_event; N] = [epoll_event; N];
-    let maxsize = N;
-    let array_ptr = array.as_mut_ptr();
-    let res = unsafe { libc::epoll_wait(epfd, array_ptr, maxsize.try_into().unwrap(), 0) };
-    if res < 0 {
-        panic!("epoll_wait failed: {}", std::io::Error::last_os_error());
-    }
-    let got_notifications =
-        unsafe { std::slice::from_raw_parts(array_ptr, res.try_into().unwrap()) };
-    let got_notifications = got_notifications.iter().map(|e| (e.events, e.u64)).collect::<Vec<_>>();
-    assert_eq!(got_notifications, expected_notifications, "got wrong notifications");
 }
 
 fn test_epoll_socketpair() {
@@ -59,14 +48,22 @@ fn test_epoll_socketpair() {
     // Write to fds[0]
     write_all(fds[0], b"abcde").unwrap();
 
-    // Register fds[1] with EPOLLIN|EPOLLOUT|EPOLLET|EPOLLRDHUP
-    epoll_ctl_add(epfd, fds[1], EPOLLIN | EPOLLOUT | EPOLLET | EPOLLRDHUP).unwrap();
+    // Register fds[1] with EPOLLIN|EPOLLOUT|EPOLLRDHUP (and EPOLLET if we're
+    // in the `edge_triggered` revision).
+    epoll_ctl_add(epfd, fds[1], EPOLLIN | EPOLLOUT | EPOLLRDHUP | EPOLLET_OR_ZERO).unwrap();
 
     // Check result from epoll_wait.
-    check_epoll_wait_noblock::<8>(epfd, &[Ev { data: fds[1], events: EPOLLIN | EPOLLOUT }]);
+    check_epoll_wait_noblock::<2>(epfd, &[Ev { data: fds[1], events: EPOLLIN | EPOLLOUT }]);
 
-    // Check that this is indeed using "ET" (edge-trigger) semantics: a second epoll should return nothing.
-    check_epoll_wait_noblock::<8>(epfd, &[]);
+    if cfg!(edge_triggered) {
+        // Check that this is indeed using "ET" (edge-trigger) semantics: a second wait
+        // should return nothing.
+        check_epoll_wait_noblock::<1>(epfd, &[]);
+    } else {
+        // Check that this is indeed using "LT" (level-trigger) semantics: a second wait
+        // should return the same readiness.
+        check_epoll_wait_noblock::<2>(epfd, &[Ev { data: fds[1], events: EPOLLIN | EPOLLOUT }]);
+    }
 
     // Write some more to fds[0].
     write_all(fds[0], b"abcde").unwrap();
@@ -74,14 +71,14 @@ fn test_epoll_socketpair() {
     // This did not change the readiness of fds[1], so we should get no event.
     // However, Linux seems to always deliver spurious events to the peer on each write,
     // so we match that.
-    check_epoll_wait_noblock::<8>(epfd, &[Ev { data: fds[1], events: EPOLLIN | EPOLLOUT }]);
+    check_epoll_wait_noblock::<2>(epfd, &[Ev { data: fds[1], events: EPOLLIN | EPOLLOUT }]);
 
     // Close the peer socketpair.
     errno_check(unsafe { libc::close(fds[0]) });
 
     // Check result from epoll_wait. We expect to get a read, write, HUP notification from the close
     // since closing an FD always unblocks reads and writes on its peer.
-    check_epoll_wait_noblock::<8>(
+    check_epoll_wait_noblock::<2>(
         epfd,
         &[Ev { data: fds[1], events: EPOLLIN | EPOLLOUT | EPOLLHUP | EPOLLRDHUP }],
     );
@@ -98,17 +95,19 @@ fn test_epoll_ctl_mod() {
     let mut fds = [-1, -1];
     errno_check(unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) });
 
-    // Register fds[1] with EPOLLIN|EPOLLET, and data of "0".
-    epoll_ctl(epfd, EPOLL_CTL_ADD, fds[1], Ev { events: EPOLLIN | EPOLLET, data: 0 }).unwrap();
+    // Register fds[1] with EPOLLIN (and EPOLLET if we're in the `edge_triggered` revision), and data of "0".
+    epoll_ctl(epfd, EPOLL_CTL_ADD, fds[1], Ev { events: EPOLLIN | EPOLLET_OR_ZERO, data: 0 })
+        .unwrap();
 
     // Check result from epoll_wait. No notification would be returned.
-    check_epoll_wait_noblock::<8>(epfd, &[]);
+    check_epoll_wait_noblock::<1>(epfd, &[]);
 
     // Use EPOLL_CTL_MOD to change to EPOLLOUT flag and data.
-    epoll_ctl(epfd, EPOLL_CTL_MOD, fds[1], Ev { events: EPOLLOUT | EPOLLET, data: 1 }).unwrap();
+    epoll_ctl(epfd, EPOLL_CTL_MOD, fds[1], Ev { events: EPOLLOUT | EPOLLET_OR_ZERO, data: 1 })
+        .unwrap();
 
     // Check result from epoll_wait. EPOLLOUT notification and new data is expected.
-    check_epoll_wait_noblock::<8>(epfd, &[Ev { events: EPOLLOUT, data: 1 }]);
+    check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLOUT, data: 1 }]);
 
     // Write to fds[1] and read from fds[0] to make the notification ready again
     // (relying on there always being an event when the buffer gets emptied).
@@ -116,16 +115,18 @@ fn test_epoll_ctl_mod() {
     read_exact_array::<3>(fds[0]).unwrap();
 
     // Now that the event is already ready, change the "data" value.
-    epoll_ctl(epfd, EPOLL_CTL_MOD, fds[1], Ev { events: EPOLLOUT | EPOLLET, data: 2 }).unwrap();
+    epoll_ctl(epfd, EPOLL_CTL_MOD, fds[1], Ev { events: EPOLLOUT | EPOLLET_OR_ZERO, data: 2 })
+        .unwrap();
 
     // Receive event, with latest data value.
-    check_epoll_wait_noblock::<8>(epfd, &[Ev { events: EPOLLOUT, data: 2 }]);
+    check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLOUT, data: 2 }]);
 
     // Do another update that changes nothing.
-    epoll_ctl(epfd, EPOLL_CTL_MOD, fds[1], Ev { events: EPOLLOUT | EPOLLET, data: 2 }).unwrap();
+    epoll_ctl(epfd, EPOLL_CTL_MOD, fds[1], Ev { events: EPOLLOUT | EPOLLET_OR_ZERO, data: 2 })
+        .unwrap();
 
     // This re-triggers the event, even if it's the same flags as before.
-    check_epoll_wait_noblock::<8>(epfd, &[Ev { events: EPOLLOUT, data: 2 }]);
+    check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLOUT, data: 2 }]);
 }
 
 fn test_epoll_ctl_del() {
@@ -139,18 +140,18 @@ fn test_epoll_ctl_del() {
     // Write to fds[0]
     libc_utils::write_all(fds[0], b"abcde").unwrap();
 
-    // Register fds[1] with EPOLLIN|EPOLLOUT|EPOLLET
+    // Register fds[1] with EPOLLIN|EPOLLOUT (and EPOLLET if we're in the `edge_triggered` revision).
     let mut ev = libc::epoll_event {
-        events: (libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET) as u32,
+        events: (EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO) as u32,
         u64: u64::try_from(fds[1]).unwrap(),
     };
     let res = unsafe { libc::epoll_ctl(epfd, libc::EPOLL_CTL_ADD, fds[1], &mut ev) };
     assert_eq!(res, 0);
 
     // Test EPOLL_CTL_DEL.
-    let res = unsafe { libc::epoll_ctl(epfd, libc::EPOLL_CTL_DEL, fds[1], &mut ev) };
+    let res = unsafe { libc::epoll_ctl(epfd, EPOLL_CTL_DEL, fds[1], &mut ev) };
     assert_eq!(res, 0);
-    check_epoll_wait::<8>(epfd, &[]);
+    check_epoll_wait_noblock::<1>(epfd, &[]);
 }
 
 // This test is for one fd registered under two different epoll instance.
@@ -168,15 +169,14 @@ fn test_two_epoll_instance() {
     // Write to the socketpair.
     libc_utils::write_all(fds[0], b"abcde").unwrap();
 
-    // Register one side of the socketpair with EPOLLIN | EPOLLOUT | EPOLLET.
-    epoll_ctl_add(epfd1, fds[1], libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET).unwrap();
-    epoll_ctl_add(epfd2, fds[1], libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET).unwrap();
+    // Register one side of the socketpair with EPOLLIN | EPOLLOUT (and EPOLLET
+    // if we're in the `edge_triggered` revision).
+    epoll_ctl_add(epfd1, fds[1], EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
+    epoll_ctl_add(epfd2, fds[1], EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
 
     // Notification should be received from both instance of epoll.
-    let expected_event = u32::try_from(libc::EPOLLIN | libc::EPOLLOUT).unwrap();
-    let expected_value = u64::try_from(fds[1]).unwrap();
-    check_epoll_wait::<8>(epfd1, &[(expected_event, expected_value)]);
-    check_epoll_wait::<8>(epfd2, &[(expected_event, expected_value)]);
+    check_epoll_wait_noblock::<2>(epfd1, &[Ev { events: EPOLLIN | EPOLLOUT, data: fds[1] }]);
+    check_epoll_wait_noblock::<2>(epfd2, &[Ev { events: EPOLLIN | EPOLLOUT, data: fds[1] }]);
 }
 
 // This test is for two same file description registered under the same epoll instance through dup.
@@ -194,24 +194,19 @@ fn test_two_same_fd_in_same_epoll_instance() {
     assert_ne!(newfd, -1);
 
     // Register both fd to the same epoll instance.
-    let mut ev = libc::epoll_event {
-        events: (libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET).cast_unsigned(),
-        u64: 5u64,
-    };
-    let res = unsafe { libc::epoll_ctl(epfd, libc::EPOLL_CTL_ADD, fds[1], &mut ev) };
-    assert_eq!(res, 0);
-    let res = unsafe { libc::epoll_ctl(epfd, libc::EPOLL_CTL_ADD, newfd, &mut ev) };
-    assert_eq!(res, 0);
+    epoll_ctl_add(epfd, fds[1], EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
+    epoll_ctl_add(epfd, newfd, EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
 
     // Write to the socketpair.
     libc_utils::write_all(fds[0], b"abcde").unwrap();
 
     // Two notification should be received.
-    let expected_event = u32::try_from(libc::EPOLLIN | libc::EPOLLOUT).unwrap();
-    let expected_value = 5u64;
-    check_epoll_wait::<8>(
+    check_epoll_wait_noblock::<3>(
         epfd,
-        &[(expected_event, expected_value), (expected_event, expected_value)],
+        &[
+            Ev { events: EPOLLIN | EPOLLOUT, data: fds[1] },
+            Ev { events: EPOLLIN | EPOLLOUT, data: newfd },
+        ],
     );
 }
 
@@ -226,20 +221,19 @@ fn test_epoll_eventfd() {
     // Create an epoll instance.
     let epfd = errno_result(unsafe { libc::epoll_create1(0) }).unwrap();
 
-    // Register eventfd with EPOLLIN | EPOLLOUT | EPOLLET
-    epoll_ctl_add(epfd, fd, libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET).unwrap();
+    // Register eventfd with EPOLLIN | EPOLLOUT (and EPOLLET if we're in the `edge_triggered`
+    // revision).
+    epoll_ctl_add(epfd, fd, EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
 
     // Check result from epoll_wait.
-    let expected_event = u32::try_from(libc::EPOLLIN | libc::EPOLLOUT).unwrap();
-    let expected_value = u64::try_from(fd).unwrap();
-    check_epoll_wait::<8>(epfd, &[(expected_event, expected_value)]);
+    check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLIN | EPOLLOUT, data: fd }]);
 
     // Write 0 to the eventfd.
     libc_utils::write_all(fd, &0_u64.to_ne_bytes()).unwrap();
 
     // This does not change the status, so we should get no event.
     // However, Linux performs a spurious wakeup.
-    check_epoll_wait::<8>(epfd, &[(expected_event, expected_value)]);
+    check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLIN | EPOLLOUT, data: fd }]);
 
     // Read from the eventfd.
     libc_utils::read_exact_array::<8>(fd).unwrap();
@@ -247,15 +241,13 @@ fn test_epoll_eventfd() {
     // This consumes the event, so the read status is gone. However, deactivation
     // does not trigger an event.
     // Still, we see a spurious wakeup.
-    let expected_event = u32::try_from(libc::EPOLLOUT).unwrap();
-    check_epoll_wait::<8>(epfd, &[(expected_event, expected_value)]);
+    check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLOUT, data: fd }]);
 
     // Write the maximum possible value.
     libc_utils::write_all(fd, &(u64::MAX - 1).to_ne_bytes()).unwrap();
 
     // This reactivates reads, therefore triggering an event. Writing is no longer possible.
-    let expected_event = u32::try_from(libc::EPOLLIN).unwrap();
-    check_epoll_wait::<8>(epfd, &[(expected_event, expected_value)]);
+    check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLIN, data: fd }]);
 }
 
 // When read/write happened on one side of the socketpair, only the other side will be notified.
@@ -268,8 +260,8 @@ fn test_epoll_socketpair_both_sides() {
     errno_check(unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) });
 
     // Register both fd to the same epoll instance.
-    epoll_ctl_add(epfd, fds[0], libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET).unwrap();
-    epoll_ctl_add(epfd, fds[1], libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET).unwrap();
+    epoll_ctl_add(epfd, fds[0], EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
+    epoll_ctl_add(epfd, fds[1], EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
 
     // Write to fds[1].
     // (We do the write after the register here, unlike in `test_epoll_socketpair`, to ensure
@@ -277,23 +269,28 @@ fn test_epoll_socketpair_both_sides() {
     libc_utils::write_all(fds[1], b"abcde").unwrap();
 
     // Two notification should be received.
-    let expected_event0 = u32::try_from(libc::EPOLLIN | libc::EPOLLOUT).unwrap();
-    let expected_value0 = fds[0] as u64;
-    let expected_event1 = u32::try_from(libc::EPOLLOUT).unwrap();
-    let expected_value1 = fds[1] as u64;
-    check_epoll_wait::<8>(
+    check_epoll_wait_noblock::<3>(
         epfd,
-        &[(expected_event0, expected_value0), (expected_event1, expected_value1)],
+        &[Ev { events: EPOLLIN | EPOLLOUT, data: fds[0] }, Ev { events: EPOLLOUT, data: fds[1] }],
     );
 
     // Read from fds[0].
     let buf = libc_utils::read_exact_array::<5>(fds[0]).unwrap();
     assert_eq!(buf, *b"abcde");
 
-    // The state of fds[1] does not change (was writable, is writable).
-    // However, we force a spurious wakeup as the read buffer just got emptied.
-    // fds[0] lost its readability, but becoming less active is not considered an "edge".
-    check_epoll_wait::<8>(epfd, &[(expected_event1, expected_value1)]);
+    if cfg!(edge_triggered) {
+        // The state of fds[1] does not change (was writable, is writable).
+        // However, we force a spurious wakeup as the read buffer just got emptied.
+        // fds[0] lost its readability, but becoming less active is not considered an "edge".
+        check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLOUT, data: fds[1] }])
+    } else {
+        // With level-triggered epoll, only the readable readiness for fds[0] should
+        // no longer be reported. The rest stays the same.
+        check_epoll_wait_noblock::<3>(
+            epfd,
+            &[Ev { events: EPOLLOUT, data: fds[0] }, Ev { events: EPOLLOUT, data: fds[1] }],
+        );
+    }
 }
 
 // When file description is fully closed, epoll_wait should not provide any notification for
@@ -306,8 +303,8 @@ fn test_closed_fd() {
     let flags = libc::EFD_NONBLOCK | libc::EFD_CLOEXEC;
     let fd = errno_result(unsafe { libc::eventfd(0, flags) }).unwrap();
 
-    // Register eventfd with EPOLLIN | EPOLLOUT | EPOLLET
-    epoll_ctl_add(epfd, fd, libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET).unwrap();
+    // Register eventfd with EPOLLIN | EPOLLOUT (and EPOLLET if we're in the `edge_triggered` revision).
+    epoll_ctl_add(epfd, fd, EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
 
     // Write to the eventfd instance.
     libc_utils::write_all(fd, &1_u64.to_ne_bytes()).unwrap();
@@ -316,7 +313,7 @@ fn test_closed_fd() {
     errno_check(unsafe { libc::close(fd) });
 
     // No notification should be provided because the file description is closed.
-    check_epoll_wait::<8>(epfd, &[]);
+    check_epoll_wait_noblock::<1>(epfd, &[]);
 }
 
 // When a certain file descriptor registered with epoll is closed, but the underlying file description
@@ -336,16 +333,14 @@ fn test_not_fully_closed_fd() {
     // Dup the fd.
     let newfd = errno_result(unsafe { libc::dup(fd) }).unwrap();
 
-    // Register eventfd with EPOLLIN | EPOLLOUT | EPOLLET
-    epoll_ctl_add(epfd, fd, libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET).unwrap();
+    // Register eventfd with EPOLLIN | EPOLLOUT (and EPOLLET if we're in the `edge_triggered` revision).
+    epoll_ctl_add(epfd, fd, EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
 
     // Close the original fd that being used to register with epoll.
     errno_check(unsafe { libc::close(fd) });
 
     // Notification should still be provided because the file description is not closed.
-    let expected_event = u32::try_from(libc::EPOLLOUT).unwrap();
-    let expected_value = fd as u64;
-    check_epoll_wait::<1>(epfd, &[(expected_event, expected_value)]);
+    check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLOUT, data: fd }]);
 
     // Write to the eventfd instance to produce notification.
     libc_utils::write_all(newfd, &1_u64.to_ne_bytes()).unwrap();
@@ -354,7 +349,7 @@ fn test_not_fully_closed_fd() {
     errno_check(unsafe { libc::close(newfd) });
 
     // No notification should be provided.
-    check_epoll_wait::<1>(epfd, &[]);
+    check_epoll_wait_noblock::<1>(epfd, &[]);
 }
 
 // Each time a notification is provided, it should reflect the file description's readiness
@@ -370,13 +365,8 @@ fn test_event_overwrite() {
     // Create an epoll instance.
     let epfd = errno_result(unsafe { libc::epoll_create1(0) }).unwrap();
 
-    // Register eventfd with EPOLLIN | EPOLLOUT | EPOLLET
-    let mut ev = libc::epoll_event {
-        events: (libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET).cast_unsigned(),
-        u64: u64::try_from(fd).unwrap(),
-    };
-    let res = unsafe { libc::epoll_ctl(epfd, libc::EPOLL_CTL_ADD, fd, &mut ev) };
-    assert_eq!(res, 0);
+    // Register eventfd with EPOLLIN | EPOLLOUT (and EPOLLET if we're in the `edge_triggered` revision).
+    epoll_ctl_add(epfd, fd, EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
 
     // Read from the eventfd instance.
     let mut buf: [u8; 8] = [0; 8];
@@ -384,9 +374,7 @@ fn test_event_overwrite() {
     assert_eq!(res, 8);
 
     // Check result from epoll_wait.
-    let expected_event = u32::try_from(libc::EPOLLOUT).unwrap();
-    let expected_value = u64::try_from(fd).unwrap();
-    check_epoll_wait::<8>(epfd, &[(expected_event, expected_value)]);
+    check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLOUT, data: fd }]);
 }
 
 // An epoll notification will be provided for every succesful read in a socketpair.
@@ -400,53 +388,58 @@ fn test_socketpair_read() {
     errno_check(unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) });
 
     // Register both fd to the same epoll instance.
-    let mut ev = libc::epoll_event {
-        events: (libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET).cast_unsigned(),
-        u64: fds[0] as u64,
-    };
-    let res = unsafe { libc::epoll_ctl(epfd, libc::EPOLL_CTL_ADD, fds[0], &mut ev) };
-    assert_eq!(res, 0);
-    let mut ev = libc::epoll_event {
-        events: (libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET).cast_unsigned(),
-        u64: fds[1] as u64,
-    };
-    let res = unsafe { libc::epoll_ctl(epfd, libc::EPOLL_CTL_ADD, fds[1], &mut ev) };
-    assert_eq!(res, 0);
+    epoll_ctl_add(epfd, fds[0], EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
+    epoll_ctl_add(epfd, fds[1], EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
 
     // Write a bunch of data bytes to fds[1].
     let data = [42u8; 1024];
     libc_utils::write_all(fds[1], &data).unwrap();
 
     // Two notification should be received.
-    let expected_event0 = u32::try_from(libc::EPOLLIN | libc::EPOLLOUT).unwrap();
-    let expected_value0 = fds[0] as u64;
-    let expected_event1 = u32::try_from(libc::EPOLLOUT).unwrap();
-    let expected_value1 = fds[1] as u64;
-    check_epoll_wait::<8>(
+    check_epoll_wait_noblock::<3>(
         epfd,
-        &[(expected_event0, expected_value0), (expected_event1, expected_value1)],
+        &[Ev { events: EPOLLIN | EPOLLOUT, data: fds[0] }, Ev { events: EPOLLOUT, data: fds[1] }],
     );
 
     // Read some of the data from fds[0].
     let mut buf = [0; 512];
     libc_utils::read_exact(fds[0], &mut buf).unwrap();
-
-    // fds[1] did not change, it is still writable, so we get no event.
-    let expected_event = u32::try_from(libc::EPOLLOUT).unwrap();
-    let expected_value = fds[1] as u64;
-    check_epoll_wait::<8>(epfd, &[]);
+    if cfg!(edge_triggered) {
+        // fds[1] did not change, it is still writable, so we get no event
+        // in edge-triggered mode.
+        check_epoll_wait_noblock::<1>(epfd, &[]);
+    } else {
+        // In level-triggered mode we expect the same events as before because
+        // we didn't read everything in the buffer.
+        check_epoll_wait_noblock::<3>(
+            epfd,
+            &[
+                Ev { events: EPOLLIN | EPOLLOUT, data: fds[0] },
+                Ev { events: EPOLLOUT, data: fds[1] },
+            ],
+        );
+    }
 
     // Read until the buffer is empty.
     let rest = data.len() - buf.len();
     libc_utils::read_exact(fds[0], &mut buf[..rest]).unwrap();
 
-    // Now we get a notification that fds[1] can be written. This is spurious since it
-    // could already be written before, but Linux seems to always emit a notification for
-    // the writer when a read empties the buffer.
-    check_epoll_wait::<8>(epfd, &[(expected_event, expected_value)]);
+    if cfg!(edge_triggered) {
+        // Now we get a notification that fds[1] can be written. This is spurious since it
+        // could already be written before, but Linux seems to always emit a notification for
+        // the writer when a read empties the buffer.
+        check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLOUT, data: fds[1] }]);
+    } else {
+        // In level-triggered mode we expect the same events as before just without
+        // the readable readiness of fds[0] because we now read everything.
+        check_epoll_wait_noblock::<3>(
+            epfd,
+            &[Ev { events: EPOLLOUT, data: fds[0] }, Ev { events: EPOLLOUT, data: fds[1] }],
+        );
+    }
 }
 
-// This is to test whether flag that we don't register won't trigger notification.
+// This is to test whether a flag that we don't register won't trigger notification.
 fn test_no_notification_for_unregister_flag() {
     // Create an epoll instance.
     let epfd = errno_result(unsafe { libc::epoll_create1(0) }).unwrap();
@@ -455,22 +448,15 @@ fn test_no_notification_for_unregister_flag() {
     let mut fds = [-1, -1];
     errno_check(unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) });
 
-    // Register fds[0] with EPOLLOUT|EPOLLET.
-    let mut ev = libc::epoll_event {
-        events: (libc::EPOLLOUT | libc::EPOLLET).cast_unsigned(),
-        u64: u64::try_from(fds[0]).unwrap(),
-    };
-    let res = unsafe { libc::epoll_ctl(epfd, libc::EPOLL_CTL_ADD, fds[0], &mut ev) };
-    assert_eq!(res, 0);
+    // Register fds[0] with EPOLLOUT (and EPOLLET when we're in the `edge_triggered` revision).
+    epoll_ctl_add(epfd, fds[0], EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
 
     // Write to fds[1].
     libc_utils::write_all(fds[1], b"abcde").unwrap();
 
     // Check result from epoll_wait. Since we didn't register EPOLLIN flag, the notification won't
     // contain EPOLLIN even though fds[0] is now readable.
-    let expected_event = u32::try_from(libc::EPOLLOUT).unwrap();
-    let expected_value = u64::try_from(fds[0]).unwrap();
-    check_epoll_wait::<8>(epfd, &[(expected_event, expected_value)]);
+    check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLOUT, data: fds[0] }]);
 }
 
 fn test_epoll_wait_maxevent_zero() {
@@ -500,17 +486,15 @@ fn test_socketpair_epollerr() {
     // EPOLLERR will be triggered if we close peer fd that still has data in its read buffer.
     errno_check(unsafe { libc::close(fds[1]) });
 
-    // Register fds[1] with EPOLLIN|EPOLLOUT|EPOLLET|EPOLLRDHUP
-    epoll_ctl_add(epfd, fds[0], libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET | libc::EPOLLRDHUP)
-        .unwrap();
+    // Register fds[1] with EPOLLIN|EPOLLOUT|EPOLLRDHUP (and EPOLLET when we're in the
+    // `edge_triggered` revision).
+    epoll_ctl_add(epfd, fds[0], EPOLLIN | EPOLLOUT | EPOLLRDHUP | EPOLLET_OR_ZERO).unwrap();
 
     // Check result from epoll_wait.
-    let expected_event = u32::try_from(
-        libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLHUP | libc::EPOLLRDHUP | libc::EPOLLERR,
-    )
-    .unwrap();
-    let expected_value = u64::try_from(fds[0]).unwrap();
-    check_epoll_wait::<8>(epfd, &[(expected_event, expected_value)]);
+    check_epoll_wait_noblock::<2>(
+        epfd,
+        &[Ev { events: EPOLLIN | EPOLLOUT | EPOLLHUP | EPOLLRDHUP | EPOLLERR, data: fds[0] }],
+    );
 }
 
 // This is a test for https://github.com/rust-lang/miri/issues/3812,
@@ -524,18 +508,24 @@ fn test_epoll_lost_events() {
     errno_check(unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) });
 
     // Register both fd to the same epoll instance.
-    epoll_ctl_add(epfd, fds[0], libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET).unwrap();
-    epoll_ctl_add(epfd, fds[1], libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET).unwrap();
+    epoll_ctl_add(epfd, fds[0], EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
+    epoll_ctl_add(epfd, fds[1], EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
 
     // Two notification should be received. But we only provide buffer for one event.
-    let expected_event0 = u32::try_from(libc::EPOLLOUT).unwrap();
-    let expected_value0 = fds[0] as u64;
-    check_epoll_wait::<1>(epfd, &[(expected_event0, expected_value0)]);
+    check_epoll_wait_noblock::<1>(epfd, &[Ev { events: EPOLLOUT, data: fds[0] }]);
 
-    // Previous event should be returned for the second epoll_wait.
-    let expected_event1 = u32::try_from(libc::EPOLLOUT).unwrap();
-    let expected_value1 = fds[1] as u64;
-    check_epoll_wait::<1>(epfd, &[(expected_event1, expected_value1)]);
+    if cfg!(edge_triggered) {
+        // Previous event should be returned for the second epoll_wait but because we're
+        // edge-triggered the first event should no longer be returned.
+        check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLOUT, data: fds[1] }]);
+    } else {
+        // Both events should be returned in level-triggered mode when
+        // we provide a big enough buffer.
+        check_epoll_wait_noblock::<3>(
+            epfd,
+            &[Ev { events: EPOLLOUT, data: fds[1] }, Ev { events: EPOLLOUT, data: fds[0] }],
+        );
+    }
 }
 
 // This is testing if closing an fd that is already in ready list will cause an empty entry in
@@ -551,16 +541,14 @@ fn test_ready_list_fetching_logic() {
     let fd1 = errno_result(unsafe { libc::eventfd(0, flags) }).unwrap();
 
     // Register both fd to the same epoll instance. At this point, both of them are on the ready list.
-    epoll_ctl_add(epfd, fd0, libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET).unwrap();
-    epoll_ctl_add(epfd, fd1, libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET).unwrap();
+    epoll_ctl_add(epfd, fd0, EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
+    epoll_ctl_add(epfd, fd1, EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
 
     // Close fd0 so the first entry in the ready list will be empty.
     errno_check(unsafe { libc::close(fd0) });
 
     // Notification for fd1 should be returned.
-    let expected_event1 = u32::try_from(libc::EPOLLOUT).unwrap();
-    let expected_value1 = fd1 as u64;
-    check_epoll_wait::<1>(epfd, &[(expected_event1, expected_value1)]);
+    check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLOUT, data: fd1 }]);
 }
 
 // In epoll_ctl, if the value of epfd equals to fd, EFAULT should be returned.
@@ -570,7 +558,7 @@ fn test_epoll_ctl_epfd_equal_fd() {
     let epfd = errno_result(unsafe { libc::epoll_create1(0) }).unwrap();
 
     let array_ptr = std::ptr::without_provenance_mut::<libc::epoll_event>(0x100);
-    let res = unsafe { libc::epoll_ctl(epfd, libc::EPOLL_CTL_ADD, epfd, array_ptr) };
+    let res = unsafe { libc::epoll_ctl(epfd, EPOLL_CTL_ADD, epfd, array_ptr) };
     let e = std::io::Error::last_os_error();
     assert_eq!(e.raw_os_error(), Some(libc::EFAULT));
     assert_eq!(res, -1);
@@ -578,7 +566,7 @@ fn test_epoll_ctl_epfd_equal_fd() {
 
 // We previously used check_and_update_readiness the moment a file description is registered in an
 // epoll instance. But this has an unfortunate side effect of returning notification to another
-// epfd that shouldn't receive notification.
+// epfd that shouldn't receive a notification in edge-triggered mode.
 fn test_epoll_ctl_notification() {
     // Create an epoll instance.
     let epfd0 = unsafe { libc::epoll_create1(0) };
@@ -589,24 +577,87 @@ fn test_epoll_ctl_notification() {
     errno_check(unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) });
 
     // Register one side of the socketpair with epoll.
-    epoll_ctl_add(epfd0, fds[0], libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET).unwrap();
+    epoll_ctl_add(epfd0, fds[0], EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
 
     // epoll_wait to clear notification for epfd0.
-    let expected_event = u32::try_from(libc::EPOLLOUT).unwrap();
-    let expected_value = fds[0] as u64;
-    check_epoll_wait::<1>(epfd0, &[(expected_event, expected_value)]);
+    check_epoll_wait_noblock::<2>(epfd0, &[Ev { events: EPOLLOUT, data: fds[0] }]);
 
     // Create another epoll instance.
     let epfd1 = unsafe { libc::epoll_create1(0) };
     assert_ne!(epfd1, -1);
 
     // Register the same file description for epfd1.
-    epoll_ctl_add(epfd1, fds[0], libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET).unwrap();
-    check_epoll_wait::<1>(epfd1, &[(expected_event, expected_value)]);
+    epoll_ctl_add(epfd1, fds[0], EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
+    check_epoll_wait_noblock::<2>(epfd1, &[Ev { events: EPOLLOUT, data: fds[0] }]);
 
-    // Previously this epoll_wait will receive a notification, but we shouldn't return notification
-    // for this epfd, because there is no I/O event between the two epoll_wait.
-    check_epoll_wait::<1>(epfd0, &[]);
+    if cfg!(edge_triggered) {
+        // Previously this epoll_wait will receive a notification, but we shouldn't return notification
+        // for this epfd, because there is no I/O event between the two epoll_wait.
+        check_epoll_wait_noblock::<1>(epfd0, &[]);
+    } else {
+        // We should still get the same events in level-triggered mode.
+        check_epoll_wait_noblock::<2>(epfd0, &[Ev { events: EPOLLOUT, data: fds[0] }]);
+    }
+}
+
+/// Test storing a level-triggered and an edge-triggered file descriptor
+/// in the same epoll instance and calling `epoll_wait` multiple times.
+fn test_epoll_mixed_modes() {
+    // Create an epoll instance.
+    let epfd = errno_result(unsafe { libc::epoll_create1(0) }).unwrap();
+
+    // Create a socketpair instance.
+    let mut fds = [-1, -1];
+    errno_check(unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) });
+
+    // Register both fd to the same epoll instance.
+    // `fds[0]` is added in edge-triggered mode whilst `fds[1]` is added in level-triggered mode.
+    epoll_ctl_add(epfd, fds[0], EPOLLIN | EPOLLOUT | EPOLLET).unwrap();
+    epoll_ctl_add(epfd, fds[1], EPOLLIN | EPOLLOUT | 0).unwrap();
+
+    // Write to `fds[1]`.
+    libc_utils::write_all(fds[1], b"abcde").unwrap();
+
+    // Two events should be received.
+    check_epoll_wait_noblock::<3>(
+        epfd,
+        &[Ev { events: EPOLLIN | EPOLLOUT, data: fds[0] }, Ev { events: EPOLLOUT, data: fds[1] }],
+    );
+
+    // If we call epoll_wait again immediately, only the level-triggered interests should be received again.
+    check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLOUT, data: fds[1] }]);
+}
+
+/// Test first registering a file descriptor in edge-triggered mode,
+/// then consuming it's readiness and then changing it to level-triggered
+/// mode.
+fn test_epoll_registered_mode_switch() {
+    // Create an eventfd instance.
+    let flags = libc::EFD_NONBLOCK | libc::EFD_CLOEXEC;
+    let fd = errno_result(unsafe { libc::eventfd(0, flags) }).unwrap();
+
+    // Write 1 to the eventfd instance.
+    libc_utils::write_all(fd, &1_u64.to_ne_bytes()).unwrap();
+
+    // Create an epoll instance.
+    let epfd = errno_result(unsafe { libc::epoll_create1(0) }).unwrap();
+
+    // Register eventfd with EPOLLIN | EPOLLOUT | EPOLLET.
+    epoll_ctl_add(epfd, fd, EPOLLIN | EPOLLOUT | EPOLLET).unwrap();
+
+    // Check result from `epoll_wait`.
+    check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLIN | EPOLLOUT, data: fd }]);
+
+    // Because `fd` is registered in edge-triggered mode, the next `epoll_wait` shouldn't
+    // return any events.
+    check_epoll_wait_noblock::<1>(epfd, &[]);
+
+    // Update the registration for `fd` to switch to level-triggered mode.
+    epoll_ctl(epfd, EPOLL_CTL_MOD, fd, Ev { events: EPOLLIN | EPOLLOUT, data: fd }).unwrap();
+
+    // Because `fd` is now registered in level-triggered mode, we should see
+    // the same events as from the first `epoll_wait`.
+    check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLIN | EPOLLOUT, data: fd }]);
 }
 
 // Test for ICE caused by weak epoll interest upgrade succeed, but the attempt to retrieve
@@ -623,13 +674,8 @@ fn test_issue_3858() {
     // Create an epoll instance.
     let epfd = errno_result(unsafe { libc::epoll_create1(0) }).unwrap();
 
-    // Register eventfd with EPOLLIN | EPOLLET.
-    let mut ev = libc::epoll_event {
-        events: (libc::EPOLLIN | libc::EPOLLET).cast_unsigned(),
-        u64: u64::try_from(fd).unwrap(),
-    };
-    let res = unsafe { libc::epoll_ctl(epfd, libc::EPOLL_CTL_ADD, fd, &mut ev) };
-    assert_eq!(res, 0);
+    // Register eventfd with EPOLLIN (and EPOLLET if we're in the `edge_triggered` revision).
+    epoll_ctl_add(epfd, fd, EPOLLIN | EPOLLET_OR_ZERO).unwrap();
 
     // Dup the epoll instance.
     let newfd = unsafe { libc::dup(epfd) };
@@ -655,7 +701,7 @@ fn test_issue_4374() {
     assert_eq!(unsafe { libc::fcntl(fds[1], libc::F_SETFL, libc::O_NONBLOCK) }, 0);
 
     // Register fds[0] with epoll while it is writable (but not readable).
-    epoll_ctl_add(epfd0, fds[0], libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET).unwrap();
+    epoll_ctl_add(epfd0, fds[0], EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
 
     // Fill up fds[0] so that it is not writable any more.
     let zeros = [0u8; 512];
@@ -668,7 +714,7 @@ fn test_issue_4374() {
     }
 
     // This should have canceled the previous readiness, so now we get nothing.
-    check_epoll_wait::<1>(epfd0, &[]);
+    check_epoll_wait_noblock::<1>(epfd0, &[]);
 }
 
 /// Same as above, but for becoming un-readable.
@@ -687,13 +733,11 @@ fn test_issue_4374_reads() {
     libc_utils::write_all(fds[1], b"abcde").unwrap();
 
     // Register fds[0] with epoll while it is readable.
-    epoll_ctl_add(epfd0, fds[0], libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET).unwrap();
+    epoll_ctl_add(epfd0, fds[0], EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
 
     // Read fds[0] so it is no longer readable.
     libc_utils::read_exact_array::<5>(fds[0]).unwrap();
 
     // We should now still see a notification, but only about it being writable.
-    let expected_event = u32::try_from(libc::EPOLLOUT).unwrap();
-    let expected_value = fds[0] as u64;
-    check_epoll_wait::<1>(epfd0, &[(expected_event, expected_value)]);
+    check_epoll_wait_noblock::<2>(epfd0, &[Ev { events: EPOLLOUT, data: fds[0] }]);
 }


### PR DESCRIPTION
Hi,

As a basis for implementing a `poll` shim, this pull request adds support for level-triggered epolls. Besides needing to switch from a ready set to a ready queue, the changes in the epoll shim are relatively small. 

To test the functionality of the level-triggered epoll I've added `level_triggered` and `edge_triggered` revisions to the epoll libc tests. At the moment I can't come up with any level-triggered edge cases which aren't covered by this testing method.  

As mentioned in rust-lang/miri#4725, the non-blocking epoll tests didn't use the shared `check_epoll_wait_noblock` helper but used a custom helper instead. I've changed that in the first commit (a tiny bit also slipped through into the second one). 

Closes https://github.com/rust-lang/miri/issues/3448