### PR TITLE
./miri test: run some tests natively

### DIFF
--- a/tests/pass-dep/libc/libc-epoll-blocking.rs
+++ b/tests/pass-dep/libc/libc-epoll-blocking.rs
@@ -2,6 +2,7 @@
 // test_epoll_block_then_unblock and test_epoll_race depend on a deterministic schedule.
 //@compile-flags: -Zmiri-deterministic-concurrency
 //@revisions: edge_triggered level_triggered
+//@run-native
 
 use std::convert::TryInto;
 use std::thread;

--- a/tests/pass-dep/libc/libc-epoll-no-blocking.rs
+++ b/tests/pass-dep/libc/libc-epoll-no-blocking.rs
@@ -1,5 +1,6 @@
 //@only-target: linux android illumos
 //@revisions: edge_triggered level_triggered
+//@run-native
 
 #[path = "../../utils/libc.rs"]
 mod libc_utils;

--- a/tests/pass-dep/libc/libc-fs-flock.rs
+++ b/tests/pass-dep/libc/libc-fs-flock.rs
@@ -2,6 +2,7 @@
 //@ignore-target: solaris # Does not have flock
 //@ignore-target: android # Does not (always?) have flock
 //@compile-flags: -Zmiri-disable-isolation
+//@run-native
 
 //@revisions: windows_host unix_host
 //@[unix_host] ignore-host: windows

--- a/tests/pass-dep/libc/libc-fs-permissions.rs
+++ b/tests/pass-dep/libc/libc-fs-permissions.rs
@@ -1,6 +1,7 @@
 //@ignore-target: windows # no libc
 //@ignore-host: windows # needs unix PermissionExt
 //@compile-flags: -Zmiri-disable-isolation
+//@run-native
 
 use std::ffi::{CStr, CString};
 use std::mem::MaybeUninit;

--- a/tests/pass-dep/libc/libc-fs-symlink.rs
+++ b/tests/pass-dep/libc/libc-fs-symlink.rs
@@ -2,6 +2,7 @@
 //@ignore-host: windows # creating symlinks requires admin permissions on Windows
 //@ignore-target: windows # File handling is not implemented yet
 //@compile-flags: -Zmiri-disable-isolation
+//@run-native
 
 use std::ffi::CString;
 use std::io::ErrorKind;

--- a/tests/pass-dep/libc/libc-fs.rs
+++ b/tests/pass-dep/libc/libc-fs.rs
@@ -1,5 +1,6 @@
 //@ignore-target: windows # no libc
 //@compile-flags: -Zmiri-disable-isolation
+//@run-native
 
 use std::ffi::{CStr, CString, OsString};
 use std::fs::{File, canonicalize, create_dir, remove_dir, remove_file};
@@ -396,17 +397,21 @@ fn test_posix_mkstemp() {
     drop(file);
     remove_file(path).unwrap();
 
-    let invalid_templates = vec!["foo", "barXX", "XXXXXXbaz", "whatXXXXXXever", "X"];
-    for t in invalid_templates {
-        let ptr = CString::new(t).unwrap().into_raw();
-        let fd = unsafe { libc::mkstemp(ptr) };
-        let _ = unsafe { CString::from_raw(ptr) };
-        // "On error, -1 is returned, and errno is set to
-        // indicate the error"
-        assert_eq!(fd, -1);
-        let e = std::io::Error::last_os_error();
-        assert_eq!(e.raw_os_error(), Some(libc::EINVAL));
-        assert_eq!(e.kind(), std::io::ErrorKind::InvalidInput);
+    // Test invalid inputs. We skip this on native macOS since macOS apparently does
+    // not bother to validate inputs.
+    if !cfg!(all(not(miri), target_vendor = "apple")) {
+        let invalid_templates = vec!["foo", "barXX", "XXXXXXbaz", "whatXXXXXXever", "X"];
+        for t in invalid_templates {
+            let ptr = CString::new(t).unwrap().into_raw();
+            let fd = unsafe { libc::mkstemp(ptr) };
+            let _ = unsafe { CString::from_raw(ptr) };
+            // "On error, -1 is returned, and errno is set to
+            // indicate the error"
+            assert_eq!(fd, -1, "mkstemp succeeded on invalid template {t:?}");
+            let e = std::io::Error::last_os_error();
+            assert_eq!(e.raw_os_error(), Some(libc::EINVAL));
+            assert_eq!(e.kind(), std::io::ErrorKind::InvalidInput);
+        }
     }
 
     env::set_current_dir(old_cwd).unwrap();
@@ -908,6 +913,11 @@ fn test_readv() {
 
 /// Test that vectored reads without any buffers return zero.
 fn test_readv_empty_bufs() {
+    if cfg!(all(not(miri), target_vendor = "apple")) {
+        // native macOS returns an error here :shrug:
+        return;
+    }
+
     let path = utils::prepare_with_content("pass-libc-readv-empty-bufs.txt", &[1u8, 2, 3]);
     let cpath = CString::new(path.into_os_string().into_encoded_bytes()).unwrap();
     let fd = unsafe { libc::open(cpath.as_ptr(), libc::O_RDONLY) };
@@ -1036,6 +1046,11 @@ fn test_writev() {
 
 /// Test that vectored writes without any buffers return zero.
 fn test_writev_empty_bufs() {
+    if cfg!(all(not(miri), target_vendor = "apple")) {
+        // native macOS returns an error here :shrug:
+        return;
+    }
+
     let path = utils::prepare_with_content("pass-libc-writev-empty-bufs.txt", &[1u8, 2, 3]);
     let cpath = CString::new(path.into_os_string().into_encoded_bytes()).unwrap();
     let fd = unsafe { libc::open(cpath.as_ptr(), libc::O_WRONLY) };

--- a/tests/pass-dep/libc/libc-socket-address.rs
+++ b/tests/pass-dep/libc/libc-socket-address.rs
@@ -1,5 +1,6 @@
 //@ignore-target: windows # No libc socket on Windows
 //@compile-flags: -Zmiri-disable-isolation
+//@run-native
 
 #[path = "../../utils/libc.rs"]
 mod libc_utils;

--- a/tests/pass-dep/libc/libc-socket-no-blocking-epoll.rs
+++ b/tests/pass-dep/libc/libc-socket-no-blocking-epoll.rs
@@ -1,5 +1,6 @@
 //@only-target: linux android illumos
 //@compile-flags: -Zmiri-disable-isolation
+//@run-native
 
 #![feature(io_error_inprogress)]
 

--- a/tests/pass-dep/libc/libc-socket-no-blocking.rs
+++ b/tests/pass-dep/libc/libc-socket-no-blocking.rs
@@ -3,6 +3,7 @@
 //@revisions: windows_host unix_host
 //@[unix_host] ignore-host: windows
 //@[windows_host] only-host: windows
+//@run-native
 
 #![feature(io_error_inprogress)]
 

--- a/tests/pass-dep/libc/libc-socket.rs
+++ b/tests/pass-dep/libc/libc-socket.rs
@@ -1,5 +1,6 @@
 //@ignore-target: windows # No libc socket on Windows
 //@compile-flags: -Zmiri-disable-isolation
+//@run-native
 
 #[path = "../../utils/libc.rs"]
 mod libc_utils;
@@ -176,8 +177,8 @@ fn test_set_nosigpipe_invalid_len() {
     let sockfd =
         unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
     // Value should be of type `libc::c_int` which has size 4 bytes.
-    // By providing a u64 of size 8 bytes we trigger an invalid length error.
-    let err = net::setsockopt(sockfd, libc::SOL_SOCKET, libc::SO_NOSIGPIPE, 1u64).unwrap_err();
+    // By providing a u16 of size 2 bytes we trigger an invalid length error.
+    let err = net::setsockopt(sockfd, libc::SOL_SOCKET, libc::SO_NOSIGPIPE, 1u16).unwrap_err();
     assert_eq!(err.kind(), ErrorKind::InvalidInput);
     // Check that it is the right kind of `InvalidInput`.
     assert_eq!(err.raw_os_error(), Some(libc::EINVAL));

--- a/tests/pass/shims/fs.rs
+++ b/tests/pass/shims/fs.rs
@@ -1,4 +1,5 @@
 //@compile-flags: -Zmiri-disable-isolation
+//@run-native
 
 #![feature(io_error_more)]
 #![feature(io_error_uncategorized)]
@@ -92,6 +93,11 @@ fn test_file() {
 }
 
 fn test_file_partial_reads_writes() {
+    if !cfg!(miri) {
+        // This test is not expected to work natively.
+        return;
+    }
+
     let path1 = utils::prepare_with_content("miri_test_fs_file1.txt", b"abcdefg");
     let path2 = utils::prepare_with_content("miri_test_fs_file2.txt", b"abcdefg");
 

--- a/tests/pass/shims/socket.rs
+++ b/tests/pass/shims/socket.rs
@@ -1,5 +1,6 @@
 //@ignore-target: windows # No socket support on Windows
 //@compile-flags: -Zmiri-disable-isolation
+//@run-native
 
 use std::io::{ErrorKind, Read, Write};
 use std::net::{Shutdown, TcpListener, TcpStream};
@@ -184,7 +185,7 @@ fn test_sockopt_read_timeout() {
     // By default, reads on blocking sockets should block indefinitely.
     assert_eq!(stream.read_timeout().unwrap(), None);
 
-    let short_read_timeout = Some(Duration::from_millis(10));
+    let short_read_timeout = Some(Duration::from_millis(40));
     stream.set_read_timeout(short_read_timeout).unwrap();
     assert_eq!(stream.read_timeout().unwrap(), short_read_timeout);
 
@@ -207,7 +208,7 @@ fn test_sockopt_write_timeout() {
     // By default, writes on blocking sockets should block indefinitely.
     assert_eq!(stream.write_timeout().unwrap(), None);
 
-    let short_write_timeout = Some(Duration::from_millis(10));
+    let short_write_timeout = Some(Duration::from_millis(40));
     stream.set_write_timeout(short_write_timeout).unwrap();
     assert_eq!(stream.write_timeout().unwrap(), short_write_timeout);
 

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -1,13 +1,15 @@
-use std::env;
+#![allow(clippy::let_and_return)]
 use std::num::NonZero;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::OnceLock;
+use std::{env, fmt};
 
 use colored::*;
 use regex::bytes::Regex;
 use ui_test::build_manager::BuildManager;
 use ui_test::color_eyre::eyre::{Context, Result};
+use ui_test::custom_flags::Flag;
 use ui_test::custom_flags::edition::Edition;
 use ui_test::dependencies::DependencyBuilder;
 use ui_test::per_test_config::TestConfig;
@@ -17,12 +19,35 @@ use ui_test::{CommandBuilder, Config, Match, ignore_output_conflict};
 
 #[derive(Copy, Clone, Debug)]
 enum Mode {
-    Pass,
+    Pass {
+        native: bool,
+    },
     /// Requires annotations
     Fail,
     /// Not used for tests, but for `miri run --dep`
-    RunDep,
+    RunDep {
+        native: bool,
+    },
+    /// Test must panic.
     Panic,
+}
+
+impl Mode {
+    fn native(self) -> bool {
+        matches!(self, Mode::Pass { native: true } | Mode::RunDep { native: true })
+    }
+}
+
+impl fmt::Display for Mode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Mode::Pass { native: false } => write!(f, "pass"),
+            Mode::Pass { native: true } => write!(f, "pass-native"),
+            Mode::Fail => write!(f, "fail"),
+            Mode::Panic => write!(f, "panic"),
+            Mode::RunDep { .. } => unreachable!(),
+        }
+    }
 }
 
 fn miri_path() -> PathBuf {
@@ -79,7 +104,7 @@ struct WithDependencies {
     bless: bool,
 }
 
-/// Does *not* set any args or env vars, since it is shared between the test runner and
+/// Does *not* set args or (most) env vars, since it is shared between the test runner and
 /// run_dep_mode.
 fn miri_config(
     target: &str,
@@ -90,6 +115,15 @@ fn miri_config(
     // Miri is rustc-like, so we create a default builder for rustc and modify it
     let mut program = CommandBuilder::rustc();
     program.program = miri_path();
+    if mode.native() {
+        // This means we build the program instead of running Miri.
+        program.envs.push(("MIRI_BE_RUSTC".into(), Some("host".into())));
+        // Use the right linker, if necessary. We use the `CC_*` variable as that is set by CI and
+        // unlike `CARGO_TARGET_*_LINKER` it does not require upper-casing the target.
+        if let Ok(linker) = env::var(format!("CC_{target}")) {
+            program.args.push(format!("-Clinker={linker}").into());
+        }
+    }
 
     let mut config = Config {
         target: Some(target.to_owned()),
@@ -103,10 +137,17 @@ fn miri_config(
         ..Config::rustc(path)
     };
 
+    // Register custom comments.
+    config.custom_comments.insert("run-native", |parser, _args, span| {
+        // Just remember that this is present.
+        parser.set_custom_once("run-native", (), span);
+    });
+
+    // Adjust comment defaults.
     config.comment_defaults.base().exit_status = match mode {
-        Mode::Pass => Some(0),
+        Mode::Pass { .. } => Some(0),
         Mode::Fail => Some(1),
-        Mode::RunDep => None,
+        Mode::RunDep { .. } => None,
         Mode::Panic => Some(101),
     }
     .map(Spanned::dummy)
@@ -123,9 +164,12 @@ fn miri_config(
     // keep in sync with `./miri run`
     config.comment_defaults.base().add_custom("edition", Edition("2021".into()));
 
+    // Building dependencies is also a "comment default".
     if let Some(WithDependencies { bless }) = with_dependencies {
-        config.comment_defaults.base().set_custom(
-            "dependencies",
+        let crate_manifest_path = Path::new("tests/deps").join("Cargo.toml");
+        let dep_builder = if mode.native() {
+            DependencyBuilder { crate_manifest_path, ..Default::default() }
+        } else {
             DependencyBuilder {
                 program: CommandBuilder {
                     // Set the `cargo-miri` binary, which we expect to be in the same folder as the `miri` binary.
@@ -147,12 +191,65 @@ fn miri_config(
                     ],
                     ..CommandBuilder::cargo()
                 },
-                crate_manifest_path: Path::new("tests/deps").join("Cargo.toml"),
+                crate_manifest_path,
                 build_std: None,
                 bless_lockfile: bless,
-            },
-        );
+            }
+        };
+        config.comment_defaults.base().set_custom("dependencies", dep_builder);
     }
+
+    // We only want this for actual test runs, not native run-dep mode.
+    if matches!(mode, Mode::Pass { native: true }) {
+        // Overwrite "compile-flags" so that it does nothing.
+        // FIXME: make it just skip `-Zmiri` flags.
+        config.custom_comments.insert("compile-flags", |_parser, _args, _span| {});
+
+        // Add a default comment that interprets our custom `run-native` comment.
+        #[derive(Debug)]
+        struct NativeRunner;
+        config.comment_defaults.base().set_custom("native-runner", NativeRunner);
+
+        impl Flag for NativeRunner {
+            fn clone_inner(&self) -> Box<dyn Flag> {
+                Box::new(NativeRunner)
+            }
+            fn must_be_unique(&self) -> bool {
+                true
+            }
+
+            fn test_condition(
+                &self,
+                _config: &Config,
+                comments: &ui_test::Comments,
+                revision: &str,
+            ) -> bool {
+                let should_run = comments
+                    .for_revision(revision)
+                    .any(|r| r.custom.iter().any(|(k, _v)| *k == "run-native"));
+                // We return `true` when the test should be ignored.
+                let ignore = !should_run;
+                ignore
+            }
+
+            fn post_test_action(
+                &self,
+                config: &TestConfig,
+                output: &std::process::Output,
+                build_manager: &BuildManager,
+            ) -> Result<(), ui_test::Errored> {
+                // Delegate to the native run support.
+                use ui_test::custom_flags::run::Run;
+                Run::post_test_action(
+                    &Run { exit_code: 0, output_conflict_handling: None },
+                    config,
+                    output,
+                    build_manager,
+                )
+            }
+        }
+    }
+
     config
 }
 
@@ -177,6 +274,9 @@ fn run_tests(
         assert!(!args.bless, "cannot use RUSTC_BLESS and MIRI_SKIP_UI_CHECKS at the same time");
         config.output_conflict_handling = ignore_output_conflict;
     }
+    if mode.native() {
+        config.output_conflict_handling = ignore_output_conflict;
+    }
 
     // Add a test env var to do environment communication tests.
     config.program.envs.push(("MIRI_ENV_VAR_TEST".into(), Some("0".into())));
@@ -185,23 +285,26 @@ fn run_tests(
     // If a test ICEs, we want to see a backtrace.
     config.program.envs.push(("RUST_BACKTRACE".into(), Some("1".into())));
 
-    // Add some flags we always want.
-    config.program.args.push(
-        format!(
-            "--sysroot={}",
-            env::var("MIRI_SYSROOT").expect("MIRI_SYSROOT must be set to run the ui test suite")
-        )
-        .into(),
-    );
+    // Add rustc/Miri flags.
     config.program.args.push("-Dwarnings".into());
     config.program.args.push("-Dunused".into());
     config.program.args.push("-Ainternal_features".into());
-    if let Ok(extra_flags) = env::var("MIRIFLAGS") {
-        for flag in extra_flags.split_whitespace() {
-            config.program.args.push(flag.into());
+    config.program.args.push("-Zui-testing".into());
+    if !mode.native() {
+        config.program.args.push(
+            format!(
+                "--sysroot={}",
+                env::var("MIRI_SYSROOT")
+                    .expect("MIRI_SYSROOT must be set to run the ui test suite")
+            )
+            .into(),
+        );
+        if let Ok(extra_flags) = env::var("MIRIFLAGS") {
+            for flag in extra_flags.split_whitespace() {
+                config.program.args.push(flag.into());
+            }
         }
     }
-    config.program.args.push("-Zui-testing".into());
 
     // If we're testing the native-lib functionality, then build the shared object file for testing
     // external C function calls and push the relevant compiler flag.
@@ -288,8 +391,8 @@ regexes! {
 }
 
 enum Dependencies {
-    WithDependencies,
-    WithoutDependencies,
+    WithDeps,
+    WithoutDeps,
 }
 
 use Dependencies::*;
@@ -301,12 +404,12 @@ fn ui(
     with_dependencies: Dependencies,
     tmpdir: &Path,
 ) -> Result<()> {
-    let msg = format!("## Running ui tests in {path} for {target}");
+    let msg = format!("## Running {mode} ui tests in {path} for {target}");
     println!("{}", msg.green().bold());
 
     let with_dependencies = match with_dependencies {
-        WithDependencies => true,
-        WithoutDependencies => false,
+        WithDeps => true,
+        WithoutDeps => false,
     };
     run_tests(mode, path, target, with_dependencies, tmpdir)
         .with_context(|| format!("ui tests in {path} for {target} failed"))
@@ -331,17 +434,27 @@ fn main() -> Result<()> {
 
     // Check whether this is a `./miri run` invocation
     if let Ok(mode) = env::var("MIRI_RUN_MODE") {
-        return run_mode(target, mode);
+        return run_with_deps(target, mode);
     }
 
-    ui(Mode::Pass, "tests/pass", &target, WithoutDependencies, tmpdir.path())?;
-    ui(Mode::Pass, "tests/pass-dep", &target, WithDependencies, tmpdir.path())?;
-    ui(Mode::Panic, "tests/panic", &target, WithDependencies, tmpdir.path())?;
-    ui(Mode::Fail, "tests/fail", &target, WithoutDependencies, tmpdir.path())?;
-    ui(Mode::Fail, "tests/fail-dep", &target, WithDependencies, tmpdir.path())?;
+    ui(Mode::Pass { native: false }, "tests/pass", &target, WithoutDeps, tmpdir.path())?;
+    ui(Mode::Pass { native: false }, "tests/pass-dep", &target, WithDeps, tmpdir.path())?;
+    if target == host {
+        ui(Mode::Pass { native: true }, "tests/pass", &target, WithoutDeps, tmpdir.path())?;
+        ui(Mode::Pass { native: true }, "tests/pass-dep", &target, WithDeps, tmpdir.path())?;
+    }
+    ui(Mode::Panic, "tests/panic", &target, WithDeps, tmpdir.path())?;
+    ui(Mode::Fail, "tests/fail", &target, WithoutDeps, tmpdir.path())?;
+    ui(Mode::Fail, "tests/fail-dep", &target, WithDeps, tmpdir.path())?;
     if cfg!(all(unix, feature = "native-lib")) && target == host {
-        ui(Mode::Pass, "tests/native-lib/pass", &target, WithoutDependencies, tmpdir.path())?;
-        ui(Mode::Fail, "tests/native-lib/fail", &target, WithoutDependencies, tmpdir.path())?;
+        ui(
+            Mode::Pass { native: false },
+            "tests/native-lib/pass",
+            &target,
+            WithoutDeps,
+            tmpdir.path(),
+        )?;
+        ui(Mode::Fail, "tests/native-lib/fail", &target, WithoutDeps, tmpdir.path())?;
     }
 
     // We only enable GenMC tests when the `genmc` feature is enabled, but also only on platforms we support:
@@ -354,30 +467,19 @@ fn main() -> Result<()> {
         target_endian = "little"
     )) && host == target
     {
-        ui(Mode::Pass, "tests/genmc/pass", &target, WithDependencies, tmpdir.path())?;
-        ui(Mode::Fail, "tests/genmc/fail", &target, WithDependencies, tmpdir.path())?;
+        ui(Mode::Pass { native: false }, "tests/genmc/pass", &target, WithDeps, tmpdir.path())?;
+        ui(Mode::Fail, "tests/genmc/fail", &target, WithDeps, tmpdir.path())?;
     }
 
     Ok(())
 }
 
-fn run_mode(target: String, mode: String) -> Result<()> {
+fn run_with_deps(target: String, mode: String) -> Result<()> {
     let native = mode == "native";
 
     let mut config =
-        miri_config(&target, "", Mode::RunDep, Some(WithDependencies { bless: false }));
+        miri_config(&target, "", Mode::RunDep { native }, Some(WithDependencies { bless: false }));
     config.comment_defaults.base().custom.remove("edition"); // `./miri` adds an `--edition` in `args`, so don't set it twice
-    if native {
-        // Patch things up so that we actually compile the program.
-        config.program.envs.push(("MIRI_BE_RUSTC".into(), Some("host".into())));
-        config.comment_defaults.base().set_custom(
-            "dependencies",
-            DependencyBuilder {
-                crate_manifest_path: Path::new("tests/deps").join("Cargo.toml"),
-                ..Default::default()
-            },
-        );
-    }
     config.fill_host_and_target()?;
     // Reset `args` (otherwise we'll get JSON output).
     config.program.args = vec![];
@@ -385,7 +487,8 @@ fn run_mode(target: String, mode: String) -> Result<()> {
     // Compute the actual Miri invocation command.
     let test_config = TestConfig::one_off_runner(config.clone(), PathBuf::new());
     let mut cmd = test_config.config.program.build(&test_config.config.out_dir);
-    // For some reason we need to set the target ourselves.
+    // We are not using `test_config.build_command` (as that would require us to know the filename
+    // we are invoking), so we need to set the target ourselves.
     cmd.arg("--target").arg(&target);
     // Also forward arguments to the program (skipping the binary name).
     // We don't put this in the `config` since we don't want it to affect the dependency build.
@@ -407,8 +510,8 @@ fn run_mode(target: String, mode: String) -> Result<()> {
 
     if native {
         // We just built the program, we still have to run it. We can't use the ui_test `Run` flag
-        // as that needs an actual BuildManager, not just the one-off stub we have here. So we
-        // implement the core logic ourselves.
+        // as (a) that always captures the output, and (b) that needs an actual BuildManager, not
+        // just the one-off stub we have here. So we implement the core logic ourselves.
 
         // First, figure out the output binary by re-running the compiler with `--print`.
         cmd.arg("--print").arg("file-names");


### PR DESCRIPTION
Some aspects of this are a bit quirky, but IMO acceptable:
- We ignore all `compile-flags` rather than just the `-Zmiri` ones. Seems fine for now, we don't have many (any?) other flags anyway.
- We do not compare stdout/stderr with the reference files. Seems fine for now, the relevant tests usually use assertions anyway.

I made the fs, socket, and epoll tests run natively in CI.

r? @oli-obk 
Fixes https://github.com/rust-lang/miri/issues/3810