### PR TITLE
Ensure no additional epoll events when using `check_epoll_wait`

### DIFF
--- a/tests/fail-dep/libc/libc-epoll-data-race.rs
+++ b/tests/fail-dep/libc/libc-epoll-data-race.rs
@@ -48,7 +48,7 @@ fn main() {
     thread::yield_now();
 
     // With room for one event: check result from epoll_wait.
-    check_epoll_wait_explicit(epfd, &[Ev { events: EPOLLIN, data: fds_a[1] }], 1, -1);
+    check_epoll_wait_partial(epfd, &[Ev { events: EPOLLIN, data: fds_a[1] }], 1, -1);
 
     // Since we only received one event, we have synchronized with
     // the write to VAL_ONE but not with the one to VAL_TWO.

--- a/tests/fail-dep/libc/libc-epoll-data-race.rs
+++ b/tests/fail-dep/libc/libc-epoll-data-race.rs
@@ -48,7 +48,7 @@ fn main() {
     thread::yield_now();
 
     // With room for one event: check result from epoll_wait.
-    check_epoll_wait::<1>(epfd, &[Ev { events: EPOLLIN, data: fds_a[1] }], -1);
+    check_epoll_wait_explicit(epfd, &[Ev { events: EPOLLIN, data: fds_a[1] }], 1, -1);
 
     // Since we only received one event, we have synchronized with
     // the write to VAL_ONE but not with the one to VAL_TWO.

--- a/tests/fail-dep/libc/libc-epoll-data-race.rs
+++ b/tests/fail-dep/libc/libc-epoll-data-race.rs
@@ -6,33 +6,13 @@
 // ensure deterministic schedule
 //@compile-flags: -Zmiri-deterministic-concurrency
 
-use std::convert::TryInto;
 use std::thread;
 use std::thread::spawn;
 
 #[path = "../../utils/libc.rs"]
 mod libc_utils;
-
-#[track_caller]
-fn check_epoll_wait<const N: usize>(epfd: i32, expected_notifications: &[(u32, u64)]) {
-    let epoll_event = libc::epoll_event { events: 0, u64: 0 };
-    let mut array: [libc::epoll_event; N] = [epoll_event; N];
-    let maxsize = N;
-    let array_ptr = array.as_mut_ptr();
-    let res = unsafe { libc::epoll_wait(epfd, array_ptr, maxsize.try_into().unwrap(), 0) };
-    if res < 0 {
-        panic!("epoll_wait failed: {}", std::io::Error::last_os_error());
-    }
-    assert_eq!(
-        res,
-        expected_notifications.len().try_into().unwrap(),
-        "got wrong number of notifications"
-    );
-    let got_notifications =
-        unsafe { std::slice::from_raw_parts(array_ptr, res.try_into().unwrap()) };
-    let got_notifications = got_notifications.iter().map(|e| (e.events, e.u64)).collect::<Vec<_>>();
-    assert_eq!(got_notifications, expected_notifications, "got wrong notifications");
-}
+use libc_utils::epoll::*;
+use libc_utils::*;
 
 fn main() {
     // Create an epoll instance.
@@ -41,27 +21,17 @@ fn main() {
 
     // Create two socketpair instances.
     let mut fds_a = [-1, -1];
-    let res = unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds_a.as_mut_ptr()) };
-    assert_eq!(res, 0);
-
+    unsafe {
+        errno_check(libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds_a.as_mut_ptr()))
+    };
     let mut fds_b = [-1, -1];
-    let res = unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds_b.as_mut_ptr()) };
-    assert_eq!(res, 0);
+    unsafe {
+        errno_check(libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds_b.as_mut_ptr()))
+    };
 
     // Register both pipe read ends.
-    let mut ev = libc::epoll_event {
-        events: (libc::EPOLLIN | libc::EPOLLET) as _,
-        u64: u64::try_from(fds_a[1]).unwrap(),
-    };
-    let res = unsafe { libc::epoll_ctl(epfd, libc::EPOLL_CTL_ADD, fds_a[1], &mut ev) };
-    assert_eq!(res, 0);
-
-    let mut ev = libc::epoll_event {
-        events: (libc::EPOLLIN | libc::EPOLLET) as _,
-        u64: u64::try_from(fds_b[1]).unwrap(),
-    };
-    let res = unsafe { libc::epoll_ctl(epfd, libc::EPOLL_CTL_ADD, fds_b[1], &mut ev) };
-    assert_eq!(res, 0);
+    epoll_ctl_add(epfd, fds_a[1], EPOLLIN | EPOLLET).unwrap();
+    epoll_ctl_add(epfd, fds_b[1], EPOLLIN | EPOLLET).unwrap();
 
     static mut VAL_ONE: u8 = 40; // This one will be read soundly.
     static mut VAL_TWO: u8 = 50; // This one will be read unsoundly.
@@ -78,9 +48,7 @@ fn main() {
     thread::yield_now();
 
     // With room for one event: check result from epoll_wait.
-    let expected_event = u32::try_from(libc::EPOLLIN).unwrap();
-    let expected_value = u64::try_from(fds_a[1]).unwrap();
-    check_epoll_wait::<1>(epfd, &[(expected_event, expected_value)]);
+    check_epoll_wait::<1>(epfd, &[Ev { events: EPOLLIN, data: fds_a[1] }], -1);
 
     // Since we only received one event, we have synchronized with
     // the write to VAL_ONE but not with the one to VAL_TWO.

--- a/tests/fail-dep/libc/libc_epoll_block_two_thread.rs
+++ b/tests/fail-dep/libc/libc_epoll_block_two_thread.rs
@@ -8,9 +8,6 @@ use std::thread;
 mod libc_utils;
 use libc_utils::epoll::*;
 
-// Using `as` cast since `EPOLLET` wraps around
-const EPOLL_IN_OUT_ET: u32 = (EPOLLIN | EPOLLOUT | EPOLLET) as _;
-
 // Test if only one thread is unblocked if multiple threads blocked on same epfd.
 // Expected execution:
 // 1. Thread 1 blocks.
@@ -29,8 +26,8 @@ fn main() {
     let fd2 = unsafe { libc::dup(fd1) };
 
     // Register both with epoll.
-    epoll_ctl_add(epfd, fd1, EPOLL_IN_OUT_ET as i32).unwrap();
-    epoll_ctl_add(epfd, fd2, EPOLL_IN_OUT_ET as i32).unwrap();
+    epoll_ctl_add(epfd, fd1, EPOLLIN | EPOLLOUT | EPOLLET).unwrap();
+    epoll_ctl_add(epfd, fd2, EPOLLIN | EPOLLOUT | EPOLLET).unwrap();
 
     // Consume the initial events.
     check_epoll_wait(

--- a/tests/fail-dep/libc/libc_epoll_block_two_thread.rs
+++ b/tests/fail-dep/libc/libc_epoll_block_two_thread.rs
@@ -33,14 +33,14 @@ fn main() {
     epoll_ctl_add(epfd, fd2, EPOLL_IN_OUT_ET as i32).unwrap();
 
     // Consume the initial events.
-    check_epoll_wait::<8>(
+    check_epoll_wait(
         epfd,
         &[Ev { events: EPOLLOUT, data: fd1 }, Ev { events: EPOLLOUT, data: fd2 }],
         -1,
     );
 
     let thread1 = thread::spawn(move || {
-        check_epoll_wait::<2>(
+        check_epoll_wait(
             epfd,
             &[Ev { events: EPOLLOUT, data: fd1 }, Ev { events: EPOLLOUT, data: fd2 }],
             -1,
@@ -48,7 +48,7 @@ fn main() {
     });
     let thread2 = thread::spawn(move || {
         //~vERROR: deadlocked
-        check_epoll_wait::<2>(
+        check_epoll_wait(
             epfd,
             &[Ev { events: EPOLLOUT, data: fd1 }, Ev { events: EPOLLOUT, data: fd2 }],
             -1,

--- a/tests/fail-dep/libc/libc_epoll_block_two_thread.rs
+++ b/tests/fail-dep/libc/libc_epoll_block_two_thread.rs
@@ -2,42 +2,14 @@
 //@only-target: linux android illumos
 //@error-in-other-file: deadlock
 
-use std::convert::TryInto;
 use std::thread;
 
 #[path = "../../utils/libc.rs"]
 mod libc_utils;
+use libc_utils::epoll::*;
 
 // Using `as` cast since `EPOLLET` wraps around
-const EPOLL_IN_OUT_ET: u32 = (libc::EPOLLIN | libc::EPOLLOUT | libc::EPOLLET) as _;
-
-#[track_caller]
-fn check_epoll_wait<const N: usize>(
-    epfd: i32,
-    expected_notifications: &[(u32, u64)],
-    timeout: i32,
-) {
-    let epoll_event = libc::epoll_event { events: 0, u64: 0 };
-    let mut array: [libc::epoll_event; N] = [epoll_event; N];
-    let maxsize = N;
-    let array_ptr = array.as_mut_ptr();
-    let res = unsafe { libc::epoll_wait(epfd, array_ptr, maxsize.try_into().unwrap(), timeout) };
-    if res < 0 {
-        panic!("epoll_wait failed: {}", std::io::Error::last_os_error());
-    }
-    assert_eq!(
-        res,
-        expected_notifications.len().try_into().unwrap(),
-        "got wrong number of notifications"
-    );
-    let slice = unsafe { std::slice::from_raw_parts(array_ptr, res.try_into().unwrap()) };
-    for (return_event, expected_event) in slice.iter().zip(expected_notifications.iter()) {
-        let event = return_event.events;
-        let data = return_event.u64;
-        assert_eq!(event, expected_event.0, "got wrong events");
-        assert_eq!(data, expected_event.1, "got wrong data");
-    }
-}
+const EPOLL_IN_OUT_ET: u32 = (EPOLLIN | EPOLLOUT | EPOLLET) as _;
 
 // Test if only one thread is unblocked if multiple threads blocked on same epfd.
 // Expected execution:
@@ -57,23 +29,30 @@ fn main() {
     let fd2 = unsafe { libc::dup(fd1) };
 
     // Register both with epoll.
-    let mut ev = libc::epoll_event { events: EPOLL_IN_OUT_ET, u64: fd1 as u64 };
-    let res = unsafe { libc::epoll_ctl(epfd, libc::EPOLL_CTL_ADD, fd1, &mut ev) };
-    assert_eq!(res, 0);
-    let mut ev = libc::epoll_event { events: EPOLL_IN_OUT_ET, u64: fd2 as u64 };
-    let res = unsafe { libc::epoll_ctl(epfd, libc::EPOLL_CTL_ADD, fd2, &mut ev) };
-    assert_eq!(res, 0);
+    epoll_ctl_add(epfd, fd1, EPOLL_IN_OUT_ET as i32).unwrap();
+    epoll_ctl_add(epfd, fd2, EPOLL_IN_OUT_ET as i32).unwrap();
 
     // Consume the initial events.
-    let expected = [(libc::EPOLLOUT as u32, fd1 as u64), (libc::EPOLLOUT as u32, fd2 as u64)];
-    check_epoll_wait::<8>(epfd, &expected, -1);
+    check_epoll_wait::<8>(
+        epfd,
+        &[Ev { events: EPOLLOUT, data: fd1 }, Ev { events: EPOLLOUT, data: fd2 }],
+        -1,
+    );
 
     let thread1 = thread::spawn(move || {
-        check_epoll_wait::<2>(epfd, &expected, -1);
+        check_epoll_wait::<2>(
+            epfd,
+            &[Ev { events: EPOLLOUT, data: fd1 }, Ev { events: EPOLLOUT, data: fd2 }],
+            -1,
+        );
     });
     let thread2 = thread::spawn(move || {
-        check_epoll_wait::<2>(epfd, &expected, -1);
-        //~^ERROR: deadlocked
+        //~vERROR: deadlocked
+        check_epoll_wait::<2>(
+            epfd,
+            &[Ev { events: EPOLLOUT, data: fd1 }, Ev { events: EPOLLOUT, data: fd2 }],
+            -1,
+        );
     });
     // Yield so the threads are both blocked.
     thread::yield_now();

--- a/tests/fail-dep/libc/libc_epoll_block_two_thread.stderr
+++ b/tests/fail-dep/libc/libc_epoll_block_two_thread.stderr
@@ -18,8 +18,12 @@ LL |         let ret = unsafe { libc::pthread_join(id, ptr::null_mut()) };
 error: the evaluated program deadlocked
   --> tests/fail-dep/libc/libc_epoll_block_two_thread.rs:LL:CC
    |
-LL |         check_epoll_wait::<TAG>(epfd, &expected, -1);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ thread got stuck here
+LL | /         check_epoll_wait::<TAG>(
+LL | |             epfd,
+LL | |             &[Ev { events: EPOLLOUT, data: fd1 }, Ev { events: EPOLLOUT, data: fd2 }],
+LL | |             -1,
+LL | |         );
+   | |_________^ thread got stuck here
    |
    = note: this is on thread `unnamed-ID`
 note: the current function got called indirectly due to this code
@@ -27,8 +31,11 @@ note: the current function got called indirectly due to this code
    |
 LL |       let thread2 = thread::spawn(move || {
    |  ___________________^
-LL | |         check_epoll_wait::<TAG>(epfd, &expected, -1);
 LL | |
+LL | |         check_epoll_wait::<TAG>(
+LL | |             epfd,
+...  |
+LL | |         );
 LL | |     });
    | |______^
 

--- a/tests/fail-dep/libc/libc_epoll_block_two_thread.stderr
+++ b/tests/fail-dep/libc/libc_epoll_block_two_thread.stderr
@@ -18,7 +18,7 @@ LL |         let ret = unsafe { libc::pthread_join(id, ptr::null_mut()) };
 error: the evaluated program deadlocked
   --> tests/fail-dep/libc/libc_epoll_block_two_thread.rs:LL:CC
    |
-LL | /         check_epoll_wait::<TAG>(
+LL | /         check_epoll_wait(
 LL | |             epfd,
 LL | |             &[Ev { events: EPOLLOUT, data: fd1 }, Ev { events: EPOLLOUT, data: fd2 }],
 LL | |             -1,
@@ -32,7 +32,7 @@ note: the current function got called indirectly due to this code
 LL |       let thread2 = thread::spawn(move || {
    |  ___________________^
 LL | |
-LL | |         check_epoll_wait::<TAG>(
+LL | |         check_epoll_wait(
 LL | |             epfd,
 ...  |
 LL | |         );

--- a/tests/fail-dep/libc/socket-connect-after-failed-connection.rs
+++ b/tests/fail-dep/libc/socket-connect-after-failed-connection.rs
@@ -41,7 +41,7 @@ fn main() {
     epoll_ctl_add(epfd, client_sockfd, EPOLLOUT | EPOLLET | libc::EPOLLERR).unwrap();
 
     // Wait until the socket has an error.
-    check_epoll_wait::<8>(
+    check_epoll_wait(
         epfd,
         &[Ev { events: libc::EPOLLERR | EPOLLOUT | EPOLLHUP, data: client_sockfd }],
         -1,

--- a/tests/pass-dep/libc/libc-epoll-blocking.rs
+++ b/tests/pass-dep/libc/libc-epoll-blocking.rs
@@ -41,15 +41,15 @@ fn test_epoll_block_without_notification() {
     epoll_ctl_add(epfd, fd, EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
 
     // epoll_wait to clear notification.
-    check_epoll_wait::<8>(epfd, &[Ev { events: EPOLLOUT, data: fd }], -1);
+    check_epoll_wait(epfd, &[Ev { events: EPOLLOUT, data: fd }], -1);
 
     if cfg!(edge_triggered) {
         // This epoll wait blocks, and timeout without notification.
-        check_epoll_wait::<1>(epfd, &[], 5);
+        check_epoll_wait(epfd, &[], 5);
     } else {
         // In level-triggered mode we should receive the same events
         // as before without timing out.
-        check_epoll_wait::<8>(epfd, &[Ev { events: EPOLLOUT, data: fd }], -1);
+        check_epoll_wait(epfd, &[Ev { events: EPOLLOUT, data: fd }], -1);
     }
 }
 
@@ -68,7 +68,7 @@ fn test_epoll_block_then_unblock() {
     epoll_ctl_add(epfd, fds[0], EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
 
     // epoll_wait to clear notification.
-    check_epoll_wait::<2>(epfd, &[Ev { events: EPOLLOUT, data: fds[0] }], -1);
+    check_epoll_wait(epfd, &[Ev { events: EPOLLOUT, data: fds[0] }], -1);
 
     let thread1 = thread::spawn(move || {
         thread::yield_now();
@@ -80,11 +80,11 @@ fn test_epoll_block_then_unblock() {
         // Edge-triggered epoll will block until the write succeeds and the buffer
         // becomes readable. This is because we already read the writable edge
         // before so at the time of calling `epoll_wait` there is no active readiness.
-        check_epoll_wait::<2>(epfd, &[Ev { events: EPOLLIN | EPOLLOUT, data: fds[0] }], 10);
+        check_epoll_wait(epfd, &[Ev { events: EPOLLIN | EPOLLOUT, data: fds[0] }], 10);
     } else {
         // Level-triggered epoll won't wait for the write to succeed because
         // _some_ readiness is already set (in this case the EPOLLOUT).
-        check_epoll_wait::<2>(epfd, &[Ev { events: EPOLLOUT, data: fds[0] }], -1);
+        check_epoll_wait(epfd, &[Ev { events: EPOLLOUT, data: fds[0] }], -1);
     }
 
     thread1.join().unwrap();
@@ -104,23 +104,23 @@ fn test_notification_after_timeout() {
     epoll_ctl_add(epfd, fds[0], EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
 
     // epoll_wait to clear notification.
-    check_epoll_wait::<2>(epfd, &[Ev { events: EPOLLOUT, data: fds[0] }], -1);
+    check_epoll_wait(epfd, &[Ev { events: EPOLLOUT, data: fds[0] }], -1);
 
     if cfg!(edge_triggered) {
         // Edge-triggered epoll wait times out without notification because
         // we just processed the edge.
-        check_epoll_wait::<1>(epfd, &[], 10);
+        check_epoll_wait(epfd, &[], 10);
     } else {
         // Level-triggered epoll just returns the same events as before
         // without blocking.
-        check_epoll_wait::<2>(epfd, &[Ev { events: EPOLLOUT, data: fds[0] }], -1);
+        check_epoll_wait(epfd, &[Ev { events: EPOLLOUT, data: fds[0] }], -1);
     }
 
     // Trigger epoll notification after timeout.
     write_all(fds[1], b"abcde").unwrap();
 
     // Check the result of the notification.
-    check_epoll_wait::<2>(epfd, &[Ev { events: EPOLLIN | EPOLLOUT, data: fds[0] }], 10);
+    check_epoll_wait(epfd, &[Ev { events: EPOLLIN | EPOLLOUT, data: fds[0] }], 10);
 }
 
 // This test shows a data race before epoll had vector clocks added.
@@ -144,7 +144,7 @@ fn test_epoll_race() {
     });
     thread::yield_now();
     // epoll_wait for EPOLLIN.
-    check_epoll_wait::<8>(epfd, &[Ev { events: EPOLLIN, data: fd }], -1);
+    check_epoll_wait(epfd, &[Ev { events: EPOLLIN, data: fd }], -1);
     // Read from the static mut variable.
     assert_eq!(unsafe { VAL }, 1);
     thread1.join().unwrap();
@@ -165,7 +165,7 @@ fn wakeup_on_new_interest() {
 
     // Block a thread on the epoll instance.
     let t = std::thread::spawn(move || {
-        check_epoll_wait::<8>(epfd, &[Ev { events: EPOLLIN | EPOLLOUT, data: fds[1] }], -1);
+        check_epoll_wait(epfd, &[Ev { events: EPOLLIN | EPOLLOUT, data: fds[1] }], -1);
     });
     // Ensure the thread is blocked.
     std::thread::yield_now();
@@ -196,7 +196,7 @@ fn multiple_events_wake_multiple_threads() {
 
     // Consume the initial events.
     let expected = [Ev { events: EPOLLOUT, data: fd1 }, Ev { events: EPOLLOUT, data: fd2 }];
-    check_epoll_wait::<8>(epfd, &expected, -1);
+    check_epoll_wait(epfd, &expected, -1);
 
     // Block two threads on the epoll, both wanting to get just one event.
     let t1 = thread::spawn(move || {

--- a/tests/pass-dep/libc/libc-epoll-no-blocking.rs
+++ b/tests/pass-dep/libc/libc-epoll-no-blocking.rs
@@ -53,16 +53,16 @@ fn test_epoll_socketpair() {
     epoll_ctl_add(epfd, fds[1], EPOLLIN | EPOLLOUT | EPOLLRDHUP | EPOLLET_OR_ZERO).unwrap();
 
     // Check result from epoll_wait.
-    check_epoll_wait_noblock::<2>(epfd, &[Ev { data: fds[1], events: EPOLLIN | EPOLLOUT }]);
+    check_epoll_wait_noblock(epfd, &[Ev { data: fds[1], events: EPOLLIN | EPOLLOUT }]);
 
     if cfg!(edge_triggered) {
         // Check that this is indeed using "ET" (edge-trigger) semantics: a second wait
         // should return nothing.
-        check_epoll_wait_noblock::<1>(epfd, &[]);
+        check_epoll_wait_noblock(epfd, &[]);
     } else {
         // Check that this is indeed using "LT" (level-trigger) semantics: a second wait
         // should return the same readiness.
-        check_epoll_wait_noblock::<2>(epfd, &[Ev { data: fds[1], events: EPOLLIN | EPOLLOUT }]);
+        check_epoll_wait_noblock(epfd, &[Ev { data: fds[1], events: EPOLLIN | EPOLLOUT }]);
     }
 
     // Write some more to fds[0].
@@ -71,14 +71,14 @@ fn test_epoll_socketpair() {
     // This did not change the readiness of fds[1], so we should get no event.
     // However, Linux seems to always deliver spurious events to the peer on each write,
     // so we match that.
-    check_epoll_wait_noblock::<2>(epfd, &[Ev { data: fds[1], events: EPOLLIN | EPOLLOUT }]);
+    check_epoll_wait_noblock(epfd, &[Ev { data: fds[1], events: EPOLLIN | EPOLLOUT }]);
 
     // Close the peer socketpair.
     errno_check(unsafe { libc::close(fds[0]) });
 
     // Check result from epoll_wait. We expect to get a read, write, HUP notification from the close
     // since closing an FD always unblocks reads and writes on its peer.
-    check_epoll_wait_noblock::<2>(
+    check_epoll_wait_noblock(
         epfd,
         &[Ev { data: fds[1], events: EPOLLIN | EPOLLOUT | EPOLLHUP | EPOLLRDHUP }],
     );
@@ -100,14 +100,14 @@ fn test_epoll_ctl_mod() {
         .unwrap();
 
     // Check result from epoll_wait. No notification would be returned.
-    check_epoll_wait_noblock::<1>(epfd, &[]);
+    check_epoll_wait_noblock(epfd, &[]);
 
     // Use EPOLL_CTL_MOD to change to EPOLLOUT flag and data.
     epoll_ctl(epfd, EPOLL_CTL_MOD, fds[1], Ev { events: EPOLLOUT | EPOLLET_OR_ZERO, data: 1 })
         .unwrap();
 
     // Check result from epoll_wait. EPOLLOUT notification and new data is expected.
-    check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLOUT, data: 1 }]);
+    check_epoll_wait_noblock(epfd, &[Ev { events: EPOLLOUT, data: 1 }]);
 
     // Write to fds[1] and read from fds[0] to make the notification ready again
     // (relying on there always being an event when the buffer gets emptied).
@@ -119,14 +119,14 @@ fn test_epoll_ctl_mod() {
         .unwrap();
 
     // Receive event, with latest data value.
-    check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLOUT, data: 2 }]);
+    check_epoll_wait_noblock(epfd, &[Ev { events: EPOLLOUT, data: 2 }]);
 
     // Do another update that changes nothing.
     epoll_ctl(epfd, EPOLL_CTL_MOD, fds[1], Ev { events: EPOLLOUT | EPOLLET_OR_ZERO, data: 2 })
         .unwrap();
 
     // This re-triggers the event, even if it's the same flags as before.
-    check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLOUT, data: 2 }]);
+    check_epoll_wait_noblock(epfd, &[Ev { events: EPOLLOUT, data: 2 }]);
 }
 
 fn test_epoll_ctl_del() {
@@ -151,7 +151,7 @@ fn test_epoll_ctl_del() {
     // Test EPOLL_CTL_DEL.
     let res = unsafe { libc::epoll_ctl(epfd, EPOLL_CTL_DEL, fds[1], &mut ev) };
     assert_eq!(res, 0);
-    check_epoll_wait_noblock::<1>(epfd, &[]);
+    check_epoll_wait_noblock(epfd, &[]);
 }
 
 // This test is for one fd registered under two different epoll instance.
@@ -175,8 +175,8 @@ fn test_two_epoll_instance() {
     epoll_ctl_add(epfd2, fds[1], EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
 
     // Notification should be received from both instance of epoll.
-    check_epoll_wait_noblock::<2>(epfd1, &[Ev { events: EPOLLIN | EPOLLOUT, data: fds[1] }]);
-    check_epoll_wait_noblock::<2>(epfd2, &[Ev { events: EPOLLIN | EPOLLOUT, data: fds[1] }]);
+    check_epoll_wait_noblock(epfd1, &[Ev { events: EPOLLIN | EPOLLOUT, data: fds[1] }]);
+    check_epoll_wait_noblock(epfd2, &[Ev { events: EPOLLIN | EPOLLOUT, data: fds[1] }]);
 }
 
 // This test is for two same file description registered under the same epoll instance through dup.
@@ -201,7 +201,7 @@ fn test_two_same_fd_in_same_epoll_instance() {
     libc_utils::write_all(fds[0], b"abcde").unwrap();
 
     // Two notification should be received.
-    check_epoll_wait_noblock::<3>(
+    check_epoll_wait_noblock(
         epfd,
         &[
             Ev { events: EPOLLIN | EPOLLOUT, data: fds[1] },
@@ -226,14 +226,14 @@ fn test_epoll_eventfd() {
     epoll_ctl_add(epfd, fd, EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
 
     // Check result from epoll_wait.
-    check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLIN | EPOLLOUT, data: fd }]);
+    check_epoll_wait_noblock(epfd, &[Ev { events: EPOLLIN | EPOLLOUT, data: fd }]);
 
     // Write 0 to the eventfd.
     libc_utils::write_all(fd, &0_u64.to_ne_bytes()).unwrap();
 
     // This does not change the status, so we should get no event.
     // However, Linux performs a spurious wakeup.
-    check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLIN | EPOLLOUT, data: fd }]);
+    check_epoll_wait_noblock(epfd, &[Ev { events: EPOLLIN | EPOLLOUT, data: fd }]);
 
     // Read from the eventfd.
     libc_utils::read_exact_array::<8>(fd).unwrap();
@@ -241,13 +241,13 @@ fn test_epoll_eventfd() {
     // This consumes the event, so the read status is gone. However, deactivation
     // does not trigger an event.
     // Still, we see a spurious wakeup.
-    check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLOUT, data: fd }]);
+    check_epoll_wait_noblock(epfd, &[Ev { events: EPOLLOUT, data: fd }]);
 
     // Write the maximum possible value.
     libc_utils::write_all(fd, &(u64::MAX - 1).to_ne_bytes()).unwrap();
 
     // This reactivates reads, therefore triggering an event. Writing is no longer possible.
-    check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLIN, data: fd }]);
+    check_epoll_wait_noblock(epfd, &[Ev { events: EPOLLIN, data: fd }]);
 }
 
 // When read/write happened on one side of the socketpair, only the other side will be notified.
@@ -269,7 +269,7 @@ fn test_epoll_socketpair_both_sides() {
     libc_utils::write_all(fds[1], b"abcde").unwrap();
 
     // Two notification should be received.
-    check_epoll_wait_noblock::<3>(
+    check_epoll_wait_noblock(
         epfd,
         &[Ev { events: EPOLLIN | EPOLLOUT, data: fds[0] }, Ev { events: EPOLLOUT, data: fds[1] }],
     );
@@ -282,11 +282,11 @@ fn test_epoll_socketpair_both_sides() {
         // The state of fds[1] does not change (was writable, is writable).
         // However, we force a spurious wakeup as the read buffer just got emptied.
         // fds[0] lost its readability, but becoming less active is not considered an "edge".
-        check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLOUT, data: fds[1] }])
+        check_epoll_wait_noblock(epfd, &[Ev { events: EPOLLOUT, data: fds[1] }])
     } else {
         // With level-triggered epoll, only the readable readiness for fds[0] should
         // no longer be reported. The rest stays the same.
-        check_epoll_wait_noblock::<3>(
+        check_epoll_wait_noblock(
             epfd,
             &[Ev { events: EPOLLOUT, data: fds[0] }, Ev { events: EPOLLOUT, data: fds[1] }],
         );
@@ -313,7 +313,7 @@ fn test_closed_fd() {
     errno_check(unsafe { libc::close(fd) });
 
     // No notification should be provided because the file description is closed.
-    check_epoll_wait_noblock::<1>(epfd, &[]);
+    check_epoll_wait_noblock(epfd, &[]);
 }
 
 // When a certain file descriptor registered with epoll is closed, but the underlying file description
@@ -340,7 +340,7 @@ fn test_not_fully_closed_fd() {
     errno_check(unsafe { libc::close(fd) });
 
     // Notification should still be provided because the file description is not closed.
-    check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLOUT, data: fd }]);
+    check_epoll_wait_noblock(epfd, &[Ev { events: EPOLLOUT, data: fd }]);
 
     // Write to the eventfd instance to produce notification.
     libc_utils::write_all(newfd, &1_u64.to_ne_bytes()).unwrap();
@@ -349,7 +349,7 @@ fn test_not_fully_closed_fd() {
     errno_check(unsafe { libc::close(newfd) });
 
     // No notification should be provided.
-    check_epoll_wait_noblock::<1>(epfd, &[]);
+    check_epoll_wait_noblock(epfd, &[]);
 }
 
 // Each time a notification is provided, it should reflect the file description's readiness
@@ -374,7 +374,7 @@ fn test_event_overwrite() {
     assert_eq!(res, 8);
 
     // Check result from epoll_wait.
-    check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLOUT, data: fd }]);
+    check_epoll_wait_noblock(epfd, &[Ev { events: EPOLLOUT, data: fd }]);
 }
 
 // An epoll notification will be provided for every succesful read in a socketpair.
@@ -396,7 +396,7 @@ fn test_socketpair_read() {
     libc_utils::write_all(fds[1], &data).unwrap();
 
     // Two notification should be received.
-    check_epoll_wait_noblock::<3>(
+    check_epoll_wait_noblock(
         epfd,
         &[Ev { events: EPOLLIN | EPOLLOUT, data: fds[0] }, Ev { events: EPOLLOUT, data: fds[1] }],
     );
@@ -407,11 +407,11 @@ fn test_socketpair_read() {
     if cfg!(edge_triggered) {
         // fds[1] did not change, it is still writable, so we get no event
         // in edge-triggered mode.
-        check_epoll_wait_noblock::<1>(epfd, &[]);
+        check_epoll_wait_noblock(epfd, &[]);
     } else {
         // In level-triggered mode we expect the same events as before because
         // we didn't read everything in the buffer.
-        check_epoll_wait_noblock::<3>(
+        check_epoll_wait_noblock(
             epfd,
             &[
                 Ev { events: EPOLLIN | EPOLLOUT, data: fds[0] },
@@ -428,11 +428,11 @@ fn test_socketpair_read() {
         // Now we get a notification that fds[1] can be written. This is spurious since it
         // could already be written before, but Linux seems to always emit a notification for
         // the writer when a read empties the buffer.
-        check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLOUT, data: fds[1] }]);
+        check_epoll_wait_noblock(epfd, &[Ev { events: EPOLLOUT, data: fds[1] }]);
     } else {
         // In level-triggered mode we expect the same events as before just without
         // the readable readiness of fds[0] because we now read everything.
-        check_epoll_wait_noblock::<3>(
+        check_epoll_wait_noblock(
             epfd,
             &[Ev { events: EPOLLOUT, data: fds[0] }, Ev { events: EPOLLOUT, data: fds[1] }],
         );
@@ -456,7 +456,7 @@ fn test_no_notification_for_unregister_flag() {
 
     // Check result from epoll_wait. Since we didn't register EPOLLIN flag, the notification won't
     // contain EPOLLIN even though fds[0] is now readable.
-    check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLOUT, data: fds[0] }]);
+    check_epoll_wait_noblock(epfd, &[Ev { events: EPOLLOUT, data: fds[0] }]);
 }
 
 fn test_epoll_wait_maxevent_zero() {
@@ -491,7 +491,7 @@ fn test_socketpair_epollerr() {
     epoll_ctl_add(epfd, fds[0], EPOLLIN | EPOLLOUT | EPOLLRDHUP | EPOLLET_OR_ZERO).unwrap();
 
     // Check result from epoll_wait.
-    check_epoll_wait_noblock::<2>(
+    check_epoll_wait_noblock(
         epfd,
         &[Ev { events: EPOLLIN | EPOLLOUT | EPOLLHUP | EPOLLRDHUP | EPOLLERR, data: fds[0] }],
     );
@@ -512,16 +512,16 @@ fn test_epoll_lost_events() {
     epoll_ctl_add(epfd, fds[1], EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
 
     // Two notification should be received. But we only provide buffer for one event.
-    check_epoll_wait_noblock::<1>(epfd, &[Ev { events: EPOLLOUT, data: fds[0] }]);
+    check_epoll_wait_explicit(epfd, &[Ev { events: EPOLLOUT, data: fds[0] }], 1, 0);
 
     if cfg!(edge_triggered) {
         // Previous event should be returned for the second epoll_wait but because we're
         // edge-triggered the first event should no longer be returned.
-        check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLOUT, data: fds[1] }]);
+        check_epoll_wait_noblock(epfd, &[Ev { events: EPOLLOUT, data: fds[1] }]);
     } else {
         // Both events should be returned in level-triggered mode when
         // we provide a big enough buffer.
-        check_epoll_wait_noblock::<3>(
+        check_epoll_wait_noblock(
             epfd,
             &[Ev { events: EPOLLOUT, data: fds[1] }, Ev { events: EPOLLOUT, data: fds[0] }],
         );
@@ -548,7 +548,7 @@ fn test_ready_list_fetching_logic() {
     errno_check(unsafe { libc::close(fd0) });
 
     // Notification for fd1 should be returned.
-    check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLOUT, data: fd1 }]);
+    check_epoll_wait_noblock(epfd, &[Ev { events: EPOLLOUT, data: fd1 }]);
 }
 
 // In epoll_ctl, if the value of epfd equals to fd, EFAULT should be returned.
@@ -580,7 +580,7 @@ fn test_epoll_ctl_notification() {
     epoll_ctl_add(epfd0, fds[0], EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
 
     // epoll_wait to clear notification for epfd0.
-    check_epoll_wait_noblock::<2>(epfd0, &[Ev { events: EPOLLOUT, data: fds[0] }]);
+    check_epoll_wait_noblock(epfd0, &[Ev { events: EPOLLOUT, data: fds[0] }]);
 
     // Create another epoll instance.
     let epfd1 = unsafe { libc::epoll_create1(0) };
@@ -588,15 +588,15 @@ fn test_epoll_ctl_notification() {
 
     // Register the same file description for epfd1.
     epoll_ctl_add(epfd1, fds[0], EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
-    check_epoll_wait_noblock::<2>(epfd1, &[Ev { events: EPOLLOUT, data: fds[0] }]);
+    check_epoll_wait_noblock(epfd1, &[Ev { events: EPOLLOUT, data: fds[0] }]);
 
     if cfg!(edge_triggered) {
         // Previously this epoll_wait will receive a notification, but we shouldn't return notification
         // for this epfd, because there is no I/O event between the two epoll_wait.
-        check_epoll_wait_noblock::<1>(epfd0, &[]);
+        check_epoll_wait_noblock(epfd0, &[]);
     } else {
         // We should still get the same events in level-triggered mode.
-        check_epoll_wait_noblock::<2>(epfd0, &[Ev { events: EPOLLOUT, data: fds[0] }]);
+        check_epoll_wait_noblock(epfd0, &[Ev { events: EPOLLOUT, data: fds[0] }]);
     }
 }
 
@@ -619,13 +619,13 @@ fn test_epoll_mixed_modes() {
     libc_utils::write_all(fds[1], b"abcde").unwrap();
 
     // Two events should be received.
-    check_epoll_wait_noblock::<3>(
+    check_epoll_wait_noblock(
         epfd,
         &[Ev { events: EPOLLIN | EPOLLOUT, data: fds[0] }, Ev { events: EPOLLOUT, data: fds[1] }],
     );
 
     // If we call epoll_wait again immediately, only the level-triggered interests should be received again.
-    check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLOUT, data: fds[1] }]);
+    check_epoll_wait_noblock(epfd, &[Ev { events: EPOLLOUT, data: fds[1] }]);
 }
 
 /// Test first registering a file descriptor in edge-triggered mode,
@@ -646,18 +646,18 @@ fn test_epoll_registered_mode_switch() {
     epoll_ctl_add(epfd, fd, EPOLLIN | EPOLLOUT | EPOLLET).unwrap();
 
     // Check result from `epoll_wait`.
-    check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLIN | EPOLLOUT, data: fd }]);
+    check_epoll_wait_noblock(epfd, &[Ev { events: EPOLLIN | EPOLLOUT, data: fd }]);
 
     // Because `fd` is registered in edge-triggered mode, the next `epoll_wait` shouldn't
     // return any events.
-    check_epoll_wait_noblock::<1>(epfd, &[]);
+    check_epoll_wait_noblock(epfd, &[]);
 
     // Update the registration for `fd` to switch to level-triggered mode.
     epoll_ctl(epfd, EPOLL_CTL_MOD, fd, Ev { events: EPOLLIN | EPOLLOUT, data: fd }).unwrap();
 
     // Because `fd` is now registered in level-triggered mode, we should see
     // the same events as from the first `epoll_wait`.
-    check_epoll_wait_noblock::<2>(epfd, &[Ev { events: EPOLLIN | EPOLLOUT, data: fd }]);
+    check_epoll_wait_noblock(epfd, &[Ev { events: EPOLLIN | EPOLLOUT, data: fd }]);
 }
 
 // Test for ICE caused by weak epoll interest upgrade succeed, but the attempt to retrieve
@@ -714,7 +714,7 @@ fn test_issue_4374() {
     }
 
     // This should have canceled the previous readiness, so now we get nothing.
-    check_epoll_wait_noblock::<1>(epfd0, &[]);
+    check_epoll_wait_noblock(epfd0, &[]);
 }
 
 /// Same as above, but for becoming un-readable.
@@ -739,5 +739,5 @@ fn test_issue_4374_reads() {
     libc_utils::read_exact_array::<5>(fds[0]).unwrap();
 
     // We should now still see a notification, but only about it being writable.
-    check_epoll_wait_noblock::<2>(epfd0, &[Ev { events: EPOLLOUT, data: fds[0] }]);
+    check_epoll_wait_noblock(epfd0, &[Ev { events: EPOLLOUT, data: fds[0] }]);
 }

--- a/tests/pass-dep/libc/libc-epoll-no-blocking.rs
+++ b/tests/pass-dep/libc/libc-epoll-no-blocking.rs
@@ -512,7 +512,7 @@ fn test_epoll_lost_events() {
     epoll_ctl_add(epfd, fds[1], EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
 
     // Two notification should be received. But we only provide buffer for one event.
-    check_epoll_wait_explicit(epfd, &[Ev { events: EPOLLOUT, data: fds[0] }], 1, 0);
+    check_epoll_wait_partial(epfd, &[Ev { events: EPOLLOUT, data: fds[0] }], 1, 0);
 
     if cfg!(edge_triggered) {
         // Previous event should be returned for the second epoll_wait but because we're

--- a/tests/pass-dep/libc/libc-socket-no-blocking-epoll.rs
+++ b/tests/pass-dep/libc/libc-socket-no-blocking-epoll.rs
@@ -61,7 +61,7 @@ fn test_connect_nonblock() {
     epoll_ctl_add(epfd, client_sockfd, EPOLLOUT | EPOLLET | EPOLLERR).unwrap();
 
     // Wait until we are done connecting.
-    check_epoll_wait::<8>(epfd, &[Ev { events: EPOLLOUT, data: client_sockfd }], -1);
+    check_epoll_wait(epfd, &[Ev { events: EPOLLOUT, data: client_sockfd }], -1);
 
     // There should be no error during async connection.
     let errno =
@@ -95,7 +95,7 @@ fn test_accept_nonblock() {
         epoll_ctl_add(epfd, server_sockfd, EPOLLIN | EPOLLET | EPOLLERR).unwrap();
 
         // Wait until we get a readable event on the server socket.
-        check_epoll_wait::<8>(epfd, &[Ev { events: EPOLLIN, data: server_sockfd }], -1);
+        check_epoll_wait(epfd, &[Ev { events: EPOLLIN, data: server_sockfd }], -1);
 
         // Accepting should now be possible.
         net::accept_ipv4(server_sockfd).unwrap();
@@ -149,7 +149,7 @@ fn test_connect_nonblock_err() {
     epoll_ctl_add(epfd, client_sockfd, EPOLLOUT | EPOLLET | libc::EPOLLERR).unwrap();
 
     // Wait until the socket has an error.
-    check_epoll_wait::<8>(
+    check_epoll_wait(
         epfd,
         &[Ev { events: libc::EPOLLERR | EPOLLOUT | EPOLLHUP, data: client_sockfd }],
         -1,
@@ -229,7 +229,7 @@ fn test_recv_nonblock() {
             Ok(received) => bytes_received += received as usize,
             Err(err) if err.kind() == ErrorKind::WouldBlock => {
                 // Use epoll to block until there's data available again.
-                check_epoll_wait::<8>(epfd, &[Ev { events: EPOLLIN, data: client_sockfd }], -1);
+                check_epoll_wait(epfd, &[Ev { events: EPOLLIN, data: client_sockfd }], -1);
             }
             Err(err) => panic!("unexpected error whilst receiving: {err}"),
         }
@@ -339,7 +339,7 @@ fn test_send_nonblock() {
     });
 
     // Wait until the socket is again writable.
-    check_epoll_wait::<8>(epfd, &[Ev { events: EPOLLOUT, data: client_sockfd }], -1);
+    check_epoll_wait(epfd, &[Ev { events: EPOLLOUT, data: client_sockfd }], -1);
 
     let fill_buf = [1u8; 100];
     // We should be able to write again without blocking because we just received
@@ -371,7 +371,7 @@ fn test_shutdown_read_write() {
     unsafe { libc::shutdown(client_sockfd, libc::SHUT_RDWR) };
 
     // Ensure that the "read end closed", "write end closed", and "readable" readiness are set.
-    check_epoll_wait::<8>(
+    check_epoll_wait(
         epfd,
         &[Ev { events: EPOLLRDHUP | EPOLLHUP | EPOLLIN, data: client_sockfd }],
         -1,
@@ -399,7 +399,7 @@ fn test_shutdown_read() {
     unsafe { libc::shutdown(client_sockfd, libc::SHUT_RD) };
 
     // Ensure that the "read end closed" readiness is set.
-    check_epoll_wait::<8>(epfd, &[Ev { events: EPOLLRDHUP, data: client_sockfd }], -1);
+    check_epoll_wait(epfd, &[Ev { events: EPOLLRDHUP, data: client_sockfd }], -1);
 
     server_thread.join().unwrap();
 }
@@ -425,7 +425,7 @@ fn test_shutdown_write() {
 
     // Ensure that the "read end closed" readiness is set when
     // the write end of the peer is closed.
-    check_epoll_wait::<8>(epfd, &[Ev { events: EPOLLRDHUP, data: client_sockfd }], -1);
+    check_epoll_wait(epfd, &[Ev { events: EPOLLRDHUP, data: client_sockfd }], -1);
 
     server_thread.join().unwrap();
 }
@@ -460,7 +460,7 @@ fn test_readiness_after_short_read() {
     epoll_ctl_add(epfd, client_sockfd, EPOLLET | EPOLLIN).unwrap();
 
     // Wait until the socket becomes readable.
-    check_epoll_wait::<8>(epfd, &[Ev { events: EPOLLIN, data: client_sockfd }], -1);
+    check_epoll_wait(epfd, &[Ev { events: EPOLLIN, data: client_sockfd }], -1);
 
     let mut buffer = [0u8; 1024];
 
@@ -499,7 +499,7 @@ fn test_readiness_after_short_read() {
 
     // Wait until the client socket becomes readable again.
     // If this blocks indefinitely, Miri lost track of the proper status of this socket.
-    check_epoll_wait::<8>(epfd, &[Ev { events: EPOLLIN, data: client_sockfd }], -1);
+    check_epoll_wait(epfd, &[Ev { events: EPOLLIN, data: client_sockfd }], -1);
 
     // Now we can read the 2nd chunk of data.
     unsafe {
@@ -583,7 +583,7 @@ fn test_readiness_after_short_write() {
     epoll_ctl_add(epfd, client_sockfd, EPOLLET | EPOLLOUT).unwrap();
 
     // Wait until the socket becomes writable.
-    check_epoll_wait::<8>(epfd, &[Ev { events: EPOLLOUT, data: client_sockfd }], -1);
+    check_epoll_wait(epfd, &[Ev { events: EPOLLOUT, data: client_sockfd }], -1);
 
     // We now want to fill the write buffer of the socket by repeatedly writing
     // `buffer` into it. The last write should then be a short write.
@@ -630,7 +630,7 @@ fn test_readiness_after_short_write() {
 
     // Wait until the socket becomes writable again.
     // If this blocks indefinitely, Miri lost track of the proper status of this socket.
-    check_epoll_wait::<8>(epfd, &[Ev { events: EPOLLOUT, data: client_sockfd }], -1);
+    check_epoll_wait(epfd, &[Ev { events: EPOLLOUT, data: client_sockfd }], -1);
 
     // We should again be able to write into the socket.
     libc_utils::write_all(client_sockfd, &buffer).unwrap();

--- a/tests/utils/libc.rs
+++ b/tests/utils/libc.rs
@@ -164,24 +164,41 @@ pub mod epoll {
         epoll_ctl(epfd, EPOLL_CTL_ADD, fd, Ev { events, data: fd })
     }
 
+    /// Call `epoll_wait` on `epfd` with the provided `timeout`.
+    /// It fetches at most `max_events` events from `epfd` and
+    /// ensures that the returned events match the `expected` events.
     #[track_caller]
-    pub fn check_epoll_wait<const N: usize>(epfd: i32, expected: &[Ev], timeout: i32) {
-        let mut array: [libc::epoll_event; N] = [libc::epoll_event { events: 0, u64: 0 }; N];
+    pub fn check_epoll_wait_explicit(epfd: i32, expected: &[Ev], max_events: usize, timeout: i32) {
+        let mut events = vec![libc::epoll_event { events: 0, u64: 0 }; max_events];
         let num = errno_result(unsafe {
-            libc::epoll_wait(epfd, array.as_mut_ptr(), N.try_into().unwrap(), timeout)
+            libc::epoll_wait(epfd, events.as_mut_ptr(), i32::try_from(max_events).unwrap(), timeout)
         })
         .expect("epoll_wait returned an error");
-        let got = &mut array[..num.try_into().unwrap()];
-        let got = got
+        let got = events
             .iter()
+            .take(num as usize)
             .map(|e| Ev { events: e.events.cast_signed(), data: e.u64.try_into().unwrap() })
             .collect::<Vec<_>>();
-        assert_eq!(got, expected, "got wrong notifications");
+        assert_eq!(got, expected, "got wrong ready events");
     }
 
+    /// Call `epoll_wait` on `epfd` with the provided `timeout` and ensure
+    /// that the returned events match the `expected` events.
+    /// This function checks whether `expected` is equal to **all** ready events
+    /// of `epfd`. If you only want to ensure that `expected` matches a subset
+    /// of the ready events [`check_epoll_wait_explicit`] should be used instead.
     #[track_caller]
-    pub fn check_epoll_wait_noblock<const N: usize>(epfd: i32, expected: &[Ev]) {
-        check_epoll_wait::<N>(epfd, expected, 0);
+    pub fn check_epoll_wait(epfd: i32, expected: &[Ev], timeout: i32) {
+        // We set `max_events` to `expected.len() + 1` to ensure that
+        // there are no additional ready events besides those which are
+        // contained in `expected`.
+        check_epoll_wait_explicit(epfd, &expected, expected.len() + 1, timeout);
+    }
+
+    /// This does the same as [`check_epoll_wait`] just without blocking (zero `timeout`).
+    #[track_caller]
+    pub fn check_epoll_wait_noblock(epfd: i32, expected: &[Ev]) {
+        check_epoll_wait(epfd, expected, 0);
     }
 
     /// Query the current epoll readiness of a file descriptor.

--- a/tests/utils/libc.rs
+++ b/tests/utils/libc.rs
@@ -168,7 +168,7 @@ pub mod epoll {
     /// It fetches at most `max_events` events from `epfd` and
     /// ensures that the returned events match the `expected` events.
     #[track_caller]
-    pub fn check_epoll_wait_explicit(epfd: i32, expected: &[Ev], max_events: usize, timeout: i32) {
+    pub fn check_epoll_wait_partial(epfd: i32, expected: &[Ev], max_events: usize, timeout: i32) {
         let mut events = vec![libc::epoll_event { events: 0, u64: 0 }; max_events];
         let num = errno_result(unsafe {
             libc::epoll_wait(epfd, events.as_mut_ptr(), i32::try_from(max_events).unwrap(), timeout)
@@ -183,16 +183,12 @@ pub mod epoll {
     }
 
     /// Call `epoll_wait` on `epfd` with the provided `timeout` and ensure
-    /// that the returned events match the `expected` events.
-    /// This function checks whether `expected` is equal to **all** ready events
-    /// of `epfd`. If you only want to ensure that `expected` matches a subset
-    /// of the ready events [`check_epoll_wait_explicit`] should be used instead.
+    /// that the set of *all* ready events matches `expected`.
     #[track_caller]
     pub fn check_epoll_wait(epfd: i32, expected: &[Ev], timeout: i32) {
-        // We set `max_events` to `expected.len() + 1` to ensure that
-        // there are no additional ready events besides those which are
-        // contained in `expected`.
-        check_epoll_wait_explicit(epfd, &expected, expected.len() + 1, timeout);
+        // We set `max_events` to `expected.len() + 1` to ensure that there are no additional ready
+        // events besides those which are contained in `expected`.
+        check_epoll_wait_partial(epfd, &expected, expected.len() + 1, timeout);
     }
 
     /// This does the same as [`check_epoll_wait`] just without blocking (zero `timeout`).


### PR DESCRIPTION
As previously discussed, with the current implementation of `check_epoll_wait` the `const N: usize` generic is mostly set to `expected.len()` which means we don't ensure that there are no additional ready events other what we specified in `expected`. 

This PR now adds a new `check_epoll_wait_explicit` method, which takes a `max_events` argument. This method can be used when we intentionally don't want to read all ready events. Otherwise, the `check_epoll_wait` (as well as the non-blocking variant) no longer accept the generic `N` and instead call `check_epoll_wait_explicit` with `max_events = expected.len() + 1`. 

The first two commits of this PR also remove the custom `check_epoll_wait` implementations from two other tests.