### PR TITLE
CreateFileW: retry to deal with race conditions

### DIFF
--- a/src/shims/windows/fs.rs
+++ b/src/shims/windows/fs.rs
@@ -157,29 +157,16 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             throw_unsup_format!("CreateFileW: Template files are not supported");
         }
 
-        // We need to know if the file is a directory to correctly open directory handles. This is
-        // racy, but currently the stdlib doesn't appear to offer a better solution. We do later
-        // verify that our guess was correct so worst-case, Miri ICEs here.
-        // FIXME: retry in a loop if we get an error indicating we got the wrong file type?
-        let is_dir = file_name.is_dir();
-
-        // BACKUP_SEMANTICS is how Windows calls the act of opening a directory handle.
-        if !attributes.contains(FileAttributes::BACKUP_SEMANTICS) && is_dir {
-            this.set_last_error(IoError::WindowsError("ERROR_ACCESS_DENIED"))?;
-            return interp_ok(Handle::Invalid);
-        }
-
-        let desired_read = desired_access & generic_read != 0;
-        let desired_write = desired_access & generic_write != 0;
-
-        let mut options = fs::OpenOptions::new();
-        if desired_read {
+        // Parse desired_access
+        let mut desired_read = false;
+        if desired_access & generic_read != 0 {
+            desired_read = true;
             desired_access &= !generic_read;
-            options.read(true);
         }
-        if desired_write {
+        let mut desired_write = false;
+        if desired_access & generic_write != 0 {
+            desired_write = true;
             desired_access &= !generic_write;
-            options.write(true);
         }
 
         if desired_access != 0 {
@@ -188,90 +175,150 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             );
         }
 
-        // Per the documentation:
-        // If the specified file exists and is writable, the function truncates the file,
-        // the function succeeds, and last-error code is set to ERROR_ALREADY_EXISTS.
-        // If the specified file does not exist and is a valid path, a new file is created,
-        // the function succeeds, and the last-error code is set to zero.
-        // https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew
-        //
-        // This is racy, but there doesn't appear to be an std API that both succeeds if a
-        // file exists but tells us it isn't new. Either we accept racing one way or another,
-        // or we use an iffy heuristic like file creation time. This implementation prefers
-        // to fail in the direction of erroring more often.
-        if let CreateAlways | OpenAlways = creation_disposition
-            && file_name.exists()
-        {
-            this.set_last_error(IoError::WindowsError("ERROR_ALREADY_EXISTS"))?;
-        }
-
-        let handle = if is_dir {
-            // Open this as a directory.
-            // FIXME: shouldn't we check `creation_disposition` here?
-            Dir::open(&file_name).map(|dir| {
-                #[cfg(not(bootstrap))]
-                assert!(
-                    dir.metadata().unwrap().is_dir(),
-                    "we tried to open a directory and got a file"
+        // We start a retry loop to deal with the `is_dir` and `exists_already` race, see below.
+        // We add a retry counter to avoid infinite loops when things go wrong.
+        let mut counter = 0u32;
+        loop {
+            if counter >= 100 {
+                panic!(
+                    "CreateFileW seems stuck in an infinite retry loop. \
+                    If you can reproduce this, please file a bug."
                 );
+            }
+            counter = counter.strict_add(1);
+
+            // We need to know if the file is a directory to correctly open directory handles.
+            // The standard library only lets us open something as a file or a directory, so
+            // we check for that and then retry if we end up with the wrong thing.
+            let is_dir = file_name.is_dir();
+
+            // BACKUP_SEMANTICS is how Windows calls the act of opening a directory handle.
+            if !attributes.contains(FileAttributes::BACKUP_SEMANTICS) && is_dir {
+                this.set_last_error(IoError::WindowsError("ERROR_ACCESS_DENIED"))?;
+                return interp_ok(Handle::Invalid);
+            }
+
+            if is_dir {
+                // Open this as a directory.
+                // FIXME: shouldn't we check `creation_disposition` here? We do know that it already
+                // exists.
+                let dir = match Dir::open(&file_name) {
+                    Ok(dir) => dir,
+                    Err(e) => {
+                        if e.kind() == io::ErrorKind::NotADirectory {
+                            // This changed from a directory to a file. Retry.
+                            continue;
+                        }
+                        this.set_last_error(e)?;
+                        return interp_ok(Handle::Invalid);
+                    }
+                };
+                #[cfg(not(bootstrap))]
+                if !dir.metadata().unwrap().is_dir() {
+                    // This changed from a directory to a file. Retry.
+                    continue;
+                }
+
+                // Windows communicates information via the error code on success.
+                if let CreateAlways | OpenAlways = creation_disposition {
+                    this.set_last_error(IoError::WindowsError("ERROR_ALREADY_EXISTS"))?;
+                }
+
                 let fd_num = this.machine.fds.insert_new(DirHandle { dir, path: file_name });
-                Handle::File(fd_num)
-            })
-        } else {
-            // Open this as a standard file. We already set the `read`/`write` flags above,
-            // but we still need to represent the `creation_disposition`.
-            match creation_disposition {
-                CreateAlways | OpenAlways => {
-                    options.create(true);
-                    if creation_disposition == CreateAlways {
+                return interp_ok(Handle::File(fd_num));
+            } else {
+                // Per the documentation:
+                // If the specified file exists and is writable, the function truncates the file,
+                // the function succeeds, and last-error code is set to ERROR_ALREADY_EXISTS.
+                // If the specified file does not exist and is a valid path, a new file is created,
+                // the function succeeds, and the last-error code is set to zero.
+                // https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew
+                //
+                // We check whether it exists before trying to open it. This is racy, but there
+                // doesn't appear to be an std API that both succeeds whether or not a file already
+                // exists and tells us whether it is new. So instead we will open the file in a way
+                // that we can verify whether our guess is correct, and retry if it is not.
+                let exists_already = file_name.exists();
+
+                // Open this as a standard file.
+                let mut options = fs::OpenOptions::new();
+                options.read(desired_read);
+                options.write(desired_write);
+                match creation_disposition {
+                    CreateAlways | OpenAlways => {
+                        // We verify `exists_already`: if we expect it to already exist, we set no
+                        // flag, thus failing if it doesn't exist. If we expect the file to not
+                        // exist, we use `create_new` to fail if it does exist.
+                        if !exists_already {
+                            options.create_new(true);
+                        }
+                        if creation_disposition == CreateAlways {
+                            options.truncate(true);
+                        }
+                    }
+                    CreateNew => {
+                        options.create_new(true);
+                        // Per `create_new` documentation:
+                        // The file must be opened with write or append access in order to create a new file.
+                        // https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.create_new
+                        if !desired_write {
+                            options.append(true);
+                        }
+                    }
+                    OpenExisting => {
+                        if !desired_read && !desired_write {
+                            // Windows supports handles with no permissions. These allow things such as
+                            // reading metadata, but not file content. This is used by `Path::metadata`.
+                            // `std` does not support this. To ensure we behave correctly as often as
+                            // possible, we open the file for reading and live with the fact that this
+                            // might incorrectly return `PermissionDenied`.
+                            // FIXME: We could probably use `OpenOptionsExt`? On a Unix host,
+                            // `O_PATH` apparently can open files for metadata use only.
+                            options.read(true);
+                        }
+                    }
+                    TruncateExisting => {
                         options.truncate(true);
                     }
                 }
-                CreateNew => {
-                    options.create_new(true);
-                    // Per `create_new` documentation:
-                    // The file must be opened with write or append access in order to create a new file.
-                    // https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.create_new
-                    if !desired_write {
-                        options.append(true);
-                    }
-                }
-                OpenExisting => {
-                    if !desired_read && !desired_write {
-                        // Windows supports handles with no permissions. These allow things such as
-                        // reading metadata, but not file content. This is used by `Path::metadata`.
-                        // `std` does not support this. To ensure we behave correctly as often as
-                        // possible, we open the file for reading and live with the fact that this
-                        // might incorrectly return `PermissionDenied`.
-                        // FIXME: We could probably use `OpenOptionsExt`? On a Unix host,
-                        // `O_PATH` apparently can open files for metadata use only.
-                        options.read(true);
-                    }
-                }
-                TruncateExisting => {
-                    options.truncate(true);
-                }
-            }
 
-            options.open(file_name).map(|file| {
-                assert!(
-                    !file.metadata().unwrap().is_dir(),
-                    "we tried to open a file and got a directory"
-                );
+                let file = match options.open(&file_name) {
+                    Ok(file) => file,
+                    Err(e) => {
+                        let kind = e.kind();
+                        if kind == io::ErrorKind::IsADirectory {
+                            // This changed from a file to a directory. Retry.
+                            continue;
+                        }
+                        if exists_already && kind == io::ErrorKind::NotFound {
+                            // The file disappeared. Retry.
+                            continue;
+                        }
+                        if !exists_already && kind == io::ErrorKind::AlreadyExists {
+                            // The file got created by something else. Retry.
+                            continue;
+                        }
+                        this.set_last_error(e)?;
+                        return interp_ok(Handle::Invalid);
+                    }
+                };
+                if file.metadata().unwrap().is_dir() {
+                    // This changed from a file to a directory. Retry.
+                    continue;
+                }
+
+                // Windows communicates information via the error code on success.
+                if let CreateAlways | OpenAlways = creation_disposition
+                    && exists_already
+                {
+                    this.set_last_error(IoError::WindowsError("ERROR_ALREADY_EXISTS"))?;
+                }
                 let fd_num = this.machine.fds.insert_new(FileHandle {
                     file,
                     writable: desired_write,
                     readable: desired_read,
                 });
-                Handle::File(fd_num)
-            })
-        };
-
-        match handle {
-            Ok(handle) => interp_ok(handle),
-            Err(e) => {
-                this.set_last_error(e)?;
-                interp_ok(Handle::Invalid)
+                return interp_ok(Handle::File(fd_num));
             }
         }
     }


### PR DESCRIPTION
Deal with the race conditions in `CreateFileW` by verifying whether what we saw in our initial check is still correct, and retrying the entire operation if it is not.

@CraftSpider any chance you could have a look at this? Does it make any sense?