### PR TITLE
move cron job earlier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - 'master'
   schedule:
-    - cron: '44 4 * * *' # At 4:44 UTC every day.
+    - cron: '14 4 * * *' # At 4:14 UTC every day.
 
 defaults:
   run:


### PR DESCRIPTION
There seems to be a around 1.5h delay until the cron job actually starts. So let's move it earlier in the hope that then it is done by 6am UTC.

Cc @rust-lang/infra in case you have thoughts / know more about this.