### PR TITLE
use Size::unsigned_int_max to make code more readable

### DIFF
--- a/src/shims/tls.rs
+++ b/src/shims/tls.rs
@@ -63,19 +63,19 @@ impl<'tcx> Default for TlsData<'tcx> {
 
 impl<'tcx> TlsData<'tcx> {
     /// Generate a new TLS key with the given destructor.
-    /// `max_size` determines the integer size the key has to fit in.
+    /// `key_size` determines the integer size the key has to fit in.
     #[expect(clippy::arithmetic_side_effects)]
     pub fn create_tls_key(
         &mut self,
         dtor: Option<(ty::Instance<'tcx>, Span)>,
-        max_size: Size,
+        key_size: Size,
     ) -> InterpResult<'tcx, TlsKey> {
         let new_key = self.next_key;
         self.next_key += 1;
         self.keys.try_insert(new_key, TlsEntry { data: Default::default(), dtor }).unwrap();
         trace!("New TLS key allocated: {} with dtor {:?}", new_key, dtor);
 
-        if max_size.bits() < 128 && new_key >= (1u128 << max_size.bits()) {
+        if new_key > key_size.unsigned_int_max() {
             throw_unsup_format!("we ran out of TLS key space");
         }
         interp_ok(new_key)

--- a/src/shims/windows/foreign_items.rs
+++ b/src/shims/windows/foreign_items.rs
@@ -638,6 +638,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
             // Thread-local storage
             "TlsAlloc" => {
+                // FIXME: This does not have a direct test (#3179).
                 // This just creates a key; Windows does not natively support TLS destructors.
 
                 // Create key and return it.
@@ -651,6 +652,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 this.write_scalar(Scalar::from_uint(key, dest.layout.size), dest)?;
             }
             "TlsGetValue" => {
+                // FIXME: This does not have a direct test (#3179).
                 let [key] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(u32) -> *mut _),
                     link_name,
@@ -663,6 +665,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 this.write_scalar(ptr, dest)?;
             }
             "TlsSetValue" => {
+                // FIXME: This does not have a direct test (#3179).
                 let [key, new_ptr] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(u32, *mut _) -> winapi::BOOL),
                     link_name,
@@ -678,6 +681,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 this.write_int(1, dest)?;
             }
             "TlsFree" => {
+                // FIXME: This does not have a direct test (#3179).
                 let [key] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(u32) -> winapi::BOOL),
                     link_name,
@@ -693,6 +697,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
             // Fiber-local storage - similar to TLS but supports destructors.
             "FlsAlloc" => {
+                // FIXME: This does not have a direct test (#3179).
                 // Create key and return it.
                 let [dtor] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(winapi::PFLS_CALLBACK_FUNCTION) -> u32),
@@ -716,6 +721,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 this.write_scalar(Scalar::from_uint(key, dest.layout.size), dest)?;
             }
             "FlsGetValue" => {
+                // FIXME: This does not have a direct test (#3179).
                 let [key] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(u32) -> *mut _),
                     link_name,
@@ -728,6 +734,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 this.write_scalar(ptr, dest)?;
             }
             "FlsSetValue" => {
+                // FIXME: This does not have a direct test (#3179).
                 let [key, new_ptr] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(u32, *mut _) -> winapi::BOOL),
                     link_name,
@@ -743,6 +750,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 this.write_int(1, dest)?;
             }
             "FlsFree" => {
+                // FIXME: This does not have a direct test (#3179).
                 let [key] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(u32) -> winapi::BOOL),
                     link_name,
@@ -763,6 +771,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 this.write_int(1, dest)?;
             }
             "IsThreadAFiber" => {
+                // FIXME: This does not have a direct test (#3179).
                 let [] = this.check_shim_sig(
                     shim_sig!(extern "system" fn() -> winapi::BOOL),
                     link_name,


### PR DESCRIPTION
also add missing FIXME for Windows TLS API tests