### PR TITLE
triagebot: remove assign.custom_welcome_messages

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -17,12 +17,6 @@ allow-unauthenticated = [
 [assign]
 warn_non_default_branch = true
 contributing_url = "https://github.com/rust-lang/miri/blob/master/CONTRIBUTING.md#pr-review-process"
-[assign.custom_welcome_messages]
-welcome-message = "(unused)"
-welcome-message-no-reviewer = """
-Thank you for contributing to Miri! A reviewer will take a look at your PR, typically within a week or two.
-Please remember to not force-push to the PR branch except when you need to rebase due to a conflict or when the reviewer asks you for it.
-"""
 
 [no-merges]
 exclude_titles = ["Rustup"]


### PR DESCRIPTION
With the nice diff links that we have now, not force-pushing has become less critical. So we don't need this reminder in every PR any more I think.

rust-lang/rust also does not have this section in their triagebot config.