### PR TITLE
Move epoll readiness logic into `ReadinessWatcher`s

### DIFF
--- a/src/concurrency/blocking_io.rs
+++ b/src/concurrency/blocking_io.rs
@@ -1,15 +1,12 @@
 use std::cell::RefMut;
 use std::collections::BTreeMap;
 use std::io;
-use std::ops::BitOrAssign;
 use std::time::Duration;
 
 use mio::event::Source;
 use mio::{Events, Interest, Poll, Token};
 
-use crate::shims::{
-    EpollEvalContextExt, FdId, FileDescription, FileDescriptionRef, WeakFileDescriptionRef,
-};
+use crate::shims::{FdId, FileDescription, FileDescriptionRef, WeakFileDescriptionRef};
 use crate::*;
 
 /// Capacity of the event queue which can be polled at a time.
@@ -23,7 +20,7 @@ pub trait SourceFileDescription: FileDescription {
     fn with_source(&self, f: &mut dyn FnMut(&mut dyn Source) -> io::Result<()>) -> io::Result<()>;
 
     /// Get a mutable reference to the readiness of the source.
-    fn get_readiness_mut(&self) -> RefMut<'_, BlockingIoSourceReadiness>;
+    fn get_readiness_mut(&self) -> RefMut<'_, Readiness>;
 }
 
 /// An I/O interest for a blocked thread. Note that all threads are always considered
@@ -39,58 +36,21 @@ pub enum BlockingIoInterest {
     ReadWrite,
 }
 
-/// Struct reflecting the readiness of a source file description.
-#[derive(Debug)]
-pub struct BlockingIoSourceReadiness {
-    /// Boolean whether the source is currently readable.
-    pub readable: bool,
-    /// Boolean whether the source is currently writable.
-    pub writable: bool,
-    /// Boolean whether the read end of the source has been
-    /// closed.
-    pub read_closed: bool,
-    /// Boolean whether the write end of the source has been
-    /// closed.
-    pub write_closed: bool,
-    /// Boolean whether the source currently has an error.
-    pub error: bool,
-}
-
-impl BlockingIoSourceReadiness {
-    pub fn empty() -> Self {
-        Self {
-            readable: false,
-            writable: false,
-            read_closed: false,
-            write_closed: false,
-            error: false,
-        }
-    }
-
-    /// Check whether the current readiness fulfills the blocking I/O interest of
-    /// `interest`.
+impl BlockingIoInterest {
+    /// Check whether the [`Readiness`] fulfills this blocking I/O interest.
     /// This function also returns `true` if the error readiness is set
     /// even when the requested interest might not be fulfilled.
-    fn fulfills_interest(&self, interest: &BlockingIoInterest) -> bool {
-        match interest {
-            BlockingIoInterest::Read => self.readable || self.error,
-            BlockingIoInterest::Write => self.writable || self.error,
-            BlockingIoInterest::ReadWrite => self.readable || self.writable || self.error,
+    fn is_fulfilled_by(&self, readiness: &Readiness) -> bool {
+        match self {
+            BlockingIoInterest::Read => readiness.readable || readiness.error,
+            BlockingIoInterest::Write => readiness.writable || readiness.error,
+            BlockingIoInterest::ReadWrite =>
+                readiness.readable || readiness.writable || readiness.error,
         }
     }
 }
 
-impl BitOrAssign for BlockingIoSourceReadiness {
-    fn bitor_assign(&mut self, rhs: Self) {
-        self.readable |= rhs.readable;
-        self.writable |= rhs.writable;
-        self.read_closed |= rhs.read_closed;
-        self.write_closed |= rhs.write_closed;
-        self.error |= rhs.error;
-    }
-}
-
-impl From<&mio::event::Event> for BlockingIoSourceReadiness {
+impl From<&mio::event::Event> for Readiness {
     fn from(event: &mio::event::Event) -> Self {
         Self {
             readable: event.is_readable(),
@@ -119,10 +79,10 @@ struct BlockingIoSource {
 ///
 /// The semantics of this manager are that host I/O sources are registered
 /// to a [`Poll`] for their entire lifespan. Once host readiness events happen
-/// on a registered source, its internal epoll readiness gets updated -- even
-/// when the source isn't part of an active epoll instance. Also, for the entire
+/// on a registered source, its internal readiness gets updated -- even when
+/// the source isn't part of an active [`ReadinessWatcher`]. Also, for the entire
 /// lifespan of the source, threads can be added which should be unblocked
-/// once a certain [`BlockingIoSourceReadiness`] for an I/O source is satisfied.
+/// once a certain [`Readiness`] for an I/O source is satisfied.
 ///
 /// Since blocking host I/O is inherently non-deterministic, no method on this
 /// manager should be called when isolation is enabled. The only exception is
@@ -155,7 +115,7 @@ impl BlockingIoManager {
 
     /// Poll for new I/O events from the OS or wait until the timeout expired.
     /// The timeout semantics are the same as described in [`Poll::poll`].
-    /// The events also immediately get processed: threads get unblocked, and epoll readiness gets updated.
+    /// The events also immediately get processed: threads get unblocked, and fd readiness gets updated.
     fn poll<'tcx>(
         ecx: &mut MiriInterpCx<'tcx>,
         timeout: Option<Duration>,
@@ -193,17 +153,17 @@ impl BlockingIoManager {
 
                 assert_eq!(fd.id(), fd_id);
                 // Update the readiness of the source.
-                *fd.get_readiness_mut() |= BlockingIoSourceReadiness::from(event);
+                *fd.get_readiness_mut() |= Readiness::from(event);
                 // Put FD into `event_fds` list.
                 fd
             })
             .collect::<Vec<_>>();
 
-        // Update the epoll readiness for all source file descriptions which received an event. Also,
+        // Update the readiness for all source file descriptions which received an event. Also,
         // unblock the threads which are blocked on such a source and whose interests are now fulfilled.
         for fd in event_fds.into_iter() {
-            // Update epoll readiness for the `fd` source.
-            ecx.update_epoll_active_events(fd.clone(), false)?;
+            // Update readiness for the `fd` source.
+            ecx.update_fd_readiness(fd.clone(), false)?;
 
             let source =
                 ecx.machine.blocking_io.sources.get(&fd.id()).expect(
@@ -218,7 +178,7 @@ impl BlockingIoManager {
                 .blocked_threads
                 .iter()
                 .filter_map(|(thread_id, interest)| {
-                    fd.get_readiness_mut().fulfills_interest(interest).then_some(*thread_id)
+                    interest.is_fulfilled_by(&fd.get_readiness_mut()).then_some(*thread_id)
                 })
                 .collect::<Vec<_>>();
 
@@ -360,7 +320,7 @@ pub trait EvalContextExt<'tcx>: MiriInterpCxExt<'tcx> {
         // We always have to do this since the thread will de-register itself.
         this.machine.blocking_io.add_blocked_thread(source_fd.id(), this.active_thread(), interest);
 
-        if source_fd.get_readiness_mut().fulfills_interest(&interest) {
+        if interest.is_fulfilled_by(&source_fd.get_readiness_mut()) {
             // The requested readiness is currently already fulfilled for the provided source.
             // Instead of actually blocking the thread, we just run the callback function.
             callback.call(this, UnblockKind::Ready)

--- a/src/concurrency/thread.rs
+++ b/src/concurrency/thread.rs
@@ -1,6 +1,7 @@
 //! Implements threads.
 
 use std::mem;
+use std::rc::Rc;
 use std::sync::atomic::Ordering::Relaxed;
 use std::task::Poll;
 use std::time::{Duration, SystemTime};
@@ -19,7 +20,7 @@ use rustc_span::{DUMMY_SP, Span};
 use rustc_target::spec::Os;
 
 use crate::concurrency::GlobalDataRaceHandler;
-use crate::shims::{Epoll, EpollEvalContextExt, FileDescriptionRef, tls};
+use crate::shims::tls;
 use crate::*;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -107,8 +108,8 @@ pub enum BlockReason {
     Futex,
     /// Blocked on an InitOnce.
     InitOnce,
-    /// Blocked on epoll.
-    Epoll { epfd: FileDescriptionRef<Epoll> },
+    /// Blocked until a file description readiness is satisfied.
+    Readiness { watcher: Rc<ReadinessWatcher> },
     /// Blocked on eventfd.
     Eventfd,
     /// Blocked on virtual socket.
@@ -790,8 +791,8 @@ trait EvalContextPrivExt<'tcx>: MiriInterpCxExt<'tcx> {
         let this = self.eval_context_ref();
         match &thread.state {
             ThreadState::Blocked { reason: BlockReason::IO, .. } => true,
-            ThreadState::Blocked { reason: BlockReason::Epoll { epfd }, .. } =>
-                this.has_epoll_host_interests(epfd),
+            ThreadState::Blocked { reason: BlockReason::Readiness { watcher }, .. } =>
+                this.has_watcher_host_interests(watcher),
             _ => false,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@
     clippy::too_long_first_doc_paragraph,
     clippy::len_zero,
     clippy::collapsible_match,
+    clippy::question_mark,
     // We are not implementing queries here so it's fine
     rustc::potential_query_instability,
 )]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,8 +138,7 @@ pub use crate::borrow_tracker::{
 };
 pub use crate::clock::{Deadline, Instant, MonotonicClock, TimeoutClock, TimeoutStyle};
 pub use crate::concurrency::blocking_io::{
-    BlockingIoInterest, BlockingIoManager, BlockingIoSourceReadiness, EvalContextExt as _,
-    SourceFileDescription,
+    BlockingIoInterest, BlockingIoManager, EvalContextExt as _, SourceFileDescription,
 };
 pub use crate::concurrency::cpu_affinity::MAX_CPUS;
 pub use crate::concurrency::data_race::{
@@ -174,6 +173,10 @@ pub use crate::shims::foreign_items::{DynSym, EvalContextExt as _};
 pub use crate::shims::io_error::{EvalContextExt as _, IoError, LibcError};
 pub use crate::shims::os_str::EvalContextExt as _;
 pub use crate::shims::panic::EvalContextExt as _;
+pub use crate::shims::readiness::{
+    EvalContextExt as _, Readiness, ReadinessInterest, ReadinessInterestKey,
+    ReadinessInterestTable, ReadinessWatcher,
+};
 pub use crate::shims::sig::EvalContextExt as _;
 pub use crate::shims::time::EvalContextExt as _;
 pub use crate::shims::tls::TlsData;

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -532,8 +532,8 @@ pub struct MiriMachine<'tcx> {
     /// The table of directory descriptors.
     pub(crate) dirs: shims::DirTable,
 
-    /// The list of all EpollEventInterest.
-    pub(crate) epoll_interests: shims::EpollInterestTable,
+    /// The table of all active [`ReadinessWatcher`]s.
+    pub(crate) readiness_interests: ReadinessInterestTable,
 
     /// This machine's monotone clock.
     pub(crate) monotonic_clock: MonotonicClock,
@@ -770,7 +770,7 @@ impl<'tcx> MiriMachine<'tcx> {
             isolated_op: config.isolated_op,
             validation: config.validation,
             fds: shims::FdTable::init(config.mute_stdout_stderr),
-            epoll_interests: shims::EpollInterestTable::new(),
+            readiness_interests: ReadinessInterestTable::new(),
             dirs: Default::default(),
             layouts,
             threads,
@@ -1035,7 +1035,7 @@ impl VisitProvenance for MiriMachine<'_> {
             alloc_addresses,
             fds,
             blocking_io:_,
-            epoll_interests:_,
+            readiness_interests: _,
             tcx: _,
             isolated_op: _,
             validation: _,

--- a/src/shims/files.rs
+++ b/src/shims/files.rs
@@ -127,8 +127,8 @@ impl<T: FileDescription + 'static> FileDescriptionExt for T {
     ) -> InterpResult<'tcx, io::Result<()>> {
         match Rc::into_inner(self.0) {
             Some(fd) => {
-                // There might have been epolls interested in this FD. Remove that.
-                ecx.machine.epoll_interests.remove_epolls(fd.id);
+                // There might have been readiness watchers interested in this FD. Remove them.
+                ecx.machine.readiness_interests.remove_watchers_for_fd(fd.id);
 
                 fd.inner.destroy(fd.id, communicate_allowed, ecx)
             }
@@ -248,6 +248,11 @@ pub trait FileDescription: std::fmt::Debug + FileDescriptionExt {
         _ecx: &mut MiriInterpCx<'tcx>,
     ) -> InterpResult<'tcx, Scalar> {
         throw_unsup_format!("fcntl: {} is not supported for F_SETFL", self.name());
+    }
+
+    /// Get the current I/O readiness of the file description.
+    fn readiness<'tcx>(&self) -> InterpResult<'tcx, Readiness> {
+        throw_unsup_format!("{}: this file description doesn't support I/O readiness", self.name());
     }
 }
 

--- a/src/shims/mod.rs
+++ b/src/shims/mod.rs
@@ -19,6 +19,7 @@ pub mod global_ctor;
 pub mod io_error;
 pub mod os_str;
 pub mod panic;
+pub mod readiness;
 pub mod sig;
 pub mod time;
 pub mod tls;
@@ -27,7 +28,7 @@ pub mod unwind;
 pub use self::files::{FdId, FdTable, FileDescription, FileDescriptionRef, WeakFileDescriptionRef};
 #[cfg(all(feature = "native-lib", unix))]
 pub use self::native_lib::trace::{init_sv, register_retcode_sv};
-pub use self::unix::{DirTable, Epoll, EpollEvalContextExt, EpollInterestTable};
+pub use self::unix::DirTable;
 
 /// What needs to be done after emulating an item (a shim or an intrinsic) is done.
 pub enum EmulateItemResult {

--- a/src/shims/readiness.rs
+++ b/src/shims/readiness.rs
@@ -1,0 +1,532 @@
+use std::cell::{Ref, RefCell};
+use std::collections::{BTreeMap, VecDeque};
+use std::rc::{Rc, Weak};
+
+use crate::concurrency::VClock;
+use crate::shims::files::{DynFileDescriptionRef, FdNum};
+use crate::shims::*;
+use crate::*;
+
+/// Struct reflecting the readiness of a file description.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Readiness {
+    /// Boolean whether the file description is readable.
+    pub readable: bool,
+    /// Boolean whether the file description is writable.
+    pub writable: bool,
+    /// Boolean whether the read end of the file description
+    /// is closed.
+    pub read_closed: bool,
+    /// Boolean whether the write end of the file description
+    /// is closed.
+    pub write_closed: bool,
+    /// Boolean whether the file description has an error.
+    pub error: bool,
+}
+
+impl std::ops::BitAnd for Readiness {
+    type Output = Readiness;
+
+    fn bitand(self, rhs: Readiness) -> Self::Output {
+        Readiness {
+            readable: self.readable && rhs.readable,
+            writable: self.writable && rhs.writable,
+            read_closed: self.read_closed && rhs.read_closed,
+            write_closed: self.write_closed && rhs.write_closed,
+            error: self.error && rhs.error,
+        }
+    }
+}
+
+impl std::ops::BitOrAssign for Readiness {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.readable |= rhs.readable;
+        self.writable |= rhs.writable;
+        self.read_closed |= rhs.read_closed;
+        self.write_closed |= rhs.write_closed;
+        self.error |= rhs.error;
+    }
+}
+
+impl Readiness {
+    pub const EMPTY: Readiness = Readiness {
+        readable: false,
+        writable: false,
+        read_closed: false,
+        write_closed: false,
+        error: false,
+    };
+}
+
+pub type ReadinessInterestKey = (FdId, FdNum);
+
+/// Returns the range of all [`ReadinessInterestKey`] for the given FD ID.
+fn range_for_id(id: FdId) -> std::ops::RangeInclusive<ReadinessInterestKey> {
+    (id, 0)..=(id, FdNum::MAX)
+}
+
+#[derive(Debug, Clone)]
+pub struct ReadinessInterest {
+    /// The mask of events the interest is interested in
+    /// for this file descriptor.
+    pub relevant: Readiness,
+    /// Boolean whether this is an edge-triggered interest.
+    /// When [`false`] it's a level-triggered interest instead.
+    pub is_edge_triggered: bool,
+    /// Data attached to the interest.
+    // FIXME: In the future we might want to support more data types,
+    // then this should no longer be a `u64` but a `dyn Any` instead.
+    pub data: u64,
+    /// The currently active readiness for this file descriptor.
+    active: Readiness,
+    /// The vector clock for wakeups.
+    clock: VClock,
+}
+
+impl ReadinessInterest {
+    pub fn active(&self) -> &Readiness {
+        &self.active
+    }
+
+    pub fn clock(&self) -> &VClock {
+        &self.clock
+    }
+}
+
+/// A struct which stores [`ReadinessInterest`]s for a set of file descriptions
+/// together with which interests are currently satisfied, and a list of
+/// threads which should be unblocked once a [`ReadinessInterest`] of the
+/// watcher is fulfilled.
+#[derive(Debug)]
+pub struct ReadinessWatcher {
+    /// Globally unique identifier of the watcher.
+    id: usize,
+    /// A map of [`ReadinessInterest`]s registered for this watcher. Each entry is
+    /// identified using a [`FdId`] [`FdNum`] tuple.
+    interests: RefCell<BTreeMap<ReadinessInterestKey, ReadinessInterest>>,
+    /// The subset of interests that is currently considered "ready". Stored separately so we
+    /// can access it more efficiently.
+    /// This is implemented as a queue so that with level-triggered interests, all events eventually
+    /// get returned from [`ReadinessWatcher::get_ready_interests`]. The queue does not contain any
+    /// duplicates.
+    ready: RefCell<VecDeque<ReadinessInterestKey>>,
+    /// The queue of threads blocked on this watcher.
+    queue: RefCell<VecDeque<ThreadId>>,
+}
+
+impl ReadinessWatcher {
+    /// Get a reference to the map of registered interests of the watcher
+    /// together with their keys.
+    pub fn interests(&self) -> Ref<'_, BTreeMap<ReadinessInterestKey, ReadinessInterest>> {
+        self.interests.borrow()
+    }
+
+    /// Add an interest for the file description to which the file descriptor
+    /// `fd_num` belongs.
+    /// `relevant` contains the readiness mask of relevant events.
+    /// `is_edge_triggered` specifies whether the interest is edge-triggered
+    /// ([`true`]) or level-triggered ([`false`]).
+    /// `data` is the user-data which is associated with the interest.
+    ///
+    /// The function returns `Ok(())` when the interest was successfully
+    /// added, and `Err(())` when an interest with this key was already registered.
+    pub fn add_interest<'tcx>(
+        self: &Rc<Self>,
+        fd_num: FdNum,
+        relevant: Readiness,
+        is_edge_triggered: bool,
+        data: u64,
+        ecx: &mut MiriInterpCx<'tcx>,
+    ) -> InterpResult<'tcx, Result<(), ()>> {
+        let fd_ref = ecx.machine.fds.get(fd_num).expect("File description should exist");
+        let fd_id = fd_ref.id();
+        let key = (fd_id, fd_num);
+
+        let interest = ReadinessInterest {
+            active: Readiness::EMPTY,
+            clock: VClock::default(),
+            relevant,
+            is_edge_triggered,
+            data,
+        };
+        let mut interests = self.interests.borrow_mut();
+        if interests.range(range_for_id(fd_id)).next().is_none() {
+            // This is the first time this FD got added to the watcher.
+            // We need to remember that in the global list such that we
+            // get notified about FD events.
+            ecx.machine.readiness_interests.insert(fd_id, self);
+        }
+        if interests.try_insert(key, interest).is_err() {
+            return interp_ok(Err(()));
+        }
+
+        // After adding a new interest for a fd, we need to forcefully update
+        // the readiness of this fd.
+
+        ecx.update_readiness(
+            self,
+            fd_ref.readiness()?,
+            /* force_edge */ true,
+            move |callback| {
+                // Need to release the RefCell when this closure returns, so we have to move
+                // it into the closure, so we have to do a re-lookup here.
+                callback(key, interests.get_mut(&key).unwrap())
+            },
+        )?;
+
+        interp_ok(Ok(()))
+    }
+
+    /// Update the interest which is registered for `key`.
+    /// `cb` gets invoked with a mutable reference to the registered
+    /// [`ReadinessInterest`].
+    ///
+    /// This function returns [`None`] when no interest is registered
+    /// for the specified `key`.
+    pub fn update_interest<'tcx>(
+        self: &Rc<Self>,
+        key: ReadinessInterestKey,
+        ecx: &mut MiriInterpCx<'tcx>,
+        cb: impl FnOnce(&mut ReadinessInterest),
+    ) -> InterpResult<'tcx, Option<()>> {
+        let mut interests = self.interests.borrow_mut();
+        let Some(interest) = interests.get_mut(&key) else { return interp_ok(None) };
+        cb(interest);
+
+        // After updating an interest for a fd, we need to forcefully update
+        // the readiness of this fd.
+
+        let fd_ref = ecx.machine.fds.get(key.1).expect("File description should exist");
+        ecx.update_readiness(
+            self,
+            fd_ref.readiness()?,
+            /* force_edge */ true,
+            move |callback| {
+                // Need to release the RefCell when this closure returns, so we have to move
+                // it into the closure, so we have to do a re-lookup here.
+                callback(key, interests.get_mut(&key).unwrap())
+            },
+        )?;
+
+        interp_ok(Some(()))
+    }
+
+    /// Remove the interest registered for `key`.
+    ///
+    /// This function returns [`None`] when no interest is registered
+    /// for the specified `key`.
+    pub fn remove_interest<'tcx>(
+        self: &Rc<ReadinessWatcher>,
+        key: ReadinessInterestKey,
+        ecx: &mut MiriInterpCx<'tcx>,
+    ) -> Option<()> {
+        self.interests.borrow_mut().remove(&key)?;
+
+        // Remove the ready event for this key, should one exist.
+        let mut ready = self.ready.borrow_mut();
+        if let Some(idx) = ready.iter().position(|k| k == &key) {
+            ready.remove(idx);
+        }
+
+        let is_last = self.interests.borrow().range(range_for_id(key.0)).next().is_none();
+        if is_last {
+            // If this was the last interest in this FD, we remove the watcher from
+            // the global list of who is interested in this FD.
+            ecx.machine.readiness_interests.remove(key.0, self);
+        }
+
+        Some(())
+    }
+
+    /// Add the thread with id `thread_id` to the queue of
+    /// blocked threads which will be unblocked when the
+    /// watcher becomes ready.
+    pub fn add_blocked_thread(&self, thread_id: ThreadId) {
+        self.queue.borrow_mut().push_back(thread_id);
+    }
+
+    /// Remove all threads with id `thread_id` from the queue
+    /// of blocked threads which will be unblocked when the
+    /// watcher becomes ready.
+    pub fn remove_blocked_thread(&self, thread_id: ThreadId) {
+        self.queue.borrow_mut().retain(|id| id != &thread_id);
+    }
+
+    /// Get the amount of interests which are registered to this
+    /// watcher and which are currently ready.
+    pub fn ready_count(&self) -> usize {
+        self.ready.borrow().len()
+    }
+
+    /// Get at most the first `count` ready interests from the ready queue.
+    ///
+    /// If the interest is a level-triggered interest, it's automatically
+    /// added to the end of the queue again such that it will only be reported
+    /// after all other ready interest have been returned.
+    ///
+    /// This method returns at most every event from the ready queue once.
+    /// This ensures that every returned interest is unique, even when there
+    /// are level-triggered interests.
+    pub fn get_ready_interests<'tcx>(
+        &self,
+        count: usize,
+        ecx: &mut MiriInterpCx<'tcx>,
+    ) -> InterpResult<'tcx, Vec<ReadinessInterest>> {
+        let interests = self.interests.borrow();
+        let mut ready = self.ready.borrow_mut();
+        let count = count.min(ready.len());
+        let mut ready_interests = Vec::with_capacity(count);
+
+        // Sanity-check to ensure that all event info is up-to-date.
+        if cfg!(debug_assertions) {
+            for (key, interest) in interests.iter() {
+                // Ensure this matches the latest readiness of this FD.
+                // We have to do an FD lookup by ID for this. The FdNum might be already closed.
+                let fd = ecx.machine.fds.fds.values().find(|fd| fd.id() == key.0).unwrap();
+                let current_active = fd.readiness()?;
+                assert_eq!(interest.active(), &(current_active & interest.relevant.clone()));
+            }
+        }
+
+        // We iterate over the first `count` entries from the `ready` queue
+        // and push the associated interests into the `ready_interests` list.
+        // If an interest is level-triggered, it's also added to the back of
+        // the queue again.
+        while ready_interests.len() < count
+            && let Some(key) = ready.pop_front()
+        {
+            let interest = interests.get(&key).expect("non-existing interest in ready set");
+
+            if !interest.is_edge_triggered {
+                // This is a level-triggered interest, so we need to re-add the event
+                // at the end of the ready queue like Linux does with epoll:
+                // <https://github.com/torvalds/linux/blob/HEAD/fs/eventpoll.c#L1835-L1847>
+                ready.push_back(key);
+            }
+
+            ready_interests.push(interest.clone());
+        }
+
+        interp_ok(ready_interests)
+    }
+
+    /// Destroy the watcher instance.
+    ///
+    /// This also deregisters all interests of the watcher
+    /// from the global readiness interest table.
+    pub fn destroy<'tcx>(self, ecx: &mut MiriInterpCx<'tcx>) {
+        // If we were interested in some FDs, we can remove that now.
+        let mut ids = self.interests.borrow().keys().map(|(id, _num)| *id).collect::<Vec<_>>();
+        // Because the ids come out of the map sorted,
+        // deduping only keeps all unique entries.
+        ids.dedup();
+        for id in ids {
+            ecx.machine.readiness_interests.remove(id, &self);
+        }
+    }
+}
+
+impl PartialEq for ReadinessWatcher {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl Eq for ReadinessWatcher {}
+
+impl VisitProvenance for ReadinessWatcher {
+    fn visit_provenance(&self, _visit: &mut VisitWith<'_>) {}
+}
+
+/// The table with all [`ReadinessWatcher`]s.
+/// This tracks, for each file description, which watchers have an interest in events
+/// for this file description.
+pub struct ReadinessInterestTable {
+    /// The id of the next [`ReadinessWatcher`] created through
+    /// [`ReadinessInterestTable::new_watcher`].
+    next_watcher_id: usize,
+    /// Maps each file description (identified by its [`FdId`]) to the list of watchers that are
+    /// interested in that FD. We also store the [`ReadinessWatcher`]s ID
+    /// separately so we can access it without calling `upgrade`. The list
+    /// is sorted by that id.
+    interests: BTreeMap<FdId, Vec<(usize, Weak<ReadinessWatcher>)>>,
+}
+
+impl ReadinessInterestTable {
+    pub(crate) fn new() -> Self {
+        ReadinessInterestTable { interests: BTreeMap::new(), next_watcher_id: 0 }
+    }
+
+    /// Create a new [`ReadinessWatcher`] with a globally unique id.
+    /// Every watcher gets a sequentially increasing id such that no two
+    /// watchers ever get the same id.
+    pub fn new_watcher(&mut self) -> ReadinessWatcher {
+        let id = self.next_watcher_id;
+        self.next_watcher_id = id.strict_add(1);
+        ReadinessWatcher {
+            id,
+            interests: RefCell::new(BTreeMap::new()),
+            ready: RefCell::new(VecDeque::new()),
+            queue: RefCell::new(VecDeque::new()),
+        }
+    }
+
+    /// Add an interest for `watcher` for the file description with id `fd_id`.
+    fn insert(&mut self, fd_id: FdId, watcher: &Rc<ReadinessWatcher>) {
+        let watchers = self.interests.entry(fd_id).or_default();
+        let idx = watchers
+            .binary_search_by_key(&watcher.id, |&(id, _)| id)
+            .expect_err("watcher already has a registered interest in the provided fd");
+        watchers.insert(idx, (watcher.id, Rc::downgrade(watcher)));
+    }
+
+    /// Remove the interest of `watcher` for the file description with id `fd_id`.
+    fn remove(&mut self, fd_id: FdId, watcher: &ReadinessWatcher) {
+        let watchers = self.interests.entry(fd_id).or_default();
+        let idx = watchers
+            .binary_search_by_key(&watcher.id, |&(id, _)| id)
+            .expect("watcher has no registered interest in the provided fd");
+        watchers.remove(idx);
+    }
+
+    /// Get all watchers which have a registered interest in the file description
+    /// with id `fd_id`.
+    fn get_watchers_for_fd(&mut self, fd_id: &FdId) -> Option<Vec<Rc<ReadinessWatcher>>> {
+        let watchers = self.interests.get_mut(fd_id)?;
+        Some(
+            watchers
+                .iter()
+                .map(|(_id, watcher)| {
+                    watcher.upgrade().expect(
+                        "someone forgot to remove the garbage from `machine.readiness_interests`",
+                    )
+                })
+                .collect(),
+        )
+    }
+
+    /// Remove all watchers for the file description with id `fd_id`.
+    pub fn remove_watchers_for_fd(&mut self, fd_id: FdId) {
+        let Some(watchers) = self.interests.remove(&fd_id) else {
+            return;
+        };
+
+        for watcher in watchers.iter().filter_map(|(_id, watcher)| Weak::upgrade(watcher)) {
+            // This is a still-live watcher with interest in this FD. Remove all
+            // relevant interests (including from the ready set).
+            watcher
+                .interests
+                .borrow_mut()
+                .extract_if(range_for_id(fd_id), |_, _| true)
+                // Consume the iterator.
+                .for_each(drop);
+            // Remove the ready interests for this file description.
+            watcher.ready.borrow_mut().retain(|(id, _)| id != &fd_id);
+        }
+    }
+}
+
+impl<'tcx> EvalContextExt<'tcx> for MiriInterpCx<'tcx> {}
+pub trait EvalContextExt<'tcx>: MiriInterpCxExt<'tcx> {
+    /// Recursively check whether the [`ReadinessWatcher`] contains
+    /// interests which are host I/O source file descriptions.
+    fn has_watcher_host_interests(&self, watcher: &ReadinessWatcher) -> bool {
+        let this = self.eval_context_ref();
+        watcher.interests().keys().any(|(fd_id, _fd_num)| {
+            // By looking up whether the file description is currently registered,
+            // we get whether it's a host I/O source file description.
+            this.machine.blocking_io.contains_source(fd_id)
+        })
+    }
+
+    /// For a specific file description, get its current readiness and send it to everyone who
+    /// registered interest in this FD. This function must be called whenever the result of
+    /// `FileDescription::readiness` might change.
+    ///
+    /// If `force_edge` is set, edge-triggered interests will be triggered even if the set of
+    /// ready events did not change. This can lead to spurious wakeups. Use with caution!
+    fn update_fd_readiness(
+        &mut self,
+        fd: DynFileDescriptionRef,
+        force_edge: bool,
+    ) -> InterpResult<'tcx> {
+        let this = self.eval_context_mut();
+        let fd_id = fd.id();
+
+        let Some(watchers) = this.machine.readiness_interests.get_watchers_for_fd(&fd_id) else {
+            return interp_ok(());
+        };
+        let active_readiness = fd.readiness()?;
+        for watcher in watchers {
+            this.update_readiness(&watcher, active_readiness.clone(), force_edge, |callback| {
+                for (&key, interest) in
+                    watcher.interests.borrow_mut().range_mut(range_for_id(fd_id))
+                {
+                    callback(key, interest)?;
+                }
+                interp_ok(())
+            })?;
+        }
+
+        interp_ok(())
+    }
+}
+
+impl<'tcx> EvalContextPrivExt<'tcx> for MiriInterpCx<'tcx> {}
+pub trait EvalContextPrivExt<'tcx>: MiriInterpCxExt<'tcx> {
+    /// Call this when the interests denoted by `for_each_interest` have their active readiness changed
+    /// to `active`. The list is provided indirectly via the `for_each_interest` closure, which
+    /// will call its argument closure for each relevant interest.
+    ///
+    /// Any [`RefCell`]s should be released by the time `for_each_interest` returns since we will then
+    /// be waking up threads which might require access to those [`RefCell`]s.
+    fn update_readiness(
+        &mut self,
+        watcher: &Rc<ReadinessWatcher>,
+        active: Readiness,
+        force_edge: bool,
+        for_each_interest: impl FnOnce(
+            &mut dyn FnMut(ReadinessInterestKey, &mut ReadinessInterest) -> InterpResult<'tcx>,
+        ) -> InterpResult<'tcx>,
+    ) -> InterpResult<'tcx> {
+        let this = self.eval_context_mut();
+        let mut ready = watcher.ready.borrow_mut();
+        for_each_interest(&mut |key, interest| {
+            let new_readiness = interest.relevant.clone() & active.clone();
+            let prev_readiness = std::mem::replace(&mut interest.active, new_readiness.clone());
+            if new_readiness == Readiness::EMPTY {
+                // Un-trigger this, there's nothing left to report here.
+                if let Some(idx) = ready.iter().position(|k| k == &key) {
+                    ready.remove(idx);
+                }
+            } else if force_edge || new_readiness != prev_readiness & new_readiness.clone() {
+                // Either we force an "edge" to be detected or there's a bit set in `new_readiness`
+                // that was not set in `prev_readiness`. In both cases, this is ready now.
+
+                // We need to ensure that this event is not already part of the `ready` queue
+                // before enqueueing, as Linux does it with epoll:
+                // <https://github.com/torvalds/linux/blob/HEAD/fs/eventpoll.c#L1292-L1296>
+                if !ready.contains(&key) {
+                    ready.push_back(key);
+                }
+
+                // No matter whether this is newly ready or just re-triggered,
+                // the waiter fetching this event should sync with the current thread.
+                this.release_clock(|clock| {
+                    interest.clock.join(clock);
+                })?;
+            }
+            interp_ok(())
+        })?;
+
+        // While there are events ready to be delivered, wake up a thread to receive them.
+        while !ready.is_empty()
+            && let Some(thread_id) = watcher.queue.borrow_mut().pop_front()
+        {
+            drop(ready);
+            this.unblock_thread(thread_id, BlockReason::Readiness { watcher: watcher.clone() })?;
+            ready = watcher.ready.borrow_mut();
+        }
+        interp_ok(())
+    }
+}

--- a/src/shims/readiness.rs
+++ b/src/shims/readiness.rs
@@ -220,18 +220,21 @@ impl ReadinessWatcher {
         key: ReadinessInterestKey,
         ecx: &mut MiriInterpCx<'tcx>,
     ) -> Option<()> {
-        self.interests.borrow_mut().remove(&key)?;
+        let mut interests = self.interests.borrow_mut();
 
-        // Remove the ready event for this key, should one exist.
-        let mut ready = self.ready.borrow_mut();
-        if let Some(idx) = ready.iter().position(|k| k == &key) {
-            ready.remove(idx);
+        if interests.remove(&key).is_none() {
+            // We did not have interest in this.
+            return None;
         }
 
-        let is_last = self.interests.borrow().range(range_for_id(key.0)).next().is_none();
-        if is_last {
-            // If this was the last interest in this FD, we remove the watcher from
-            // the global list of who is interested in this FD.
+        // Remove the ready event for this key, should one exist.
+        let mut ready_events = self.ready.borrow_mut();
+        if let Some(idx) = ready_events.iter().position(|k| k == &key) {
+            ready_events.remove(idx);
+        }
+        // If this was the last interest in this FD, remove us from the global list
+        // of who is interested in this FD.
+        if interests.range(range_for_id(key.0)).next().is_none() {
             ecx.machine.readiness_interests.remove(key.0, self);
         }
 
@@ -274,8 +277,6 @@ impl ReadinessWatcher {
     ) -> InterpResult<'tcx, Vec<ReadinessInterest>> {
         let interests = self.interests.borrow();
         let mut ready = self.ready.borrow_mut();
-        let count = count.min(ready.len());
-        let mut ready_interests = Vec::with_capacity(count);
 
         // Sanity-check to ensure that all event info is up-to-date.
         if cfg!(debug_assertions) {
@@ -288,13 +289,14 @@ impl ReadinessWatcher {
             }
         }
 
-        // We iterate over the first `count` entries from the `ready` queue
-        // and push the associated interests into the `ready_interests` list.
-        // If an interest is level-triggered, it's also added to the back of
-        // the queue again.
-        while ready_interests.len() < count
-            && let Some(key) = ready.pop_front()
-        {
+        // Compute how many events we can actually return.
+        let count = count.min(ready.len());
+        let mut ready_interests = Vec::with_capacity(count);
+
+        // We have to bound this iterator by `count`. Iterating until `ready` is empty would not
+        // work since we are re-adding level-triggered events to `ready` during the loop.
+        while ready_interests.len() < count {
+            let key = ready.pop_front().unwrap();
             let interest = interests.get(&key).expect("non-existing interest in ready set");
 
             if !interest.is_edge_triggered {

--- a/src/shims/unix/fd.rs
+++ b/src/shims/unix/fd.rs
@@ -10,7 +10,6 @@ use rustc_target::spec::Os;
 
 use crate::shims::files::{DynFileDescriptionRef, FileDescription};
 use crate::shims::sig::check_min_vararg_count;
-use crate::shims::unix::linux_like::epoll::EpollReadiness;
 use crate::shims::unix::*;
 use crate::*;
 
@@ -74,11 +73,6 @@ pub trait UnixFileDescription: FileDescription {
         _ecx: &mut MiriInterpCx<'tcx>,
     ) -> InterpResult<'tcx, i32> {
         throw_unsup_format!("cannot use ioctl on {}", self.name());
-    }
-
-    /// Return which epoll events are currently active.
-    fn epoll_active_events<'tcx>(&self) -> InterpResult<'tcx, EpollReadiness> {
-        throw_unsup_format!("{}: epoll does not support this file description", self.name());
     }
 }
 

--- a/src/shims/unix/linux/foreign_items.rs
+++ b/src/shims/unix/linux/foreign_items.rs
@@ -8,6 +8,7 @@ use self::shims::unix::linux_like::eventfd::EvalContextExt as _;
 use self::shims::unix::linux_like::syscall::syscall;
 use crate::machine::{SIGRTMAX, SIGRTMIN};
 use crate::shims::unix::foreign_items::EvalContextExt as _;
+use crate::shims::unix::linux_like::epoll::EvalContextExt as _;
 use crate::shims::unix::linux_like::thread::prctl;
 use crate::shims::unix::*;
 use crate::*;

--- a/src/shims/unix/linux_like/epoll.rs
+++ b/src/shims/unix/linux_like/epoll.rs
@@ -1,133 +1,24 @@
-use std::cell::RefCell;
-use std::collections::{BTreeMap, VecDeque};
 use std::io;
+use std::rc::Rc;
 use std::time::Duration;
 
 use rustc_abi::FieldIdx;
 
-use crate::concurrency::VClock;
-use crate::shims::files::{
-    DynFileDescriptionRef, FdId, FdNum, FileDescription, FileDescriptionRef, WeakFileDescriptionRef,
-};
+use crate::shims::files::{FdId, FileDescription, FileDescriptionRef};
 use crate::shims::unix::UnixFileDescription;
 use crate::*;
 
-type EpollEventKey = (FdId, FdNum);
-
 /// An `Epoll` file descriptor connects file handles and epoll events
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Epoll {
-    /// A map of EpollEventInterests registered under this epoll instance. Each entry is
-    /// differentiated using FdId and file descriptor value.
-    interest_list: RefCell<BTreeMap<EpollEventKey, EpollEventInterest>>,
-    /// The subset of interests that is currently considered "ready". Stored separately so we
-    /// can access it more efficiently.
-    /// This is implemented as a queue so that for level-triggered epoll, all events eventually
-    /// get returned from `epoll_wait`. The queue does not contain any duplicates.
-    ready_events: RefCell<VecDeque<EpollEventKey>>,
-    /// The queue of threads blocked on this epoll instance.
-    queue: RefCell<VecDeque<ThreadId>>,
+    /// Watcher used for registering interests in the global readiness
+    /// interest table.
+    watcher: Rc<ReadinessWatcher>,
 }
 
 impl VisitProvenance for Epoll {
     fn visit_provenance(&self, _visit: &mut VisitWith<'_>) {
         // No provenance anywhere in this type.
-    }
-}
-
-/// Returns the range of all EpollEventKey for the given FD ID.
-fn range_for_id(id: FdId) -> std::ops::RangeInclusive<EpollEventKey> {
-    (id, 0)..=(id, i32::MAX)
-}
-
-/// Tracks the events that this epoll is interested in for a given file descriptor.
-#[derive(Debug)]
-pub struct EpollEventInterest {
-    /// The events bitmask the epoll is interested in.
-    relevant_events: u32,
-    /// The currently active events for this file descriptor.
-    active_events: u32,
-    /// Boolean whether this is an edge-triggered interest.
-    /// When [`false`] it's a level-triggered interest instead.
-    is_edge_triggered: bool,
-    /// The vector clock for wakeups.
-    clock: VClock,
-    /// User-defined data associated with this interest.
-    /// libc's data field in epoll_event can store integer or pointer,
-    /// but only u64 is supported for now.
-    /// <https://man7.org/linux/man-pages/man3/epoll_event.3type.html>
-    data: u64,
-}
-
-/// Struct reflecting the readiness of a file description.
-#[derive(Debug)]
-pub struct EpollReadiness {
-    /// The associated file is available for read(2) operations, in the sense that a read will not block.
-    /// (I.e., returning EOF is considered "ready".)
-    pub epollin: bool,
-    /// The associated file is available for write(2) operations, in the sense that a write will not block.
-    pub epollout: bool,
-    /// Stream socket peer closed connection, or shut down writing
-    /// half of connection.
-    pub epollrdhup: bool,
-    /// For stream socket, this event merely indicates that the peer
-    /// closed its end of the channel.
-    /// Unlike epollrdhup, this should only be set when the stream is fully closed.
-    /// epollrdhup also gets set when only the write half is closed, which is possible
-    /// via `shutdown(_, SHUT_WR)`.
-    pub epollhup: bool,
-    /// Error condition happened on the associated file descriptor.
-    pub epollerr: bool,
-}
-
-impl EpollReadiness {
-    pub fn empty() -> Self {
-        EpollReadiness {
-            epollin: false,
-            epollout: false,
-            epollrdhup: false,
-            epollhup: false,
-            epollerr: false,
-        }
-    }
-
-    pub fn get_event_bitmask<'tcx>(&self, ecx: &MiriInterpCx<'tcx>) -> u32 {
-        let epollin = ecx.eval_libc_u32("EPOLLIN");
-        let epollout = ecx.eval_libc_u32("EPOLLOUT");
-        let epollrdhup = ecx.eval_libc_u32("EPOLLRDHUP");
-        let epollhup = ecx.eval_libc_u32("EPOLLHUP");
-        let epollerr = ecx.eval_libc_u32("EPOLLERR");
-
-        let mut bitmask = 0;
-        if self.epollin {
-            bitmask |= epollin;
-        }
-        if self.epollout {
-            bitmask |= epollout;
-        }
-        if self.epollrdhup {
-            bitmask |= epollrdhup;
-        }
-        if self.epollhup {
-            bitmask |= epollhup;
-        }
-        if self.epollerr {
-            bitmask |= epollerr;
-        }
-        bitmask
-    }
-}
-
-// Best-effort mapping from cross platform readiness to epoll readiness.
-impl From<&BlockingIoSourceReadiness> for EpollReadiness {
-    fn from(readiness: &BlockingIoSourceReadiness) -> Self {
-        Self {
-            epollin: readiness.readable,
-            epollout: readiness.writable,
-            epollrdhup: readiness.read_closed,
-            epollhup: readiness.write_closed,
-            epollerr: readiness.error,
-        }
     }
 }
 
@@ -144,17 +35,14 @@ impl FileDescription for Epoll {
     }
 
     fn destroy<'tcx>(
-        mut self,
-        self_id: FdId,
+        self,
+        _self_id: FdId,
         _communicate_allowed: bool,
         ecx: &mut MiriInterpCx<'tcx>,
     ) -> InterpResult<'tcx, io::Result<()>> {
-        // If we were interested in some FDs, we can remove that now.
-        let mut ids = self.interest_list.get_mut().keys().map(|(id, _num)| *id).collect::<Vec<_>>();
-        ids.dedup(); // they come out of the map sorted
-        for id in ids {
-            ecx.machine.epoll_interests.remove(id, self_id);
-        }
+        let watcher = Rc::into_inner(self.watcher)
+            .expect("Epoll instance should contain the only strong reference to the watcher");
+        watcher.destroy(ecx);
         interp_ok(Ok(()))
     }
 
@@ -164,55 +52,6 @@ impl FileDescription for Epoll {
 }
 
 impl UnixFileDescription for Epoll {}
-
-/// The table of all EpollEventInterest.
-/// This tracks, for each file description, which epoll instances have an interest in events
-/// for this file description. The `FdId` is the ID of the epoll instance, so that we can recognize
-/// it later when it is slated for removal. The vector is sorted by that ID.
-pub struct EpollInterestTable(BTreeMap<FdId, Vec<(FdId, WeakFileDescriptionRef<Epoll>)>>);
-
-impl EpollInterestTable {
-    pub(crate) fn new() -> Self {
-        EpollInterestTable(BTreeMap::new())
-    }
-
-    fn insert(&mut self, id: FdId, epoll: &FileDescriptionRef<Epoll>) {
-        let epolls = self.0.entry(id).or_default();
-        let idx = epolls
-            .binary_search_by_key(&epoll.id(), |&(id, _)| id)
-            .expect_err("trying to add an epoll that's already in the list");
-        epolls.insert(idx, (epoll.id(), FileDescriptionRef::downgrade(epoll)));
-    }
-
-    fn remove(&mut self, id: FdId, epoll_id: FdId) {
-        let epolls = self.0.entry(id).or_default();
-        let idx = epolls
-            .binary_search_by_key(&epoll_id, |&(id, _)| id)
-            .expect("trying to remove an epoll that's not in the list");
-        epolls.remove(idx);
-    }
-
-    fn get_epolls(&self, id: FdId) -> Option<impl Iterator<Item = &WeakFileDescriptionRef<Epoll>>> {
-        self.0.get(&id).map(|epolls| epolls.iter().map(|(_id, epoll)| epoll))
-    }
-
-    pub fn remove_epolls(&mut self, id: FdId) {
-        if let Some(epolls) = self.0.remove(&id) {
-            for epoll in epolls.iter().filter_map(|(_id, epoll)| epoll.upgrade()) {
-                // This is a still-live epoll with interest in this FD. Remove all
-                // relevant interests (including from the ready set).
-                epoll
-                    .interest_list
-                    .borrow_mut()
-                    .extract_if(range_for_id(id), |_, _| true)
-                    // Consume the iterator.
-                    .for_each(drop);
-                // Remove the ready events for this file description.
-                epoll.ready_events.borrow_mut().retain(|(fd_id, _)| fd_id != &id);
-            }
-        }
-    }
-}
 
 impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
 pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
@@ -236,7 +75,10 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             );
         }
 
-        let fd = this.machine.fds.insert_new(Epoll::default());
+        let fd = this
+            .machine
+            .fds
+            .insert_new(Epoll { watcher: Rc::new(this.machine.readiness_interests.new_watcher()) });
         interp_ok(Scalar::from_i32(fd))
     }
 
@@ -290,33 +132,32 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             .downcast::<Epoll>()
             .ok_or_else(|| err_unsup_format!("non-epoll FD passed to `epoll_ctl`"))?;
 
-        let mut interest_list = epfd.interest_list.borrow_mut();
-
         let Some(fd_ref) = this.machine.fds.get(fd) else {
             return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
         };
         let id = fd_ref.id();
+        let interest_key = (id, fd);
 
         if op == epoll_ctl_add || op == epoll_ctl_mod {
             // Read event bitmask and data from epoll_event passed by caller.
-            let mut events =
+            let mut relevant_bitflag =
                 this.read_scalar(&this.project_field(&event, FieldIdx::ZERO)?)?.to_u32()?;
             let data = this.read_scalar(&this.project_field(&event, FieldIdx::ONE)?)?.to_u64()?;
 
-            let is_edge_triggered = if events & epollet == epollet {
-                events &= !epollet;
+            let is_edge_triggered = if relevant_bitflag & epollet == epollet {
+                relevant_bitflag &= !epollet;
                 true
             } else {
                 false
             };
 
             // Unset the flag we support to discover if any unsupported flags are used.
-            let mut flags = events;
+            let mut flags = relevant_bitflag;
             // epoll_wait(2) will always wait for epollhup and epollerr; it is not
             // necessary to set it in events when calling epoll_ctl().
             // So we will always set these two event types.
-            events |= epollhup;
-            events |= epollerr;
+            relevant_bitflag |= epollhup;
+            relevant_bitflag |= epollerr;
 
             if flags & epollin == epollin {
                 flags &= !epollin;
@@ -340,75 +181,38 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 );
             }
 
-            // Add new interest to list. Experiments show that we need to reset all state
-            // on `EPOLL_CTL_MOD`, including the edge tracking.
-            let epoll_key = (id, fd);
+            let relevant = this.epoll_bitflag_to_readiness(relevant_bitflag);
+
             if op == epoll_ctl_add {
-                if interest_list.range(range_for_id(id)).next().is_none() {
-                    // This is the first time this FD got added to this epoll.
-                    // Remember that in the global list so we get notified about FD events.
-                    this.machine.epoll_interests.insert(id, &epfd);
-                }
-                let new_interest = EpollEventInterest {
-                    relevant_events: events,
-                    is_edge_triggered,
-                    data,
-                    active_events: 0,
-                    clock: VClock::default(),
-                };
-                if interest_list.try_insert(epoll_key, new_interest).is_err() {
-                    // We already had interest in this.
+                // Add a new interest to the watcher.
+                let result =
+                    epfd.watcher.add_interest(fd, relevant, is_edge_triggered, data, this)?;
+                if result.is_err() {
+                    // We already had an interest in this.
                     return this.set_errno_and_return_neg1_i32(LibcError("EEXIST"));
                 }
             } else {
                 // Modify the existing interest.
-                let Some(interest) = interest_list.get_mut(&epoll_key) else {
+                let result = epfd.watcher.update_interest(interest_key, this, |interest| {
+                    interest.is_edge_triggered = is_edge_triggered;
+                    interest.relevant = relevant;
+                    interest.data = data;
+                })?;
+                if result.is_none() {
+                    // There is no interest registered for the specified key.
                     return this.set_errno_and_return_neg1_i32(LibcError("ENOENT"));
-                };
-                interest.relevant_events = events;
-                interest.is_edge_triggered = is_edge_triggered;
-                interest.data = data;
+                }
             }
-
-            let active_events = fd_ref.as_unix(this).epoll_active_events()?.get_event_bitmask(this);
-
-            // Deliver events for the new interest.
-            update_readiness(
-                this,
-                &epfd,
-                active_events,
-                /* force_edge */ true,
-                move |callback| {
-                    // Need to release the RefCell when this closure returns, so we have to move
-                    // it into the closure, so we have to do a re-lookup here.
-                    callback(epoll_key, interest_list.get_mut(&epoll_key).unwrap())
-                },
-            )?;
-
-            interp_ok(Scalar::from_i32(0))
         } else if op == epoll_ctl_del {
-            let epoll_key = (id, fd);
-
-            // Remove epoll_event_interest from interest_list and ready_set.
-            if interest_list.remove(&epoll_key).is_none() {
+            if epfd.watcher.remove_interest(interest_key, this).is_none() {
                 // We did not have interest in this.
                 return this.set_errno_and_return_neg1_i32(LibcError("ENOENT"));
             };
-            // Remove the ready event for this key, should one exist.
-            let mut ready_events = epfd.ready_events.borrow_mut();
-            if let Some(idx) = ready_events.iter().position(|k| k == &epoll_key) {
-                ready_events.remove(idx);
-            }
-            // If this was the last interest in this FD, remove us from the global list
-            // of who is interested in this FD.
-            if interest_list.range(range_for_id(id)).next().is_none() {
-                this.machine.epoll_interests.remove(id, epfd.id());
-            }
-
-            interp_ok(Scalar::from_i32(0))
         } else {
             throw_unsup_format!("unsupported epoll_ctl operation: {op}");
         }
+
+        interp_ok(Scalar::from_i32(0))
     }
 
     /// The `epoll_wait()` system call waits for events on the `Epoll`
@@ -476,9 +280,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return this.set_errno_and_return_neg1(LibcError("EBADF"), dest);
         };
 
-        if timeout == 0 || !epfd.ready_events.borrow().is_empty() {
+        if timeout == 0 || epfd.watcher.ready_count() != 0 {
             // If the timeout is 0 or there is a ready event, we can return immediately.
-            return_ready_list(&epfd, dest, &event, this)?;
+            this.return_ready_list(&epfd, dest, &event)?;
         } else {
             // Blocking, with a relative timeout.
             let deadline = match timeout {
@@ -493,15 +297,16 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     );
                 }
             };
+
             // Record this thread as blocked.
-            epfd.queue.borrow_mut().push_back(this.active_thread());
+            epfd.watcher.add_blocked_thread(this.active_thread());
             // And block it.
             let dest = dest.clone();
-            // We keep a strong ref to the underlying `Epoll` to make sure it sticks around.
+            // We keep a strong ref to the underlying `ReadinessWatcher` to make sure it sticks around.
             // This means there'll be a leak if we never wake up, but that anyway would imply
             // a thread is permanently blocked so this is fine.
             this.block_thread(
-                BlockReason::Epoll { epfd: epfd.clone() },
+                BlockReason::Readiness { watcher: epfd.watcher.clone() },
                 deadline,
                 callback!(
                     @capture<'tcx> {
@@ -512,15 +317,13 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     |this, unblock: UnblockKind| {
                         match unblock {
                             UnblockKind::Ready => {
-                                let events = return_ready_list(&epfd, &dest, &event, this)?;
+                                let events = this.return_ready_list(&epfd, &dest, &event)?;
                                 assert!(events > 0, "we got woken up with no events to deliver");
                                 interp_ok(())
                             },
                             UnblockKind::TimedOut => {
-                                // Remove the current active thread_id from the blocked thread_id list.
-                                epfd
-                                    .queue.borrow_mut()
-                                    .retain(|&id| id != this.active_thread());
+                                // Remove the current active thread id from the blocked threads list.
+                                epfd.watcher.remove_blocked_thread(this.active_thread());
                                 this.write_int(0, &dest)?;
                                 interp_ok(())
                             },
@@ -531,161 +334,91 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         }
         interp_ok(())
     }
+}
 
-    /// For a specific file description, get its currently active events and send it to everyone who
-    /// registered interest in this FD. This function must be called whenever the result of
-    /// `epoll_active_events` might change.
-    ///
-    /// If `force_edge` is set, edge-triggered interests will be triggered even if the set of
-    /// ready events did not change. This can lead to spurious wakeups. Use with caution!
-    fn update_epoll_active_events(
-        &mut self,
-        fd_ref: DynFileDescriptionRef,
-        force_edge: bool,
-    ) -> InterpResult<'tcx> {
-        let this = self.eval_context_mut();
-        let id = fd_ref.id();
-        // Figure out who is interested in this. We need to clone this list since we can't prove
-        // that `send_active_events_to_interest` won't mutate it.
-        let Some(epolls) = this.machine.epoll_interests.get_epolls(id) else {
-            return interp_ok(());
-        };
-        let epolls = epolls
-            .map(|weak| {
-                weak.upgrade()
-                    .expect("someone forgot to remove the garbage from `machine.epoll_interests`")
-            })
-            .collect::<Vec<_>>();
-        let active_events = fd_ref.as_unix(this).epoll_active_events()?.get_event_bitmask(this);
-        for epoll in epolls {
-            update_readiness(this, &epoll, active_events, force_edge, |callback| {
-                for (&key, interest) in epoll.interest_list.borrow_mut().range_mut(range_for_id(id))
-                {
-                    callback(key, interest)?;
-                }
-                interp_ok(())
-            })?;
-        }
-
-        interp_ok(())
-    }
-
-    /// Recursively check whether the [`Epoll`] file description contains
-    /// interests which are host I/O source file descriptions.
-    fn has_epoll_host_interests(&self, epfd: &FileDescriptionRef<Epoll>) -> bool {
+impl<'tcx> EvalContextPrivExt<'tcx> for crate::MiriInterpCx<'tcx> {}
+trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
+    /// Convert a [`Readiness`] instance into the corresponding epoll
+    /// readiness bitflag.
+    fn readiness_to_epoll_bitflag(&self, readiness: &Readiness) -> u32 {
         let this = self.eval_context_ref();
-        epfd.interest_list.borrow().iter().any(|((fd_id, _fd_num), _)| {
-            // By looking up whether the file description is currently registered,
-            // we get whether it's a host I/O source file description.
-            this.machine.blocking_io.contains_source(fd_id)
-        })
-    }
-}
 
-/// Call this when the interests denoted by `for_each_interest` have their active event set changed
-/// to `active_events`. The list is provided indirectly via the `for_each_interest` closure, which
-/// will call its argument closure for each relevant interest.
-///
-/// Any `RefCell` should be released by the time `for_each_interest` returns since we will then
-/// be waking up threads which might require access to those `RefCell`.
-fn update_readiness<'tcx>(
-    ecx: &mut MiriInterpCx<'tcx>,
-    epoll: &FileDescriptionRef<Epoll>,
-    active_events: u32,
-    force_edge: bool,
-    for_each_interest: impl FnOnce(
-        &mut dyn FnMut(EpollEventKey, &mut EpollEventInterest) -> InterpResult<'tcx>,
-    ) -> InterpResult<'tcx>,
-) -> InterpResult<'tcx> {
-    let mut ready_events = epoll.ready_events.borrow_mut();
-    for_each_interest(&mut |key, interest| {
-        // Update the ready events tracked in this interest.
-        let new_readiness = interest.relevant_events & active_events;
-        let prev_readiness = std::mem::replace(&mut interest.active_events, new_readiness);
-        if new_readiness == 0 {
-            // Un-trigger this, there's nothing left to report here.
-            if let Some(idx) = ready_events.iter().position(|k| k == &key) {
-                ready_events.remove(idx);
-            }
-        } else if force_edge || new_readiness != prev_readiness & new_readiness {
-            // Either we force an "edge" to be detected or there's a bit set in `new_readiness`
-            // that was not set in `prev_readiness`. In both cases, this is ready now.
+        let epollin = this.eval_libc_u32("EPOLLIN");
+        let epollout = this.eval_libc_u32("EPOLLOUT");
+        let epollrdhup = this.eval_libc_u32("EPOLLRDHUP");
+        let epollhup = this.eval_libc_u32("EPOLLHUP");
+        let epollerr = this.eval_libc_u32("EPOLLERR");
 
-            // We need to ensure that this event is not already part of the
-            // `ready_events` queue before enqueueing:
-            // <https://github.com/torvalds/linux/blob/HEAD/fs/eventpoll.c#L1292-L1296>
-            if !ready_events.contains(&key) {
-                ready_events.push_back(key);
-            }
-
-            // No matter whether this is newly ready or just re-triggered,
-            // the `epoll_wait` fetching this event should sync with the current thread.
-            ecx.release_clock(|clock| {
-                interest.clock.join(clock);
-            })?;
+        let mut bitflag = 0;
+        if readiness.readable {
+            bitflag |= epollin;
         }
-        interp_ok(())
-    })?;
-    // While there are events ready to be delivered, wake up a thread to receive them.
-    while !ready_events.is_empty()
-        && let Some(thread_id) = epoll.queue.borrow_mut().pop_front()
-    {
-        drop(ready_events); // release the "lock" so the unblocked thread can have it
-        ecx.unblock_thread(thread_id, BlockReason::Epoll { epfd: epoll.clone() })?;
-        ready_events = epoll.ready_events.borrow_mut();
+        if readiness.writable {
+            bitflag |= epollout;
+        }
+        if readiness.read_closed {
+            bitflag |= epollrdhup;
+        }
+        if readiness.write_closed {
+            bitflag |= epollhup;
+        }
+        if readiness.error {
+            bitflag |= epollerr;
+        }
+        bitflag
     }
 
-    interp_ok(())
-}
+    /// Convert an epoll readiness bitflag into the corresponding
+    /// [`Readiness`] instance.
+    fn epoll_bitflag_to_readiness(&self, bitflag: u32) -> Readiness {
+        let this = self.eval_context_ref();
 
-/// Stores the ready list of the `epfd` epoll instance into `events` (which must be an array),
-/// and the number of returned events into `dest`.
-fn return_ready_list<'tcx>(
-    epfd: &FileDescriptionRef<Epoll>,
-    dest: &MPlaceTy<'tcx>,
-    events: &MPlaceTy<'tcx>,
-    ecx: &mut MiriInterpCx<'tcx>,
-) -> InterpResult<'tcx, i32> {
-    let mut interest_list = epfd.interest_list.borrow_mut();
-    let mut ready_events = epfd.ready_events.borrow_mut();
-    let mut num_of_events: i32 = 0;
-    let mut array_iter = ecx.project_array_fields(events)?;
+        let epollin = this.eval_libc_u32("EPOLLIN");
+        let epollout = this.eval_libc_u32("EPOLLOUT");
+        let epollrdhup = this.eval_libc_u32("EPOLLRDHUP");
+        let epollhup = this.eval_libc_u32("EPOLLHUP");
+        let epollerr = this.eval_libc_u32("EPOLLERR");
 
-    // Sanity-check to ensure that all event info is up-to-date.
-    if cfg!(debug_assertions) {
-        for (key, interest) in interest_list.iter() {
-            // Ensure this matches the latest readiness of this FD.
-            // We have to do an FD lookup by ID for this. The FdNum might be already closed.
-            let fd = ecx.machine.fds.fds.values().find(|fd| fd.id() == key.0).unwrap();
-            let current_active = fd.as_unix(ecx).epoll_active_events()?.get_event_bitmask(ecx);
-            assert_eq!(interest.active_events, current_active & interest.relevant_events);
+        Readiness {
+            readable: bitflag & epollin == epollin,
+            writable: bitflag & epollout == epollout,
+            read_closed: bitflag & epollrdhup == epollrdhup,
+            write_closed: bitflag & epollhup == epollhup,
+            error: bitflag & epollerr == epollerr,
         }
     }
 
-    // We will fill at most the first `ready_events_len` slots of the array.
-    // Bounding the iterator this way ensures that we can re-add events
-    // to the end of the queue during the loop without having them show up in the array.
-    let ready_events_len = u64::try_from(ready_events.len()).unwrap();
-    while let Some((idx, slot)) = array_iter.next(ecx)?
-        && idx < ready_events_len
-        && let Some(key) = ready_events.pop_front()
-    {
-        let interest = interest_list.get_mut(&key).expect("non-existent event in ready set");
-        // Deliver event to caller.
-        ecx.write_int_fields_named(
-            &[("events", interest.active_events.into()), ("u64", interest.data.into())],
-            &slot,
-        )?;
-        num_of_events = num_of_events.strict_add(1);
-        // Synchronize receiving thread with the event of interest.
-        ecx.acquire_clock(&interest.clock)?;
-        if !interest.is_edge_triggered {
-            // This is a level-triggered interest, so we need to re-add the event
-            // at the end of the ready queue:
-            // <https://github.com/torvalds/linux/blob/HEAD/fs/eventpoll.c#L1835-L1847>
-            ready_events.push_back(key);
+    /// Stores the ready list of the `epfd` epoll instance into `events` (which must be an array),
+    /// and the number of returned events into `dest`.
+    fn return_ready_list(
+        &mut self,
+        epfd: &FileDescriptionRef<Epoll>,
+        dest: &MPlaceTy<'tcx>,
+        events: &MPlaceTy<'tcx>,
+    ) -> InterpResult<'tcx, i32> {
+        let this = self.eval_context_mut();
+
+        let mut num_of_events = 0i32;
+        let mut array_iter = this.project_array_fields(events)?;
+        let max_events_num: usize = events.len(this)?.try_into().unwrap();
+
+        // We get up to the first `max_events_num` ready events from the
+        // watcher and fill them into the slots of the array.
+        for interest in epfd.watcher.get_ready_interests(max_events_num, this)? {
+            let (_idx, slot) = array_iter.next(this)?.expect("Array should have slot for interest");
+            // Deliver event to caller.
+            this.write_int_fields_named(
+                &[
+                    ("events", this.readiness_to_epoll_bitflag(interest.active()).into()),
+                    ("u64", interest.data.into()),
+                ],
+                &slot,
+            )?;
+            num_of_events = num_of_events.strict_add(1);
+            // Synchronize receiving thread with the event of interest.
+            this.acquire_clock(interest.clock())?;
         }
+        this.write_int(num_of_events, dest)?;
+        interp_ok(num_of_events)
     }
-    ecx.write_int(num_of_events, dest)?;
-    interp_ok(num_of_events)
 }

--- a/src/shims/unix/linux_like/eventfd.rs
+++ b/src/shims/unix/linux_like/eventfd.rs
@@ -6,7 +6,6 @@ use std::io::ErrorKind;
 use crate::concurrency::VClock;
 use crate::shims::files::{FdId, FileDescription, FileDescriptionRef, WeakFileDescriptionRef};
 use crate::shims::unix::UnixFileDescription;
-use crate::shims::unix::linux_like::epoll::{EpollReadiness, EvalContextExt as _};
 use crate::*;
 
 /// Maximum value that the eventfd counter can hold.
@@ -109,23 +108,23 @@ impl FileDescription for EventFd {
         eventfd_write(buf_place, self, ecx, finish)
     }
 
+    fn readiness<'tcx>(&self) -> InterpResult<'tcx, Readiness> {
+        // We only check the "readable" and "writable" readiness for eventfd. If other event flags
+        // need to be supported in the future, the check should be added here.
+
+        interp_ok(Readiness {
+            readable: self.counter.get() != 0,
+            writable: self.counter.get() != MAX_COUNTER,
+            ..Readiness::EMPTY
+        })
+    }
+
     fn as_unix<'tcx>(&self, _ecx: &MiriInterpCx<'tcx>) -> &dyn UnixFileDescription {
         self
     }
 }
 
-impl UnixFileDescription for EventFd {
-    fn epoll_active_events<'tcx>(&self) -> InterpResult<'tcx, EpollReadiness> {
-        // We only check the status of EPOLLIN and EPOLLOUT flags for eventfd. If other event flags
-        // need to be supported in the future, the check should be added here.
-
-        interp_ok(EpollReadiness {
-            epollin: self.counter.get() != 0,
-            epollout: self.counter.get() != MAX_COUNTER,
-            ..EpollReadiness::empty()
-        })
-    }
-}
+impl UnixFileDescription for EventFd {}
 
 impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
 pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
@@ -228,7 +227,7 @@ fn eventfd_write<'tcx>(
             // Linux seems to cause spurious wakeups here, and Tokio seems to rely on that
             // (see <https://github.com/rust-lang/miri/pull/4676#discussion_r2510528994>
             // and also <https://www.illumos.org/issues/16700>).
-            ecx.update_epoll_active_events(eventfd, /* force_edge */ true)?;
+            ecx.update_fd_readiness(eventfd, /* force_edge */ true)?;
 
             // Return how many bytes we consumed from the user-provided buffer.
             return finish.call(ecx, Ok(buf_place.layout.size.bytes_usize()));
@@ -324,7 +323,7 @@ fn eventfd_read<'tcx>(
         // The state changed; we check and update the status of all supported event
         // types for current file description.
         // Linux seems to always emit do notifications here, even if we were already writable.
-        ecx.update_epoll_active_events(eventfd, /* force_edge */ true)?;
+        ecx.update_fd_readiness(eventfd, /* force_edge */ true)?;
 
         // Tell userspace how many bytes we put into the buffer.
         return finish.call(ecx, Ok(buf_place.layout.size.bytes_usize()));

--- a/src/shims/unix/mod.rs
+++ b/src/shims/unix/mod.rs
@@ -21,9 +21,6 @@ mod solarish;
 pub use self::env::{EvalContextExt as _, UnixEnvVars};
 pub use self::fd::{EvalContextExt as _, UnixFileDescription};
 pub use self::fs::{DirTable, EvalContextExt as _};
-pub use self::linux_like::epoll::{
-    Epoll, EpollInterestTable, EvalContextExt as EpollEvalContextExt,
-};
 pub use self::mem::EvalContextExt as _;
 pub use self::socket::EvalContextExt as _;
 pub use self::socket_address::EvalContextExt as _;

--- a/src/shims/unix/socket.rs
+++ b/src/shims/unix/socket.rs
@@ -14,7 +14,6 @@ use rustc_target::spec::Os;
 
 use crate::shims::files::{EvalContextExt as _, FdId, FileDescription, FileDescriptionRef};
 use crate::shims::unix::UnixFileDescription;
-use crate::shims::unix::linux_like::epoll::{EpollReadiness, EvalContextExt as _};
 use crate::shims::unix::socket_address::EvalContextExt as _;
 use crate::*;
 
@@ -65,7 +64,7 @@ struct Socket {
     /// Whether this fd is non-blocking or not.
     is_non_block: Cell<bool>,
     /// The current blocking I/O readiness of the file description.
-    io_readiness: RefCell<BlockingIoSourceReadiness>,
+    io_readiness: RefCell<Readiness>,
     /// [`Some`] when the socket had an async error which has not yet been fetched via `SO_ERROR`.
     error: RefCell<Option<io::Error>>,
     /// Read timeout of the socket. [`None`] means that reads can block indefinitely.
@@ -248,6 +247,10 @@ impl FileDescription for Socket {
 
         interp_ok(Scalar::from_i32(0))
     }
+
+    fn readiness<'tcx>(&self) -> InterpResult<'tcx, Readiness> {
+        interp_ok(self.io_readiness.borrow().clone())
+    }
 }
 
 impl UnixFileDescription for Socket {
@@ -286,10 +289,6 @@ impl UnixFileDescription for Socket {
         }
 
         throw_unsup_format!("ioctl: unsupported operation {op:#x} on socket");
-    }
-
-    fn epoll_active_events<'tcx>(&self) -> InterpResult<'tcx, EpollReadiness> {
-        interp_ok(EpollReadiness::from(&*self.io_readiness.borrow()))
     }
 }
 
@@ -368,7 +367,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             family,
             state: RefCell::new(SocketState::Initial),
             is_non_block: Cell::new(is_sock_nonblock),
-            io_readiness: RefCell::new(BlockingIoSourceReadiness::empty()),
+            io_readiness: RefCell::new(Readiness::EMPTY),
             error: RefCell::new(None),
             read_timeout: Cell::new(None),
             write_timeout: Cell::new(None),
@@ -1165,9 +1164,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 socket.error.replace(None);
 
                 // We know there is no longer an async error and thus we need to update the
-                // I/O and epoll readiness of the socket.
+                // I/O and fd readiness of the socket.
                 socket.io_readiness.borrow_mut().error = false;
-                this.update_epoll_active_events(socket, /* force_edge */ false)?;
+                this.update_fd_readiness(socket, /* force_edge */ false)?;
 
                 // Allocate new buffer on the stack with the `i32` layout.
                 let value_buffer = this.allocate(this.machine.layouts.i32, MemoryKind::Stack)?;
@@ -1476,15 +1475,15 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
         drop(state);
 
-        // Because we map cross platform mio readiness to epoll readiness and
+        // Because we map cross platform mio readiness to our readiness struct and
         // the different platforms don't treat `shutdown` the same way, we set
-        // the readiness after a `shutdown` manually to achieve more consistent
-        // epoll readiness. Otherwise we do not generate enough epoll events
+        // the readiness after a `shutdown` manually to achieve a more consistent
+        // readiness. Otherwise we do not generate enough readiness events
         // on partial shutdowns on Windows hosts.
         let mut readiness = socket.io_readiness.borrow_mut();
-        // Closing the read end of a socket causes an EPOLLRDHUP event.
+        // Closing the read end of a socket causes an (E)POLLRDHUP event.
         readiness.read_closed |= is_read_shutdown || is_read_write_shutdown;
-        // Only shutting down the write end doesn't cause an EPOLLHUP event
+        // Only shutting down the write end doesn't cause an (E)POLLHUP event
         // and thus we won't set the `write_closed` readiness for it here.
         readiness.write_closed |= is_read_write_shutdown;
         // The Linux kernel also sets EPOLLIN when the read end of a socket is closed:
@@ -1493,8 +1492,8 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
         drop(readiness);
 
-        // Update the epoll readiness for the socket.
-        this.update_epoll_active_events(socket, /* force_edge */ false)?;
+        // Update the readiness for the socket.
+        this.update_fd_readiness(socket, /* force_edge */ false)?;
 
         interp_ok(Scalar::from_i32(0))
     }
@@ -1603,7 +1602,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
                 // We know that the source is not readable so we need to update its readiness.
                 socket.io_readiness.borrow_mut().readable = false;
-                this.update_epoll_active_events(socket.clone(), /* force_edge */ false)?;
+                this.update_fd_readiness(socket.clone(), /* force_edge */ false)?;
 
                 return interp_ok(Err(IoError::HostError(e)));
             }
@@ -1626,7 +1625,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             family,
             state: RefCell::new(SocketState::Connected(stream)),
             is_non_block: Cell::new(is_client_sock_nonblock),
-            io_readiness: RefCell::new(BlockingIoSourceReadiness::empty()),
+            io_readiness: RefCell::new(Readiness::EMPTY),
             error: RefCell::new(None),
             read_timeout: Cell::new(None),
             write_timeout: Cell::new(None),
@@ -1716,9 +1715,9 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             Err(IoError::HostError(e))
                 if matches!(e.kind(), io::ErrorKind::NotConnected | io::ErrorKind::WouldBlock) =>
             {
-                // We know that the source is not writable so we need to update it's readiness.
+                // We know that the source is not writable so we need to update its readiness.
                 socket.io_readiness.borrow_mut().writable = false;
-                this.update_epoll_active_events(socket.clone(), /* force_edge */ false)?;
+                this.update_fd_readiness(socket.clone(), /* force_edge */ false)?;
 
                 // On Windows hosts, `send` can return WSAENOTCONN where EAGAIN or EWOULDBLOCK
                 // would be returned on UNIX-like systems. We thus remap this error to an EWOULDBLOCK.
@@ -1727,7 +1726,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             Ok(bytes_written) if bytes_written < length => {
                 // We had a short write. On Unix hosts using the `epoll` and `kqueue` backends, a
                 // short write means that the write buffer is full. We update the readiness
-                // accordingly, which means that next time we see "writable" we will report an epoll
+                // accordingly, which means that next time we see "writable" we will report an
                 // edge. Some applications (e.g. tokio) rely on this behavior; see
                 // <https://github.com/tokio-rs/tokio/blob/HEAD/tokio/src/io/poll_evented.rs#L244-L264>.
                 if cfg!(any(
@@ -1748,7 +1747,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     target_os = "watchos",
                 )) {
                     socket.io_readiness.borrow_mut().writable = false;
-                    this.update_epoll_active_events(socket.clone(), /* force_edge */ false)?;
+                    this.update_fd_readiness(socket.clone(), /* force_edge */ false)?;
                 } else {
                     // On hosts which don't use the `epoll` or `kqueue` backends, a short write
                     // doesn't imply a full write buffer. However, the target we are emulating might
@@ -1759,7 +1758,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     // This results in an unrealistic execution but we don't have another way of
                     // finding out whether the write buffer is full. The "default case" of linux
                     // host and linux target isn't affected by this.
-                    this.update_epoll_active_events(socket.clone(), /* force_edge */ true)?;
+                    this.update_fd_readiness(socket.clone(), /* force_edge */ true)?;
                 }
                 interp_ok(result)
             }
@@ -1849,9 +1848,9 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             Err(IoError::HostError(e))
                 if matches!(e.kind(), io::ErrorKind::NotConnected | io::ErrorKind::WouldBlock) =>
             {
-                // We know that the source is not readable so we need to update it's readiness.
+                // We know that the source is not readable so we need to update its readiness.
                 socket.io_readiness.borrow_mut().readable = false;
-                this.update_epoll_active_events(socket.clone(), /* force_edge */ false)?;
+                this.update_fd_readiness(socket.clone(), /* force_edge */ false)?;
 
                 // On Windows hosts, `recv` can return WSAENOTCONN where EAGAIN or EWOULDBLOCK
                 // would be returned on UNIX-like systems. We thus remap this error to an EWOULDBLOCK.
@@ -1869,7 +1868,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // already been closed as those never block a read, i.e., they are always read-ready.)
                 // On Unix hosts using the `epoll` and `kqueue` backends, a short read means that the
                 // read buffer is empty. We update the readiness accordingly, which means that next time
-                // we see "readable" we will report an epoll edge. Some applications (e.g. tokio) rely on
+                // we see "readable" we will report an edge. Some applications (e.g. tokio) rely on
                 // this behavior; see
                 // <https://github.com/tokio-rs/tokio/blob/HEAD/tokio/src/io/poll_evented.rs#L190-L210>
                 if cfg!(any(
@@ -1890,7 +1889,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     target_os = "watchos",
                 )) {
                     socket.io_readiness.borrow_mut().readable = false;
-                    this.update_epoll_active_events(socket.clone(), /* force_edge */ false)?;
+                    this.update_fd_readiness(socket.clone(), /* force_edge */ false)?;
                 } else {
                     // On hosts which don't use the `epoll` or `kqueue` backends, a short read
                     // doesn't imply an empty read buffer. However, the target we are emulating
@@ -1901,7 +1900,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     // This results in an unrealistic execution but we don't have another way of
                     // finding out whether the read buffer is empty. The "default case" of linux
                     // host and linux target isn't affected by this.
-                    this.update_epoll_active_events(socket.clone(), /* force_edge */ true)?;
+                    this.update_fd_readiness(socket.clone(), /* force_edge */ true)?;
                 }
                 interp_ok(result)
             }
@@ -2109,7 +2108,7 @@ impl SourceFileDescription for Socket {
         }
     }
 
-    fn get_readiness_mut(&self) -> RefMut<'_, BlockingIoSourceReadiness> {
+    fn get_readiness_mut(&self) -> RefMut<'_, Readiness> {
         self.io_readiness.borrow_mut()
     }
 }

--- a/src/shims/unix/virtual_socket.rs
+++ b/src/shims/unix/virtual_socket.rs
@@ -13,7 +13,6 @@ use crate::shims::files::{
     EvalContextExt as _, FdId, FileDescription, FileDescriptionRef, WeakFileDescriptionRef,
 };
 use crate::shims::unix::UnixFileDescription;
-use crate::shims::unix::linux_like::epoll::{EpollReadiness, EvalContextExt as _};
 use crate::*;
 
 /// The maximum capacity of the socketpair buffer in bytes.
@@ -108,7 +107,7 @@ impl FileDescription for VirtualSocket {
                 }
             }
             // Notify peer fd that close has happened, since that can unblock reads and writes.
-            ecx.update_epoll_active_events(peer_fd, /* force_edge */ false)?;
+            ecx.update_fd_readiness(peer_fd, /* force_edge */ false)?;
         }
         interp_ok(Ok(()))
     }
@@ -198,7 +197,55 @@ impl FileDescription for VirtualSocket {
 
         interp_ok(Scalar::from_i32(0))
     }
+
+    fn readiness<'tcx>(&self) -> InterpResult<'tcx, Readiness> {
+        // We only check the "readable", "writable", "read closed" and "write closed" readiness.
+        // If other event flags need to be supported in the future, the check should be added here.
+
+        let mut readiness = Readiness::EMPTY;
+
+        // Check if it is readable.
+        if let Some(readbuf) = &self.readbuf {
+            if !readbuf.borrow().buf.is_empty() {
+                readiness.readable = true;
+            }
+        } else {
+            // Without a read buffer, reading never blocks, so we are always ready.
+            readiness.readable = true;
+        }
+
+        // Check if is writable.
+        if let Some(peer_fd) = self.peer_fd().upgrade() {
+            if let Some(writebuf) = &peer_fd.readbuf {
+                let data_size = writebuf.borrow().buf.len();
+                let available_space = MAX_SOCKETPAIR_BUFFER_CAPACITY.strict_sub(data_size);
+                if available_space != 0 {
+                    readiness.writable = true;
+                }
+            } else {
+                // Without a write buffer, writing never blocks.
+                readiness.writable = true;
+            }
+        } else {
+            // Peer FD has been closed. This always sets both the "read closed" and "write closed" flags
+            // as we do not support `shutdown` that could be used to partially close the stream.
+            readiness.read_closed = true;
+            readiness.write_closed = true;
+            // Since the peer is closed, even if no data is available reads will return EOF and
+            // writes will return EPIPE. In other words, they won't block, so we mark this as ready
+            // for read and write.
+            readiness.readable = true;
+            readiness.writable = true;
+            // If there is data lost in peer_fd, set error readiness.
+            if self.peer_lost_data.get() {
+                readiness.error = true;
+            }
+        }
+        interp_ok(readiness)
+    }
 }
+
+impl UnixFileDescription for VirtualSocket {}
 
 /// Write to VirtualSocket based on the space available and return the written byte size.
 fn virtual_socket_write<'tcx>(
@@ -278,11 +325,11 @@ fn virtual_socket_write<'tcx>(
         for thread_id in waiting_threads {
             ecx.unblock_thread(thread_id, BlockReason::VirtualSocket)?;
         }
-        // Notify epoll waiters: we might be no longer writable, peer might now be readable.
+        // Notify readiness watchers: we might be no longer writable, peer might now be readable.
         // The notification to the peer seems to be always sent on Linux, even if the
         // FD was readable before.
-        ecx.update_epoll_active_events(self_ref, /* force_edge */ false)?;
-        ecx.update_epoll_active_events(peer_fd, /* force_edge */ true)?;
+        ecx.update_fd_readiness(self_ref, /* force_edge */ false)?;
+        ecx.update_fd_readiness(peer_fd, /* force_edge */ true)?;
 
         return finish.call(ecx, Ok(write_size));
     }
@@ -366,8 +413,8 @@ fn virtual_socket_read<'tcx>(
         // implementation. For optimization reasons, the kernel will only mark the file description
         // as "writable" when it can write more than a certain number of bytes. Since we
         // don't know what that *certain number* is, we will provide a notification every time
-        // a read is successful. This might result in our epoll emulation providing more
-        // notifications than the real system.
+        // a read is successful. This might result in our readiness emulation providing more
+        // events than the real system.
         if let Some(peer_fd) = self_ref.peer_fd().upgrade() {
             // Unblock all threads that are currently blocked on peer_fd's write.
             let waiting_threads = std::mem::take(&mut *peer_fd.blocked_write_tid.borrow_mut());
@@ -375,66 +422,18 @@ fn virtual_socket_read<'tcx>(
             for thread_id in waiting_threads {
                 ecx.unblock_thread(thread_id, BlockReason::VirtualSocket)?;
             }
-            // Notify epoll waiters: peer is now writable.
+            // Notify readiness watchers: peer is now writable.
             // Linux seems to always notify the peer if the read buffer is now empty.
             // (Linux also does that if this was a "big" read, but to avoid some arbitrary
             // threshold, we do not match that.)
-            ecx.update_epoll_active_events(peer_fd, /* force_edge */ readbuf_now_empty)?;
+            ecx.update_fd_readiness(peer_fd, /* force_edge */ readbuf_now_empty)?;
         };
-        // Notify epoll waiters: we might be no longer readable.
-        ecx.update_epoll_active_events(self_ref, /* force_edge */ false)?;
+        // Notify readiness watchers: we might be no longer readable.
+        ecx.update_fd_readiness(self_ref, /* force_edge */ false)?;
 
         return finish.call(ecx, Ok(read_size));
     }
     interp_ok(())
-}
-
-impl UnixFileDescription for VirtualSocket {
-    fn epoll_active_events<'tcx>(&self) -> InterpResult<'tcx, EpollReadiness> {
-        // We only check the status of EPOLLIN, EPOLLOUT, EPOLLHUP and EPOLLRDHUP flags.
-        // If other event flags need to be supported in the future, the check should be added here.
-
-        let mut epoll_readiness = EpollReadiness::empty();
-
-        // Check if it is readable.
-        if let Some(readbuf) = &self.readbuf {
-            if !readbuf.borrow().buf.is_empty() {
-                epoll_readiness.epollin = true;
-            }
-        } else {
-            // Without a read buffer, reading never blocks, so we are always ready.
-            epoll_readiness.epollin = true;
-        }
-
-        // Check if is writable.
-        if let Some(peer_fd) = self.peer_fd().upgrade() {
-            if let Some(writebuf) = &peer_fd.readbuf {
-                let data_size = writebuf.borrow().buf.len();
-                let available_space = MAX_SOCKETPAIR_BUFFER_CAPACITY.strict_sub(data_size);
-                if available_space != 0 {
-                    epoll_readiness.epollout = true;
-                }
-            } else {
-                // Without a write buffer, writing never blocks.
-                epoll_readiness.epollout = true;
-            }
-        } else {
-            // Peer FD has been closed. This always sets both the RDHUP and HUP flags
-            // as we do not support `shutdown` that could be used to partially close the stream.
-            epoll_readiness.epollrdhup = true;
-            epoll_readiness.epollhup = true;
-            // Since the peer is closed, even if no data is available reads will return EOF and
-            // writes will return EPIPE. In other words, they won't block, so we mark this as ready
-            // for read and write.
-            epoll_readiness.epollin = true;
-            epoll_readiness.epollout = true;
-            // If there is data lost in peer_fd, set EPOLLERR.
-            if self.peer_lost_data.get() {
-                epoll_readiness.epollerr = true;
-            }
-        }
-        interp_ok(epoll_readiness)
-    }
 }
 
 impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}

--- a/tests/fail-dep/libc/libc_epoll_unsupported_fd.rs
+++ b/tests/fail-dep/libc/libc_epoll_unsupported_fd.rs
@@ -15,6 +15,6 @@ fn main() {
     let mut ev =
         libc::epoll_event { events: (libc::EPOLLIN | libc::EPOLLET) as _, u64: epfd1 as u64 };
     let res = unsafe { libc::epoll_ctl(epfd0, libc::EPOLL_CTL_ADD, epfd1, &mut ev) };
-    //~^ERROR: epoll does not support this file description
+    //~^ERROR: epoll: this file description doesn't support I/O readiness
     assert_eq!(res, 0);
 }

--- a/tests/fail-dep/libc/libc_epoll_unsupported_fd.stderr
+++ b/tests/fail-dep/libc/libc_epoll_unsupported_fd.stderr
@@ -1,4 +1,4 @@
-error: unsupported operation: epoll: epoll does not support this file description
+error: unsupported operation: epoll: this file description doesn't support I/O readiness
   --> tests/fail-dep/libc/libc_epoll_unsupported_fd.rs:LL:CC
    |
 LL |     let res = unsafe { libc::epoll_ctl(epfd0, libc::EPOLL_CTL_ADD, epfd1, &mut ev) };


### PR DESCRIPTION
Hi,

This pull request adds a new `ReadinessManager` which receives readiness updates from file descriptions or the blocking I/O manager and then notifies interested `ReadinessConsumers` about the changed readiness.

Previously, all this logic was directly integrated into the epoll shim. In order to enable implementations for `poll`, `select`, etc. shims the logic is now outsourced into the readiness manager and the epoll shim is just another `ReadinessConsumer`. 

We also no longer have different types of readiness (`EpollReadiness`, `BlockingIoReadiness`) and instead everything just uses the new `Readiness` struct from the readiness manager.