### PR TITLE
Mask CRC intrinsic inputs to match LoongArch hardware semantics

### DIFF
--- a/src/shims/loongarch.rs
+++ b/src/shims/loongarch.rs
@@ -1,4 +1,4 @@
-use rustc_abi::CanonAbi;
+use rustc_abi::{CanonAbi, Size};
 use rustc_middle::ty::Ty;
 use rustc_span::Symbol;
 use rustc_target::callconv::FnAbi;
@@ -55,10 +55,17 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // b/h/w variants and i64 for the d variant, per the LLVM intrinsic
                 // definitions.
                 // https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/IR/IntrinsicsLoongArch.td
-                // If the higher bits are non-zero, `compute_crc32` will panic. We should probably
-                // raise a proper error instead, but outside stdarch nobody can trigger this anyway.
+                // LoongArch CRC b/h/w instructions ignore any bits above `bit_size`.
+                // https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html#crc-check-instructions
+                // Miri's `compute_crc32` requires all higher bits to be zero and may
+                // panic otherwise, so we explicitly mask them off here to reproduce the
+                // hardware behavior.
                 let crc = crc.to_u32()?;
-                let data = if bit_size == 64 { data.to_u64()? } else { u64::from(data.to_u32()?) };
+                let data = if bit_size == 64 {
+                    data.to_u64()?
+                } else {
+                    Size::from_bits(bit_size).truncate(data.to_u32()?.into()).try_into().unwrap()
+                };
 
                 let result = compute_crc32(crc, data, bit_size, polynomial);
                 this.write_scalar(Scalar::from_u32(result), dest)?;

--- a/tests/pass/shims/loongarch/intrinsics-loongarch64-crc.rs
+++ b/tests/pass/shims/loongarch/intrinsics-loongarch64-crc.rs
@@ -1,8 +1,19 @@
 // We're testing loongarch64-specific intrinsics
 //@only-target: loongarch64
-#![feature(stdarch_loongarch)]
+#![feature(abi_unadjusted, link_llvm_intrinsics, stdarch_loongarch)]
 
 use std::arch::loongarch64::*;
+
+unsafe extern "unadjusted" {
+    #[link_name = "llvm.loongarch.crc.w.b.w"]
+    fn _crc_w_b_w(a: i32, b: i32) -> i32;
+    #[link_name = "llvm.loongarch.crc.w.h.w"]
+    fn _crc_w_h_w(a: i32, b: i32) -> i32;
+    #[link_name = "llvm.loongarch.crcc.w.b.w"]
+    fn _crcc_w_b_w(a: i32, b: i32) -> i32;
+    #[link_name = "llvm.loongarch.crcc.w.h.w"]
+    fn _crcc_w_h_w(a: i32, b: i32) -> i32;
+}
 
 fn main() {
     test_crc_ieee();
@@ -12,13 +23,19 @@ fn main() {
 fn test_crc_ieee() {
     // crc.w.b.w: 8-bit input
     assert_eq!(crc_w_b_w(0x01, 0x00000000), 0x77073096);
+    assert_eq!(unsafe { _crc_w_b_w(0x1_01, 0x00000000) }, 0x77073096); // higher bits in the first argument are ignored
     assert_eq!(crc_w_b_w(0x61, 0xffffffff_u32 as i32), 0x174841bc);
+    assert_eq!(unsafe { _crc_w_b_w(0x2_61, 0xffffffff_u32 as i32) }, 0x174841bc);
     assert_eq!(crc_w_b_w(0x2a, 0x2aa1e72b), 0x772d9171);
+    assert_eq!(unsafe { _crc_w_b_w(0x3_2a, 0x2aa1e72b) }, 0x772d9171);
 
     // crc.w.h.w: 16-bit input
     assert_eq!(crc_w_h_w(0x0001, 0x00000000), 0x191b3141);
+    assert_eq!(unsafe { _crc_w_h_w(0x1_0001, 0x00000000) }, 0x191b3141);
     assert_eq!(crc_w_h_w(0x1234, 0xffffffff_u32 as i32), 0xf6b56fbf_u32 as i32);
+    assert_eq!(unsafe { _crc_w_h_w(0x2_1234, 0xffffffff_u32 as i32) }, 0xf6b56fbf_u32 as i32);
     assert_eq!(crc_w_h_w(0x022b, 0x8ecec3b5_u32 as i32), 0x03a1db7c);
+    assert_eq!(unsafe { _crc_w_h_w(0x3_022b, 0x8ecec3b5_u32 as i32) }, 0x03a1db7c);
 
     // crc.w.w.w: 32-bit input
     assert_eq!(crc_w_w_w(0x00000001, 0x00000000), 0xb8bc6765_u32 as i32);
@@ -34,13 +51,19 @@ fn test_crc_ieee() {
 fn test_crc_castagnoli() {
     // crcc.w.b.w: 8-bit input
     assert_eq!(crcc_w_b_w(0x01, 0x00000000), 0xf26b8303_u32 as i32);
+    assert_eq!(unsafe { _crcc_w_b_w(0x1_01, 0x00000000) }, 0xf26b8303_u32 as i32);
     assert_eq!(crcc_w_b_w(0x61, 0xffffffff_u32 as i32), 0x3e2fbccf);
+    assert_eq!(unsafe { _crcc_w_b_w(0x2_61, 0xffffffff_u32 as i32) }, 0x3e2fbccf);
     assert_eq!(crcc_w_b_w(0x2a, 0x2aa1e72b), 0xf24122e4_u32 as i32);
+    assert_eq!(unsafe { _crcc_w_b_w(0x3_2a, 0x2aa1e72b) }, 0xf24122e4_u32 as i32);
 
     // crcc.w.h.w: 16-bit input
     assert_eq!(crcc_w_h_w(0x0001, 0x00000000), 0x13a29877);
+    assert_eq!(unsafe { _crcc_w_h_w(0x1_0001, 0x00000000) }, 0x13a29877);
     assert_eq!(crcc_w_h_w(0x1234, 0xffffffff_u32 as i32), 0xf13f4cea_u32 as i32);
+    assert_eq!(unsafe { _crcc_w_h_w(0x2_1234, 0xffffffff_u32 as i32) }, 0xf13f4cea_u32 as i32);
     assert_eq!(crcc_w_h_w(0x022b, 0x8ecec3b5_u32 as i32), 0x013bb2fb);
+    assert_eq!(unsafe { _crcc_w_h_w(0x3_022b, 0x8ecec3b5_u32 as i32) }, 0x013bb2fb);
 
     // crcc.w.w.w: 32-bit input
     assert_eq!(crcc_w_w_w(0x00000001, 0x00000000), 0xdd45aab8_u32 as i32);


### PR DESCRIPTION
LoongArch CRC b/h/w instructions only consume the low 8/16/32 bits of their input operand, ignoring any higher bits. However, Miri forwarded the full value to compute_crc32, which expects all bits above the specified width to be zero and may panic otherwise.

Mask off the unused high bits before calling compute_crc32 so the shim matches hardware behavior and correctly handles sign-extended intrinsic arguments.