### PR TITLE
add borrow model test for mixed-mutability static

### DIFF
--- a/tests/fail/both_borrows/mixed_mutability_static.rs
+++ b/tests/fail/both_borrows/mixed_mutability_static.rs
@@ -1,0 +1,16 @@
+//! Ensure that we do not permit mutating the part of an interior mutable static
+//! that is outside the `Cell`.
+
+//@revisions: stack tree
+//@[tree]compile-flags: -Zmiri-tree-borrows
+
+use std::sync::atomic::*;
+
+static X: (i32, AtomicI32) = (0, AtomicI32::new(1));
+
+fn main() {
+    let ptr = &raw const X;
+    unsafe { ptr.cast_mut().write((1, AtomicI32::new(0))) };
+    //~[stack]^ERROR: that tag only grants SharedReadOnly permission
+    //~[tree]|ERROR: /write access .* is forbidden/
+}

--- a/tests/fail/both_borrows/mixed_mutability_static.stack.stderr
+++ b/tests/fail/both_borrows/mixed_mutability_static.stack.stderr
@@ -1,0 +1,18 @@
+error: Undefined Behavior: attempting a write access using <TAG> at ALLOC[0x0], but that tag only grants SharedReadOnly permission for this location
+  --> tests/fail/both_borrows/mixed_mutability_static.rs:LL:CC
+   |
+LL |     unsafe { ptr.cast_mut().write((1, AtomicI32::new(0))) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this error occurs as part of an access at ALLOC[0x0..0x8]
+   |
+   = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
+   = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
+help: <TAG> was created by a SharedReadOnly retag at offsets [0x0..0x4]
+  --> tests/fail/both_borrows/mixed_mutability_static.rs:LL:CC
+   |
+LL |     let ptr = &raw const X;
+   |               ^^^^^^^^^^^^
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/tests/fail/both_borrows/mixed_mutability_static.tree.stderr
+++ b/tests/fail/both_borrows/mixed_mutability_static.tree.stderr
@@ -1,0 +1,19 @@
+error: Undefined Behavior: write access through <TAG> at ALLOC[0x0] is forbidden
+  --> tests/fail/both_borrows/mixed_mutability_static.rs:LL:CC
+   |
+LL |     unsafe { ptr.cast_mut().write((1, AtomicI32::new(0))) };
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+   |
+   = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
+   = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/tree-borrows.md for further information
+   = help: the accessed tag <TAG> has state Frozen which forbids this child write access
+help: the accessed tag <TAG> was created here, in the initial state Cell
+  --> tests/fail/both_borrows/mixed_mutability_static.rs:LL:CC
+   |
+LL |     let ptr = &raw const X;
+   |                          ^
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
I actually don't understand why this is UB in Tree Borrows -- somehow "precise interior mutable" tracking seems to be kicking in?
This came up in https://github.com/rust-lang/rust/issues/156789

Cc @JoJoDeveloping 