### PR TITLE
Don't clear TCP socket readable readiness when read end is already closed

### DIFF
--- a/src/shims/unix/socket.rs
+++ b/src/shims/unix/socket.rs
@@ -1487,9 +1487,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // Only shutting down the write end doesn't cause an EPOLLHUP event
         // and thus we won't set the `write_closed` readiness for it here.
         readiness.write_closed |= is_read_write_shutdown;
-        // The Linux kernel also sets EPOLLIN when both ends of a socket are closed:
+        // The Linux kernel also sets EPOLLIN when the read end of a socket is closed:
         // <https://github.com/torvalds/linux/blob/HEAD/net/ipv4/tcp.c#L584-L588>
-        readiness.readable |= is_read_write_shutdown;
+        readiness.readable |= is_read_shutdown || is_read_write_shutdown;
 
         drop(readiness);
 
@@ -1697,12 +1697,16 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     ) -> InterpResult<'tcx, Result<usize, IoError>> {
         let this = self.eval_context_mut();
 
-        let SocketState::Connected(stream) = &mut *socket.state.borrow_mut() else {
+        let mut state = socket.state.borrow_mut();
+        let SocketState::Connected(stream) = &mut *state else {
             panic!("try_non_block_send must only be called when the socket is connected")
         };
 
         // This is a *non-blocking* write.
         let result = this.write_to_host(stream, length, buffer_ptr)?;
+
+        drop(state);
+
         match result {
             Err(IoError::HostError(e))
                 if matches!(e.kind(), io::ErrorKind::NotConnected | io::ErrorKind::WouldBlock) =>
@@ -1715,8 +1719,13 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // would be returned on UNIX-like systems. We thus remap this error to an EWOULDBLOCK.
                 interp_ok(Err(IoError::HostError(io::ErrorKind::WouldBlock.into())))
             }
-            Ok(bytes_written) if bytes_written < length => {
-                // We had a short write. On Unix hosts using the `epoll` and `kqueue` backends, a
+            Ok(bytes_written)
+                if bytes_written < length && !socket.io_readiness.borrow().write_closed =>
+            {
+                // We had a short write. (Note that we don't want to clear the writable readiness for
+                // sockets whose write end has already been closed as those never block a write, i.e.,
+                // they are always write-ready.)
+                // On Unix hosts using the `epoll` and `kqueue` backends, a
                 // short write means that the write buffer is full. We update the readiness
                 // accordingly, which means that next time we see "writable" we will report an epoll
                 // edge. Some applications (e.g. tokio) rely on this behavior; see
@@ -1820,7 +1829,8 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     ) -> InterpResult<'tcx, Result<usize, IoError>> {
         let this = self.eval_context_mut();
 
-        let SocketState::Connected(stream) = &mut *socket.state.borrow_mut() else {
+        let mut state = socket.state.borrow_mut();
+        let SocketState::Connected(stream) = &mut *state else {
             panic!("try_non_block_recv must only be called when the socket is connected")
         };
 
@@ -1832,6 +1842,9 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             length,
             buffer_ptr,
         )?;
+
+        drop(state);
+
         match result {
             Err(IoError::HostError(e))
                 if matches!(e.kind(), io::ErrorKind::NotConnected | io::ErrorKind::WouldBlock) =>
@@ -1844,9 +1857,16 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // would be returned on UNIX-like systems. We thus remap this error to an EWOULDBLOCK.
                 interp_ok(Err(IoError::HostError(io::ErrorKind::WouldBlock.into())))
             }
-            Ok(bytes_read) if !should_peek && bytes_read < length && bytes_read > 0 => {
+            Ok(bytes_read)
+                if !should_peek
+                    && bytes_read < length
+                    && bytes_read > 0
+                    && !socket.io_readiness.borrow().read_closed =>
+            {
                 // We had a short read (and were not peeking). (Note that reading 0 bytes is guaranteed
-                // to indicate EOF, and can never happen spuriously, so we have to exclude that case.)
+                // to indicate EOF, and can never happen spuriously, so we have to exclude that case.
+                // We also don't want to clear the readable readiness for sockets whose read end has
+                // already been closed as those never block a read, i.e., they are always read-ready.)
                 // On Unix hosts using the `epoll` and `kqueue` backends, a short read means that the
                 // read buffer is empty. We update the readiness accordingly, which means that next time
                 // we see "readable" we will report an epoll edge. Some applications (e.g. tokio) rely on

--- a/tests/pass-dep/libc/libc-socket-no-blocking-epoll.rs
+++ b/tests/pass-dep/libc/libc-socket-no-blocking-epoll.rs
@@ -1,8 +1,5 @@
 //@only-target: linux android illumos
 //@compile-flags: -Zmiri-disable-isolation
-//@revisions: windows_host unix_host
-//@[unix_host] ignore-host: windows
-//@[windows_host] only-host: windows
 //@run-native
 
 #![feature(io_error_inprogress)]
@@ -646,63 +643,28 @@ fn test_readable_after_read_shutdown_and_short_read() {
 
         // Write `TEST_BYTES` into the stream.
         libc_utils::write_all(peerfd, TEST_BYTES).unwrap();
+
+        // Close the write end, so that the reader will get an EOF.
+        // (We could alternatively test this by closing the read end of the client socket,
+        // but Windows has some special behavior when closing a read end while there's still
+        // data coming in, so we avoid that.)
+        unsafe { errno_check(libc::shutdown(peerfd, libc::SHUT_WR)) };
     });
 
     net::connect_ipv4(client_sockfd, addr).unwrap();
 
-    unsafe {
-        // Change client socket to be non-blocking.
-        errno_check(libc::fcntl(client_sockfd, libc::F_SETFL, libc::O_NONBLOCK));
-    }
+    // Change client socket to be non-blocking.
+    unsafe { errno_check(libc::fcntl(client_sockfd, libc::F_SETFL, libc::O_NONBLOCK)) };
 
     server_thread.join().unwrap();
-
-    // Close the read end of the client socket.
-    unsafe {
-        errno_check(libc::shutdown(client_sockfd, libc::SHUT_RD));
-    }
 
     // Add client socket with "read closed" and "readable" interest to epoll.
     epoll_ctl_add(epfd, client_sockfd, EPOLLET | EPOLLIN | EPOLLRDHUP).unwrap();
 
-    let events = if cfg!(windows_host) {
-        // On Windows hosts, the TCP connection is reset when the read-end of the
-        // socket is closed whilst there still being some unread/incoming data.
-        // We thus also expect the EPOLLHUP readiness (we don't need to register it,
-        // as `epoll_wait` registers it implicitly).
-        // See <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-shutdown>:
-        // "For TCP sockets, if there is still data queued on the socket waiting to
-        // be received, or data arrives subsequently, the connection is reset, since
-        // the data cannot be delivered to the user"
-        EPOLLIN | EPOLLRDHUP | EPOLLHUP
-    } else {
-        EPOLLIN | EPOLLRDHUP
-    };
-
     // Ensure that the socket is readable and that its read end is closed.
-    check_epoll_wait(epfd, &[Ev { events, data: client_sockfd }], -1);
+    check_epoll_wait(epfd, &[Ev { events: EPOLLIN | EPOLLRDHUP, data: client_sockfd }], -1);
 
     let mut buffer = [0u8; 1024];
-
-    if cfg!(windows_host) {
-        // Because the TCP connection has been reset on Windows hosts,
-        // we cannot read anything from the client socket anymore.
-        // We thus only test that the connection has indeed been reset
-        // and then we return from the test.
-        let err = unsafe {
-            errno_result(libc::read(
-                client_sockfd,
-                buffer.as_mut_ptr().cast(),
-                // Attempt to read a chunk of 16 bytes.
-                16,
-            ))
-            .unwrap_err()
-        };
-        assert_eq!(err.kind(), ErrorKind::ConnectionAborted);
-        return;
-    }
-
-    // We're not on a Windows host.
 
     // We want to read in chunks of 16 bytes. To ensure we get a short read, `TEST_BYTES.len()`
     // must not be dividable by 16.
@@ -741,11 +703,11 @@ fn test_readable_after_read_shutdown_and_short_read() {
         EPOLLIN | EPOLLRDHUP
     );
 
+    // A read should not block and return 0, indicating EOF.
     let mut buffer = [1u8; 16];
     let bytes_read = unsafe {
         errno_result(libc::read(client_sockfd, buffer.as_mut_ptr().cast(), buffer.len())).unwrap()
     };
-    // The read should not block and return 0, indicating EOF.
     assert_eq!(bytes_read, 0);
 }
 
@@ -810,4 +772,9 @@ fn test_writable_after_write_shutdown_with_full_buffer() {
 
     // The socket should no longer block on writes after its write end is closed.
     check_epoll_wait(epfd, &[Ev { events: EPOLLOUT, data: client_sockfd }], -1);
+
+    // A write should not block and return an error.
+    let result =
+        unsafe { errno_result(libc::write(client_sockfd, buffer.as_ptr().cast(), buffer.len())) };
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::BrokenPipe);
 }

--- a/tests/pass-dep/libc/libc-socket-no-blocking-epoll.rs
+++ b/tests/pass-dep/libc/libc-socket-no-blocking-epoll.rs
@@ -1,5 +1,8 @@
 //@only-target: linux android illumos
 //@compile-flags: -Zmiri-disable-isolation
+//@revisions: windows_host unix_host
+//@[unix_host] ignore-host: windows
+//@[windows_host] only-host: windows
 //@run-native
 
 #![feature(io_error_inprogress)]
@@ -28,6 +31,8 @@ fn main() {
     test_readiness_after_short_read();
     test_readiness_after_short_peek();
     test_readiness_after_short_write();
+    test_readable_after_read_shutdown_and_short_read();
+    test_writable_after_write_shutdown_with_full_buffer();
 }
 
 /// Test that connecting to a server socket works when the client
@@ -562,23 +567,13 @@ fn test_readiness_after_short_write() {
         unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
     let epfd = errno_result(unsafe { libc::epoll_create1(0) }).unwrap();
 
-    // Spawn the server thread.
-    let server_thread = thread::spawn(move || {
-        let (peerfd, _) = net::accept_ipv4(server_sockfd).unwrap();
-        // Return the peer socket file descriptor such that we can use
-        // it after joining the server thread.
-        peerfd
-    });
-
     net::connect_ipv4(client_sockfd, addr).unwrap();
+    let (peerfd, _) = net::accept_ipv4(server_sockfd).unwrap();
 
     unsafe {
         // Change client socket to be non-blocking.
         errno_check(libc::fcntl(client_sockfd, libc::F_SETFL, libc::O_NONBLOCK));
     }
-
-    // The peer socket is a blocking socket.
-    let peerfd = server_thread.join().unwrap();
 
     // Add client socket with writable interest to epoll.
     epoll_ctl_add(epfd, client_sockfd, EPOLLET | EPOLLOUT).unwrap();
@@ -635,4 +630,184 @@ fn test_readiness_after_short_write() {
 
     // We should again be able to write into the socket.
     libc_utils::write_all(client_sockfd, &buffer).unwrap();
+}
+
+/// Test that Miri correctly keeps the readable readiness when the read end of the client
+/// socket has been closed -- even after a short read.
+fn test_readable_after_read_shutdown_and_short_read() {
+    let (server_sockfd, addr) = net::make_listener_ipv4().unwrap();
+    let client_sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+    let epfd = errno_result(unsafe { libc::epoll_create1(0) }).unwrap();
+
+    // Spawn the server thread.
+    let server_thread = thread::spawn(move || {
+        let (peerfd, _) = net::accept_ipv4(server_sockfd).unwrap();
+
+        // Write `TEST_BYTES` into the stream.
+        libc_utils::write_all(peerfd, TEST_BYTES).unwrap();
+    });
+
+    net::connect_ipv4(client_sockfd, addr).unwrap();
+
+    unsafe {
+        // Change client socket to be non-blocking.
+        errno_check(libc::fcntl(client_sockfd, libc::F_SETFL, libc::O_NONBLOCK));
+    }
+
+    server_thread.join().unwrap();
+
+    // Close the read end of the client socket.
+    unsafe {
+        errno_check(libc::shutdown(client_sockfd, libc::SHUT_RD));
+    }
+
+    // Add client socket with "read closed" and "readable" interest to epoll.
+    epoll_ctl_add(epfd, client_sockfd, EPOLLET | EPOLLIN | EPOLLRDHUP).unwrap();
+
+    let events = if cfg!(windows_host) {
+        // On Windows hosts, the TCP connection is reset when the read-end of the
+        // socket is closed whilst there still being some unread/incoming data.
+        // We thus also expect the EPOLLHUP readiness (we don't need to register it,
+        // as `epoll_wait` registers it implicitly).
+        // See <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-shutdown>:
+        // "For TCP sockets, if there is still data queued on the socket waiting to
+        // be received, or data arrives subsequently, the connection is reset, since
+        // the data cannot be delivered to the user"
+        EPOLLIN | EPOLLRDHUP | EPOLLHUP
+    } else {
+        EPOLLIN | EPOLLRDHUP
+    };
+
+    // Ensure that the socket is readable and that its read end is closed.
+    check_epoll_wait(epfd, &[Ev { events, data: client_sockfd }], -1);
+
+    let mut buffer = [0u8; 1024];
+
+    if cfg!(windows_host) {
+        // Because the TCP connection has been reset on Windows hosts,
+        // we cannot read anything from the client socket anymore.
+        // We thus only test that the connection has indeed been reset
+        // and then we return from the test.
+        let err = unsafe {
+            errno_result(libc::read(
+                client_sockfd,
+                buffer.as_mut_ptr().cast(),
+                // Attempt to read a chunk of 16 bytes.
+                16,
+            ))
+            .unwrap_err()
+        };
+        assert_eq!(err.kind(), ErrorKind::ConnectionAborted);
+        return;
+    }
+
+    // We're not on a Windows host.
+
+    // We want to read in chunks of 16 bytes. To ensure we get a short read, `TEST_BYTES.len()`
+    // must not be dividable by 16.
+    assert!(TEST_BYTES.len() % 16 != 0);
+
+    let mut total_bytes_read = 0;
+    // Read everything from the socket until we get a short read.
+    // We don't want to provide `TEST_BYTES.len()` as `count` because then we won't trigger
+    // a short read.
+    loop {
+        let bytes_read = unsafe {
+            errno_result(libc::read(
+                client_sockfd,
+                buffer.as_mut_ptr().byte_add(total_bytes_read).cast(),
+                // Read a chunk of 16 bytes.
+                16,
+            ))
+            .unwrap()
+        };
+
+        total_bytes_read += bytes_read as usize;
+        if bytes_read < 16 {
+            // We had a short read; we thus assume the read buffer is empty.
+            break;
+        }
+    }
+    assert_eq!(total_bytes_read, TEST_BYTES.len());
+
+    // We had a short read because `buffer` is bigger than `TEST_BYTES`.
+    // Because the read end of the socket is closed, we should still be able to
+    // read to detect EOFs.
+
+    // Ensure that the "readable" and "read closed" readiness flags are still set.
+    assert_eq!(
+        current_epoll_readiness::<8>(client_sockfd, EPOLLIN | EPOLLET | EPOLLRDHUP),
+        EPOLLIN | EPOLLRDHUP
+    );
+
+    let mut buffer = [1u8; 16];
+    let bytes_read = unsafe {
+        errno_result(libc::read(client_sockfd, buffer.as_mut_ptr().cast(), buffer.len())).unwrap()
+    };
+    // The read should not block and return 0, indicating EOF.
+    assert_eq!(bytes_read, 0);
+}
+
+/// Test that the writable readiness gets set when the write end of a socket
+/// is closed -- even when the socket write buffer is full.
+fn test_writable_after_write_shutdown_with_full_buffer() {
+    let (server_sockfd, addr) = net::make_listener_ipv4().unwrap();
+    let client_sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+    let epfd = errno_result(unsafe { libc::epoll_create1(0) }).unwrap();
+
+    net::connect_ipv4(client_sockfd, addr).unwrap();
+    net::accept_ipv4(server_sockfd).unwrap();
+
+    unsafe {
+        // Change client socket to be non-blocking.
+        errno_check(libc::fcntl(client_sockfd, libc::F_SETFL, libc::O_NONBLOCK));
+    }
+
+    // Add client socket with level-triggered "writable" and "write closed" interest to epoll.
+    epoll_ctl_add(epfd, client_sockfd, EPOLLOUT | EPOLLHUP).unwrap();
+
+    // Wait until the socket becomes writable.
+    check_epoll_wait(epfd, &[Ev { events: EPOLLOUT, data: client_sockfd }], -1);
+
+    // We now want to fill the write buffer of the socket by repeatedly writing
+    // `buffer` into it. The last write should then be a short write.
+    // We assume/hope that the write buffer length is not divisible by 1039.
+    let buffer = [123u8; 1039];
+
+    loop {
+        let result = unsafe {
+            errno_result(libc::write(client_sockfd, buffer.as_ptr().cast(), buffer.len()))
+        };
+
+        match result {
+            Ok(bytes_written) => {
+                if (bytes_written as usize) < buffer.len() {
+                    // We had a short write; we thus assume the write buffer is full.
+                    break;
+                }
+            }
+            Err(err) if err.kind() == ErrorKind::WouldBlock => {
+                // Windows and Apple hosts behave weirdly when attempting to fill up the write buffer.
+                // Instead of doing a short write to completely fill the buffer, they can return an
+                // EWOULDBLOCK when the next write wouldn't fit into the buffer.
+                // When we get such an error, we also assume the write buffer is full.
+                break;
+            }
+            Err(err) => panic!("unexpected error whilst filling up buffer: {err}"),
+        }
+    }
+
+    // The write buffer is full; because this is a level-triggered interest,
+    // a readiness of 0 means that the socket would now block on writes.
+    check_epoll_wait(epfd, &[], 0);
+
+    // Close the socket write end.
+    unsafe {
+        errno_check(libc::shutdown(client_sockfd, libc::SHUT_WR));
+    }
+
+    // The socket should no longer block on writes after its write end is closed.
+    check_epoll_wait(epfd, &[Ev { events: EPOLLOUT, data: client_sockfd }], -1);
 }


### PR DESCRIPTION
This pull request fixes the problems experienced in https://github.com/tokio-rs/tokio/pull/8205.

In the previous implementation we always removed the readable readiness for sockets after a short read -- even when the read end has been closed. When we still have some data in the read buffer whilst the read end gets closed, this could lead to the situation where we have a short read and thus remove the readable readiness before reading zero (indicating EOF).

During debugging I also noticed that we only set the `readable` readiness on `shutdown(SHUT_RDWR)`, however, it should also be set on `shutdown(SHUT_RD)`. 