### PR TITLE
[Priroda] Add `stepi` and `locals` commands, and handle repeated breakpoint hits on the same source line

### DIFF
--- a/priroda/README.md
+++ b/priroda/README.md
@@ -60,6 +60,7 @@ RUSTC_BLESS=1 cargo test
 | Command | Description |
 |---|---|
 | Enter, `si`, `stepi` | Execute one Miri interpreter step. |
+| `s`, `step` | Step until the displayed source location changes. |
 | `c`, `continue` | Continue until the program finishes or reaches a breakpoint. |
 | `b <path>:<line>`, `break <path>:<line>` | Add a source-location breakpoint. |
 | `q`, `quit` | Exit Priroda. |

--- a/priroda/README.md
+++ b/priroda/README.md
@@ -8,6 +8,7 @@ Current focus:
 - single-threaded stepping with Miri's interpreter
 - source-location output after stepping
 - source-location breakpoint prototype
+- source-local listing prototype
 
 ## Setup
 
@@ -63,6 +64,7 @@ RUSTC_BLESS=1 cargo test
 | `s`, `step` | Step until the displayed source location changes. |
 | `c`, `continue` | Continue until the program finishes or reaches a breakpoint. |
 | `b <path>:<line>`, `break <path>:<line>` | Add a source-location breakpoint. |
+| `l`, `locals` | List source-level locals in the current frame by name. |
 | `q`, `quit` | Exit Priroda. |
 
 EOF also exits Priroda cleanly.

--- a/priroda/README.md
+++ b/priroda/README.md
@@ -59,7 +59,7 @@ RUSTC_BLESS=1 cargo test
 
 | Command | Description |
 |---|---|
-| Enter, `s`, `step` | Execute one Miri interpreter step. |
+| Enter, `si`, `stepi` | Execute one Miri interpreter step. |
 | `c`, `continue` | Continue until the program finishes or reaches a breakpoint. |
 | `b <path>:<line>`, `break <path>:<line>` | Add a source-location breakpoint. |
 | `q`, `quit` | Exit Priroda. |

--- a/priroda/src/main.rs
+++ b/priroda/src/main.rs
@@ -168,20 +168,25 @@ impl<'tcx> PrirodaContext<'tcx> {
         location.local_path(source_map)
     }
 
+    fn current_source_position(&self) -> Option<(PathBuf, usize)> {
+        let location = self.current_location.as_ref()?;
+        Some((self.local_path(location)?, location.line))
+    }
+
+    // Used to treat `continue` like a source-level step for breakpoint checks:
+    // several MIR locations can point at one source line, but they should only
+    // report that source breakpoint once.
+    fn last_source_position(&self) -> Option<(PathBuf, usize)> {
+        let location = self.last_location.as_ref()?;
+        Some((self.local_path(location)?, location.line))
+    }
+
     /// Step to the next visible MIR instruction.
     fn stepi(&mut self) -> InterpResult<'tcx, StepResult> {
         self.resume(ResumeMode::MirInstruction)
     }
     fn step(&mut self) -> InterpResult<'tcx, StepResult> {
-        let Some(location) = &self.current_location else {
-            return self.resume(ResumeMode::SourceLine(None));
-        };
-
-        let Some(path) = self.local_path(location) else {
-            return self.resume(ResumeMode::SourceLine(None));
-        };
-
-        self.resume(ResumeMode::SourceLine(Some((path, location.line))))
+        self.resume(ResumeMode::SourceLine(self.current_source_position()))
     }
 
     /// Continue execution until reaching a breakpoint or propagating termination.
@@ -288,20 +293,20 @@ impl<'tcx> PrirodaContext<'tcx> {
     }
 
     fn is_at_breakpoint(&self) -> bool {
-        // FIXME: avoid repeated stops when one source line maps to multiple MIR statements.
-        let Some(location) = &self.current_location else {
+        let Some(bp) = self.current_breakpoint() else {
             return false;
         };
 
-        let Some(path) = &self.local_path(location) else {
-            return false;
-        };
+        // If the previous interpreter step had the same source position, this
+        // is another MIR location for the breakpoint we just reported.
+        self.last_source_position().as_ref() != Some(&bp)
+    }
 
-        let lines = match self.breakpoints.get(path) {
-            Some(lines) => lines,
-            None => return false,
-        };
-        lines.contains(&location.line)
+    fn current_breakpoint(&self) -> Option<(PathBuf, usize)> {
+        let (path, line) = self.current_source_position()?;
+        let lines = self.breakpoints.get(&path)?;
+
+        if lines.contains(&line) { Some((path, line)) } else { None }
     }
 
     fn resolve_current_location(&self) -> Option<SourceLocation> {

--- a/priroda/src/main.rs
+++ b/priroda/src/main.rs
@@ -71,7 +71,7 @@ impl rustc_driver::Callbacks for PrirodaCompilerCalls {
         let ecx = create_ecx(tcx);
 
         let mut session = PrirodaContext::new(ecx);
-        let cli = CLI {};
+        let cli = Cli {};
         let result = cli.run_cli_loop(&mut session);
 
         match result.report_err() {
@@ -320,7 +320,7 @@ impl<'tcx> PrirodaContext<'tcx> {
         let source_map = self.ecx.tcx.sess.source_map();
         let loc = source_map.lookup_char_pos(span.lo());
 
-        Some(SourceLocation { span: span, line: loc.line })
+        Some(SourceLocation { span, line: loc.line })
     }
 
     fn run_command(&mut self, command: DebuggerCommand) -> InterpResult<'tcx, CommandResult> {
@@ -358,9 +358,9 @@ enum CommandResult {
     TerminateSession,
 }
 
-struct CLI;
+struct Cli;
 
-impl CLI {
+impl Cli {
     pub fn run_cli_loop<'tcx>(&self, session: &mut PrirodaContext<'tcx>) -> InterpResult<'tcx> {
         loop {
             print!("(priroda) ");
@@ -380,7 +380,7 @@ impl CLI {
                         if matches!(result, StepResult::Breakpoint) {
                             println!("Hit breakpoint");
                         }
-                        self.print_location(&session);
+                        self.print_location(session);
                     }
                     CommandResult::BreakpointResult(res) =>
                         match res {

--- a/priroda/src/main.rs
+++ b/priroda/src/main.rs
@@ -133,6 +133,10 @@ struct PrirodaContext<'tcx> {
 enum ResumeMode {
     /// Stop at the next visible MIR instruction.
     MirInstruction,
+    /// Stop at the next source line
+    ///
+    /// Take `Option` because some cases current state has no mapped to source code location
+    SourceLine(Option<(PathBuf, usize)>),
     /// Continue until reaching a breakpoint.
     Continue,
 }
@@ -159,9 +163,25 @@ impl<'tcx> PrirodaContext<'tcx> {
         Self { ecx, breakpoints: HashMap::new(), current_location: None, last_location: None }
     }
 
+    fn local_path(&self, location: &SourceLocation) -> Option<PathBuf> {
+        let source_map = self.ecx.tcx.sess.source_map();
+        location.local_path(source_map)
+    }
+
     /// Step to the next visible MIR instruction.
     fn stepi(&mut self) -> InterpResult<'tcx, StepResult> {
         self.resume(ResumeMode::MirInstruction)
+    }
+    fn step(&mut self) -> InterpResult<'tcx, StepResult> {
+        let Some(location) = &self.current_location else {
+            return self.resume(ResumeMode::SourceLine(None));
+        };
+
+        let Some(path) = self.local_path(location) else {
+            return self.resume(ResumeMode::SourceLine(None));
+        };
+
+        self.resume(ResumeMode::SourceLine(Some((path, location.line))))
     }
 
     /// Continue execution until reaching a breakpoint or propagating termination.
@@ -202,6 +222,26 @@ impl<'tcx> PrirodaContext<'tcx> {
                 {
                     return interp_ok(StepResult::Step);
                 }
+
+                ResumeMode::SourceLine(ref prev_location) => {
+                    match (prev_location, &self.current_location) {
+                        // We started from an unmapped source location. Stop at the first mapped source location we can show to the user.
+                        (None, Some(_)) => return interp_ok(StepResult::Step),
+
+                        (Some((prev_path, prev_line)), Some(current_location)) => {
+                            if let Some(current_path) = self.local_path(current_location) {
+                                // A source step stops when the visible source position changes to a different file or line.
+                                if *prev_path != current_path || *prev_line != current_location.line
+                                {
+                                    return interp_ok(StepResult::Step);
+                                }
+                            }
+                        }
+
+                        _ => {}
+                    }
+                }
+
                 ResumeMode::MirInstruction | ResumeMode::Continue => {}
             }
         }
@@ -253,8 +293,7 @@ impl<'tcx> PrirodaContext<'tcx> {
             return false;
         };
 
-        let source_map = self.ecx.tcx.sess.source_map();
-        let Some(path) = &location.local_path(source_map) else {
+        let Some(path) = &self.local_path(location) else {
             return false;
         };
 
@@ -282,6 +321,7 @@ impl<'tcx> PrirodaContext<'tcx> {
     fn run_command(&mut self, command: DebuggerCommand) -> InterpResult<'tcx, CommandResult> {
         match command {
             DebuggerCommand::StepI => self.stepi().map(CommandResult::ExecutionStopped),
+            DebuggerCommand::Step => self.step().map(CommandResult::ExecutionStopped),
             DebuggerCommand::Continue =>
                 self.continue_execution().map(CommandResult::ExecutionStopped),
             DebuggerCommand::Breakpoint(path, line) =>
@@ -293,6 +333,7 @@ impl<'tcx> PrirodaContext<'tcx> {
 
 enum DebuggerCommand {
     StepI,
+    Step,
     TerminateSession,
     Continue,
     Breakpoint(PathBuf, usize),
@@ -367,7 +408,9 @@ impl CLI {
         let args = parts.next().unwrap_or("").trim();
 
         match command {
+            // FIXME: empty line should repats last command user typed not exeute specific command.
             "" | "si" | "stepi" => Some(DebuggerCommand::StepI),
+            "s" | "step" => Some(DebuggerCommand::Step),
             "q" | "quit" => Some(DebuggerCommand::TerminateSession),
             "c" | "continue" => Some(DebuggerCommand::Continue),
             "b" | "break" => self.parse_breakpoint(args),
@@ -376,12 +419,12 @@ impl CLI {
     }
 
     fn print_location(&self, session: &PrirodaContext) {
-        let source_map = session.ecx.tcx.sess.source_map();
         match &session.current_location {
             Some(location) =>
-                if let Some(path) = location.local_path(source_map) {
+                if let Some(path) = session.local_path(location) {
                     println!("{}:{}", path.display(), location.line);
                 } else {
+                    let source_map = session.ecx.tcx.sess.source_map();
                     println!("{}", source_map.span_to_diagnostic_string(location.span));
                 },
             None => println!("no-location"),

--- a/priroda/src/main.rs
+++ b/priroda/src/main.rs
@@ -331,8 +331,20 @@ impl<'tcx> PrirodaContext<'tcx> {
                 self.continue_execution().map(CommandResult::ExecutionStopped),
             DebuggerCommand::Breakpoint(path, line) =>
                 interp_ok(CommandResult::BreakpointResult(self.set_breakpoint(path, line))),
+            DebuggerCommand::ListLocals => interp_ok(CommandResult::Locals(self.list_locals())),
             DebuggerCommand::TerminateSession => interp_ok(CommandResult::TerminateSession),
         }
+    }
+
+    /// Returns the names of all user-visible locals in the innermost stack frame.
+    ///
+    /// Uses `var_debug_info` from the MIR body, which is the same source that
+    /// DWARF debug info is built from, so the names match what the user wrote.
+    fn list_locals(&self) -> Vec<String> {
+        let Some(frame) = self.ecx.active_thread_stack().last() else {
+            return Vec::new();
+        };
+        frame.body().var_debug_info.iter().map(|info| info.name.to_string()).collect()
     }
 }
 
@@ -342,6 +354,7 @@ enum DebuggerCommand {
     TerminateSession,
     Continue,
     Breakpoint(PathBuf, usize),
+    ListLocals,
 }
 
 enum BreakpointSetResult {
@@ -353,6 +366,7 @@ enum BreakpointSetResult {
 enum CommandResult {
     ExecutionStopped(StepResult),
     BreakpointResult(BreakpointSetResult),
+    Locals(Vec<String>),
     // FIXME: distinguish terminating the debugger session from disconnecting a
     // frontend and terminating the interpreted program once multiple frontends exist.
     TerminateSession,
@@ -389,6 +403,14 @@ impl Cli {
 
                             BreakpointSetResult::Duplicate => println!("Duplicate breakpoint"),
                         },
+                    CommandResult::Locals(names) =>
+                        if names.is_empty() {
+                            println!("no locals");
+                        } else {
+                            for name in &names {
+                                println!("{name}");
+                            }
+                        },
                     CommandResult::TerminateSession => {
                         println!("quitting");
                         return interp_ok(());
@@ -419,6 +441,7 @@ impl Cli {
             "q" | "quit" => Some(DebuggerCommand::TerminateSession),
             "c" | "continue" => Some(DebuggerCommand::Continue),
             "b" | "break" => self.parse_breakpoint(args),
+            "l" | "locals" => Some(DebuggerCommand::ListLocals),
             _ => None,
         }
     }

--- a/priroda/src/main.rs
+++ b/priroda/src/main.rs
@@ -160,7 +160,7 @@ impl<'tcx> PrirodaContext<'tcx> {
     }
 
     /// Step to the next visible MIR instruction.
-    fn step(&mut self) -> InterpResult<'tcx, StepResult> {
+    fn stepi(&mut self) -> InterpResult<'tcx, StepResult> {
         self.resume(ResumeMode::MirInstruction)
     }
 
@@ -281,7 +281,7 @@ impl<'tcx> PrirodaContext<'tcx> {
 
     fn run_command(&mut self, command: DebuggerCommand) -> InterpResult<'tcx, CommandResult> {
         match command {
-            DebuggerCommand::Step => self.step().map(CommandResult::ExecutionStopped),
+            DebuggerCommand::StepI => self.stepi().map(CommandResult::ExecutionStopped),
             DebuggerCommand::Continue =>
                 self.continue_execution().map(CommandResult::ExecutionStopped),
             DebuggerCommand::Breakpoint(path, line) =>
@@ -292,7 +292,7 @@ impl<'tcx> PrirodaContext<'tcx> {
 }
 
 enum DebuggerCommand {
-    Step,
+    StepI,
     TerminateSession,
     Continue,
     Breakpoint(PathBuf, usize),
@@ -367,7 +367,7 @@ impl CLI {
         let args = parts.next().unwrap_or("").trim();
 
         match command {
-            "" | "s" | "step" => Some(DebuggerCommand::Step),
+            "" | "si" | "stepi" => Some(DebuggerCommand::StepI),
             "q" | "quit" => Some(DebuggerCommand::TerminateSession),
             "c" | "continue" => Some(DebuggerCommand::Continue),
             "b" | "break" => self.parse_breakpoint(args),

--- a/priroda/tests/ui/locals_in_function.rs
+++ b/priroda/tests/ui/locals_in_function.rs
@@ -1,0 +1,7 @@
+// Verifies that the `locals` command lists the names of user-declared variables
+// in the current stack frame. After stepping into `main` we should see `x` and `y`.
+fn main() {
+    let x = 1_i32;
+    let y = true;
+    let _ = (x, y);
+}

--- a/priroda/tests/ui/locals_in_function.stdin
+++ b/priroda/tests/ui/locals_in_function.stdin
@@ -1,0 +1,4 @@
+break tests/ui/locals_in_function.rs:5
+continue
+locals
+quit

--- a/priroda/tests/ui/locals_in_function.stdout
+++ b/priroda/tests/ui/locals_in_function.stdout
@@ -1,0 +1,6 @@
+(priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_in_function.rs:5
+(priroda) Hit breakpoint
+{MANIFEST_DIR}/tests/ui/locals_in_function.rs:5
+(priroda) x
+y
+(priroda) quitting

--- a/priroda/tests/ui/locals_no_frame.rs
+++ b/priroda/tests/ui/locals_no_frame.rs
@@ -1,0 +1,4 @@
+// Verifies that the `locals` command reports "no locals" when invoked before
+// any user stack frame is active (i.e. immediately at startup, while the std
+// runtime preamble is running).
+fn main() {}

--- a/priroda/tests/ui/locals_no_frame.stdin
+++ b/priroda/tests/ui/locals_no_frame.stdin
@@ -1,0 +1,2 @@
+locals
+quit

--- a/priroda/tests/ui/locals_no_frame.stdout
+++ b/priroda/tests/ui/locals_no_frame.stdout
@@ -1,0 +1,2 @@
+(priroda) no locals
+(priroda) quitting

--- a/priroda/tests/ui/repeated_same_line_breakpoint.rs
+++ b/priroda/tests/ui/repeated_same_line_breakpoint.rs
@@ -1,7 +1,8 @@
-// Documents the current repeated-stop behavior when multiple MIR locations map
-// to the same source breakpoint line.
-// This may look trivial, but a bunch of code runs in std before
-// `main` is called, so we are ensuring that that all works.
+// Verifies duplicate MIR locations on one source breakpoint line are skipped.
+// The following line gives the second `continue` a later real breakpoint.
+// This keeps the test from passing merely because the program finished.
+// Keep the breakpoint line numbers in the .stdin file in sync with this file.
 fn main() {
-    let _value = 0;
+    let _first = 0;
+    let _second = 1;
 }

--- a/priroda/tests/ui/repeated_same_line_breakpoint.stdin
+++ b/priroda/tests/ui/repeated_same_line_breakpoint.stdin
@@ -1,4 +1,5 @@
 break tests/ui/repeated_same_line_breakpoint.rs:6
+break tests/ui/repeated_same_line_breakpoint.rs:7
 continue
 continue
 quit

--- a/priroda/tests/ui/repeated_same_line_breakpoint.stdout
+++ b/priroda/tests/ui/repeated_same_line_breakpoint.stdout
@@ -1,6 +1,7 @@
 (priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/repeated_same_line_breakpoint.rs:6
+(priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/repeated_same_line_breakpoint.rs:7
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/repeated_same_line_breakpoint.rs:6
 (priroda) Hit breakpoint
-{MANIFEST_DIR}/tests/ui/repeated_same_line_breakpoint.rs:6
+{MANIFEST_DIR}/tests/ui/repeated_same_line_breakpoint.rs:7
 (priroda) quitting

--- a/priroda/tests/ui/source_step_changes_line.stdin
+++ b/priroda/tests/ui/source_step_changes_line.stdin
@@ -1,3 +1,3 @@
+si
 s
-step
 quit

--- a/priroda/tests/ui/source_step_changes_line.stdout
+++ b/priroda/tests/ui/source_step_changes_line.stdout
@@ -1,3 +1,3 @@
 (priroda) {RUSTC_SYSROOT}/lib/rustlib/src/rust/library/std/src/rt.rs:206
-(priroda) {RUSTC_SYSROOT}/lib/rustlib/src/rust/library/std/src/rt.rs:206
+(priroda) {RUSTC_SYSROOT}/lib/rustlib/src/rust/library/std/src/rt.rs:207
 (priroda) quitting

--- a/priroda/tests/ui/step_aliases.stdin
+++ b/priroda/tests/ui/step_aliases.stdin
@@ -1,4 +1,4 @@
-s
-step
+si
+stepi
 
 quit


### PR DESCRIPTION
- Rename step to stepi.
- Add a new step command to step over a source line.
- Fix repeated breakpoint hits on the same source line when continuing execution.
- Fix Clippy warnings.
- Add a simple locals command.