### PR TITLE
Update `cargo miri --help` to point to README.md.

### DIFF
--- a/cargo-miri/src/phases.rs
+++ b/cargo-miri/src/phases.rs
@@ -36,6 +36,9 @@ Examples:
         This will print the path to the generated sysroot (and nothing else) on stdout.
         stderr will still contain progress information about how the build is doing.
 
+For documentation on `-Zmiri-...` flags, see miri's local README.md
+(for example, $(rustc --print sysroot)/share/doc/miri/README.md)
+or the rendered version at [https://github.com/rust-lang/miri/blob/master/README.md].
 ";
 
 fn show_help() {

--- a/cargo-miri/src/phases.rs
+++ b/cargo-miri/src/phases.rs
@@ -36,9 +36,9 @@ Examples:
         This will print the path to the generated sysroot (and nothing else) on stdout.
         stderr will still contain progress information about how the build is doing.
 
-For documentation on `-Zmiri-...` flags, see miri's local README.md
-(for example, $(rustc --print sysroot)/share/doc/miri/README.md)
-or the rendered version at [https://github.com/rust-lang/miri/blob/master/README.md].
+For documentation on `-Zmiri-...` flags, see Miri's README.md, available at:
+- $(rustc --print sysroot)/share/doc/miri/README.md
+- https://github.com/rust-lang/miri/blob/master/README.md
 ";
 
 fn show_help() {


### PR DESCRIPTION
Adds a reference to two potential locations for the miri docs as mentioned in comments to the original report.

To test: `./miri build`, `./miri install`, `cargo miri --help`.

I realize the shell syntax reference is Unix-y, but maybe that's not too bad. 

(note that the recommended prefix doesn't work in the dev build because the sysroot is stripped down... but in dev builds the path is also `./README.md`!)

Fixes https://github.com/rust-lang/miri/issues/5110.
