### PR TITLE
Support File::set_times via futimens shim

### DIFF
--- a/src/shims/extern_static.rs
+++ b/src/shims/extern_static.rs
@@ -44,7 +44,10 @@ impl<'tcx> MiriMachine<'tcx> {
                 Self::weak_symbol_extern_statics(ecx, &["getrandom", "gettid", "statx", "strlen"])?;
             }
             Os::Android => {
-                Self::weak_symbol_extern_statics(ecx, &["signal", "getrandom", "gettid"])?;
+                Self::weak_symbol_extern_statics(
+                    ecx,
+                    &["signal", "getrandom", "gettid", "futimens"],
+                )?;
             }
             Os::Windows => {
                 // "_tls_used"

--- a/src/shims/time.rs
+++ b/src/shims/time.rs
@@ -463,8 +463,8 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     /// Parse a `timespec` struct and return it as a [`Duration`]. It returns [`None`]
     /// if the value in the `timespec` struct is invalid. Some libc functions will return
     /// EINVAL in this case.
-    fn read_timespec(&mut self, tp: &MPlaceTy<'tcx>) -> InterpResult<'tcx, Option<Duration>> {
-        let this = self.eval_context_mut();
+    fn read_timespec(&self, tp: &MPlaceTy<'tcx>) -> InterpResult<'tcx, Option<Duration>> {
+        let this = self.eval_context_ref();
         let sec_field = this.project_field_named(tp, "tv_sec")?;
         let sec = this.read_scalar(&sec_field)?.to_int(sec_field.layout.size)?;
         let nsec_field = this.project_field_named(tp, "tv_nsec")?;

--- a/src/shims/unix/foreign_items.rs
+++ b/src/shims/unix/foreign_items.rs
@@ -27,6 +27,9 @@ pub fn is_dyn_sym(name: &str, target_os: &Os) -> bool {
         "signal" => true,
         // needed at least on macOS to avoid file-based fallback in getrandom
         "getentropy" | "getrandom" => true,
+        // `futimens` is set up as a weak symbol in `init_extern_statics` (on Android), so we
+        // allow it here too (it exists on all our Unix targets).
+        "futimens" => true,
         // Give specific OSes a chance to allow their symbols.
         _ =>
             match *target_os {
@@ -543,6 +546,16 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     args,
                 )?;
                 let result = this.fdatasync(fd)?;
+                this.write_scalar(result, dest)?;
+            }
+            "futimens" => {
+                let [fd, times] = this.check_shim_sig(
+                    shim_sig!(extern "C" fn(i32, *const _) -> i32),
+                    link_name,
+                    abi,
+                    args,
+                )?;
+                let result = this.futimens(fd, times)?;
                 this.write_scalar(result, dest)?;
             }
             "readlink" => {

--- a/src/shims/unix/fs.rs
+++ b/src/shims/unix/fs.rs
@@ -2,12 +2,12 @@
 
 use std::borrow::Cow;
 use std::ffi::OsString;
-use std::fs::{self, DirBuilder, File, FileType, OpenOptions, TryLockError};
+use std::fs::{self, DirBuilder, File, FileTimes, FileType, OpenOptions, TryLockError};
 use std::io::{self, ErrorKind, Read, Seek, SeekFrom, Write};
 use std::path::{self, Path};
 use std::time::SystemTime;
 
-use rustc_abi::Size;
+use rustc_abi::{FieldIdx, Size};
 use rustc_data_structures::either::Either;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_target::spec::Os;
@@ -51,6 +51,13 @@ struct DirEntry {
     name: OsString,
     ino: u64,
     d_type: i32,
+}
+
+/// What a `futimens` `timespec` asks for: leave the timestamp alone (`UTIME_OMIT`) or set it.
+#[derive(Copy, Clone)]
+enum TimeUpdate {
+    Omit,
+    Set(SystemTime),
 }
 
 impl UnixFileDescription for FileHandle {
@@ -224,6 +231,33 @@ fn maybe_sync_file(
 
 impl<'tcx> EvalContextExtPrivate<'tcx> for crate::MiriInterpCx<'tcx> {}
 trait EvalContextExtPrivate<'tcx>: crate::MiriInterpCxExt<'tcx> {
+    /// Decode one `futimens` `timespec`, handling the `UTIME_NOW`/`UTIME_OMIT` `tv_nsec` values.
+    /// `None` means the `timespec` is invalid and the caller should report `EINVAL`.
+    fn parse_utimens_timespec(
+        &self,
+        tp: &MPlaceTy<'tcx>,
+    ) -> InterpResult<'tcx, Option<TimeUpdate>> {
+        let this = self.eval_context_ref();
+        // `UTIME_NOW` reads the host clock, which we must not do under isolation.
+        assert!(this.machine.communicate(), "isolation should have prevented reaching this");
+
+        // `tv_nsec` and the `UTIME_*` constants are `c_long`, i.e. the target's `isize`.
+        let nsec_place = this.project_field(tp, FieldIdx::ONE)?;
+        let nsec = this.read_scalar(&nsec_place)?.to_target_isize(this)?;
+
+        if nsec == this.eval_libc("UTIME_OMIT").to_target_isize(this)? {
+            return interp_ok(Some(TimeUpdate::Omit));
+        }
+        if nsec == this.eval_libc("UTIME_NOW").to_target_isize(this)? {
+            return interp_ok(Some(TimeUpdate::Set(SystemTime::now())));
+        }
+
+        let Some(duration) = this.read_timespec(tp)? else {
+            return interp_ok(None);
+        };
+        interp_ok(SystemTime::UNIX_EPOCH.checked_add(duration).map(TimeUpdate::Set))
+    }
+
     fn write_stat_buf(
         &mut self,
         metadata: FileMetadata,
@@ -1441,6 +1475,53 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
         let io_result = maybe_sync_file(&file.file, file.writable, File::sync_data);
         interp_ok(Scalar::from_i32(this.try_unwrap_io_result(io_result)?))
+    }
+
+    /// `futimens(fd, times)`: set `fd`'s access/modification times. `times` is `[atime, mtime]`, or
+    /// NULL to set both to now.
+    fn futimens(
+        &mut self,
+        fd_op: &OpTy<'tcx>,
+        times_op: &OpTy<'tcx>,
+    ) -> InterpResult<'tcx, Scalar> {
+        let this = self.eval_context_mut();
+
+        let fd_num = this.read_scalar(fd_op)?.to_i32()?;
+        let times_ptr = this.read_pointer(times_op)?;
+
+        let Some(fd) = this.machine.fds.get(fd_num) else {
+            return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
+        };
+        let file = fd.downcast::<FileHandle>().ok_or_else(|| {
+            err_unsup_format!("`futimens` is only supported on file-backed file descriptors")
+        })?;
+        assert!(this.machine.communicate(), "isolation should have prevented even opening a file");
+
+        let (access, modified) = if this.ptr_is_null(times_ptr)? {
+            let now = TimeUpdate::Set(SystemTime::now());
+            (now, now)
+        } else {
+            let timespec = this.libc_ty_layout("timespec");
+            let access_place = this.deref_pointer_as(times_op, timespec)?;
+            let modified_place = access_place.offset(timespec.size, timespec, this)?;
+            let Some(access) = this.parse_utimens_timespec(&access_place)? else {
+                return this.set_errno_and_return_neg1_i32(LibcError("EINVAL"));
+            };
+            let Some(modified) = this.parse_utimens_timespec(&modified_place)? else {
+                return this.set_errno_and_return_neg1_i32(LibcError("EINVAL"));
+            };
+            (access, modified)
+        };
+
+        let mut filetimes = FileTimes::new();
+        if let TimeUpdate::Set(access) = access {
+            filetimes = filetimes.set_accessed(access);
+        }
+        if let TimeUpdate::Set(modified) = modified {
+            filetimes = filetimes.set_modified(modified);
+        }
+        let result = file.file.set_times(filetimes);
+        interp_ok(Scalar::from_i32(this.try_unwrap_io_result(result.map(|()| 0i32))?))
     }
 
     fn sync_file_range(

--- a/tests/pass-dep/libc/libc-fs.rs
+++ b/tests/pass-dep/libc/libc-fs.rs
@@ -16,7 +16,7 @@ mod utils;
 #[path = "../../utils/libc.rs"]
 mod libc_utils;
 
-use libc_utils::errno_result;
+use libc_utils::{errno_check, errno_result};
 
 fn main() {
     test_dup();
@@ -165,8 +165,6 @@ fn test_statx_on_file_path() {
 
 #[cfg(target_os = "linux")]
 fn test_statx_empty_path_on_pipe() {
-    use libc_utils::errno_check;
-
     unsafe {
         let mut fds = [0; 2];
         errno_check(libc::pipe(fds.as_mut_ptr()));
@@ -254,7 +252,7 @@ fn test_file_open_dir() {
     // let err =
     //     errno_result(unsafe { libc::read(fd, buf.as_mut_ptr().cast(), buf.len()) }).unwrap_err();
     // assert_eq!(err.raw_os_error().unwrap(), libc::EISDIR, "unexpected errno: {err}");
-    // libc_utils::errno_check(unsafe { libc::close(fd) });
+    // errno_check(unsafe { libc::close(fd) });
 }
 
 fn test_dup_stdout_stderr() {
@@ -731,7 +729,7 @@ fn test_futimens() {
     // Reads back the file's (access, modification) times as `(sec, nsec)` pairs via `fstat`.
     let get_times = || {
         let mut stat = MaybeUninit::<libc::stat>::uninit();
-        libc_utils::errno_check(unsafe { libc::fstat(fd, stat.as_mut_ptr()) });
+        errno_check(unsafe { libc::fstat(fd, stat.as_mut_ptr()) });
         let stat = unsafe { stat.assume_init_ref() };
         ((stat.st_atime, stat.st_atime_nsec), (stat.st_mtime, stat.st_mtime_nsec))
     };
@@ -742,7 +740,7 @@ fn test_futimens() {
         libc::timespec { tv_sec: 1_000_000_000, tv_nsec: 100_000_000 },
         libc::timespec { tv_sec: 1_234_567_890, tv_nsec: 200_000_000 },
     ];
-    libc_utils::errno_check(unsafe { libc::futimens(fd, times.as_ptr()) });
+    errno_check(unsafe { libc::futimens(fd, times.as_ptr()) });
     assert_eq!(get_times(), ((1_000_000_000, 100_000_000), (1_234_567_890, 200_000_000)));
 
     // `UTIME_OMIT` leaves the access time unchanged while updating the modification time.
@@ -750,7 +748,7 @@ fn test_futimens() {
         libc::timespec { tv_sec: 0, tv_nsec: libc::UTIME_OMIT },
         libc::timespec { tv_sec: 2_000_000_000, tv_nsec: 0 },
     ];
-    libc_utils::errno_check(unsafe { libc::futimens(fd, times.as_ptr()) });
+    errno_check(unsafe { libc::futimens(fd, times.as_ptr()) });
     assert_eq!(get_times(), ((1_000_000_000, 100_000_000), (2_000_000_000, 0)));
 
     // `UTIME_NOW` sets a timestamp to the current time (here for access, alongside `UTIME_OMIT`).
@@ -759,19 +757,19 @@ fn test_futimens() {
         libc::timespec { tv_sec: 0, tv_nsec: libc::UTIME_NOW },
         libc::timespec { tv_sec: 0, tv_nsec: libc::UTIME_OMIT },
     ];
-    libc_utils::errno_check(unsafe { libc::futimens(fd, times.as_ptr()) });
+    errno_check(unsafe { libc::futimens(fd, times.as_ptr()) });
     let (atime, mtime) = get_times();
     assert!(atime.0 as u64 >= before);
     assert_eq!(mtime, (2_000_000_000, 0));
 
     // A NULL `times` pointer sets both timestamps to the current time.
-    libc_utils::errno_check(unsafe { libc::futimens(fd, std::ptr::null()) });
+    errno_check(unsafe { libc::futimens(fd, std::ptr::null()) });
     let (atime, mtime) = get_times();
     assert!(atime.0 as u64 >= before);
     assert!(mtime.0 as u64 >= before);
 
     // A bad file descriptor fails with `EBADF`.
-    let err = libc_utils::errno_result(unsafe { libc::futimens(-1, times.as_ptr()) }).unwrap_err();
+    let err = errno_result(unsafe { libc::futimens(-1, times.as_ptr()) }).unwrap_err();
     assert_eq!(err.raw_os_error(), Some(libc::EBADF));
 
     remove_file(&path).unwrap();
@@ -1257,7 +1255,7 @@ fn test_linkat() {
 
     // Call linkat
     unsafe {
-        libc_utils::errno_check(libc::linkat(
+        errno_check(libc::linkat(
             libc::AT_FDCWD,
             c_source.as_ptr(),
             libc::AT_FDCWD,

--- a/tests/pass-dep/libc/libc-fs.rs
+++ b/tests/pass-dep/libc/libc-fs.rs
@@ -47,6 +47,7 @@ fn main() {
     test_fstat();
     test_stat();
     test_lstat();
+    test_futimens();
     test_isatty();
     test_read_and_uninit();
     test_nofollow_not_symlink();
@@ -716,6 +717,63 @@ fn test_lstat() {
     check_stat_fields(stat);
 
     remove_file(&symlink_path).unwrap();
+    remove_file(&path).unwrap();
+}
+
+fn test_futimens() {
+    use std::mem::MaybeUninit;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let path = utils::prepare_with_content("miri_test_libc_futimens.txt", b"hello");
+    let file = File::options().write(true).open(&path).unwrap();
+    let fd = file.as_raw_fd();
+
+    // Reads back the file's (access, modification) times as `(sec, nsec)` pairs via `fstat`.
+    let get_times = || {
+        let mut stat = MaybeUninit::<libc::stat>::uninit();
+        libc_utils::errno_check(unsafe { libc::fstat(fd, stat.as_mut_ptr()) });
+        let stat = unsafe { stat.assume_init_ref() };
+        ((stat.st_atime, stat.st_atime_nsec), (stat.st_mtime, stat.st_mtime_nsec))
+    };
+
+    // Setting both timestamps round-trips, including sub-second precision. We use 100ms since the
+    // coarsest clock any host rounds to is Windows/NTFS's 100ns.
+    let times = [
+        libc::timespec { tv_sec: 1_000_000_000, tv_nsec: 100_000_000 },
+        libc::timespec { tv_sec: 1_234_567_890, tv_nsec: 200_000_000 },
+    ];
+    libc_utils::errno_check(unsafe { libc::futimens(fd, times.as_ptr()) });
+    assert_eq!(get_times(), ((1_000_000_000, 100_000_000), (1_234_567_890, 200_000_000)));
+
+    // `UTIME_OMIT` leaves the access time unchanged while updating the modification time.
+    let times = [
+        libc::timespec { tv_sec: 0, tv_nsec: libc::UTIME_OMIT },
+        libc::timespec { tv_sec: 2_000_000_000, tv_nsec: 0 },
+    ];
+    libc_utils::errno_check(unsafe { libc::futimens(fd, times.as_ptr()) });
+    assert_eq!(get_times(), ((1_000_000_000, 100_000_000), (2_000_000_000, 0)));
+
+    // `UTIME_NOW` sets a timestamp to the current time (here for access, alongside `UTIME_OMIT`).
+    let before = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+    let times = [
+        libc::timespec { tv_sec: 0, tv_nsec: libc::UTIME_NOW },
+        libc::timespec { tv_sec: 0, tv_nsec: libc::UTIME_OMIT },
+    ];
+    libc_utils::errno_check(unsafe { libc::futimens(fd, times.as_ptr()) });
+    let (atime, mtime) = get_times();
+    assert!(atime.0 as u64 >= before);
+    assert_eq!(mtime, (2_000_000_000, 0));
+
+    // A NULL `times` pointer sets both timestamps to the current time.
+    libc_utils::errno_check(unsafe { libc::futimens(fd, std::ptr::null()) });
+    let (atime, mtime) = get_times();
+    assert!(atime.0 as u64 >= before);
+    assert!(mtime.0 as u64 >= before);
+
+    // A bad file descriptor fails with `EBADF`.
+    let err = libc_utils::errno_result(unsafe { libc::futimens(-1, times.as_ptr()) }).unwrap_err();
+    assert_eq!(err.raw_os_error(), Some(libc::EBADF));
+
     remove_file(&path).unwrap();
 }
 

--- a/tests/pass/shims/fs.rs
+++ b/tests/pass/shims/fs.rs
@@ -35,6 +35,16 @@ fn main() {
     test_file_set_len();
     test_file_sync();
     test_rename();
+    // Only these targets lower `File::set_times` to the `futimens` shim (macOS/Windows differ).
+    if cfg!(any(
+        target_os = "linux",
+        target_os = "freebsd",
+        target_os = "solaris",
+        target_os = "illumos",
+        target_os = "android"
+    )) {
+        test_file_set_times();
+    }
     // Windows file handling is very incomplete.
     if cfg!(not(windows)) {
         test_directory();
@@ -258,6 +268,34 @@ fn test_file_sync() {
         file.sync_data().unwrap_err();
         file.sync_all().unwrap_err();
     }
+
+    remove_file(&path).unwrap();
+}
+
+fn test_file_set_times() {
+    use std::fs::FileTimes;
+    use std::time::{Duration, SystemTime};
+
+    let path = utils::prepare_with_content("miri_test_fs_set_times.txt", b"hello");
+    let file = OpenOptions::new().write(true).open(&path).unwrap();
+
+    // Use fixed, whole-second timestamps to avoid sub-second granularity differences between
+    // file systems.
+    let accessed = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000_000_000);
+    let modified = SystemTime::UNIX_EPOCH + Duration::from_secs(1_234_567_890);
+
+    // Setting both timestamps round-trips through the file's metadata.
+    file.set_times(FileTimes::new().set_accessed(accessed).set_modified(modified)).unwrap();
+    let metadata = file.metadata().unwrap();
+    assert_eq!(metadata.accessed().unwrap(), accessed);
+    assert_eq!(metadata.modified().unwrap(), modified);
+
+    // Setting only the modification time (`UTIME_OMIT` for access) leaves the access time alone.
+    let newer_modified = SystemTime::UNIX_EPOCH + Duration::from_secs(2_000_000_000);
+    file.set_times(FileTimes::new().set_modified(newer_modified)).unwrap();
+    let metadata = file.metadata().unwrap();
+    assert_eq!(metadata.accessed().unwrap(), accessed);
+    assert_eq!(metadata.modified().unwrap(), newer_modified);
 
     remove_file(&path).unwrap();
 }


### PR DESCRIPTION
Closes rust-lang/miri#5018.

`futimens`'s exactly what std's `File::set_times` lowers to on `linux/freebsd/solaris/illumos/android`, so one shim covers all of them. macOS uses `fsetattrlist` instead (also can do it if you want). we already do all file ops on the real host file (`open/read/write/fstat` all go straight to the host), so the natural move is to just hand the request to the host's `File::set_times` via `std::fs::FileTimes`. the times you set with `futimens` are then exactly what `fstat` reads back, because both go through the host, thus no separate bookkeeping needed. not obvious part is `tv_nsec`. each of the two timespecs can be a normal time, `UTIME_NOW` (use current time) or `UTIME_OMIT` (leave that timestamp alone). a `NULL` times means set both to now. that maps cleanly onto `FileTimes`. i pulled the per-timespec decoding into a small `parse_utimens_timespec` helper returning a `TimeUpdate { Omit, Set(SystemTime) }`, since the same logic will be reused if anyone wires up `utimensat` later.

android specific here too. there `File::set_times` resolves futimens as a weak symbol (it needs API level 19), so I register it in `init_extern_statics + is_dyn_sym` like signal, otherwise std would see it as missing and bail with "requires API level >= 19" instead of calling the shim. on 32-bit `glibc` nothing extra is needed — std's `__futimens64` weak probe falls back to plain `futimens` on its own now that unknown weak symbols default to null.

about tests. `File::set_times` round-trip in `tests/pass/shims/fs.rs`, plus a direct `libc` test in `libc-fs.rs` covering the concrete values, `UTIME_OMIT`, `UTIME_NOW`, `NULL` and `EBADF`. green on linux (x86_64 + i686), android, freebsd, solaris, illumos and the macOS host.