### PR TITLE
Move socket logic into shared trait, rename `Socket` to `TcpSocket`

### DIFF
--- a/src/shims/files.rs
+++ b/src/shims/files.rs
@@ -232,7 +232,10 @@ pub trait FileDescription: std::fmt::Debug + FileDescriptionExt {
         false
     }
 
-    fn as_unix<'tcx>(&self, _ecx: &MiriInterpCx<'tcx>) -> &dyn UnixFileDescription {
+    fn as_unix<'tcx>(
+        self: FileDescriptionRef<Self>,
+        _ecx: &MiriInterpCx<'tcx>,
+    ) -> FileDescriptionRef<dyn UnixFileDescription> {
         panic!("Not a unix file descriptor: {}", self.name());
     }
 
@@ -470,7 +473,10 @@ impl FileDescription for FileHandle {
         true
     }
 
-    fn as_unix<'tcx>(&self, ecx: &MiriInterpCx<'tcx>) -> &dyn UnixFileDescription {
+    fn as_unix<'tcx>(
+        self: FileDescriptionRef<Self>,
+        ecx: &MiriInterpCx<'tcx>,
+    ) -> FileDescriptionRef<dyn UnixFileDescription> {
         assert!(
             ecx.target_os_is_unix(),
             "unix file operations are only available for unix targets"

--- a/src/shims/unix/fd.rs
+++ b/src/shims/unix/fd.rs
@@ -8,8 +8,10 @@ use rand::RngExt;
 use rustc_abi::{Align, Size};
 use rustc_target::spec::Os;
 
+use crate::shims::FileDescriptionRef;
 use crate::shims::files::{DynFileDescriptionRef, FileDescription};
 use crate::shims::sig::check_min_vararg_count;
+use crate::shims::unix::socket::UnixSocketFileDescription;
 use crate::shims::unix::*;
 use crate::*;
 
@@ -73,6 +75,13 @@ pub trait UnixFileDescription: FileDescription {
         _ecx: &mut MiriInterpCx<'tcx>,
     ) -> InterpResult<'tcx, i32> {
         throw_unsup_format!("cannot use ioctl on {}", self.name());
+    }
+
+    fn as_socket<'tcx>(
+        self: FileDescriptionRef<Self>,
+        _ecx: &MiriInterpCx<'tcx>,
+    ) -> FileDescriptionRef<dyn UnixSocketFileDescription> {
+        panic!("Not a unix socket file descriptor: {}", self.name());
     }
 }
 

--- a/src/shims/unix/linux_like/epoll.rs
+++ b/src/shims/unix/linux_like/epoll.rs
@@ -46,7 +46,10 @@ impl FileDescription for Epoll {
         interp_ok(Ok(()))
     }
 
-    fn as_unix<'tcx>(&self, _ecx: &MiriInterpCx<'tcx>) -> &dyn UnixFileDescription {
+    fn as_unix<'tcx>(
+        self: FileDescriptionRef<Self>,
+        _ecx: &MiriInterpCx<'tcx>,
+    ) -> FileDescriptionRef<dyn UnixFileDescription> {
         self
     }
 }

--- a/src/shims/unix/linux_like/eventfd.rs
+++ b/src/shims/unix/linux_like/eventfd.rs
@@ -119,7 +119,10 @@ impl FileDescription for EventFd {
         })
     }
 
-    fn as_unix<'tcx>(&self, _ecx: &MiriInterpCx<'tcx>) -> &dyn UnixFileDescription {
+    fn as_unix<'tcx>(
+        self: FileDescriptionRef<Self>,
+        _ecx: &MiriInterpCx<'tcx>,
+    ) -> FileDescriptionRef<dyn UnixFileDescription> {
         self
     }
 }

--- a/src/shims/unix/linux_like/syscall.rs
+++ b/src/shims/unix/linux_like/syscall.rs
@@ -7,7 +7,7 @@ use crate::shims::sig::check_min_vararg_count;
 use crate::shims::unix::env::EvalContextExt;
 use crate::shims::unix::linux_like::eventfd::EvalContextExt as _;
 use crate::shims::unix::linux_like::sync::futex;
-use crate::shims::unix::socket::EvalContextExt as _;
+use crate::shims::unix::tcp_socket::EvalContextExt as _;
 use crate::*;
 
 pub fn syscall<'tcx>(

--- a/src/shims/unix/linux_like/syscall.rs
+++ b/src/shims/unix/linux_like/syscall.rs
@@ -7,7 +7,7 @@ use crate::shims::sig::check_min_vararg_count;
 use crate::shims::unix::env::EvalContextExt;
 use crate::shims::unix::linux_like::eventfd::EvalContextExt as _;
 use crate::shims::unix::linux_like::sync::futex;
-use crate::shims::unix::tcp_socket::EvalContextExt as _;
+use crate::shims::unix::socket::EvalContextExt as _;
 use crate::*;
 
 pub fn syscall<'tcx>(

--- a/src/shims/unix/mod.rs
+++ b/src/shims/unix/mod.rs
@@ -26,7 +26,6 @@ pub use self::mem::EvalContextExt as _;
 pub use self::socket::EvalContextExt as _;
 pub use self::socket_address::EvalContextExt as _;
 pub use self::sync::EvalContextExt as _;
-pub use self::tcp_socket::EvalContextExt as _;
 pub use self::thread::{EvalContextExt as _, ThreadNameResult};
 pub use self::virtual_socket::EvalContextExt as _;
 

--- a/src/shims/unix/mod.rs
+++ b/src/shims/unix/mod.rs
@@ -23,6 +23,7 @@ pub use self::env::{EvalContextExt as _, UnixEnvVars};
 pub use self::fd::{EvalContextExt as _, UnixFileDescription};
 pub use self::fs::{DirTable, EvalContextExt as _};
 pub use self::mem::EvalContextExt as _;
+pub use self::socket::EvalContextExt as _;
 pub use self::socket_address::EvalContextExt as _;
 pub use self::sync::EvalContextExt as _;
 pub use self::tcp_socket::EvalContextExt as _;

--- a/src/shims/unix/mod.rs
+++ b/src/shims/unix/mod.rs
@@ -4,9 +4,9 @@ mod env;
 mod fd;
 mod fs;
 mod mem;
-mod socket;
 mod socket_address;
 mod sync;
+mod tcp_socket;
 mod thread;
 mod virtual_socket;
 
@@ -22,9 +22,9 @@ pub use self::env::{EvalContextExt as _, UnixEnvVars};
 pub use self::fd::{EvalContextExt as _, UnixFileDescription};
 pub use self::fs::{DirTable, EvalContextExt as _};
 pub use self::mem::EvalContextExt as _;
-pub use self::socket::EvalContextExt as _;
 pub use self::socket_address::EvalContextExt as _;
 pub use self::sync::EvalContextExt as _;
+pub use self::tcp_socket::EvalContextExt as _;
 pub use self::thread::{EvalContextExt as _, ThreadNameResult};
 pub use self::virtual_socket::EvalContextExt as _;
 

--- a/src/shims/unix/mod.rs
+++ b/src/shims/unix/mod.rs
@@ -4,6 +4,7 @@ mod env;
 mod fd;
 mod fs;
 mod mem;
+mod socket;
 mod socket_address;
 mod sync;
 mod tcp_socket;

--- a/src/shims/unix/socket.rs
+++ b/src/shims/unix/socket.rs
@@ -491,4 +491,94 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             )
         )
     }
+
+    fn recv(
+        &mut self,
+        socket: &OpTy<'tcx>,
+        buffer: &OpTy<'tcx>,
+        length: &OpTy<'tcx>,
+        flags: &OpTy<'tcx>,
+        // Location where the output scalar is written to.
+        dest: &MPlaceTy<'tcx>,
+    ) -> InterpResult<'tcx> {
+        let this = self.eval_context_mut();
+
+        let socket = this.read_scalar(socket)?.to_i32()?;
+        let buffer_ptr = this.read_pointer(buffer)?;
+        let size_layout = this.libc_ty_layout("size_t");
+        let length: usize =
+            this.read_scalar(length)?.to_uint(size_layout.size)?.try_into().unwrap();
+        let mut flags = this.read_scalar(flags)?.to_i32()?;
+
+        // Get the file handle
+        let Some(fd) = this.machine.fds.get(socket) else {
+            return this.set_errno_and_return_neg1(LibcError("EBADF"), dest);
+        };
+
+        let socket = fd.as_unix(this).as_socket(this);
+
+        let mut is_peek = false;
+        let mut is_non_block = false;
+
+        // Interpret the flag. Every flag we recognize is "subtracted" from `flags`, so
+        // if there is anything left at the end, that's an unsupported flag.
+
+        let msg_peek = this.eval_libc_i32("MSG_PEEK");
+        if flags & msg_peek == msg_peek {
+            is_peek = true;
+            flags &= !msg_peek;
+        }
+
+        if matches!(this.tcx.sess.target.os, Os::Linux | Os::Android | Os::FreeBsd | Os::Illumos) {
+            // MSG_CMSG_CLOEXEC only exists on Linux, Android, FreeBSD,
+            // and Illumos targets.
+            let msg_cmsg_cloexec = this.eval_libc_i32("MSG_CMSG_CLOEXEC");
+            if flags & msg_cmsg_cloexec == msg_cmsg_cloexec {
+                // We don't support `exec` so we can ignore this.
+                flags &= !msg_cmsg_cloexec;
+            }
+        }
+
+        if matches!(
+            this.tcx.sess.target.os,
+            Os::Linux | Os::Android | Os::FreeBsd | Os::Solaris | Os::Illumos
+        ) {
+            // MSG_DONTWAIT only exists on Linux, Android, FreeBSD,
+            // Solaris, and Illumos targets.
+            let msg_dontwait = this.eval_libc_i32("MSG_DONTWAIT");
+            if flags & msg_dontwait == msg_dontwait {
+                flags &= !msg_dontwait;
+                is_non_block = true;
+            }
+        }
+
+        if flags != 0 {
+            throw_unsup_format!(
+                "recv: flag {flags:#x} is unsupported, only MSG_PEEK, MSG_DONTWAIT \
+                and MSG_CMSG_CLOEXEC are allowed",
+            );
+        }
+
+        let dest = dest.clone();
+
+        socket.recv(
+            this.machine.communicate(),
+            buffer_ptr,
+            length,
+            is_peek,
+            is_non_block,
+            this,
+            callback!(
+                @capture<'tcx> {
+                    dest: MPlaceTy<'tcx>,
+                } |this, result: Result<usize, IoError>| {
+                    match result {
+                        Ok(bytes_sent) =>
+                            this.write_scalar(Scalar::from_target_usize(bytes_sent.try_into().unwrap(), this), &dest),
+                        Err(e) => this.set_errno_and_return_neg1(e, &dest)
+                    }
+                }
+            ),
+        )
+    }
 }

--- a/src/shims/unix/socket.rs
+++ b/src/shims/unix/socket.rs
@@ -688,4 +688,31 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
         interp_ok(Scalar::from_i32(0))
     }
+
+    fn getsockname(
+        &mut self,
+        socket: &OpTy<'tcx>,
+        address: &OpTy<'tcx>,
+        address_len: &OpTy<'tcx>,
+    ) -> InterpResult<'tcx, Scalar> {
+        let this = self.eval_context_mut();
+
+        let socket = this.read_scalar(socket)?.to_i32()?;
+        let address_ptr = this.read_pointer(address)?;
+        let address_len_ptr = this.read_pointer(address_len)?;
+
+        // Get the file handle
+        let Some(fd) = this.machine.fds.get(socket) else {
+            return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
+        };
+
+        let socket = fd.as_unix(this).as_socket(this);
+        let address = match socket.getsockname(this.machine.communicate(), this)? {
+            Ok(address) => address,
+            Err(e) => return this.set_errno_and_return_neg1_i32(e),
+        };
+
+        this.write_socket_address(&address, address_ptr, address_len_ptr, "getsockname")
+            .map(|_| Scalar::from_i32(0))
+    }
 }

--- a/src/shims/unix/socket.rs
+++ b/src/shims/unix/socket.rs
@@ -414,4 +414,81 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             ),
         )
     }
+
+    fn send(
+        &mut self,
+        socket: &OpTy<'tcx>,
+        buffer: &OpTy<'tcx>,
+        length: &OpTy<'tcx>,
+        flags: &OpTy<'tcx>,
+        // Location where the output scalar is written to.
+        dest: &MPlaceTy<'tcx>,
+    ) -> InterpResult<'tcx> {
+        let this = self.eval_context_mut();
+
+        let socket = this.read_scalar(socket)?.to_i32()?;
+        let buffer_ptr = this.read_pointer(buffer)?;
+        let size_layout = this.libc_ty_layout("size_t");
+        let length: usize =
+            this.read_scalar(length)?.to_uint(size_layout.size)?.try_into().unwrap();
+        let mut flags = this.read_scalar(flags)?.to_i32()?;
+
+        // Get the file handle
+        let Some(fd) = this.machine.fds.get(socket) else {
+            return this.set_errno_and_return_neg1(LibcError("EBADF"), dest);
+        };
+
+        let socket = fd.as_unix(this).as_socket(this);
+
+        let mut is_non_block = false;
+
+        // Interpret the flag. Every flag we recognize is "subtracted" from `flags`, so
+        // if there is anything left at the end, that's an unsupported flag.
+        if matches!(
+            this.tcx.sess.target.os,
+            Os::Linux | Os::Android | Os::FreeBsd | Os::Solaris | Os::Illumos
+        ) {
+            // MSG_NOSIGNAL and MSG_DONTWAIT only exist on Linux, Android, FreeBSD,
+            // Solaris, and Illumos targets.
+            let msg_nosignal = this.eval_libc_i32("MSG_NOSIGNAL");
+            let msg_dontwait = this.eval_libc_i32("MSG_DONTWAIT");
+            if flags & msg_nosignal == msg_nosignal {
+                // This is only needed to ensure that no EPIPE signal is sent when
+                // trying to send into a stream which is no longer connected.
+                // Since we don't support signals, we can ignore this.
+                flags &= !msg_nosignal;
+            }
+            if flags & msg_dontwait == msg_dontwait {
+                flags &= !msg_dontwait;
+                is_non_block = true;
+            }
+        }
+
+        if flags != 0 {
+            throw_unsup_format!(
+                "send: flag {flags:#x} is unsupported, only MSG_NOSIGNAL and MSG_DONTWAIT are allowed",
+            );
+        }
+
+        let dest = dest.clone();
+
+        socket.send(
+            this.machine.communicate(),
+            buffer_ptr,
+            length,
+            is_non_block,
+            this,
+            callback!(
+                @capture<'tcx> {
+                    dest: MPlaceTy<'tcx>,
+                } |this, result: Result<usize, IoError>| {
+                    match result {
+                        Ok(bytes_sent) =>
+                            this.write_scalar(Scalar::from_target_usize(bytes_sent.try_into().unwrap(), this), &dest),
+                        Err(e) => this.set_errno_and_return_neg1(e, &dest)
+                    }
+                }
+            )
+        )
+    }
 }

--- a/src/shims/unix/socket.rs
+++ b/src/shims/unix/socket.rs
@@ -266,4 +266,22 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             Err(e) => this.set_errno_and_return_neg1_i32(e),
         }
     }
+
+    fn listen(&mut self, socket: &OpTy<'tcx>, backlog: &OpTy<'tcx>) -> InterpResult<'tcx, Scalar> {
+        let this = self.eval_context_mut();
+
+        let socket = this.read_scalar(socket)?.to_i32()?;
+        let backlog = this.read_scalar(backlog)?.to_i32()?;
+
+        // Get the file handle
+        let Some(fd) = this.machine.fds.get(socket) else {
+            return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
+        };
+
+        let socket = fd.as_unix(this).as_socket(this);
+        match socket.listen(this.machine.communicate(), backlog, this)? {
+            Ok(_) => interp_ok(Scalar::from_i32(0)),
+            Err(e) => this.set_errno_and_return_neg1_i32(e),
+        }
+    }
 }

--- a/src/shims/unix/socket.rs
+++ b/src/shims/unix/socket.rs
@@ -372,4 +372,46 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             ),
         )
     }
+
+    fn connect(
+        &mut self,
+        socket: &OpTy<'tcx>,
+        address: &OpTy<'tcx>,
+        address_len: &OpTy<'tcx>,
+        // Location where the output scalar is written to.
+        dest: &MPlaceTy<'tcx>,
+    ) -> InterpResult<'tcx> {
+        let this = self.eval_context_mut();
+
+        let socket = this.read_scalar(socket)?.to_i32()?;
+        let address = match this.read_socket_address(address, address_len, "connect")? {
+            Ok(address) => address,
+            Err(e) => return this.set_errno_and_return_neg1(e, dest),
+        };
+
+        // Get the file handle
+        let Some(fd) = this.machine.fds.get(socket) else {
+            return this.set_errno_and_return_neg1(LibcError("EBADF"), dest);
+        };
+
+        let socket = fd.as_unix(this).as_socket(this);
+
+        let dest = dest.clone();
+
+        socket.connect(
+            this.machine.communicate(),
+            address,
+            this,
+            callback!(
+                @capture<'tcx> {
+                    dest: MPlaceTy<'tcx>
+                 } |this, result: Result<(), IoError>| {
+                     match result {
+                         Ok(_) => this.write_null(&dest),
+                         Err(e) => this.set_errno_and_return_neg1(e, &dest)
+                     }
+                 }
+            ),
+        )
+    }
 }

--- a/src/shims/unix/socket.rs
+++ b/src/shims/unix/socket.rs
@@ -284,4 +284,92 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             Err(e) => this.set_errno_and_return_neg1_i32(e),
         }
     }
+
+    /// For more information on the arguments see the accept manpage:
+    /// <https://linux.die.net/man/2/accept4>
+    fn accept4(
+        &mut self,
+        socket: &OpTy<'tcx>,
+        address: &OpTy<'tcx>,
+        address_len: &OpTy<'tcx>,
+        flags: Option<&OpTy<'tcx>>,
+        // Location where the output scalar is written to.
+        dest: &MPlaceTy<'tcx>,
+    ) -> InterpResult<'tcx> {
+        let this = self.eval_context_mut();
+
+        let socket = this.read_scalar(socket)?.to_i32()?;
+        let address_ptr = this.read_pointer(address)?;
+        let address_len_ptr = this.read_pointer(address_len)?;
+        let mut flags =
+            if let Some(flags) = flags { this.read_scalar(flags)?.to_i32()? } else { 0 };
+
+        // Get the file handle
+        let Some(fd) = this.machine.fds.get(socket) else {
+            return this.set_errno_and_return_neg1(LibcError("EBADF"), dest);
+        };
+
+        let socket = fd.as_unix(this).as_socket(this);
+
+        let mut is_client_sock_nonblock = false;
+
+        // Interpret the flag. Every flag we recognize is "subtracted" from `flags`, so
+        // if there is anything left at the end, that's an unsupported flag.
+        if matches!(
+            this.tcx.sess.target.os,
+            Os::Linux | Os::Android | Os::FreeBsd | Os::Solaris | Os::Illumos
+        ) {
+            // SOCK_NONBLOCK and SOCK_CLOEXEC only exist on Linux, Android, FreeBSD,
+            // Solaris, and Illumos targets.
+            let sock_nonblock = this.eval_libc_i32("SOCK_NONBLOCK");
+            let sock_cloexec = this.eval_libc_i32("SOCK_CLOEXEC");
+            if flags & sock_nonblock == sock_nonblock {
+                is_client_sock_nonblock = true;
+                flags &= !sock_nonblock;
+            }
+            if flags & sock_cloexec == sock_cloexec {
+                // We don't support `exec` so we can ignore this.
+                flags &= !sock_cloexec;
+            }
+        }
+
+        if flags != 0 {
+            throw_unsup_format!(
+                "accept4: flag {flags:#x} is unsupported, only SOCK_CLOEXEC \
+                and SOCK_NONBLOCK are allowed",
+            );
+        }
+
+        let dest = dest.clone();
+        socket.accept(
+            this.machine.communicate(),
+            is_client_sock_nonblock,
+            this,
+            callback!(
+                @capture<'tcx> {
+                    address_ptr: Pointer,
+                    address_len_ptr: Pointer,
+                    dest: MPlaceTy<'tcx>
+                } |this, result: Result<(i32, SocketAddr), IoError>| {
+                    let (client_sockfd, address) = match result {
+                        Ok((sockfd, address)) => (sockfd, address),
+                        Err(e) => return this.set_errno_and_return_neg1(e, &dest),
+                    };
+
+                    if address_ptr != Pointer::null() {
+                        // We only attempt a write if the address pointer is not a null pointer.
+                        // If the address pointer is a null pointer the user isn't interested in the
+                        // address and we don't need to write anything.
+                        this.write_socket_address(&address, address_ptr, address_len_ptr, "accept4")?;
+                    }
+
+                    // We need to create the scalar using the destination size since
+                    // `syscall(SYS_accept4, ...)` returns a long which doesn't match
+                    // the int returned from the `accept`/`accept4` syscalls.
+                    // See <https://man7.org/linux/man-pages/man2/syscall.2.html>.
+                    this.write_scalar(Scalar::from_int(client_sockfd, dest.layout.size), &dest)
+                }
+            ),
+        )
+    }
 }

--- a/src/shims/unix/socket.rs
+++ b/src/shims/unix/socket.rs
@@ -1,5 +1,6 @@
 use std::net::{Shutdown, SocketAddr};
 
+use rustc_abi::Size;
 use rustc_target::spec::Os;
 
 use crate::shims::FileDescriptionRef;
@@ -611,5 +612,80 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             Ok(_) => interp_ok(Scalar::from_i32(0)),
             Err(e) => this.set_errno_and_return_neg1_i32(e),
         }
+    }
+
+    fn getsockopt(
+        &mut self,
+        socket: &OpTy<'tcx>,
+        level: &OpTy<'tcx>,
+        option_name: &OpTy<'tcx>,
+        option_value: &OpTy<'tcx>,
+        option_len: &OpTy<'tcx>,
+    ) -> InterpResult<'tcx, Scalar> {
+        let this = self.eval_context_mut();
+
+        let socket = this.read_scalar(socket)?.to_i32()?;
+        let level = this.read_scalar(level)?.to_i32()?;
+        let option_name = this.read_scalar(option_name)?.to_i32()?;
+        // These two pointers are used to return the value: `len_ptr` initially stores how much space
+        // is available. If the actual value fits into that space, it is written to
+        // `value_ptr` and `len_ptr` is updated to represent how many bytes
+        // were actually written. If the value does not fit, it is silently truncated.
+        // Also see <https://pubs.opengroup.org/onlinepubs/9799919799/functions/getsockopt.html>.
+        let option_value_ptr = this.read_pointer(option_value)?;
+        let option_len_ptr = this.read_pointer(option_len)?;
+
+        // Get the file handle
+        let Some(fd) = this.machine.fds.get(socket) else {
+            return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
+        };
+
+        let socket = fd.as_unix(this).as_socket(this);
+
+        if option_value_ptr == Pointer::null() || option_len_ptr == Pointer::null() {
+            // This socket option returns a value and thus we need to return EFAULT
+            // when either the value or the length pointers are null pointers.
+            return this.set_errno_and_return_neg1_i32(LibcError("EFAULT"));
+        }
+
+        let socklen_layout = this.libc_ty_layout("socklen_t");
+        let option_len_ptr_mplace = this.ptr_to_mplace(option_len_ptr, socklen_layout);
+        let option_len: usize = this
+            .read_scalar(&option_len_ptr_mplace)?
+            .to_int(socklen_layout.size)?
+            .try_into()
+            .unwrap();
+
+        // `socket.getsockopt` returns a temporary buffer as `option_value_ptr` might not point
+        // to a large enough buffer, in which case we have to truncate.
+        let value_mplace = match socket.getsockopt(level, option_name, this)? {
+            Ok(value_mplace) => value_mplace,
+            Err(e) => return this.set_errno_and_return_neg1_i32(e),
+        };
+
+        // Truncated size of the output value.
+        let output_value_len = value_mplace.layout.size.min(Size::from_bytes(option_len));
+        // Copy the truncated value into the buffer pointed to by `option_value_ptr`.
+        this.mem_copy(
+            value_mplace.ptr(),
+            option_value_ptr,
+            // Truncate the value to fit the provided buffer.
+            output_value_len,
+            // The buffers are guaranteed to not overlap since the `value_mplace`
+            // was just newly allocated on the stack.
+            true,
+        )?;
+        // Deallocate the value buffer as it was only needed to store the value and
+        // copy it into the buffer pointed to by `option_value_ptr`.
+        this.deallocate_ptr(value_mplace.ptr(), None, MemoryKind::Stack)?;
+
+        // On output, the length pointer contains the amount of bytes written -- not the size
+        // of the value before truncation.
+        this.write_scalar(
+            Scalar::from_uint(output_value_len.bytes(), socklen_layout.size),
+            &option_len_ptr_mplace,
+        )?;
+
+        interp_ok(Scalar::from_i32(0))
     }
 }

--- a/src/shims/unix/socket.rs
+++ b/src/shims/unix/socket.rs
@@ -1,0 +1,162 @@
+use std::net::{Shutdown, SocketAddr};
+
+use crate::shims::FileDescriptionRef;
+use crate::shims::files::FdNum;
+use crate::shims::unix::UnixFileDescription;
+use crate::*;
+
+#[derive(Debug, PartialEq)]
+pub enum SocketFamily {
+    // IPv4 internet protocols
+    IPv4,
+    // IPv6 internet protocols
+    IPv6,
+}
+
+/// Represents unix-specific socket file descriptions.
+///
+/// Not to be confused with Unix domain sockets.
+pub trait UnixSocketFileDescription: UnixFileDescription {
+    /// Bind the socket to `address`.
+    fn bind<'tcx>(
+        self: FileDescriptionRef<Self>,
+        _communicate_allowed: bool,
+        _address: SocketAddr,
+        _ecx: &mut MiriInterpCx<'tcx>,
+    ) -> InterpResult<'tcx, Result<(), IoError>> {
+        throw_unsup_format!("cannot bind {}", self.name());
+    }
+
+    /// Start listening on the socket.
+    /// `backlog` specifies how many pending incoming connections can exist
+    /// at the same time before new requests are rejected.
+    fn listen<'tcx>(
+        self: FileDescriptionRef<Self>,
+        _communicate_allowed: bool,
+        _backlog: i32,
+        _ecx: &mut MiriInterpCx<'tcx>,
+    ) -> InterpResult<'tcx, Result<(), IoError>> {
+        throw_unsup_format!("cannot listen on {}", self.name());
+    }
+
+    /// Accept an incoming connection on the socket.
+    /// `is_client_sock_non_block` specifies whether the newly accepted
+    /// client connection should be non-blocking.
+    /// After a successful accept, `finish` should be called with a
+    /// tuple containing the file descriptor of the peer socket and
+    /// it's address.
+    fn accept<'tcx>(
+        self: FileDescriptionRef<Self>,
+        _communicate_allowed: bool,
+        _is_client_sock_non_block: bool,
+        _ecx: &mut MiriInterpCx<'tcx>,
+        _finish: DynMachineCallback<'tcx, Result<(FdNum, SocketAddr), IoError>>,
+    ) -> InterpResult<'tcx> {
+        throw_unsup_format!("cannot accept {}", self.name());
+    }
+
+    /// Connect the socket to `address`.
+    fn connect<'tcx>(
+        self: FileDescriptionRef<Self>,
+        _communicate_allowed: bool,
+        _address: SocketAddr,
+        _ecx: &mut MiriInterpCx<'tcx>,
+        _finish: DynMachineCallback<'tcx, Result<(), IoError>>,
+    ) -> InterpResult<'tcx> {
+        throw_unsup_format!("cannot connect {}", self.name());
+    }
+
+    /// Recieve data on the socket into the given buffer `ptr`.
+    /// `len` indicates how many bytes we should try to receive.
+    /// `is_peek` specifies whether the receive removes the bytes
+    /// from the receive buffer ([`false`]) or leaves them in the
+    /// reiceve buffer ([`true`]).
+    /// `is_non_block` specifies whether the receive operation is
+    /// non-blocking.
+    /// After a successful receive, `finish` should be called with
+    /// the amount of bytes received.
+    fn recv<'tcx>(
+        self: FileDescriptionRef<Self>,
+        _communicate_allowed: bool,
+        _ptr: Pointer,
+        _len: usize,
+        _is_peek: bool,
+        _is_non_block: bool,
+        _ecx: &mut MiriInterpCx<'tcx>,
+        _finish: DynMachineCallback<'tcx, Result<usize, IoError>>,
+    ) -> InterpResult<'tcx> {
+        throw_unsup_format!("cannot receive from {}", self.name());
+    }
+
+    /// Send data from the given buffer `ptr` into the socket.
+    /// `len` indicates how many bytes we should try to send.
+    /// `is_non_block` specifies whether the send operation is
+    /// non-blocking.
+    /// After a successful send, `finish` should be called with
+    /// the amount of bytes sent.
+    fn send<'tcx>(
+        self: FileDescriptionRef<Self>,
+        _communicate_allowed: bool,
+        _ptr: Pointer,
+        _len: usize,
+        _is_non_block: bool,
+        _ecx: &mut MiriInterpCx<'tcx>,
+        _finish: DynMachineCallback<'tcx, Result<usize, IoError>>,
+    ) -> InterpResult<'tcx> {
+        throw_unsup_format!("cannot send to {}", self.name());
+    }
+
+    /// Set the socket option `option` on `level`.
+    /// `value_ptr` points to the new value of the socket option,
+    /// and `value_len` contains the amount of bytes the value uses
+    /// at `value_ptr`.
+    fn setsockopt<'tcx>(
+        self: FileDescriptionRef<Self>,
+        _level: i32,
+        _option: i32,
+        _value_ptr: Pointer,
+        _value_len: u64,
+        _ecx: &mut MiriInterpCx<'tcx>,
+    ) -> InterpResult<'tcx, Result<(), IoError>> {
+        throw_unsup_format!("cannot set socket option on {}", self.name());
+    }
+
+    /// Get the value of a socket option `option` on `level`.
+    fn getsockopt<'tcx>(
+        self: FileDescriptionRef<Self>,
+        _level: i32,
+        _option: i32,
+        _ecx: &mut MiriInterpCx<'tcx>,
+    ) -> InterpResult<'tcx, Result<MPlaceTy<'tcx>, IoError>> {
+        throw_unsup_format!("cannot get socket option for {}", self.name());
+    }
+
+    /// Get the address of the socket.
+    fn getsockname<'tcx>(
+        self: FileDescriptionRef<Self>,
+        _communicate_allowed: bool,
+        _ecx: &mut MiriInterpCx<'tcx>,
+    ) -> InterpResult<'tcx, Result<SocketAddr, IoError>> {
+        throw_unsup_format!("cannot get socket name for {}", self.name());
+    }
+
+    /// Get the address of the connected socket.
+    fn getpeername<'tcx>(
+        self: FileDescriptionRef<Self>,
+        _communicate_allowed: bool,
+        _ecx: &mut MiriInterpCx<'tcx>,
+        _finish: DynMachineCallback<'tcx, Result<SocketAddr, IoError>>,
+    ) -> InterpResult<'tcx> {
+        throw_unsup_format!("cannot get peer name for {}", self.name());
+    }
+
+    /// Shut down the read and/or the write end of the socket.
+    fn shutdown<'tcx>(
+        self: FileDescriptionRef<Self>,
+        _communicate_allowed: bool,
+        _how: Shutdown,
+        _ecx: &mut MiriInterpCx<'tcx>,
+    ) -> InterpResult<'tcx, Result<(), IoError>> {
+        throw_unsup_format!("cannot shut down {}", self.name());
+    }
+}

--- a/src/shims/unix/socket.rs
+++ b/src/shims/unix/socket.rs
@@ -715,4 +715,52 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         this.write_socket_address(&address, address_ptr, address_len_ptr, "getsockname")
             .map(|_| Scalar::from_i32(0))
     }
+
+    fn getpeername(
+        &mut self,
+        socket: &OpTy<'tcx>,
+        address: &OpTy<'tcx>,
+        address_len: &OpTy<'tcx>,
+        // Location where the output scalar is written to.
+        dest: &MPlaceTy<'tcx>,
+    ) -> InterpResult<'tcx> {
+        let this = self.eval_context_mut();
+
+        let socket = this.read_scalar(socket)?.to_i32()?;
+        let address_ptr = this.read_pointer(address)?;
+        let address_len_ptr = this.read_pointer(address_len)?;
+
+        // Get the file handle
+        let Some(fd) = this.machine.fds.get(socket) else {
+            return this.set_errno_and_return_neg1(LibcError("EBADF"), dest);
+        };
+
+        let socket = fd.as_unix(this).as_socket(this);
+        let dest = dest.clone();
+
+        socket.getpeername(
+            this.machine.communicate(),
+            this,
+            callback!(
+                @capture<'tcx> {
+                    address_ptr: Pointer,
+                    address_len_ptr: Pointer,
+                    dest: MPlaceTy<'tcx>,
+                } |this, result: Result<SocketAddr, IoError>| {
+                    let address = match result {
+                        Ok(address) => address,
+                        Err(e) => return this.set_errno_and_return_neg1(e, &dest)
+                    };
+
+                    this.write_socket_address(
+                        &address,
+                        address_ptr,
+                        address_len_ptr,
+                        "getpeername",
+                    )?;
+                   this.write_scalar(Scalar::from_i32(0), &dest)
+                }
+            ),
+        )
+    }
 }

--- a/src/shims/unix/socket.rs
+++ b/src/shims/unix/socket.rs
@@ -1,8 +1,11 @@
 use std::net::{Shutdown, SocketAddr};
 
+use rustc_target::spec::Os;
+
 use crate::shims::FileDescriptionRef;
 use crate::shims::files::FdNum;
 use crate::shims::unix::UnixFileDescription;
+use crate::shims::unix::tcp_socket::TcpSocket;
 use crate::*;
 
 #[derive(Debug, PartialEq)]
@@ -158,5 +161,82 @@ pub trait UnixSocketFileDescription: UnixFileDescription {
         _ecx: &mut MiriInterpCx<'tcx>,
     ) -> InterpResult<'tcx, Result<(), IoError>> {
         throw_unsup_format!("cannot shut down {}", self.name());
+    }
+}
+
+impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
+pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
+    /// For more information on the arguments see the socket manpage:
+    /// <https://linux.die.net/man/2/socket>
+    fn socket(
+        &mut self,
+        domain: &OpTy<'tcx>,
+        type_: &OpTy<'tcx>,
+        protocol: &OpTy<'tcx>,
+    ) -> InterpResult<'tcx, Scalar> {
+        let this = self.eval_context_mut();
+
+        let domain = this.read_scalar(domain)?.to_i32()?;
+        let mut flags = this.read_scalar(type_)?.to_i32()?;
+        let protocol = this.read_scalar(protocol)?.to_i32()?;
+
+        // Reject if isolation is enabled
+        if let IsolatedOp::Reject(reject_with) = this.machine.isolated_op {
+            this.reject_in_isolation("`socket`", reject_with)?;
+            return this.set_errno_and_return_neg1_i32(LibcError("EACCES"));
+        }
+
+        let mut is_non_block = false;
+
+        // Interpret the flag. Every flag we recognize is "subtracted" from `flags`, so
+        // if there is anything left at the end, that's an unsupported flag.
+        if matches!(
+            this.tcx.sess.target.os,
+            Os::Linux | Os::Android | Os::FreeBsd | Os::Solaris | Os::Illumos
+        ) {
+            // SOCK_NONBLOCK and SOCK_CLOEXEC only exist on Linux, Android, FreeBSD,
+            // Solaris, and Illumos targets.
+            let sock_nonblock = this.eval_libc_i32("SOCK_NONBLOCK");
+            let sock_cloexec = this.eval_libc_i32("SOCK_CLOEXEC");
+            if flags & sock_nonblock == sock_nonblock {
+                is_non_block = true;
+                flags &= !sock_nonblock;
+            }
+            if flags & sock_cloexec == sock_cloexec {
+                // We don't support `exec` so we can ignore this.
+                flags &= !sock_cloexec;
+            }
+        }
+
+        let family = if domain == this.eval_libc_i32("AF_INET") {
+            SocketFamily::IPv4
+        } else if domain == this.eval_libc_i32("AF_INET6") {
+            SocketFamily::IPv6
+        } else {
+            throw_unsup_format!(
+                "socket: domain {:#x} is unsupported, only AF_INET and \
+            AF_INET6 are allowed.",
+                domain
+            );
+        };
+
+        if flags != this.eval_libc_i32("SOCK_STREAM") {
+            throw_unsup_format!(
+                "socket: type {:#x} is unsupported, only SOCK_STREAM, \
+            SOCK_CLOEXEC and SOCK_NONBLOCK are allowed",
+                flags
+            );
+        }
+        if protocol != 0 && protocol != this.eval_libc_i32("IPPROTO_TCP") {
+            throw_unsup_format!(
+                "socket: socket protocol {protocol} is unsupported, \
+            only IPPROTO_TCP and 0 are allowed"
+            );
+        }
+
+        let fds = &mut this.machine.fds;
+        let fd = fds.new_ref(TcpSocket::new(family, is_non_block));
+
+        interp_ok(Scalar::from_i32(fds.insert(fd)))
     }
 }

--- a/src/shims/unix/socket.rs
+++ b/src/shims/unix/socket.rs
@@ -33,8 +33,8 @@ pub trait UnixSocketFileDescription: UnixFileDescription {
     }
 
     /// Start listening on the socket.
-    /// `backlog` specifies how many pending incoming connections can exist
-    /// at the same time before new requests are rejected.
+    /// `backlog` specifies how many pending incoming connections can exist at the same
+    /// time before new requests are rejected.
     fn listen<'tcx>(
         self: FileDescriptionRef<Self>,
         _communicate_allowed: bool,
@@ -45,11 +45,10 @@ pub trait UnixSocketFileDescription: UnixFileDescription {
     }
 
     /// Accept an incoming connection on the socket.
-    /// `is_client_sock_non_block` specifies whether the newly accepted
-    /// client connection should be non-blocking.
-    /// After a successful accept, `finish` should be called with a
-    /// tuple containing the file descriptor of the peer socket and
-    /// it's address.
+    /// `is_client_sock_non_block` specifies whether the newly accepted client connection
+    /// should be non-blocking.
+    /// After a successful accept, `finish` should be called with a tuple containing the
+    /// file descriptor of the peer socket and it's address.
     fn accept<'tcx>(
         self: FileDescriptionRef<Self>,
         _communicate_allowed: bool,
@@ -73,13 +72,10 @@ pub trait UnixSocketFileDescription: UnixFileDescription {
 
     /// Recieve data on the socket into the given buffer `ptr`.
     /// `len` indicates how many bytes we should try to receive.
-    /// `is_peek` specifies whether the receive removes the bytes
-    /// from the receive buffer ([`false`]) or leaves them in the
-    /// reiceve buffer ([`true`]).
-    /// `is_non_block` specifies whether the receive operation is
-    /// non-blocking.
-    /// After a successful receive, `finish` should be called with
-    /// the amount of bytes received.
+    /// `is_peek` specifies whether the receive removes the bytes from the receive buffer
+    /// ([`false`]) or leaves them in the reiceve buffer ([`true`]).
+    /// `is_non_block` specifies whether the receive operation is non-blocking.
+    /// After a successful receive, `finish` should be called with the amount of bytes received.
     fn recv<'tcx>(
         self: FileDescriptionRef<Self>,
         _communicate_allowed: bool,
@@ -95,10 +91,8 @@ pub trait UnixSocketFileDescription: UnixFileDescription {
 
     /// Send data from the given buffer `ptr` into the socket.
     /// `len` indicates how many bytes we should try to send.
-    /// `is_non_block` specifies whether the send operation is
-    /// non-blocking.
-    /// After a successful send, `finish` should be called with
-    /// the amount of bytes sent.
+    /// `is_non_block` specifies whether the send operation is non-blocking.
+    /// After a successful send, `finish` should be called with the amount of bytes sent.
     fn send<'tcx>(
         self: FileDescriptionRef<Self>,
         _communicate_allowed: bool,
@@ -112,9 +106,8 @@ pub trait UnixSocketFileDescription: UnixFileDescription {
     }
 
     /// Set the socket option `option` on `level`.
-    /// `value_ptr` points to the new value of the socket option,
-    /// and `value_len` contains the amount of bytes the value uses
-    /// at `value_ptr`.
+    /// `value_ptr` points to the new value of the socket option, and `value_len` contains
+    /// the amount of bytes the value uses at `value_ptr`.
     fn setsockopt<'tcx>(
         self: FileDescriptionRef<Self>,
         _level: i32,
@@ -136,7 +129,7 @@ pub trait UnixSocketFileDescription: UnixFileDescription {
         throw_unsup_format!("cannot get socket option for {}", self.name());
     }
 
-    /// Get the address of the socket.
+    /// Get the local address of the socket.
     fn getsockname<'tcx>(
         self: FileDescriptionRef<Self>,
         _communicate_allowed: bool,
@@ -145,7 +138,7 @@ pub trait UnixSocketFileDescription: UnixFileDescription {
         throw_unsup_format!("cannot get socket name for {}", self.name());
     }
 
-    /// Get the address of the connected socket.
+    /// Get the remote address of the socket.
     fn getpeername<'tcx>(
         self: FileDescriptionRef<Self>,
         _communicate_allowed: bool,
@@ -351,9 +344,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     address_ptr: Pointer,
                     address_len_ptr: Pointer,
                     dest: MPlaceTy<'tcx>
-                } |this, result: Result<(i32, SocketAddr), IoError>| {
+                } |this, result: Result<(FdNum, SocketAddr), IoError>| {
                     let (client_sockfd, address) = match result {
-                        Ok((sockfd, address)) => (sockfd, address),
+                        Ok(data) => data,
                         Err(e) => return this.set_errno_and_return_neg1(e, &dest),
                     };
 
@@ -408,7 +401,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     dest: MPlaceTy<'tcx>
                  } |this, result: Result<(), IoError>| {
                      match result {
-                         Ok(_) => this.write_null(&dest),
+                         Ok(()) => this.write_null(&dest),
                          Err(e) => this.set_errno_and_return_neg1(e, &dest)
                      }
                  }

--- a/src/shims/unix/socket.rs
+++ b/src/shims/unix/socket.rs
@@ -763,4 +763,35 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             ),
         )
     }
+
+    fn shutdown(&mut self, socket: &OpTy<'tcx>, how: &OpTy<'tcx>) -> InterpResult<'tcx, Scalar> {
+        let this = self.eval_context_mut();
+
+        let socket = this.read_scalar(socket)?.to_i32()?;
+        let how = this.read_scalar(how)?.to_i32()?;
+
+        // Get the file handle
+        let Some(fd) = this.machine.fds.get(socket) else {
+            return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
+        };
+
+        let socket = fd.as_unix(this).as_socket(this);
+
+        let is_read_shutdown = how == this.eval_libc_i32("SHUT_RD");
+        let is_write_shutdown = how == this.eval_libc_i32("SHUT_WR");
+        let is_read_write_shutdown = how == this.eval_libc_i32("SHUT_RDWR");
+
+        let how = match () {
+            _ if is_read_shutdown => Shutdown::Read,
+            _ if is_write_shutdown => Shutdown::Write,
+            _ if is_read_write_shutdown => Shutdown::Both,
+            // An invalid value was passed to `how`.
+            _ => return this.set_errno_and_return_neg1_i32(LibcError("EINVAL")),
+        };
+
+        match socket.shutdown(this.machine.communicate(), how, this)? {
+            Ok(_) => interp_ok(Scalar::from_i32(0)),
+            Err(e) => this.set_errno_and_return_neg1_i32(e),
+        }
+    }
 }

--- a/src/shims/unix/socket.rs
+++ b/src/shims/unix/socket.rs
@@ -5,6 +5,7 @@ use rustc_target::spec::Os;
 use crate::shims::FileDescriptionRef;
 use crate::shims::files::FdNum;
 use crate::shims::unix::UnixFileDescription;
+use crate::shims::unix::socket_address::EvalContextExt as _;
 use crate::shims::unix::tcp_socket::TcpSocket;
 use crate::*;
 
@@ -238,5 +239,31 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let fd = fds.new_ref(TcpSocket::new(family, is_non_block));
 
         interp_ok(Scalar::from_i32(fds.insert(fd)))
+    }
+
+    fn bind(
+        &mut self,
+        socket: &OpTy<'tcx>,
+        address: &OpTy<'tcx>,
+        address_len: &OpTy<'tcx>,
+    ) -> InterpResult<'tcx, Scalar> {
+        let this = self.eval_context_mut();
+
+        let socket = this.read_scalar(socket)?.to_i32()?;
+        let address = match this.read_socket_address(address, address_len, "bind")? {
+            Ok(addr) => addr,
+            Err(e) => return this.set_errno_and_return_neg1_i32(e),
+        };
+
+        // Get the file handle
+        let Some(fd) = this.machine.fds.get(socket) else {
+            return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
+        };
+
+        let socket = fd.as_unix(this).as_socket(this);
+        match socket.bind(this.machine.communicate(), address, this)? {
+            Ok(_) => interp_ok(Scalar::from_i32(0)),
+            Err(e) => this.set_errno_and_return_neg1_i32(e),
+        }
     }
 }

--- a/src/shims/unix/socket.rs
+++ b/src/shims/unix/socket.rs
@@ -581,4 +581,35 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             ),
         )
     }
+
+    fn setsockopt(
+        &mut self,
+        socket: &OpTy<'tcx>,
+        level: &OpTy<'tcx>,
+        option_name: &OpTy<'tcx>,
+        option_value: &OpTy<'tcx>,
+        option_len: &OpTy<'tcx>,
+    ) -> InterpResult<'tcx, Scalar> {
+        let this = self.eval_context_mut();
+
+        let socket = this.read_scalar(socket)?.to_i32()?;
+        let level = this.read_scalar(level)?.to_i32()?;
+        let option_name = this.read_scalar(option_name)?.to_i32()?;
+        let option_value_ptr = this.read_pointer(option_value)?;
+        let socklen_layout = this.libc_ty_layout("socklen_t");
+        let option_len: u64 =
+            this.read_scalar(option_len)?.to_int(socklen_layout.size)?.try_into().unwrap();
+
+        // Get the file handle
+        let Some(fd) = this.machine.fds.get(socket) else {
+            return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
+        };
+
+        let socket = fd.as_unix(this).as_socket(this);
+        let result = socket.setsockopt(level, option_name, option_value_ptr, option_len, this)?;
+        match result {
+            Ok(_) => interp_ok(Scalar::from_i32(0)),
+            Err(e) => this.set_errno_and_return_neg1_i32(e),
+        }
+    }
 }

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -536,85 +536,24 @@ impl UnixSocketFileDescription for TcpSocket {
             ),
         )
     }
-}
 
-impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
-pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
-    fn recv(
-        &mut self,
-        socket: &OpTy<'tcx>,
-        buffer: &OpTy<'tcx>,
-        length: &OpTy<'tcx>,
-        flags: &OpTy<'tcx>,
-        // Location where the output scalar is written to.
-        dest: &MPlaceTy<'tcx>,
+    fn recv<'tcx>(
+        self: FileDescriptionRef<Self>,
+        communicate_allowed: bool,
+        ptr: Pointer,
+        len: usize,
+        is_peek: bool,
+        is_non_block: bool,
+        ecx: &mut MiriInterpCx<'tcx>,
+        finish: DynMachineCallback<'tcx, Result<usize, IoError>>,
     ) -> InterpResult<'tcx> {
-        let this = self.eval_context_mut();
+        assert!(communicate_allowed, "cannot have `TcpSocket` with isolation enabled!");
 
-        let socket = this.read_scalar(socket)?.to_i32()?;
-        let buffer_ptr = this.read_pointer(buffer)?;
-        let size_layout = this.libc_ty_layout("size_t");
-        let length: usize =
-            this.read_scalar(length)?.to_uint(size_layout.size)?.try_into().unwrap();
-        let mut flags = this.read_scalar(flags)?.to_i32()?;
+        let is_non_block = is_non_block || self.is_non_block.get();
+        let deadline = ecx.action_deadline(is_non_block, self.read_timeout.get());
 
-        // Get the file handle
-        let Some(fd) = this.machine.fds.get(socket) else {
-            return this.set_errno_and_return_neg1(LibcError("EBADF"), dest);
-        };
-
-        let Some(socket) = fd.downcast::<TcpSocket>() else {
-            // Man page specifies to return ENOTSOCK if `fd` is not a socket
-            return this.set_errno_and_return_neg1(LibcError("ENOTSOCK"), dest);
-        };
-
-        let mut should_peek = false;
-        let mut is_op_non_block = false;
-
-        // Interpret the flag. Every flag we recognize is "subtracted" from `flags`, so
-        // if there is anything left at the end, that's an unsupported flag.
-
-        let msg_peek = this.eval_libc_i32("MSG_PEEK");
-        if flags & msg_peek == msg_peek {
-            should_peek = true;
-            flags &= !msg_peek;
-        }
-
-        if matches!(this.tcx.sess.target.os, Os::Linux | Os::Android | Os::FreeBsd | Os::Illumos) {
-            // MSG_CMSG_CLOEXEC only exists on Linux, Android, FreeBSD,
-            // and Illumos targets.
-            let msg_cmsg_cloexec = this.eval_libc_i32("MSG_CMSG_CLOEXEC");
-            if flags & msg_cmsg_cloexec == msg_cmsg_cloexec {
-                // We don't support `exec` so we can ignore this.
-                flags &= !msg_cmsg_cloexec;
-            }
-        }
-
-        if matches!(
-            this.tcx.sess.target.os,
-            Os::Linux | Os::Android | Os::FreeBsd | Os::Solaris | Os::Illumos
-        ) {
-            // MSG_DONTWAIT only exists on Linux, Android, FreeBSD,
-            // Solaris, and Illumos targets.
-            let msg_dontwait = this.eval_libc_i32("MSG_DONTWAIT");
-            if flags & msg_dontwait == msg_dontwait {
-                flags &= !msg_dontwait;
-                is_op_non_block = true;
-            }
-        }
-
-        if flags != 0 {
-            throw_unsup_format!(
-                "recv: flag {flags:#x} is unsupported, only MSG_PEEK, MSG_DONTWAIT \
-                and MSG_CMSG_CLOEXEC are allowed",
-            );
-        }
-
-        let is_non_block = is_op_non_block || socket.is_non_block.get();
-        let deadline = this.action_deadline(is_non_block, socket.read_timeout.get());
-        let dest = dest.clone();
-
-        this.ensure_connected(
+        let socket = self;
+        ecx.ensure_connected(
             socket.clone(),
             deadline.clone(),
             "recv",
@@ -622,47 +561,34 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 @capture<'tcx> {
                     socket: FileDescriptionRef<TcpSocket>,
                     deadline: Option<Deadline>,
-                    buffer_ptr: Pointer,
-                    length: usize,
-                    should_peek: bool,
+                    ptr: Pointer,
+                    len: usize,
+                    is_peek: bool,
                     is_non_block: bool,
-                    dest: MPlaceTy<'tcx>,
+                    finish: DynMachineCallback<'tcx, Result<usize, IoError>>,
                 } |this, result: Result<(), ()>| {
                     if result.is_err() {
-                        return this.set_errno_and_return_neg1(LibcError("ENOTCONN"), &dest)
+                        return finish.call(this, Err(LibcError("ENOTCONN")))
                     }
 
                     if is_non_block {
                         // We have a non-blocking operation or a non-blocking socket and
                         // thus don't want to block until we can receive.
-                        match this.try_non_block_recv(&socket, buffer_ptr, length, should_peek)? {
-                            Ok(size) => this.write_scalar(Scalar::from_target_isize(size.try_into().unwrap(), this), &dest),
-                            Err(e) => this.set_errno_and_return_neg1(e, &dest),
-                        }
+                        let result = this.try_non_block_recv(&socket, ptr, len, is_peek)?;
+                        finish.call(this, result)
                     } else {
                         // The socket is in blocking mode and thus the receive call should block
                         // until we can receive some bytes from the socket or the timeout exceeded.
-                        this.block_for_recv(
-                            socket,
-                            deadline,
-                            buffer_ptr,
-                            length,
-                            should_peek,
-                            callback!(@capture<'tcx> {
-                                dest: MPlaceTy<'tcx>
-                            } |this, result: Result<usize, IoError>| {
-                                match result {
-                                    Ok(size) => this.write_scalar(Scalar::from_target_isize(size.try_into().unwrap(), this), &dest),
-                                    Err(e) => this.set_errno_and_return_neg1(e, &dest)
-                                }
-                            }),
-                        )
+                        this.block_for_recv(socket, deadline, ptr, len, is_peek, finish)
                     }
                 }
             ),
         )
     }
+}
 
+impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
+pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     fn setsockopt(
         &mut self,
         socket: &OpTy<'tcx>,

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -478,13 +478,20 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         if socket.is_non_block.get() {
             // We have a non-blocking socket and thus don't want to block until
             // we can accept an incoming connection.
-            match this.try_non_block_accept(
-                &socket,
-                address_ptr,
-                address_len_ptr,
-                is_client_sock_nonblock,
-            )? {
-                Ok(sockfd) => {
+            match this.try_non_block_accept(&socket, is_client_sock_nonblock)? {
+                Ok((sockfd, address)) => {
+                    if address_ptr != Pointer::null() {
+                        // We only attempt a write if the address pointer is not a null pointer.
+                        // If the address pointer is a null pointer the user isn't interested in the
+                        // address and we don't need to write anything.
+                        this.write_socket_address(
+                            &address,
+                            address_ptr,
+                            address_len_ptr,
+                            "accept4",
+                        )?;
+                    }
+
                     // We need to create the scalar using the destination size since
                     // `syscall(SYS_accept4, ...)` returns a long which doesn't match
                     // the int returned from the `accept`/`accept4` syscalls.
@@ -507,12 +514,35 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 )
             }
 
+            let dest = dest.clone();
             this.block_for_accept(
                 socket,
-                address_ptr,
-                address_len_ptr,
                 is_client_sock_nonblock,
-                dest.clone(),
+                callback!(
+                    @capture<'tcx> {
+                        address_ptr: Pointer,
+                        address_len_ptr: Pointer,
+                        dest: MPlaceTy<'tcx>
+                    } |this, result: Result<(i32, SocketAddr), IoError>| {
+                        let (client_sockfd, address) = match result {
+                            Ok((sockfd, address)) => (sockfd, address),
+                            Err(e) => return this.set_errno_and_return_neg1(e, &dest),
+                        };
+
+                        if address_ptr != Pointer::null() {
+                            // We only attempt a write if the address pointer is not a null pointer.
+                            // If the address pointer is a null pointer the user isn't interested in the
+                            // address and we don't need to write anything.
+                            this.write_socket_address(&address, address_ptr, address_len_ptr, "accept4")?;
+                        }
+
+                        // We need to create the scalar using the destination size since
+                        // `syscall(SYS_accept4, ...)` returns a long which doesn't match
+                        // the int returned from the `accept`/`accept4` syscalls.
+                        // See <https://man7.org/linux/man-pages/man2/syscall.2.html>.
+                        this.write_scalar(Scalar::from_int(client_sockfd, dest.layout.size), &dest)
+                    }
+                )
             )
         }
     }
@@ -1443,10 +1473,8 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     fn block_for_accept(
         &mut self,
         socket: FileDescriptionRef<TcpSocket>,
-        address_ptr: Pointer,
-        address_len_ptr: Pointer,
         is_client_sock_nonblock: bool,
-        dest: MPlaceTy<'tcx>,
+        finish: DynMachineCallback<'tcx, Result<(i32, SocketAddr), IoError>>,
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
         this.block_thread_for_io(
@@ -1455,10 +1483,8 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             /* deadline */ None,
             callback!(@capture<'tcx> {
                 socket: FileDescriptionRef<TcpSocket>,
-                address_ptr: Pointer,
-                address_len_ptr: Pointer,
                 is_client_sock_nonblock: bool,
-                dest: MPlaceTy<'tcx>,
+                finish: DynMachineCallback<'tcx, Result<(i32, SocketAddr), IoError>>,
             } |this, kind: UnblockKind| {
                 // Remove the blocking I/O interest for unblocking this thread.
                 this.machine.blocking_io.remove_blocked_thread(socket.id(), this.machine.threads.active_thread());
@@ -1466,22 +1492,16 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 match kind {
                     UnblockKind::Ready => { /* fall-through to below */ },
                     // When the read timeout is exceeded EAGAIN/EWOULDBLOCK is returned.
-                    UnblockKind::TimedOut => return this.set_errno_and_return_neg1(LibcError("EWOULDBLOCK"), &dest)
+                    UnblockKind::TimedOut => return finish.call(this, Err(LibcError("EWOULDBLOCK")))
                 }
 
-                match this.try_non_block_accept(&socket, address_ptr, address_len_ptr, is_client_sock_nonblock)? {
-                    Ok(sockfd) => {
-                        // We need to create the scalar using the destination size since
-                        // `syscall(SYS_accept4, ...)` returns a long which doesn't match
-                        // the int returned from the `accept`/`accept4` syscalls.
-                        // See <https://man7.org/linux/man-pages/man2/syscall.2.html>.
-                        this.write_scalar(Scalar::from_int(sockfd, dest.layout.size), &dest)
-                    },
+                match this.try_non_block_accept(&socket, is_client_sock_nonblock)? {
+                    Ok((sockfd, addr)) => finish.call(this, Ok((sockfd, addr))),
                     Err(IoError::HostError(e)) if e.kind() == io::ErrorKind::WouldBlock => {
                         // We need to block the thread again as it would still block.
-                        this.block_for_accept(socket, address_ptr, address_len_ptr, is_client_sock_nonblock, dest)
+                        this.block_for_accept(socket, is_client_sock_nonblock, finish)
                     }
-                    Err(e) => this.set_errno_and_return_neg1(e, &dest),
+                    Err(e) => finish.call(this, Err(e)),
                 }
             }),
         )
@@ -1495,10 +1515,8 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     fn try_non_block_accept(
         &mut self,
         socket: &FileDescriptionRef<TcpSocket>,
-        address_ptr: Pointer,
-        address_len_ptr: Pointer,
         is_client_sock_nonblock: bool,
-    ) -> InterpResult<'tcx, Result<i32, IoError>> {
+    ) -> InterpResult<'tcx, Result<(i32, SocketAddr), IoError>> {
         let this = self.eval_context_mut();
 
         let state = socket.state.borrow();
@@ -1525,13 +1543,6 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             SocketAddr::V6(_) => SocketFamily::IPv6,
         };
 
-        if address_ptr != Pointer::null() {
-            // We only attempt a write if the address pointer is not a null pointer.
-            // If the address pointer is a null pointer the user isn't interested in the
-            // address and we don't need to write anything.
-            this.write_socket_address(&addr, address_ptr, address_len_ptr, "accept4")?;
-        }
-
         let fd = this.machine.fds.new_ref(TcpSocket {
             family,
             state: RefCell::new(SocketState::Connected(stream)),
@@ -1545,7 +1556,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // there is an associated host socket.
         this.machine.blocking_io.register(fd.clone());
         let sockfd = this.machine.fds.insert(fd);
-        interp_ok(Ok(sockfd))
+        interp_ok(Ok((sockfd, addr)))
     }
 
     /// Block the thread until we can send bytes into the connected socket

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -309,38 +309,17 @@ impl UnixFileDescription for TcpSocket {
     }
 }
 
-impl UnixSocketFileDescription for TcpSocket {}
+impl UnixSocketFileDescription for TcpSocket {
+    fn bind<'tcx>(
+        self: FileDescriptionRef<TcpSocket>,
+        communicate_allowed: bool,
+        address: SocketAddr,
+        ecx: &mut MiriInterpCx<'tcx>,
+    ) -> InterpResult<'tcx, Result<(), IoError>> {
+        assert!(communicate_allowed, "cannot have `TcpSocket` with isolation enabled!");
+        ecx.ensure_not_failed(&self, "bind")?;
 
-impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
-pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
-    fn bind(
-        &mut self,
-        socket: &OpTy<'tcx>,
-        address: &OpTy<'tcx>,
-        address_len: &OpTy<'tcx>,
-    ) -> InterpResult<'tcx, Scalar> {
-        let this = self.eval_context_mut();
-
-        let socket = this.read_scalar(socket)?.to_i32()?;
-        let address = match this.read_socket_address(address, address_len, "bind")? {
-            Ok(addr) => addr,
-            Err(e) => return this.set_errno_and_return_neg1_i32(e),
-        };
-
-        // Get the file handle
-        let Some(fd) = this.machine.fds.get(socket) else {
-            return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
-        };
-
-        let Some(socket) = fd.downcast::<TcpSocket>() else {
-            // Man page specifies to return ENOTSOCK if `fd` is not a socket.
-            return this.set_errno_and_return_neg1_i32(LibcError("ENOTSOCK"));
-        };
-
-        assert!(this.machine.communicate(), "cannot have `TcpSocket` with isolation enabled!");
-        this.ensure_not_failed(&socket, "bind")?;
-
-        let mut state = socket.state.borrow_mut();
+        let mut state = self.state.borrow_mut();
 
         match *state {
             SocketState::Initial => {
@@ -349,10 +328,10 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     SocketAddr::V6(_) => SocketFamily::IPv6,
                 };
 
-                if socket.family != address_family {
+                if self.family != address_family {
                     // Attempted to bind an address from a family that doesn't match
                     // the family of the socket.
-                    let err = if matches!(this.tcx.sess.target.os, Os::Linux | Os::Android) {
+                    let err = if matches!(ecx.tcx.sess.target.os, Os::Linux | Os::Android) {
                         // Linux man page states that `EINVAL` is used when there is an address family mismatch.
                         // See <https://man7.org/linux/man-pages/man2/bind.2.html>
                         LibcError("EINVAL")
@@ -362,27 +341,30 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                         // See <https://man7.org/linux/man-pages/man3/bind.3p.html>
                         LibcError("EAFNOSUPPORT")
                     };
-                    return this.set_errno_and_return_neg1_i32(err);
+                    return interp_ok(Err(err));
                 }
 
                 *state = SocketState::Bound(address);
             }
             SocketState::Connecting(_) | SocketState::Connected(_) =>
                 throw_unsup_format!(
-                    "bind: socket is already connected and binding a
-                    connected socket is unsupported"
+                    "bind: tcp socket is already connected and binding a
+                   connected socket is unsupported"
                 ),
             SocketState::Bound(_) | SocketState::Listening(_) =>
                 throw_unsup_format!(
-                    "bind: socket is already bound and binding a socket \
-                    multiple times is unsupported"
+                    "bind: tcp socket is already bound and binding a socket \
+                   multiple times is unsupported"
                 ),
             SocketState::ConnectionFailed(_) => unreachable!(),
         }
 
-        interp_ok(Scalar::from_i32(0))
+        interp_ok(Ok(()))
     }
+}
 
+impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
+pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     fn listen(&mut self, socket: &OpTy<'tcx>, backlog: &OpTy<'tcx>) -> InterpResult<'tcx, Scalar> {
         let this = self.eval_context_mut();
 

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -124,42 +124,14 @@ impl FileDescription for TcpSocket {
         ecx: &mut MiriInterpCx<'tcx>,
         finish: DynMachineCallback<'tcx, Result<usize, IoError>>,
     ) -> InterpResult<'tcx> {
-        assert!(communicate_allowed, "cannot have `TcpSocket` with isolation enabled!");
-
-        let socket = self;
-        let deadline = ecx.action_deadline(socket.is_non_block.get(), socket.read_timeout.get());
-
-        ecx.ensure_connected(
-            socket.clone(),
-            deadline.clone(),
-            "read",
-            callback!(
-                @capture<'tcx> {
-                    socket: FileDescriptionRef<TcpSocket>,
-                    deadline: Option<Deadline>,
-                    ptr: Pointer,
-                    len: usize,
-                    finish: DynMachineCallback<'tcx, Result<usize, IoError>>,
-                } |this, result: Result<(), ()>| {
-                    if result.is_err() {
-                        return finish.call(this, Err(LibcError("ENOTCONN")))
-                    }
-
-                    // Since `read` is the same as `recv` with no flags, we just treat
-                    // the `read` as a `recv` here.
-
-                    if socket.is_non_block.get() {
-                        // We have a non-blocking socket and thus don't want to block until
-                        // we can read.
-                        let result = this.try_non_block_recv(&socket, ptr, len, /* should_peek */ false)?;
-                        finish.call(this, result)
-                    } else {
-                        // The socket is in blocking mode and thus the read call should block
-                        // until we can read some bytes from the socket or the timeout exceeded.
-                        this.block_for_recv(socket, deadline, ptr, len, /* should_peek */ false, finish)
-                    }
-                }
-            ),
+        self.recv(
+            communicate_allowed,
+            ptr,
+            len,
+            /* is_peek */ false,
+            /* is_non_block */ false,
+            ecx,
+            finish,
         )
     }
 

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -15,15 +15,8 @@ use rustc_target::spec::Os;
 use crate::shims::files::{EvalContextExt as _, FdId, FileDescription, FileDescriptionRef};
 use crate::shims::unix::UnixFileDescription;
 use crate::shims::unix::socket_address::EvalContextExt as _;
+use crate::shims::unix::socket::SocketFamily;
 use crate::*;
-
-#[derive(Debug, PartialEq)]
-enum SocketFamily {
-    // IPv4 internet protocols
-    IPv4,
-    // IPv6 internet protocols
-    IPv6,
-}
 
 #[derive(Debug)]
 enum SocketState {

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -910,49 +910,24 @@ impl UnixSocketFileDescription for TcpSocket {
             ),
         )
     }
-}
 
-impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
-pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
-    fn shutdown(&mut self, socket: &OpTy<'tcx>, how: &OpTy<'tcx>) -> InterpResult<'tcx, Scalar> {
-        let this = self.eval_context_mut();
+    fn shutdown<'tcx>(
+        self: FileDescriptionRef<Self>,
+        communicate_allowed: bool,
+        how: Shutdown,
+        ecx: &mut MiriInterpCx<'tcx>,
+    ) -> InterpResult<'tcx, Result<(), IoError>> {
+        assert!(communicate_allowed, "cannot have `TcpSocket` with isolation enabled!");
+        ecx.ensure_not_failed(&self, "shutdown")?;
 
-        let socket = this.read_scalar(socket)?.to_i32()?;
-        let how = this.read_scalar(how)?.to_i32()?;
-
-        // Get the file handle
-        let Some(fd) = this.machine.fds.get(socket) else {
-            return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
-        };
-
-        let Some(socket) = fd.downcast::<TcpSocket>() else {
-            // Man page specifies to return ENOTSOCK if `fd` is not a socket.
-            return this.set_errno_and_return_neg1_i32(LibcError("ENOTSOCK"));
-        };
-
-        assert!(this.machine.communicate(), "cannot have `TcpSocket` with isolation enabled!");
-        this.ensure_not_failed(&socket, "shutdown")?;
-
-        let state = socket.state.borrow();
+        let state = self.state.borrow();
 
         let (SocketState::Connecting(stream) | SocketState::Connected(stream)) = &*state else {
-            return this.set_errno_and_return_neg1_i32(LibcError("ENOTCONN"));
-        };
-
-        let is_read_shutdown = how == this.eval_libc_i32("SHUT_RD");
-        let is_write_shutdown = how == this.eval_libc_i32("SHUT_WR");
-        let is_read_write_shutdown = how == this.eval_libc_i32("SHUT_RDWR");
-
-        let how = match () {
-            _ if is_read_shutdown => Shutdown::Read,
-            _ if is_write_shutdown => Shutdown::Write,
-            _ if is_read_write_shutdown => Shutdown::Both,
-            // An invalid value was passed to `how`.
-            _ => return this.set_errno_and_return_neg1_i32(LibcError("EINVAL")),
+            return interp_ok(Err(LibcError("ENOTCONN")));
         };
 
         if let Err(e) = stream.shutdown(how) {
-            return this.set_errno_and_return_neg1_i32(e);
+            return interp_ok(Err(IoError::HostError(e)));
         };
 
         drop(state);
@@ -962,22 +937,22 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // the readiness after a `shutdown` manually to achieve a more consistent
         // readiness. Otherwise we do not generate enough readiness events
         // on partial shutdowns on Windows hosts.
-        let mut readiness = socket.io_readiness.borrow_mut();
+        let mut readiness = self.io_readiness.borrow_mut();
         // Closing the read end of a socket causes an (E)POLLRDHUP event.
-        readiness.read_closed |= is_read_shutdown || is_read_write_shutdown;
+        readiness.read_closed |= matches!(how, Shutdown::Read | Shutdown::Both);
         // Only shutting down the write end doesn't cause an (E)POLLHUP event
         // and thus we won't set the `write_closed` readiness for it here.
-        readiness.write_closed |= is_read_write_shutdown;
+        readiness.write_closed |= matches!(how, Shutdown::Both);
         // The Linux kernel also sets EPOLLIN when the read end of a socket is closed:
         // <https://github.com/torvalds/linux/blob/HEAD/net/ipv4/tcp.c#L584-L588>
-        readiness.readable |= is_read_shutdown || is_read_write_shutdown;
+        readiness.readable |= matches!(how, Shutdown::Read | Shutdown::Both);
 
         drop(readiness);
 
         // Update the readiness for the socket.
-        this.update_fd_readiness(socket, /* force_edge */ false)?;
+        ecx.update_fd_readiness(self, /* force_edge */ false)?;
 
-        interp_ok(Scalar::from_i32(0))
+        interp_ok(Ok(()))
     }
 }
 

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -12,7 +12,7 @@ use rustc_const_eval::interpret::{InterpResult, interp_ok};
 use rustc_middle::throw_unsup_format;
 use rustc_target::spec::Os;
 
-use crate::shims::files::{EvalContextExt as _, FdId, FileDescription, FileDescriptionRef};
+use crate::shims::files::{EvalContextExt as _, FdId, FdNum, FileDescription, FileDescriptionRef};
 use crate::shims::unix::UnixFileDescription;
 use crate::shims::unix::socket::{SocketFamily, UnixSocketFileDescription};
 use crate::shims::unix::socket_address::EvalContextExt as _;
@@ -404,149 +404,48 @@ impl UnixSocketFileDescription for TcpSocket {
 
         interp_ok(Ok(()))
     }
-}
 
-impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
-pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
-    /// For more information on the arguments see the accept manpage:
-    /// <https://linux.die.net/man/2/accept4>
-    fn accept4(
-        &mut self,
-        socket: &OpTy<'tcx>,
-        address: &OpTy<'tcx>,
-        address_len: &OpTy<'tcx>,
-        flags: Option<&OpTy<'tcx>>,
-        // Location where the output scalar is written to.
-        dest: &MPlaceTy<'tcx>,
+    fn accept<'tcx>(
+        self: FileDescriptionRef<Self>,
+        communicate_allowed: bool,
+        is_client_sock_non_block: bool,
+        ecx: &mut MiriInterpCx<'tcx>,
+        finish: DynMachineCallback<'tcx, Result<(FdNum, SocketAddr), IoError>>,
     ) -> InterpResult<'tcx> {
-        let this = self.eval_context_mut();
+        assert!(communicate_allowed, "cannot have `TcpSocket` with isolation enabled!");
 
-        let socket = this.read_scalar(socket)?.to_i32()?;
-        let address_ptr = this.read_pointer(address)?;
-        let address_len_ptr = this.read_pointer(address_len)?;
-        let mut flags =
-            if let Some(flags) = flags { this.read_scalar(flags)?.to_i32()? } else { 0 };
-
-        // Get the file handle
-        let Some(fd) = this.machine.fds.get(socket) else {
-            return this.set_errno_and_return_neg1(LibcError("EBADF"), dest);
-        };
-
-        let Some(socket) = fd.downcast::<TcpSocket>() else {
-            // Man page specifies to return ENOTSOCK if `fd` is not a socket.
-            return this.set_errno_and_return_neg1(LibcError("ENOTSOCK"), dest);
-        };
-
-        assert!(this.machine.communicate(), "cannot have `TcpSocket` with isolation enabled!");
-        this.ensure_not_failed(&socket, "accept4")?;
-
-        if !matches!(*socket.state.borrow(), SocketState::Listening(_)) {
+        if !matches!(*self.state.borrow(), SocketState::Listening(_)) {
             throw_unsup_format!(
-                "accept4: accepting incoming connections is only allowed when socket is listening"
+                "accept: accepting incoming connections is only allowed when tcp socket is listening"
             )
         };
 
-        let mut is_client_sock_nonblock = false;
-
-        // Interpret the flag. Every flag we recognize is "subtracted" from `flags`, so
-        // if there is anything left at the end, that's an unsupported flag.
-        if matches!(
-            this.tcx.sess.target.os,
-            Os::Linux | Os::Android | Os::FreeBsd | Os::Solaris | Os::Illumos
-        ) {
-            // SOCK_NONBLOCK and SOCK_CLOEXEC only exist on Linux, Android, FreeBSD,
-            // Solaris, and Illumos targets.
-            let sock_nonblock = this.eval_libc_i32("SOCK_NONBLOCK");
-            let sock_cloexec = this.eval_libc_i32("SOCK_CLOEXEC");
-            if flags & sock_nonblock == sock_nonblock {
-                is_client_sock_nonblock = true;
-                flags &= !sock_nonblock;
-            }
-            if flags & sock_cloexec == sock_cloexec {
-                // We don't support `exec` so we can ignore this.
-                flags &= !sock_cloexec;
-            }
-        }
-
-        if flags != 0 {
-            throw_unsup_format!(
-                "accept4: flag {flags:#x} is unsupported, only SOCK_CLOEXEC \
-                and SOCK_NONBLOCK are allowed",
-            );
-        }
-
-        if socket.is_non_block.get() {
+        if self.is_non_block.get() {
             // We have a non-blocking socket and thus don't want to block until
             // we can accept an incoming connection.
-            match this.try_non_block_accept(&socket, is_client_sock_nonblock)? {
-                Ok((sockfd, address)) => {
-                    if address_ptr != Pointer::null() {
-                        // We only attempt a write if the address pointer is not a null pointer.
-                        // If the address pointer is a null pointer the user isn't interested in the
-                        // address and we don't need to write anything.
-                        this.write_socket_address(
-                            &address,
-                            address_ptr,
-                            address_len_ptr,
-                            "accept4",
-                        )?;
-                    }
-
-                    // We need to create the scalar using the destination size since
-                    // `syscall(SYS_accept4, ...)` returns a long which doesn't match
-                    // the int returned from the `accept`/`accept4` syscalls.
-                    // See <https://man7.org/linux/man-pages/man2/syscall.2.html>.
-                    this.write_scalar(Scalar::from_int(sockfd, dest.layout.size), dest)
-                }
-                Err(e) => this.set_errno_and_return_neg1(e, dest),
-            }
+            let result = ecx.try_non_block_accept(&self, is_client_sock_non_block)?;
+            finish.call(ecx, result)
         } else {
             // The socket is in blocking mode and thus the accept call should block
             // until an incoming connection is ready.
 
-            if socket.read_timeout.get().is_some() {
+            if self.read_timeout.get().is_some() {
                 // Some Unixes like Linux also apply the SO_RCVTIMEO socket option
                 // to `accept` calls:
                 // <https://github.com/torvalds/linux/blob/HEAD/net/ipv4/inet_connection_sock.c#L668-L675>
                 // This is currently not supported by Miri.
                 throw_unsup_format!(
-                    "accept4: blocking accept is not supported when SO_RCVTIMEO is non-zero"
+                    "accept: blocking tcp accept is not supported when SO_RCVTIMEO is non-zero"
                 )
             }
 
-            let dest = dest.clone();
-            this.block_for_accept(
-                socket,
-                is_client_sock_nonblock,
-                callback!(
-                    @capture<'tcx> {
-                        address_ptr: Pointer,
-                        address_len_ptr: Pointer,
-                        dest: MPlaceTy<'tcx>
-                    } |this, result: Result<(i32, SocketAddr), IoError>| {
-                        let (client_sockfd, address) = match result {
-                            Ok((sockfd, address)) => (sockfd, address),
-                            Err(e) => return this.set_errno_and_return_neg1(e, &dest),
-                        };
-
-                        if address_ptr != Pointer::null() {
-                            // We only attempt a write if the address pointer is not a null pointer.
-                            // If the address pointer is a null pointer the user isn't interested in the
-                            // address and we don't need to write anything.
-                            this.write_socket_address(&address, address_ptr, address_len_ptr, "accept4")?;
-                        }
-
-                        // We need to create the scalar using the destination size since
-                        // `syscall(SYS_accept4, ...)` returns a long which doesn't match
-                        // the int returned from the `accept`/`accept4` syscalls.
-                        // See <https://man7.org/linux/man-pages/man2/syscall.2.html>.
-                        this.write_scalar(Scalar::from_int(client_sockfd, dest.layout.size), &dest)
-                    }
-                )
-            )
+            ecx.block_for_accept(self, is_client_sock_non_block, finish)
         }
     }
+}
 
+impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
+pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     fn connect(
         &mut self,
         socket: &OpTy<'tcx>,

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -7,7 +7,6 @@ use std::time::Duration;
 
 use mio::event::Source;
 use mio::net::{TcpListener, TcpStream};
-use rustc_abi::Size;
 use rustc_const_eval::interpret::{InterpResult, interp_ok};
 use rustc_middle::throw_unsup_format;
 use rustc_target::spec::Os;
@@ -692,121 +691,77 @@ impl UnixSocketFileDescription for TcpSocket {
            and IPPROTO_TCP are allowed"
         );
     }
-}
 
-impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
-pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
-    fn getsockopt(
-        &mut self,
-        socket: &OpTy<'tcx>,
-        level: &OpTy<'tcx>,
-        option_name: &OpTy<'tcx>,
-        option_value: &OpTy<'tcx>,
-        option_len: &OpTy<'tcx>,
-    ) -> InterpResult<'tcx, Scalar> {
-        let this = self.eval_context_mut();
+    fn getsockopt<'tcx>(
+        self: FileDescriptionRef<Self>,
+        level: i32,
+        option: i32,
+        ecx: &mut MiriInterpCx<'tcx>,
+    ) -> InterpResult<'tcx, Result<MPlaceTy<'tcx>, IoError>> {
+        if level == ecx.eval_libc_i32("SOL_SOCKET") {
+            let opt_so_error = ecx.eval_libc_i32("SO_ERROR");
+            let opt_so_rcvtimeo = ecx.eval_libc_i32("SO_RCVTIMEO");
+            let opt_so_sndtimeo = ecx.eval_libc_i32("SO_SNDTIMEO");
 
-        let socket = this.read_scalar(socket)?.to_i32()?;
-        let level = this.read_scalar(level)?.to_i32()?;
-        let option_name = this.read_scalar(option_name)?.to_i32()?;
-        // These two pointers are used to return the value: `len_ptr` initially stores how much space
-        // is available. If the actual value fits into that space, it is written to
-        // `value_ptr` and `len_ptr` is updated to represent how many bytes
-        // were actually written. If the value does not fit, it is silently truncated.
-        // Also see <https://pubs.opengroup.org/onlinepubs/9799919799/functions/getsockopt.html>.
-        let option_value_ptr = this.read_pointer(option_value)?;
-        let option_len_ptr = this.read_pointer(option_len)?;
-
-        // Get the file handle
-        let Some(fd) = this.machine.fds.get(socket) else {
-            return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
-        };
-
-        let Some(socket) = fd.downcast::<TcpSocket>() else {
-            // Man page specifies to return ENOTSOCK if `fd` is not a socket.
-            return this.set_errno_and_return_neg1_i32(LibcError("ENOTSOCK"));
-        };
-
-        if option_value_ptr == Pointer::null() || option_len_ptr == Pointer::null() {
-            // This socket option returns a value and thus we need to return EFAULT
-            // when either the value or the length pointers are null pointers.
-            return this.set_errno_and_return_neg1_i32(LibcError("EFAULT"));
-        }
-
-        let socklen_layout = this.libc_ty_layout("socklen_t");
-        let option_len_ptr_mplace = this.ptr_to_mplace(option_len_ptr, socklen_layout);
-        let option_len: usize = this
-            .read_scalar(&option_len_ptr_mplace)?
-            .to_int(socklen_layout.size)?
-            .try_into()
-            .unwrap();
-
-        // We need a temporary buffer as `option_value_ptr` might not point to a large enough
-        // buffer, in which case we have to truncate.
-        let value_buffer = if level == this.eval_libc_i32("SOL_SOCKET") {
-            let opt_so_error = this.eval_libc_i32("SO_ERROR");
-            let opt_so_rcvtimeo = this.eval_libc_i32("SO_RCVTIMEO");
-            let opt_so_sndtimeo = this.eval_libc_i32("SO_SNDTIMEO");
-
-            if option_name == opt_so_error {
+            if option == opt_so_error {
                 // Reading SO_ERROR should always return the latest async error. Because our stored
                 // `socket.error` could be outdated, we attempt to update it here.
-                this.update_last_error(&socket);
+                ecx.update_last_error(&self);
 
-                let return_value = match socket.error.take() {
-                    Some(err) => this.io_error_to_errnum(err)?.to_i32()?,
+                let return_value = match self.error.take() {
+                    Some(err) => ecx.io_error_to_errnum(err)?.to_i32()?,
                     // If there is no error, we return 0 as the option value.
                     None => 0,
                 };
 
                 // Clear our own stored error -- it was either `take`n above or it is outdated.
-                socket.error.replace(None);
+                self.error.replace(None);
 
                 // We know there is no longer an async error and thus we need to update the
                 // I/O and fd readiness of the socket.
-                socket.io_readiness.borrow_mut().error = false;
-                this.update_fd_readiness(socket, /* force_edge */ false)?;
+                self.io_readiness.borrow_mut().error = false;
+                ecx.update_fd_readiness(self, /* force_edge */ false)?;
 
                 // Allocate new buffer on the stack with the `i32` layout.
-                let value_buffer = this.allocate(this.machine.layouts.i32, MemoryKind::Stack)?;
-                this.write_int(return_value, &value_buffer)?;
-                value_buffer
-            } else if option_name == opt_so_rcvtimeo || option_name == opt_so_sndtimeo {
-                let timeout = if option_name == opt_so_rcvtimeo {
-                    socket.read_timeout.get()
+                let value_buffer = ecx.allocate(ecx.machine.layouts.i32, MemoryKind::Stack)?;
+                ecx.write_int(return_value, &value_buffer)?;
+                interp_ok(Ok(value_buffer))
+            } else if option == opt_so_rcvtimeo || option == opt_so_sndtimeo {
+                let timeout = if option == opt_so_rcvtimeo {
+                    self.read_timeout.get()
                 } else {
-                    socket.write_timeout.get()
+                    self.write_timeout.get()
                 }
                 .unwrap_or_default();
 
                 let secs = timeout.as_secs();
                 let usecs = timeout.subsec_micros();
 
-                let timeval_layout = this.libc_ty_layout("timeval");
+                let timeval_layout = ecx.libc_ty_layout("timeval");
                 // Allocate new buffer on the stack with the `timeval` layout.
-                let timeval_buffer = this.allocate(timeval_layout, MemoryKind::Stack)?;
+                let timeval_buffer = ecx.allocate(timeval_layout, MemoryKind::Stack)?;
 
-                let sec_field = this.project_field_named(&timeval_buffer, "tv_sec")?;
-                this.write_int(secs, &sec_field)?;
+                let sec_field = ecx.project_field_named(&timeval_buffer, "tv_sec")?;
+                ecx.write_int(secs, &sec_field)?;
 
-                let usec_field = this.project_field_named(&timeval_buffer, "tv_usec")?;
-                this.write_int(usecs, &usec_field)?;
+                let usec_field = ecx.project_field_named(&timeval_buffer, "tv_usec")?;
+                ecx.write_int(usecs, &usec_field)?;
 
-                timeval_buffer
+                interp_ok(Ok(timeval_buffer))
             } else {
                 throw_unsup_format!(
-                    "getsockopt: option {option_name:#x} is unsupported for level SOL_SOCKET",
+                    "getsockopt: option {option:#x} is unsupported for level SOL_SOCKET",
                 );
             }
-        } else if level == this.eval_libc_i32("IPPROTO_IP") {
-            let opt_ip_ttl = this.eval_libc_i32("IP_TTL");
+        } else if level == ecx.eval_libc_i32("IPPROTO_IP") {
+            let opt_ip_ttl = ecx.eval_libc_i32("IP_TTL");
 
-            if option_name == opt_ip_ttl {
-                let ttl = match &*socket.state.borrow() {
+            if option == opt_ip_ttl {
+                let ttl = match &*self.state.borrow() {
                     SocketState::Initial | SocketState::Bound(_) =>
                         throw_unsup_format!(
                             "getsockopt: reading option IP_TTL on level IPPROTO_IP is only supported \
-                            on connected and listening sockets"
+                            on connected and listening tcp sockets"
                         ),
                     SocketState::Listening(listener) => listener.ttl(),
                     SocketState::Connecting(stream) | SocketState::Connected(stream) =>
@@ -816,27 +771,27 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 let ttl = match ttl {
                     Ok(ttl) => ttl,
-                    Err(e) => return this.set_errno_and_return_neg1_i32(e),
+                    Err(e) => return interp_ok(Err(IoError::HostError(e))),
                 };
 
                 // Allocate new buffer on the stack with the `u32` layout.
-                let value_buffer = this.allocate(this.machine.layouts.u32, MemoryKind::Stack)?;
-                this.write_int(ttl, &value_buffer)?;
-                value_buffer
+                let value_buffer = ecx.allocate(ecx.machine.layouts.u32, MemoryKind::Stack)?;
+                ecx.write_int(ttl, &value_buffer)?;
+                interp_ok(Ok(value_buffer))
             } else {
                 throw_unsup_format!(
-                    "getsockopt: option {option_name:#x} is unsupported for level IPPROTO_IP",
+                    "getsockopt: option {option:#x} is unsupported for level IPPROTO_IP",
                 );
             }
-        } else if level == this.eval_libc_i32("IPPROTO_TCP") {
-            let opt_tcp_nodelay = this.eval_libc_i32("TCP_NODELAY");
+        } else if level == ecx.eval_libc_i32("IPPROTO_TCP") {
+            let opt_tcp_nodelay = ecx.eval_libc_i32("TCP_NODELAY");
 
-            if option_name == opt_tcp_nodelay {
-                let nodelay = match &*socket.state.borrow() {
+            if option == opt_tcp_nodelay {
+                let nodelay = match &*self.state.borrow() {
                     SocketState::Initial | SocketState::Bound(_) | SocketState::Listening(_) =>
                         throw_unsup_format!(
                             "getsockopt: reading option TCP_NODELAY on level IPPROTO_TCP is only supported \
-                            on connected sockets"
+                            on connected tcp sockets"
                         ),
                     SocketState::Connecting(stream) | SocketState::Connected(stream) =>
                         stream.nodelay(),
@@ -845,51 +800,29 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 let nodelay = match nodelay {
                     Ok(nodelay) => nodelay,
-                    Err(e) => return this.set_errno_and_return_neg1_i32(e),
+                    Err(e) => return interp_ok(Err(IoError::HostError(e))),
                 };
 
                 // Allocate new buffer on the stack with the `i32` layout.
-                let value_buffer = this.allocate(this.machine.layouts.i32, MemoryKind::Stack)?;
-                this.write_int(i32::from(nodelay), &value_buffer)?;
-                value_buffer
+                let value_buffer = ecx.allocate(ecx.machine.layouts.i32, MemoryKind::Stack)?;
+                ecx.write_int(i32::from(nodelay), &value_buffer)?;
+                interp_ok(Ok(value_buffer))
             } else {
                 throw_unsup_format!(
-                    "getsockopt: option {option_name:#x} is unsupported for level IPPROTO_TCP"
+                    "getsockopt: option {option:#x} is unsupported for level IPPROTO_TCP"
                 );
             }
         } else {
             throw_unsup_format!(
                 "getsockopt: level {level:#x} is unsupported, only SOL_SOCKET, IPPROTO_IP \
-                and IPPROTO_TCP are allowed"
+               and IPPROTO_TCP are allowed"
             )
-        };
-
-        // Truncated size of the output value.
-        let output_value_len = value_buffer.layout.size.min(Size::from_bytes(option_len));
-        // Copy the truncated value into the buffer pointed to by `option_value_ptr`.
-        this.mem_copy(
-            value_buffer.ptr(),
-            option_value_ptr,
-            // Truncate the value to fit the provided buffer.
-            output_value_len,
-            // The buffers are guaranteed to not overlap since the `value_buffer`
-            // was just newly allocated on the stack.
-            true,
-        )?;
-        // Deallocate the value buffer as it was only needed to store the value and
-        // copy it into the buffer pointed to by `option_value_ptr`.
-        this.deallocate_ptr(value_buffer.ptr(), None, MemoryKind::Stack)?;
-
-        // On output, the length pointer contains the amount of bytes written -- not the size
-        // of the value before truncation.
-        this.write_scalar(
-            Scalar::from_uint(output_value_len.bytes(), socklen_layout.size),
-            &option_len_ptr_mplace,
-        )?;
-
-        interp_ok(Scalar::from_i32(0))
+        }
     }
+}
 
+impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
+pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     fn getsockname(
         &mut self,
         socket: &OpTy<'tcx>,

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -48,7 +48,7 @@ enum SocketState {
 }
 
 #[derive(Debug)]
-struct TcpSocket {
+pub(super) struct TcpSocket {
     /// Family of the socket, used to ensure socket only binds/connects to address of
     /// same family.
     family: SocketFamily,
@@ -72,6 +72,20 @@ struct TcpSocket {
     /// for relative timeouts).
     /// This is ignored when the socket is non-blocking.
     write_timeout: Cell<Option<Duration>>,
+}
+
+impl TcpSocket {
+    pub fn new(family: SocketFamily, is_non_block: bool) -> Self {
+        TcpSocket {
+            family,
+            state: RefCell::new(SocketState::Initial),
+            is_non_block: Cell::new(is_non_block),
+            io_readiness: RefCell::new(Readiness::EMPTY),
+            error: RefCell::new(None),
+            read_timeout: Cell::new(None),
+            write_timeout: Cell::new(None),
+        }
+    }
 }
 
 impl FileDescription for TcpSocket {
@@ -299,88 +313,6 @@ impl UnixSocketFileDescription for TcpSocket {}
 
 impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
 pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
-    /// For more information on the arguments see the socket manpage:
-    /// <https://linux.die.net/man/2/socket>
-    fn socket(
-        &mut self,
-        domain: &OpTy<'tcx>,
-        type_: &OpTy<'tcx>,
-        protocol: &OpTy<'tcx>,
-    ) -> InterpResult<'tcx, Scalar> {
-        let this = self.eval_context_mut();
-
-        let domain = this.read_scalar(domain)?.to_i32()?;
-        let mut flags = this.read_scalar(type_)?.to_i32()?;
-        let protocol = this.read_scalar(protocol)?.to_i32()?;
-
-        // Reject if isolation is enabled
-        if let IsolatedOp::Reject(reject_with) = this.machine.isolated_op {
-            this.reject_in_isolation("`socket`", reject_with)?;
-            return this.set_errno_and_return_neg1_i32(LibcError("EACCES"));
-        }
-
-        let mut is_sock_nonblock = false;
-
-        // Interpret the flag. Every flag we recognize is "subtracted" from `flags`, so
-        // if there is anything left at the end, that's an unsupported flag.
-        if matches!(
-            this.tcx.sess.target.os,
-            Os::Linux | Os::Android | Os::FreeBsd | Os::Solaris | Os::Illumos
-        ) {
-            // SOCK_NONBLOCK and SOCK_CLOEXEC only exist on Linux, Android, FreeBSD,
-            // Solaris, and Illumos targets.
-            let sock_nonblock = this.eval_libc_i32("SOCK_NONBLOCK");
-            let sock_cloexec = this.eval_libc_i32("SOCK_CLOEXEC");
-            if flags & sock_nonblock == sock_nonblock {
-                is_sock_nonblock = true;
-                flags &= !sock_nonblock;
-            }
-            if flags & sock_cloexec == sock_cloexec {
-                // We don't support `exec` so we can ignore this.
-                flags &= !sock_cloexec;
-            }
-        }
-
-        let family = if domain == this.eval_libc_i32("AF_INET") {
-            SocketFamily::IPv4
-        } else if domain == this.eval_libc_i32("AF_INET6") {
-            SocketFamily::IPv6
-        } else {
-            throw_unsup_format!(
-                "socket: domain {:#x} is unsupported, only AF_INET and \
-                AF_INET6 are allowed.",
-                domain
-            );
-        };
-
-        if flags != this.eval_libc_i32("SOCK_STREAM") {
-            throw_unsup_format!(
-                "socket: type {:#x} is unsupported, only SOCK_STREAM, \
-                SOCK_CLOEXEC and SOCK_NONBLOCK are allowed",
-                flags
-            );
-        }
-        if protocol != 0 && protocol != this.eval_libc_i32("IPPROTO_TCP") {
-            throw_unsup_format!(
-                "socket: socket protocol {protocol} is unsupported, \
-                only IPPROTO_TCP and 0 are allowed"
-            );
-        }
-
-        let fds = &mut this.machine.fds;
-        let fd = fds.new_ref(TcpSocket {
-            family,
-            state: RefCell::new(SocketState::Initial),
-            is_non_block: Cell::new(is_sock_nonblock),
-            io_readiness: RefCell::new(Readiness::EMPTY),
-            error: RefCell::new(None),
-            read_timeout: Cell::new(None),
-            write_timeout: Cell::new(None),
-        });
-
-        interp_ok(Scalar::from_i32(fds.insert(fd)))
-    }
-
     fn bind(
         &mut self,
         socket: &OpTy<'tcx>,

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -14,7 +14,6 @@ use rustc_target::spec::Os;
 use crate::shims::files::{EvalContextExt as _, FdId, FdNum, FileDescription, FileDescriptionRef};
 use crate::shims::unix::UnixFileDescription;
 use crate::shims::unix::socket::{SocketFamily, UnixSocketFileDescription};
-use crate::shims::unix::socket_address::EvalContextExt as _;
 use crate::*;
 
 #[derive(Debug)]
@@ -875,77 +874,46 @@ impl UnixSocketFileDescription for TcpSocket {
 
         interp_ok(Ok(address))
     }
-}
 
-impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
-pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
-    fn getpeername(
-        &mut self,
-        socket: &OpTy<'tcx>,
-        address: &OpTy<'tcx>,
-        address_len: &OpTy<'tcx>,
-        // Location where the output scalar is written to.
-        dest: &MPlaceTy<'tcx>,
+    fn getpeername<'tcx>(
+        self: FileDescriptionRef<Self>,
+        communicate_allowed: bool,
+        ecx: &mut MiriInterpCx<'tcx>,
+        finish: DynMachineCallback<'tcx, Result<SocketAddr, IoError>>,
     ) -> InterpResult<'tcx> {
-        let this = self.eval_context_mut();
+        assert!(communicate_allowed, "cannot have `TcpSocket` with isolation enabled!");
 
-        let socket = this.read_scalar(socket)?.to_i32()?;
-        let address_ptr = this.read_pointer(address)?;
-        let address_len_ptr = this.read_pointer(address_len)?;
-
-        // Get the file handle
-        let Some(fd) = this.machine.fds.get(socket) else {
-            return this.set_errno_and_return_neg1(LibcError("EBADF"), dest);
-        };
-
-        let Some(socket) = fd.downcast::<TcpSocket>() else {
-            // Man page specifies to return ENOTSOCK if `fd` is not a socket.
-            return this.set_errno_and_return_neg1(LibcError("ENOTSOCK"), dest);
-        };
-
-        assert!(this.machine.communicate(), "cannot have `TcpSocket` with isolation enabled!");
-
-        let dest = dest.clone();
-
+        let socket = self;
         // It's only safe to call [`TcpStream::peer_addr`] after the socket is connected since
         // UNIX targets should return ENOTCONN when the connection is not yet established.
-        this.ensure_connected(
+        ecx.ensure_connected(
             socket.clone(),
             // Check whether the socket is connected without blocking.
-            Some(this.machine.monotonic_clock.now().into()),
+            Some(ecx.machine.monotonic_clock.now().into()),
             "getpeername",
             callback!(
                 @capture<'tcx> {
                     socket: FileDescriptionRef<TcpSocket>,
-                    address_ptr: Pointer,
-                    address_len_ptr: Pointer,
-                    dest: MPlaceTy<'tcx>,
+                    finish: DynMachineCallback<'tcx, Result<SocketAddr, IoError>>,
                 } |this, result: Result<(), ()>| {
                     if result.is_err() {
-                        return this.set_errno_and_return_neg1(LibcError("ENOTCONN"), &dest)
+                        return finish.call(this, Err(LibcError("ENOTCONN")))
                     };
 
                     let SocketState::Connected(stream) = &*socket.state.borrow() else {
                         unreachable!()
                     };
 
-                    let address = match stream.peer_addr() {
-                        Ok(address) => address,
-                        Err(e) => return this.set_errno_and_return_neg1(e, &dest),
-                    };
-
-                    this.write_socket_address(
-                        &address,
-                        address_ptr,
-                        address_len_ptr,
-                        "getpeername",
-                    )?;
-                   this.write_scalar(Scalar::from_i32(0), &dest)
+                    let result = stream.peer_addr().map_err(IoError::HostError);
+                    finish.call(this, result)
                 }
             ),
         )
     }
+}
 
+impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
+pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     fn shutdown(&mut self, socket: &OpTy<'tcx>, how: &OpTy<'tcx>) -> InterpResult<'tcx, Scalar> {
         let this = self.eval_context_mut();
 

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -525,73 +525,23 @@ impl UnixSocketFileDescription for TcpSocket {
             )
         }
     }
-}
 
-impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
-pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
-    fn send(
-        &mut self,
-        socket: &OpTy<'tcx>,
-        buffer: &OpTy<'tcx>,
-        length: &OpTy<'tcx>,
-        flags: &OpTy<'tcx>,
-        // Location where the output scalar is written to.
-        dest: &MPlaceTy<'tcx>,
+    fn send<'tcx>(
+        self: FileDescriptionRef<Self>,
+        communicate_allowed: bool,
+        ptr: Pointer,
+        len: usize,
+        is_non_block: bool,
+        ecx: &mut MiriInterpCx<'tcx>,
+        finish: DynMachineCallback<'tcx, Result<usize, IoError>>,
     ) -> InterpResult<'tcx> {
-        let this = self.eval_context_mut();
+        assert!(communicate_allowed, "cannot have `TcpSocket` with isolation enabled!");
 
-        let socket = this.read_scalar(socket)?.to_i32()?;
-        let buffer_ptr = this.read_pointer(buffer)?;
-        let size_layout = this.libc_ty_layout("size_t");
-        let length: usize =
-            this.read_scalar(length)?.to_uint(size_layout.size)?.try_into().unwrap();
-        let mut flags = this.read_scalar(flags)?.to_i32()?;
+        let is_non_block = is_non_block || self.is_non_block.get();
+        let deadline = ecx.action_deadline(is_non_block, self.write_timeout.get());
 
-        // Get the file handle
-        let Some(fd) = this.machine.fds.get(socket) else {
-            return this.set_errno_and_return_neg1(LibcError("EBADF"), dest);
-        };
-
-        let Some(socket) = fd.downcast::<TcpSocket>() else {
-            // Man page specifies to return ENOTSOCK if `fd` is not a socket
-            return this.set_errno_and_return_neg1(LibcError("ENOTSOCK"), dest);
-        };
-
-        let mut is_op_non_block = false;
-
-        // Interpret the flag. Every flag we recognize is "subtracted" from `flags`, so
-        // if there is anything left at the end, that's an unsupported flag.
-        if matches!(
-            this.tcx.sess.target.os,
-            Os::Linux | Os::Android | Os::FreeBsd | Os::Solaris | Os::Illumos
-        ) {
-            // MSG_NOSIGNAL and MSG_DONTWAIT only exist on Linux, Android, FreeBSD,
-            // Solaris, and Illumos targets.
-            let msg_nosignal = this.eval_libc_i32("MSG_NOSIGNAL");
-            let msg_dontwait = this.eval_libc_i32("MSG_DONTWAIT");
-            if flags & msg_nosignal == msg_nosignal {
-                // This is only needed to ensure that no EPIPE signal is sent when
-                // trying to send into a stream which is no longer connected.
-                // Since we don't support signals, we can ignore this.
-                flags &= !msg_nosignal;
-            }
-            if flags & msg_dontwait == msg_dontwait {
-                flags &= !msg_dontwait;
-                is_op_non_block = true;
-            }
-        }
-
-        if flags != 0 {
-            throw_unsup_format!(
-                "send: flag {flags:#x} is unsupported, only MSG_NOSIGNAL and MSG_DONTWAIT are allowed",
-            );
-        }
-
-        let is_non_block = is_op_non_block || socket.is_non_block.get();
-        let deadline = this.action_deadline(is_non_block, socket.write_timeout.get());
-        let dest = dest.clone();
-
-        this.ensure_connected(
+        let socket = self;
+        ecx.ensure_connected(
             socket.clone(),
             deadline.clone(),
             "send",
@@ -599,46 +549,33 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 @capture<'tcx> {
                     socket: FileDescriptionRef<TcpSocket>,
                     deadline: Option<Deadline>,
-                    flags: i32,
-                    buffer_ptr: Pointer,
-                    length: usize,
+                    ptr: Pointer,
+                    len: usize,
                     is_non_block: bool,
-                    dest: MPlaceTy<'tcx>,
+                    finish: DynMachineCallback<'tcx, Result<usize, IoError>>,
                 } |this, result: Result<(), ()>| {
                     if result.is_err() {
-                        return this.set_errno_and_return_neg1(LibcError("ENOTCONN"), &dest)
+                        return finish.call(this, Err(LibcError("ENOTCONN")))
                     }
 
                     if is_non_block {
                         // We have a non-blocking operation or a non-blocking socket and
                         // thus don't want to block until we can send.
-                        match this.try_non_block_send(&socket, buffer_ptr, length)? {
-                            Ok(size) => this.write_scalar(Scalar::from_target_isize(size.try_into().unwrap(), this), &dest),
-                            Err(e) => this.set_errno_and_return_neg1(e, &dest),
-                        }
+                        let result = this.try_non_block_send(&socket, ptr, len)?;
+                        finish.call(this, result)
                     } else {
                         // The socket is in blocking mode and thus the send call should block
                         // until we can send some bytes into the socket or the timeout exceeded.
-                        this.block_for_send(
-                            socket,
-                            deadline,
-                            buffer_ptr,
-                            length,
-                            callback!(@capture<'tcx> {
-                                dest: MPlaceTy<'tcx>
-                            } |this, result: Result<usize, IoError>| {
-                                match result {
-                                    Ok(size) => this.write_scalar(Scalar::from_target_isize(size.try_into().unwrap(), this), &dest),
-                                    Err(e) => this.set_errno_and_return_neg1(e, &dest)
-                                }
-                            }),
-                        )
+                        this.block_for_send(socket, deadline, ptr, len, finish)
                     }
                 }
             ),
         )
     }
+}
 
+impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
+pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     fn recv(
         &mut self,
         socket: &OpTy<'tcx>,

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -171,43 +171,7 @@ impl FileDescription for TcpSocket {
         ecx: &mut MiriInterpCx<'tcx>,
         finish: DynMachineCallback<'tcx, Result<usize, IoError>>,
     ) -> InterpResult<'tcx> {
-        assert!(communicate_allowed, "cannot have `TcpSocket` with isolation enabled!");
-
-        let socket = self;
-        let deadline = ecx.action_deadline(socket.is_non_block.get(), socket.write_timeout.get());
-
-        ecx.ensure_connected(
-            socket.clone(),
-            deadline.clone(),
-            "write",
-            callback!(
-                @capture<'tcx> {
-                    socket: FileDescriptionRef<TcpSocket>,
-                    deadline: Option<Deadline>,
-                    ptr: Pointer,
-                    len: usize,
-                    finish: DynMachineCallback<'tcx, Result<usize, IoError>>
-                } |this, result: Result<(), ()>| {
-                    if result.is_err() {
-                        return finish.call(this, Err(LibcError("ENOTCONN")))
-                    }
-
-                    // Since `write` is the same as `send` with no flags, we just treat
-                    // the `write` as a `send` here.
-
-                    if socket.is_non_block.get() {
-                        // We have a non-blocking socket and thus don't want to block until
-                        // we can write.
-                        let result = this.try_non_block_send(&socket, ptr, len)?;
-                        return finish.call(this, result)
-                    } else {
-                        // The socket is in blocking mode and thus the write call should block
-                        // until we can write some bytes into the socket or the timeout exceeded.
-                        this.block_for_send(socket, deadline, ptr, len, finish)
-                    }
-                }
-            ),
-        )
+        self.send(communicate_allowed, ptr, len, /* is_non_block */ false, ecx, finish)
     }
 
     fn short_fd_operations(&self) -> bool {

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -361,31 +361,18 @@ impl UnixSocketFileDescription for TcpSocket {
 
         interp_ok(Ok(()))
     }
-}
 
-impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
-pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
-    fn listen(&mut self, socket: &OpTy<'tcx>, backlog: &OpTy<'tcx>) -> InterpResult<'tcx, Scalar> {
-        let this = self.eval_context_mut();
-
-        let socket = this.read_scalar(socket)?.to_i32()?;
+    fn listen<'tcx>(
+        self: FileDescriptionRef<TcpSocket>,
+        communicate_allowed: bool,
         // Since the backlog value is just a performance hint we can ignore it.
-        let _backlog = this.read_scalar(backlog)?.to_i32()?;
+        _backlog: i32,
+        ecx: &mut MiriInterpCx<'tcx>,
+    ) -> InterpResult<'tcx, Result<(), IoError>> {
+        assert!(communicate_allowed, "cannot have `TcpSocket` with isolation enabled!");
+        ecx.ensure_not_failed(&self, "listen")?;
 
-        // Get the file handle
-        let Some(fd) = this.machine.fds.get(socket) else {
-            return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
-        };
-
-        let Some(socket) = fd.downcast::<TcpSocket>() else {
-            // Man page specifies to return ENOTSOCK if `fd` is not a socket.
-            return this.set_errno_and_return_neg1_i32(LibcError("ENOTSOCK"));
-        };
-
-        assert!(this.machine.communicate(), "cannot have `TcpSocket` with isolation enabled!");
-        this.ensure_not_failed(&socket, "listen")?;
-
-        let mut state = socket.state.borrow_mut();
+        let mut state = self.state.borrow_mut();
 
         match *state {
             SocketState::Bound(socket_addr) =>
@@ -395,27 +382,32 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                         drop(state);
                         // Register the socket to the blocking I/O manager because
                         // we now have an associated host socket.
-                        this.machine.blocking_io.register(socket);
+                        ecx.machine.blocking_io.register(self);
                     }
-                    Err(e) => return this.set_errno_and_return_neg1_i32(e),
+                    Err(e) => return interp_ok(Err(IoError::HostError(e))),
                 },
             SocketState::Initial => {
                 throw_unsup_format!(
-                    "listen: listening on a socket which isn't bound is unsupported"
+                    "listen: listening on a tcp socket which isn't bound is unsupported"
                 )
             }
             SocketState::Listening(_) => {
-                throw_unsup_format!("listen: listening on a socket multiple times is unsupported")
+                throw_unsup_format!(
+                    "listen: listening on a tcp socket multiple times is unsupported"
+                )
             }
             SocketState::Connecting(_) | SocketState::Connected(_) => {
-                throw_unsup_format!("listen: listening on a connected socket is unsupported")
+                throw_unsup_format!("listen: listening on a connected tcp socket is unsupported")
             }
             SocketState::ConnectionFailed(_) => unreachable!(),
         }
 
-        interp_ok(Scalar::from_i32(0))
+        interp_ok(Ok(()))
     }
+}
 
+impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
+pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     /// For more information on the arguments see the accept manpage:
     /// <https://linux.die.net/man/2/accept4>
     fn accept4(

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -981,6 +981,8 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     }
 
     /// Block the thread until there's an incoming connection or an error occurred.
+    /// After a successful accept, `finish` is called with a tuple containing the
+    /// file descriptor of the peer socket and it's address.
     ///
     /// This recursively calls itself should the operation still block for some reason.
     ///
@@ -990,7 +992,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         &mut self,
         socket: FileDescriptionRef<TcpSocket>,
         is_client_sock_nonblock: bool,
-        finish: DynMachineCallback<'tcx, Result<(i32, SocketAddr), IoError>>,
+        finish: DynMachineCallback<'tcx, Result<(FdNum, SocketAddr), IoError>>,
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
         this.block_thread_for_io(
@@ -1000,7 +1002,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             callback!(@capture<'tcx> {
                 socket: FileDescriptionRef<TcpSocket>,
                 is_client_sock_nonblock: bool,
-                finish: DynMachineCallback<'tcx, Result<(i32, SocketAddr), IoError>>,
+                finish: DynMachineCallback<'tcx, Result<(FdNum, SocketAddr), IoError>>,
             } |this, kind: UnblockKind| {
                 // Remove the blocking I/O interest for unblocking this thread.
                 this.machine.blocking_io.remove_blocked_thread(socket.id(), this.machine.threads.active_thread());
@@ -1024,7 +1026,8 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     }
 
     /// Attempt to accept an incoming connection on the listening socket in a
-    /// non-blocking manner.
+    /// non-blocking manner. After a successful accept, a tuple containing the
+    /// file descriptor of the peer socket and it's address is returned.
     ///
     /// **Note**: This function is only safe to call when having previously ensured
     /// that the socket is in [`SocketState::Listening`].
@@ -1032,7 +1035,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         &mut self,
         socket: &FileDescriptionRef<TcpSocket>,
         is_client_sock_nonblock: bool,
-    ) -> InterpResult<'tcx, Result<(i32, SocketAddr), IoError>> {
+    ) -> InterpResult<'tcx, Result<(FdNum, SocketAddr), IoError>> {
         let this = self.eval_context_mut();
 
         let state = socket.state.borrow();

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -14,8 +14,8 @@ use rustc_target::spec::Os;
 
 use crate::shims::files::{EvalContextExt as _, FdId, FileDescription, FileDescriptionRef};
 use crate::shims::unix::UnixFileDescription;
+use crate::shims::unix::socket::{SocketFamily, UnixSocketFileDescription};
 use crate::shims::unix::socket_address::EvalContextExt as _;
-use crate::shims::unix::socket::SocketFamily;
 use crate::*;
 
 #[derive(Debug)]
@@ -204,7 +204,10 @@ impl FileDescription for TcpSocket {
         false
     }
 
-    fn as_unix<'tcx>(&self, _ecx: &MiriInterpCx<'tcx>) -> &dyn UnixFileDescription {
+    fn as_unix<'tcx>(
+        self: FileDescriptionRef<Self>,
+        _ecx: &MiriInterpCx<'tcx>,
+    ) -> FileDescriptionRef<dyn UnixFileDescription> {
         self
     }
 
@@ -283,7 +286,16 @@ impl UnixFileDescription for TcpSocket {
 
         throw_unsup_format!("ioctl: unsupported operation {op:#x} on socket");
     }
+
+    fn as_socket<'tcx>(
+        self: FileDescriptionRef<Self>,
+        _ecx: &MiriInterpCx<'tcx>,
+    ) -> FileDescriptionRef<dyn UnixSocketFileDescription> {
+        self
+    }
 }
+
+impl UnixSocketFileDescription for TcpSocket {}
 
 impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
 pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -442,51 +442,28 @@ impl UnixSocketFileDescription for TcpSocket {
             ecx.block_for_accept(self, is_client_sock_non_block, finish)
         }
     }
-}
 
-impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
-pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
-    fn connect(
-        &mut self,
-        socket: &OpTy<'tcx>,
-        address: &OpTy<'tcx>,
-        address_len: &OpTy<'tcx>,
-        // Location where the output scalar is written to.
-        dest: &MPlaceTy<'tcx>,
+    fn connect<'tcx>(
+        self: FileDescriptionRef<Self>,
+        communicate_allowed: bool,
+        address: SocketAddr,
+        ecx: &mut MiriInterpCx<'tcx>,
+        finish: DynMachineCallback<'tcx, Result<(), IoError>>,
     ) -> InterpResult<'tcx> {
-        let this = self.eval_context_mut();
+        assert!(communicate_allowed, "cannot have `TcpSocket` with isolation enabled!");
+        ecx.ensure_not_failed(&self, "connect")?;
 
-        let socket = this.read_scalar(socket)?.to_i32()?;
-        let address = match this.read_socket_address(address, address_len, "connect")? {
-            Ok(address) => address,
-            Err(e) => return this.set_errno_and_return_neg1(e, dest),
-        };
-
-        // Get the file handle
-        let Some(fd) = this.machine.fds.get(socket) else {
-            return this.set_errno_and_return_neg1(LibcError("EBADF"), dest);
-        };
-
-        let Some(socket) = fd.downcast::<TcpSocket>() else {
-            // Man page specifies to return ENOTSOCK if `fd` is not a socket
-            return this.set_errno_and_return_neg1(LibcError("ENOTSOCK"), dest);
-        };
-
-        assert!(this.machine.communicate(), "cannot have `TcpSocket` with isolation enabled!");
-        this.ensure_not_failed(&socket, "connect")?;
-
-        match &*socket.state.borrow() {
+        match &*self.state.borrow() {
             SocketState::Initial => { /* fall-through to below */ }
             // The socket is already in a connecting state.
-            SocketState::Connecting(_) =>
-                return this.set_errno_and_return_neg1(LibcError("EALREADY"), dest),
+            SocketState::Connecting(_) => return finish.call(ecx, Err(LibcError("EALREADY"))),
             // We don't return EISCONN for already connected sockets, for which we're
             // sure that the connection is established, since TCP sockets are usually
             // allowed to be connected multiple times.
             _ =>
                 throw_unsup_format!(
-                    "connect: connecting is only supported for sockets which are neither \
-                    bound, listening nor already connected"
+                    "connect: connecting is only supported for tcp sockets which are neither \
+                   bound, listening nor already connected"
                 ),
         }
 
@@ -494,27 +471,27 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // We deal with that below.
         match TcpStream::connect(address) {
             Ok(stream) => {
-                *socket.state.borrow_mut() = SocketState::Connecting(stream);
+                *self.state.borrow_mut() = SocketState::Connecting(stream);
                 // Register the socket to the blocking I/O manager because
                 // we now have an associated host socket.
-                this.machine.blocking_io.register(socket.clone());
+                ecx.machine.blocking_io.register(self.clone());
             }
-            Err(e) => return this.set_errno_and_return_neg1(e, dest),
+            Err(e) => return finish.call(ecx, Err(IoError::HostError(e))),
         };
 
-        if socket.is_non_block.get() {
+        if self.is_non_block.get() {
             // We have a non-blocking socket and thus don't want to block until
             // the connection is established.
 
             // Since the [`TcpStream::connect`] function of mio hides the EINPROGRESS
             // we just always return EINPROGRESS and check whether the connection succeeded
             // once we want to use the connected socket.
-            this.set_errno_and_return_neg1(LibcError("EINPROGRESS"), dest)
+            finish.call(ecx, Err(LibcError("EINPROGRESS")))
         } else {
             // The socket is in blocking mode and thus the connect call should block
             // until the connection with the server is established.
 
-            if socket.write_timeout.get().is_some() {
+            if self.write_timeout.get().is_some() {
                 // Some Unixes like Linux also apply the SO_SNDTIMEO socket option
                 // to `connect` calls:
                 // <https://github.com/torvalds/linux/blob/HEAD/net/ipv4/af_inet.c#L701-L710>
@@ -524,31 +501,34 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 )
             }
 
-            let dest = dest.clone();
-            this.ensure_connected(
+            let socket = self;
+            ecx.ensure_connected(
                 socket.clone(),
                 /* deadline */ None,
                 "connect",
                 callback!(
                     @capture<'tcx> {
                         socket: FileDescriptionRef<TcpSocket>,
-                        dest: MPlaceTy<'tcx>
+                        finish: DynMachineCallback<'tcx, Result<(), IoError>>,
                     } |this, result: Result<(), ()>| {
                         if result.is_err() {
                             // An error occurred whilst connecting. We know
                             // that it has been consumed by `ensure_connected`
                             // and is now stored in `socket.error`.
                             let err = socket.error.take().unwrap();
-                            this.set_errno_and_return_neg1(err, &dest)
+                            finish.call(this, Err(IoError::HostError(err)))
                         } else {
-                            this.write_scalar(Scalar::from_i32(0), &dest)
+                            finish.call(this, Ok(()))
                         }
                     }
                 ),
             )
         }
     }
+}
 
+impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
+pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     fn send(
         &mut self,
         socket: &OpTy<'tcx>,

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -55,7 +55,7 @@ enum SocketState {
 }
 
 #[derive(Debug)]
-struct Socket {
+struct TcpSocket {
     /// Family of the socket, used to ensure socket only binds/connects to address of
     /// same family.
     family: SocketFamily,
@@ -81,7 +81,7 @@ struct Socket {
     write_timeout: Cell<Option<Duration>>,
 }
 
-impl FileDescription for Socket {
+impl FileDescription for TcpSocket {
     fn name(&self) -> &'static str {
         "socket"
     }
@@ -92,7 +92,7 @@ impl FileDescription for Socket {
         communicate_allowed: bool,
         ecx: &mut MiriInterpCx<'tcx>,
     ) -> InterpResult<'tcx, io::Result<()>> {
-        assert!(communicate_allowed, "cannot have `Socket` with isolation enabled!");
+        assert!(communicate_allowed, "cannot have `TcpSocket` with isolation enabled!");
 
         if matches!(
             &*self.state.borrow(),
@@ -117,7 +117,7 @@ impl FileDescription for Socket {
         ecx: &mut MiriInterpCx<'tcx>,
         finish: DynMachineCallback<'tcx, Result<usize, IoError>>,
     ) -> InterpResult<'tcx> {
-        assert!(communicate_allowed, "cannot have `Socket` with isolation enabled!");
+        assert!(communicate_allowed, "cannot have `TcpSocket` with isolation enabled!");
 
         let socket = self;
         let deadline = ecx.action_deadline(socket.is_non_block.get(), socket.read_timeout.get());
@@ -128,7 +128,7 @@ impl FileDescription for Socket {
             "read",
             callback!(
                 @capture<'tcx> {
-                    socket: FileDescriptionRef<Socket>,
+                    socket: FileDescriptionRef<TcpSocket>,
                     deadline: Option<Deadline>,
                     ptr: Pointer,
                     len: usize,
@@ -164,7 +164,7 @@ impl FileDescription for Socket {
         ecx: &mut MiriInterpCx<'tcx>,
         finish: DynMachineCallback<'tcx, Result<usize, IoError>>,
     ) -> InterpResult<'tcx> {
-        assert!(communicate_allowed, "cannot have `Socket` with isolation enabled!");
+        assert!(communicate_allowed, "cannot have `TcpSocket` with isolation enabled!");
 
         let socket = self;
         let deadline = ecx.action_deadline(socket.is_non_block.get(), socket.write_timeout.get());
@@ -175,7 +175,7 @@ impl FileDescription for Socket {
             "write",
             callback!(
                 @capture<'tcx> {
-                    socket: FileDescriptionRef<Socket>,
+                    socket: FileDescriptionRef<TcpSocket>,
                     deadline: Option<Deadline>,
                     ptr: Pointer,
                     len: usize,
@@ -253,14 +253,14 @@ impl FileDescription for Socket {
     }
 }
 
-impl UnixFileDescription for Socket {
+impl UnixFileDescription for TcpSocket {
     fn ioctl<'tcx>(
         &self,
         op: Scalar,
         arg: Option<&OpTy<'tcx>>,
         ecx: &mut MiriInterpCx<'tcx>,
     ) -> InterpResult<'tcx, i32> {
-        assert!(ecx.machine.communicate(), "cannot have `Socket` with isolation enabled!");
+        assert!(ecx.machine.communicate(), "cannot have `TcpSocket` with isolation enabled!");
 
         let fionbio = ecx.eval_libc("FIONBIO");
 
@@ -363,7 +363,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         }
 
         let fds = &mut this.machine.fds;
-        let fd = fds.new_ref(Socket {
+        let fd = fds.new_ref(TcpSocket {
             family,
             state: RefCell::new(SocketState::Initial),
             is_non_block: Cell::new(is_sock_nonblock),
@@ -395,12 +395,12 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
         };
 
-        let Some(socket) = fd.downcast::<Socket>() else {
+        let Some(socket) = fd.downcast::<TcpSocket>() else {
             // Man page specifies to return ENOTSOCK if `fd` is not a socket.
             return this.set_errno_and_return_neg1_i32(LibcError("ENOTSOCK"));
         };
 
-        assert!(this.machine.communicate(), "cannot have `Socket` with isolation enabled!");
+        assert!(this.machine.communicate(), "cannot have `TcpSocket` with isolation enabled!");
         this.ensure_not_failed(&socket, "bind")?;
 
         let mut state = socket.state.borrow_mut();
@@ -458,12 +458,12 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
         };
 
-        let Some(socket) = fd.downcast::<Socket>() else {
+        let Some(socket) = fd.downcast::<TcpSocket>() else {
             // Man page specifies to return ENOTSOCK if `fd` is not a socket.
             return this.set_errno_and_return_neg1_i32(LibcError("ENOTSOCK"));
         };
 
-        assert!(this.machine.communicate(), "cannot have `Socket` with isolation enabled!");
+        assert!(this.machine.communicate(), "cannot have `TcpSocket` with isolation enabled!");
         this.ensure_not_failed(&socket, "listen")?;
 
         let mut state = socket.state.borrow_mut();
@@ -521,12 +521,12 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return this.set_errno_and_return_neg1(LibcError("EBADF"), dest);
         };
 
-        let Some(socket) = fd.downcast::<Socket>() else {
+        let Some(socket) = fd.downcast::<TcpSocket>() else {
             // Man page specifies to return ENOTSOCK if `fd` is not a socket.
             return this.set_errno_and_return_neg1(LibcError("ENOTSOCK"), dest);
         };
 
-        assert!(this.machine.communicate(), "cannot have `Socket` with isolation enabled!");
+        assert!(this.machine.communicate(), "cannot have `TcpSocket` with isolation enabled!");
         this.ensure_not_failed(&socket, "accept4")?;
 
         if !matches!(*socket.state.borrow(), SocketState::Listening(_)) {
@@ -627,12 +627,12 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return this.set_errno_and_return_neg1(LibcError("EBADF"), dest);
         };
 
-        let Some(socket) = fd.downcast::<Socket>() else {
+        let Some(socket) = fd.downcast::<TcpSocket>() else {
             // Man page specifies to return ENOTSOCK if `fd` is not a socket
             return this.set_errno_and_return_neg1(LibcError("ENOTSOCK"), dest);
         };
 
-        assert!(this.machine.communicate(), "cannot have `Socket` with isolation enabled!");
+        assert!(this.machine.communicate(), "cannot have `TcpSocket` with isolation enabled!");
         this.ensure_not_failed(&socket, "connect")?;
 
         match &*socket.state.borrow() {
@@ -691,7 +691,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 "connect",
                 callback!(
                     @capture<'tcx> {
-                        socket: FileDescriptionRef<Socket>,
+                        socket: FileDescriptionRef<TcpSocket>,
                         dest: MPlaceTy<'tcx>
                     } |this, result: Result<(), ()>| {
                         if result.is_err() {
@@ -732,7 +732,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return this.set_errno_and_return_neg1(LibcError("EBADF"), dest);
         };
 
-        let Some(socket) = fd.downcast::<Socket>() else {
+        let Some(socket) = fd.downcast::<TcpSocket>() else {
             // Man page specifies to return ENOTSOCK if `fd` is not a socket
             return this.set_errno_and_return_neg1(LibcError("ENOTSOCK"), dest);
         };
@@ -777,7 +777,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "send",
             callback!(
                 @capture<'tcx> {
-                    socket: FileDescriptionRef<Socket>,
+                    socket: FileDescriptionRef<TcpSocket>,
                     deadline: Option<Deadline>,
                     flags: i32,
                     buffer_ptr: Pointer,
@@ -842,7 +842,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return this.set_errno_and_return_neg1(LibcError("EBADF"), dest);
         };
 
-        let Some(socket) = fd.downcast::<Socket>() else {
+        let Some(socket) = fd.downcast::<TcpSocket>() else {
             // Man page specifies to return ENOTSOCK if `fd` is not a socket
             return this.set_errno_and_return_neg1(LibcError("ENOTSOCK"), dest);
         };
@@ -899,7 +899,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "recv",
             callback!(
                 @capture<'tcx> {
-                    socket: FileDescriptionRef<Socket>,
+                    socket: FileDescriptionRef<TcpSocket>,
                     deadline: Option<Deadline>,
                     buffer_ptr: Pointer,
                     length: usize,
@@ -964,7 +964,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
         };
 
-        let Some(socket) = fd.downcast::<Socket>() else {
+        let Some(socket) = fd.downcast::<TcpSocket>() else {
             // Man page specifies to return ENOTSOCK if `fd` is not a socket.
             return this.set_errno_and_return_neg1_i32(LibcError("ENOTSOCK"));
         };
@@ -1123,7 +1123,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
         };
 
-        let Some(socket) = fd.downcast::<Socket>() else {
+        let Some(socket) = fd.downcast::<TcpSocket>() else {
             // Man page specifies to return ENOTSOCK if `fd` is not a socket.
             return this.set_errno_and_return_neg1_i32(LibcError("ENOTSOCK"));
         };
@@ -1308,12 +1308,12 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
         };
 
-        let Some(socket) = fd.downcast::<Socket>() else {
+        let Some(socket) = fd.downcast::<TcpSocket>() else {
             // Man page specifies to return ENOTSOCK if `fd` is not a socket.
             return this.set_errno_and_return_neg1_i32(LibcError("ENOTSOCK"));
         };
 
-        assert!(this.machine.communicate(), "cannot have `Socket` with isolation enabled!");
+        assert!(this.machine.communicate(), "cannot have `TcpSocket` with isolation enabled!");
         this.ensure_not_failed(&socket, "getsockname")?;
 
         let state = socket.state.borrow();
@@ -1384,12 +1384,12 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return this.set_errno_and_return_neg1(LibcError("EBADF"), dest);
         };
 
-        let Some(socket) = fd.downcast::<Socket>() else {
+        let Some(socket) = fd.downcast::<TcpSocket>() else {
             // Man page specifies to return ENOTSOCK if `fd` is not a socket.
             return this.set_errno_and_return_neg1(LibcError("ENOTSOCK"), dest);
         };
 
-        assert!(this.machine.communicate(), "cannot have `Socket` with isolation enabled!");
+        assert!(this.machine.communicate(), "cannot have `TcpSocket` with isolation enabled!");
 
         let dest = dest.clone();
 
@@ -1402,7 +1402,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "getpeername",
             callback!(
                 @capture<'tcx> {
-                    socket: FileDescriptionRef<Socket>,
+                    socket: FileDescriptionRef<TcpSocket>,
                     address_ptr: Pointer,
                     address_len_ptr: Pointer,
                     dest: MPlaceTy<'tcx>,
@@ -1443,12 +1443,12 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
         };
 
-        let Some(socket) = fd.downcast::<Socket>() else {
+        let Some(socket) = fd.downcast::<TcpSocket>() else {
             // Man page specifies to return ENOTSOCK if `fd` is not a socket.
             return this.set_errno_and_return_neg1_i32(LibcError("ENOTSOCK"));
         };
 
-        assert!(this.machine.communicate(), "cannot have `Socket` with isolation enabled!");
+        assert!(this.machine.communicate(), "cannot have `TcpSocket` with isolation enabled!");
         this.ensure_not_failed(&socket, "shutdown")?;
 
         let state = socket.state.borrow();
@@ -1531,7 +1531,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     /// that the socket is in [`SocketState::Listening`].
     fn block_for_accept(
         &mut self,
-        socket: FileDescriptionRef<Socket>,
+        socket: FileDescriptionRef<TcpSocket>,
         address_ptr: Pointer,
         address_len_ptr: Pointer,
         is_client_sock_nonblock: bool,
@@ -1543,7 +1543,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             BlockingIoInterest::Read,
             /* deadline */ None,
             callback!(@capture<'tcx> {
-                socket: FileDescriptionRef<Socket>,
+                socket: FileDescriptionRef<TcpSocket>,
                 address_ptr: Pointer,
                 address_len_ptr: Pointer,
                 is_client_sock_nonblock: bool,
@@ -1583,7 +1583,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     /// that the socket is in [`SocketState::Listening`].
     fn try_non_block_accept(
         &mut self,
-        socket: &FileDescriptionRef<Socket>,
+        socket: &FileDescriptionRef<TcpSocket>,
         address_ptr: Pointer,
         address_len_ptr: Pointer,
         is_client_sock_nonblock: bool,
@@ -1621,7 +1621,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             this.write_socket_address(&addr, address_ptr, address_len_ptr, "accept4")?;
         }
 
-        let fd = this.machine.fds.new_ref(Socket {
+        let fd = this.machine.fds.new_ref(TcpSocket {
             family,
             state: RefCell::new(SocketState::Connected(stream)),
             is_non_block: Cell::new(is_client_sock_nonblock),
@@ -1646,7 +1646,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     /// that the socket is in [`SocketState::Connected`].
     fn block_for_send(
         &mut self,
-        socket: FileDescriptionRef<Socket>,
+        socket: FileDescriptionRef<TcpSocket>,
         deadline: Option<Deadline>,
         buffer_ptr: Pointer,
         length: usize,
@@ -1658,7 +1658,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             BlockingIoInterest::Write,
             deadline.clone(),
             callback!(@capture<'tcx> {
-                socket: FileDescriptionRef<Socket>,
+                socket: FileDescriptionRef<TcpSocket>,
                 deadline: Option<Deadline>,
                 buffer_ptr: Pointer,
                 length: usize,
@@ -1690,7 +1690,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     /// that the socket is in [`SocketState::Connected`].
     fn try_non_block_send(
         &mut self,
-        socket: &FileDescriptionRef<Socket>,
+        socket: &FileDescriptionRef<TcpSocket>,
         buffer_ptr: Pointer,
         length: usize,
     ) -> InterpResult<'tcx, Result<usize, IoError>> {
@@ -1775,7 +1775,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     /// that the socket is in [`SocketState::Connected`].
     fn block_for_recv(
         &mut self,
-        socket: FileDescriptionRef<Socket>,
+        socket: FileDescriptionRef<TcpSocket>,
         deadline: Option<Deadline>,
         buffer_ptr: Pointer,
         length: usize,
@@ -1788,7 +1788,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             BlockingIoInterest::Read,
             deadline.clone(),
             callback!(@capture<'tcx> {
-                socket: FileDescriptionRef<Socket>,
+                socket: FileDescriptionRef<TcpSocket>,
                 deadline: Option<Deadline>,
                 buffer_ptr: Pointer,
                 length: usize,
@@ -1821,7 +1821,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     /// that the socket is in [`SocketState::Connected`].
     fn try_non_block_recv(
         &mut self,
-        socket: &FileDescriptionRef<Socket>,
+        socket: &FileDescriptionRef<TcpSocket>,
         buffer_ptr: Pointer,
         length: usize,
         should_peek: bool,
@@ -1922,7 +1922,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     /// the socket reached the [`SocketState::Connected`] state.
     fn ensure_connected(
         &mut self,
-        socket: FileDescriptionRef<Socket>,
+        socket: FileDescriptionRef<TcpSocket>,
         deadline: Option<Deadline>,
         foreign_name: &'static str,
         action: DynMachineCallback<'tcx, Result<(), ()>>,
@@ -1954,7 +1954,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             deadline,
             callback!(
                 @capture<'tcx> {
-                    socket: FileDescriptionRef<Socket>,
+                    socket: FileDescriptionRef<TcpSocket>,
                     foreign_name: &'static str,
                     action: DynMachineCallback<'tcx, Result<(), ()>>,
                 } |this, kind: UnblockKind| {
@@ -2035,7 +2035,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     /// error is thrown.
     fn ensure_not_failed(
         &self,
-        socket: &FileDescriptionRef<Socket>,
+        socket: &FileDescriptionRef<TcpSocket>,
         foreign_name: &'static str,
     ) -> InterpResult<'tcx> {
         if let SocketState::ConnectionFailed(_) = &*socket.state.borrow() {
@@ -2055,7 +2055,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     /// an error on the host socket, we transition into the [`SocketState::ConnectionFailed`]
     /// state because we know that `socket` can no longer successfully establish a
     /// connection.
-    fn update_last_error(&self, socket: &FileDescriptionRef<Socket>) {
+    fn update_last_error(&self, socket: &FileDescriptionRef<TcpSocket>) {
         let mut state = socket.state.borrow_mut();
 
         let new_error = match &*state {
@@ -2089,13 +2089,13 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     }
 }
 
-impl VisitProvenance for FileDescriptionRef<Socket> {
+impl VisitProvenance for FileDescriptionRef<TcpSocket> {
     // A socket doesn't contain any references to machine memory
     // and thus we don't need to propagate the visit.
     fn visit_provenance(&self, _visit: &mut VisitWith<'_>) {}
 }
 
-impl SourceFileDescription for Socket {
+impl SourceFileDescription for TcpSocket {
     fn with_source(&self, f: &mut dyn FnMut(&mut dyn Source) -> io::Result<()>) -> io::Result<()> {
         let mut state = self.state.borrow_mut();
         match &mut *state {

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -557,110 +557,87 @@ impl UnixSocketFileDescription for TcpSocket {
             ),
         )
     }
-}
 
-impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
-pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
-    fn setsockopt(
-        &mut self,
-        socket: &OpTy<'tcx>,
-        level: &OpTy<'tcx>,
-        option_name: &OpTy<'tcx>,
-        option_value: &OpTy<'tcx>,
-        option_len: &OpTy<'tcx>,
-    ) -> InterpResult<'tcx, Scalar> {
-        let this = self.eval_context_mut();
+    fn setsockopt<'tcx>(
+        self: FileDescriptionRef<Self>,
+        level: i32,
+        option: i32,
+        value_ptr: Pointer,
+        value_len: u64,
+        ecx: &mut MiriInterpCx<'tcx>,
+    ) -> InterpResult<'tcx, Result<(), IoError>> {
+        if level == ecx.eval_libc_i32("SOL_SOCKET") {
+            let opt_so_rcvtimeo = ecx.eval_libc_i32("SO_RCVTIMEO");
+            let opt_so_sndtimeo = ecx.eval_libc_i32("SO_SNDTIMEO");
+            let opt_so_reuseaddr = ecx.eval_libc_i32("SO_REUSEADDR");
 
-        let socket = this.read_scalar(socket)?.to_i32()?;
-        let level = this.read_scalar(level)?.to_i32()?;
-        let option_name = this.read_scalar(option_name)?.to_i32()?;
-        let option_value_ptr = this.read_pointer(option_value)?;
-        let socklen_layout = this.libc_ty_layout("socklen_t");
-        let option_len = this.read_scalar(option_len)?.to_int(socklen_layout.size)?;
-
-        // Get the file handle
-        let Some(fd) = this.machine.fds.get(socket) else {
-            return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
-        };
-
-        let Some(socket) = fd.downcast::<TcpSocket>() else {
-            // Man page specifies to return ENOTSOCK if `fd` is not a socket.
-            return this.set_errno_and_return_neg1_i32(LibcError("ENOTSOCK"));
-        };
-
-        if level == this.eval_libc_i32("SOL_SOCKET") {
-            let opt_so_rcvtimeo = this.eval_libc_i32("SO_RCVTIMEO");
-            let opt_so_sndtimeo = this.eval_libc_i32("SO_SNDTIMEO");
-            let opt_so_reuseaddr = this.eval_libc_i32("SO_REUSEADDR");
-
-            if matches!(this.tcx.sess.target.os, Os::MacOs | Os::FreeBsd | Os::NetBsd) {
+            if matches!(ecx.tcx.sess.target.os, Os::MacOs | Os::FreeBsd | Os::NetBsd) {
                 // SO_NOSIGPIPE only exists on MacOS, FreeBSD, and NetBSD.
-                let opt_so_nosigpipe = this.eval_libc_i32("SO_NOSIGPIPE");
+                let opt_so_nosigpipe = ecx.eval_libc_i32("SO_NOSIGPIPE");
 
-                if option_name == opt_so_nosigpipe {
-                    if option_len != 4 {
+                if option == opt_so_nosigpipe {
+                    if value_len != 4 {
                         // Option value should be C-int which is usually 4 bytes.
-                        return this.set_errno_and_return_neg1_i32(LibcError("EINVAL"));
+                        return interp_ok(Err(LibcError("EINVAL")));
                     }
-                    let option_value =
-                        this.ptr_to_mplace(option_value_ptr, this.machine.layouts.i32);
-                    let _val = this.read_scalar(&option_value)?.to_i32()?;
+                    let option_value = ecx.ptr_to_mplace(value_ptr, ecx.machine.layouts.i32);
+                    let _val = ecx.read_scalar(&option_value)?.to_i32()?;
                     // We entirely ignore this value since we do not support signals anyway.
 
-                    return interp_ok(Scalar::from_i32(0));
+                    return interp_ok(Ok(()));
                 }
             }
 
-            if option_name == opt_so_rcvtimeo || option_name == opt_so_sndtimeo {
-                let timeval_layout = this.libc_ty_layout("timeval");
-                let option_value = this.ptr_to_mplace(option_value_ptr, timeval_layout);
+            if option == opt_so_rcvtimeo || option == opt_so_sndtimeo {
+                let timeval_layout = ecx.libc_ty_layout("timeval");
+                let option_value = ecx.ptr_to_mplace(value_ptr, timeval_layout);
 
-                let timeout = match this.read_timeval(&option_value)? {
-                    None => return this.set_errno_and_return_neg1_i32(LibcError("EINVAL")),
+                let timeout = match ecx.read_timeval(&option_value)? {
+                    None => return interp_ok(Err(LibcError("EINVAL"))),
                     Some(Duration::ZERO) => None,
                     Some(duration) => Some(duration),
                 };
 
-                if option_name == opt_so_rcvtimeo {
-                    socket.read_timeout.set(timeout);
+                if option == opt_so_rcvtimeo {
+                    self.read_timeout.set(timeout);
                 } else {
-                    socket.write_timeout.set(timeout);
+                    self.write_timeout.set(timeout);
                 }
 
-                return interp_ok(Scalar::from_i32(0));
+                return interp_ok(Ok(()));
             }
 
-            if option_name == opt_so_reuseaddr {
-                if option_len != 4 {
+            if option == opt_so_reuseaddr {
+                if value_len != 4 {
                     // Option value should be C-int which is usually 4 bytes.
-                    return this.set_errno_and_return_neg1_i32(LibcError("EINVAL"));
+                    return interp_ok(Err(LibcError("EINVAL")));
                 }
-                let option_value = this.ptr_to_mplace(option_value_ptr, this.machine.layouts.i32);
-                let _val = this.read_scalar(&option_value)?.to_i32()?;
+                let option_value = ecx.ptr_to_mplace(value_ptr, ecx.machine.layouts.i32);
+                let _val = ecx.read_scalar(&option_value)?.to_i32()?;
                 // We entirely ignore this: std always sets REUSEADDR for us, and in the end it's more of a
                 // hint to bypass some arbitrary timeout anyway.
-                return interp_ok(Scalar::from_i32(0));
+                return interp_ok(Ok(()));
             } else {
                 throw_unsup_format!(
-                    "setsockopt: option {option_name:#x} is unsupported for level SOL_SOCKET",
+                    "setsockopt: option {option:#x} is unsupported for level SOL_SOCKET",
                 );
             }
-        } else if level == this.eval_libc_i32("IPPROTO_IP") {
-            let opt_ip_ttl = this.eval_libc_i32("IP_TTL");
+        } else if level == ecx.eval_libc_i32("IPPROTO_IP") {
+            let opt_ip_ttl = ecx.eval_libc_i32("IP_TTL");
 
-            if option_name == opt_ip_ttl {
-                if option_len != 4 {
+            if option == opt_ip_ttl {
+                if value_len != 4 {
                     // Option value should be C-uint which is usually 4 bytes.
-                    return this.set_errno_and_return_neg1_i32(LibcError("EINVAL"));
+                    return interp_ok(Err(LibcError("EINVAL")));
                 }
-                let option_value = this.ptr_to_mplace(option_value_ptr, this.machine.layouts.u32);
-                let ttl = this.read_scalar(&option_value)?.to_u32()?;
+                let option_value = ecx.ptr_to_mplace(value_ptr, ecx.machine.layouts.u32);
+                let ttl = ecx.read_scalar(&option_value)?.to_u32()?;
 
-                let result = match &*socket.state.borrow() {
+                let result = match &*self.state.borrow() {
                     SocketState::Initial | SocketState::Bound(_) =>
                         throw_unsup_format!(
                             "setsockopt: setting option IP_TTL on level IPPROTO_IP is only supported \
-                            on connected and listening sockets"
+                           on connected and listening tcp sockets"
                         ),
                     SocketState::Listening(listener) => listener.set_ttl(ttl),
                     SocketState::Connecting(stream) | SocketState::Connected(stream) =>
@@ -669,30 +646,30 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 };
 
                 return match result {
-                    Ok(_) => interp_ok(Scalar::from_i32(0)),
-                    Err(e) => this.set_errno_and_return_neg1_i32(e),
+                    Ok(_) => interp_ok(Ok(())),
+                    Err(e) => interp_ok(Err(IoError::HostError(e))),
                 };
             } else {
                 throw_unsup_format!(
-                    "setsockopt: option {option_name:#x} is unsupported for level IPPROTO_IP",
+                    "setsockopt: option {option:#x} is unsupported for level IPPROTO_IP",
                 );
             }
-        } else if level == this.eval_libc_i32("IPPROTO_TCP") {
-            let opt_tcp_nodelay = this.eval_libc_i32("TCP_NODELAY");
+        } else if level == ecx.eval_libc_i32("IPPROTO_TCP") {
+            let opt_tcp_nodelay = ecx.eval_libc_i32("TCP_NODELAY");
 
-            if option_name == opt_tcp_nodelay {
-                if option_len != 4 {
+            if option == opt_tcp_nodelay {
+                if value_len != 4 {
                     // Option value should be C-int which is usually 4 bytes.
-                    return this.set_errno_and_return_neg1_i32(LibcError("EINVAL"));
+                    return interp_ok(Err(LibcError("EINVAL")));
                 }
-                let option_value = this.ptr_to_mplace(option_value_ptr, this.machine.layouts.i32);
-                let nodelay = this.read_scalar(&option_value)?.to_i32()? != 0;
+                let option_value = ecx.ptr_to_mplace(value_ptr, ecx.machine.layouts.i32);
+                let nodelay = ecx.read_scalar(&option_value)?.to_i32()? != 0;
 
-                let result = match &*socket.state.borrow() {
+                let result = match &*self.state.borrow() {
                     SocketState::Initial | SocketState::Bound(_) | SocketState::Listening(_) =>
                         throw_unsup_format!(
                             "setsockopt: setting option TCP_NODELAY on level IPPROTO_TCP is only supported \
-                            on connected sockets"
+                           on connected tcp sockets"
                         ),
                     SocketState::Connecting(stream) | SocketState::Connected(stream) =>
                         stream.set_nodelay(nodelay),
@@ -700,22 +677,25 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 };
 
                 return match result {
-                    Ok(_) => interp_ok(Scalar::from_i32(0)),
-                    Err(e) => this.set_errno_and_return_neg1_i32(e),
+                    Ok(_) => interp_ok(Ok(())),
+                    Err(e) => interp_ok(Err(IoError::HostError(e))),
                 };
             } else {
                 throw_unsup_format!(
-                    "setsockopt: option {option_name:#x} is unsupported for level IPPROTO_TCP"
+                    "setsockopt: option {option:#x} is unsupported for level IPPROTO_TCP"
                 );
             }
         }
 
         throw_unsup_format!(
             "setsockopt: level {level:#x} is unsupported, only SOL_SOCKET, IPPROTO_IP \
-            and IPPROTO_TCP are allowed"
+           and IPPROTO_TCP are allowed"
         );
     }
+}
 
+impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
+pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     fn getsockopt(
         &mut self,
         socket: &OpTy<'tcx>,

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -819,36 +819,16 @@ impl UnixSocketFileDescription for TcpSocket {
             )
         }
     }
-}
 
-impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
-pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
-    fn getsockname(
-        &mut self,
-        socket: &OpTy<'tcx>,
-        address: &OpTy<'tcx>,
-        address_len: &OpTy<'tcx>,
-    ) -> InterpResult<'tcx, Scalar> {
-        let this = self.eval_context_mut();
+    fn getsockname<'tcx>(
+        self: FileDescriptionRef<Self>,
+        communicate_allowed: bool,
+        ecx: &mut MiriInterpCx<'tcx>,
+    ) -> InterpResult<'tcx, Result<SocketAddr, IoError>> {
+        assert!(communicate_allowed, "cannot have `TcpSocket` with isolation enabled!");
+        ecx.ensure_not_failed(&self, "getsockname")?;
 
-        let socket = this.read_scalar(socket)?.to_i32()?;
-        let address_ptr = this.read_pointer(address)?;
-        let address_len_ptr = this.read_pointer(address_len)?;
-
-        // Get the file handle
-        let Some(fd) = this.machine.fds.get(socket) else {
-            return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
-        };
-
-        let Some(socket) = fd.downcast::<TcpSocket>() else {
-            // Man page specifies to return ENOTSOCK if `fd` is not a socket.
-            return this.set_errno_and_return_neg1_i32(LibcError("ENOTSOCK"));
-        };
-
-        assert!(this.machine.communicate(), "cannot have `TcpSocket` with isolation enabled!");
-        this.ensure_not_failed(&socket, "getsockname")?;
-
-        let state = socket.state.borrow();
+        let state = self.state.borrow();
 
         let address = match &*state {
             SocketState::Bound(address) => {
@@ -857,7 +837,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     // port. Since we don't yet have an underlying socket, we don't know what this
                     // random port will be and thus this is unsupported.
                     throw_unsup_format!(
-                        "getsockname: when the port is 0, getting the socket address before \
+                        "getsockname: when the port is 0, getting the tcp socket address before \
                         calling `listen` or `connect` is unsupported"
                     )
                 }
@@ -867,7 +847,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             SocketState::Listening(listener) =>
                 match listener.local_addr() {
                     Ok(address) => address,
-                    Err(e) => return this.set_errno_and_return_neg1_i32(e),
+                    Err(e) => return interp_ok(Err(IoError::HostError(e))),
                 },
             SocketState::Connecting(stream) | SocketState::Connected(stream) => {
                 if cfg!(windows) && matches!(&*state, SocketState::Connecting(_)) {
@@ -879,12 +859,12 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                     static DEDUP: AtomicBool = AtomicBool::new(false);
                     if !DEDUP.swap(true, std::sync::atomic::Ordering::Relaxed) {
-                        this.emit_diagnostic(NonHaltingDiagnostic::ConnectingSocketGetsockname);
+                        ecx.emit_diagnostic(NonHaltingDiagnostic::ConnectingSocketGetsockname);
                     }
                 }
                 match stream.local_addr() {
                     Ok(address) => address,
-                    Err(e) => return this.set_errno_and_return_neg1_i32(e),
+                    Err(e) => return interp_ok(Err(IoError::HostError(e))),
                 }
             }
             // For non-bound sockets the POSIX manual says the returned address is unspecified.
@@ -893,10 +873,12 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             SocketState::ConnectionFailed(_) => unreachable!(),
         };
 
-        this.write_socket_address(&address, address_ptr, address_len_ptr, "getsockname")
-            .map(|_| Scalar::from_i32(0))
+        interp_ok(Ok(address))
     }
+}
 
+impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
+pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     fn getpeername(
         &mut self,
         socket: &OpTy<'tcx>,

--- a/src/shims/unix/virtual_socket.rs
+++ b/src/shims/unix/virtual_socket.rs
@@ -142,7 +142,10 @@ impl FileDescription for VirtualSocket {
         false
     }
 
-    fn as_unix<'tcx>(&self, _ecx: &MiriInterpCx<'tcx>) -> &dyn UnixFileDescription {
+    fn as_unix<'tcx>(
+        self: FileDescriptionRef<Self>,
+        _ecx: &MiriInterpCx<'tcx>,
+    ) -> FileDescriptionRef<dyn UnixFileDescription> {
         self
     }
 


### PR DESCRIPTION
This pull request adds a new `UnixSocketFileDescription` trait which can be used to implement socket specific operations for file descriptions. At the moment it contains all the shimmed socket functions which were previously implemented on `Socket` directly. 
In a future pull request, this trait can be used to implement `send`/`recv` for virtual sockets (as discussed in rust-lang/miri#4958).

To allow for the implementation of other socket types, the `Socket` shim has also be renamed to `TcpSocket`.