### PR TITLE
add `vqdmulh*` aarch64 intrinsics

### DIFF
--- a/src/shims/aarch64.rs
+++ b/src/shims/aarch64.rs
@@ -146,6 +146,45 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 }
             }
 
+            // Signed saturating doubling multiply returning the high half.
+            //
+            // Used by the `vqdmulh*` functions.
+            //
+            // This LLVM intrinsic multiplies the values of corresponding elements of the two source
+            // vector registers (which are signed integers), doubles the results, places the most significant half of the
+            // final results (using a saturating cast to fit the element type) into a vector, and writes the vector to the destination register.
+            //
+            // https://developer.arm.com/architectures/instruction-sets/intrinsics#f:@navigationhierarchiessimdisa=[Neon]&q=vqdmulh
+            name if name.starts_with("neon.sqdmulh.") => {
+                let [left, right] =
+                    this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
+
+                let (left, left_len) = this.project_to_simd(left)?;
+                let (right, right_len) = this.project_to_simd(right)?;
+                let (dest, dest_len) = this.project_to_simd(dest)?;
+                assert_eq!(left_len, right_len);
+                assert_eq!(left_len, dest_len);
+
+                let elem_size = dest.layout.field(this, 0).size;
+                let bits = elem_size.bits();
+                let min = elem_size.signed_int_min();
+                let max = elem_size.signed_int_max();
+
+                for i in 0..dest_len {
+                    let a = this.read_scalar(&this.project_index(&left, i)?)?.to_int(elem_size)?;
+                    let b = this.read_scalar(&this.project_index(&right, i)?)?.to_int(elem_size)?;
+
+                    // Uses i128 arithmetic, which cannot overflow because the intrinsic takes at most i32.
+                    let doubled = a.strict_mul(b).strict_mul(2);
+                    let res = (doubled >> bits).clamp(min, max);
+
+                    this.write_scalar(
+                        Scalar::from_int(res, elem_size),
+                        &this.project_index(&dest, i)?,
+                    )?;
+                }
+            }
+
             // Vector table lookup: each index selects a byte from the 16-byte table, out-of-range -> 0.
             // Used to implement vtbl1_u8 function.
             // LLVM does not have a portable shuffle that takes non-const indices

--- a/tests/pass/shims/aarch64/intrinsics-aarch64-neon.rs
+++ b/tests/pass/shims/aarch64/intrinsics-aarch64-neon.rs
@@ -14,6 +14,7 @@ fn main() {
         test_tbl1_v16i8_basic();
         test_vpadd();
         test_vpaddl();
+        test_vqdmulh();
     }
 }
 
@@ -156,4 +157,52 @@ unsafe fn test_vpaddl() {
     let mut r = [0u64; 2];
     vst1q_u64(r.as_mut_ptr(), vpaddlq_u32(a));
     assert_eq!(r, e);
+}
+
+#[target_feature(enable = "neon")]
+unsafe fn test_vqdmulh() {
+    let a = vld1_s32([i32::MIN, i32::MAX].as_ptr());
+    let r: [i32; 2] = transmute(vqdmulh_n_s32(a, i32::MIN));
+    assert_eq!(r, [i32::MAX, -i32::MAX]);
+
+    // This is the actual calculation that happens.
+    let product = i32::MIN as i128 * i32::MIN as i128 * 2;
+    assert_eq!(i32::MAX, (product >> 32).clamp(i32::MIN as i128, i32::MAX as i128) as i32);
+
+    let product = i32::MAX as i128 * i32::MIN as i128 * 2;
+    assert_eq!(-i32::MAX, (product >> 32).clamp(i32::MIN as i128, i32::MAX as i128) as i32);
+
+    let b = vld1_s32([123, i32::MIN].as_ptr());
+    let r: [i32; 2] = transmute(vqdmulh_s32(a, b));
+    assert_eq!(r, [-123, -i32::MAX]);
+
+    // Wider 32-bit versions.
+    let a = vld1q_s32([0x4000_0000, -0x4000_0000, i32::MIN, i32::MAX].as_ptr());
+
+    let b = vld1q_s32([123, 456, 0x4000_0000, 789].as_ptr());
+    let r: [i32; 4] = transmute(vqdmulhq_s32(a, b));
+    assert_eq!(r, [61, -228, -1073741824, 788]);
+
+    let r: [i32; 4] = transmute(vqdmulhq_n_s32(a, 0x4000_0000));
+    assert_eq!(r, [536870912, -536870912, -1073741824, 1073741823]);
+
+    // 16-bit versions.
+
+    let a = vld1_s16([i16::MIN, i16::MAX, 0, 16384].as_ptr());
+    let r: [i16; 4] = transmute(vqdmulh_n_s16(a, i16::MIN));
+    assert_eq!(r, [i16::MAX, -i16::MAX, 0, -16384]);
+
+    let b = vld1_s16([123, i16::MIN, 456, 789].as_ptr());
+    let r: [i16; 4] = transmute(vqdmulh_s16(a, b));
+    assert_eq!(r, [-123, -i16::MAX, 0, 394]);
+
+    // Wider 16-bit versions.
+
+    let a = vld1q_s16([i16::MIN, i16::MAX, 0, 16384, -16384, 8192, 1, -1].as_ptr());
+    let b = vld1q_s16([123, 456, 789, i16::MIN, 1, 2, 3, 4].as_ptr());
+    let r: [i16; 8] = transmute(vqdmulhq_s16(a, b));
+    assert_eq!(r, [-123, 455, 0, -16384, -1, 0, 0, -1]);
+
+    let r: [i16; 8] = transmute(vqdmulhq_n_s16(a, i16::MIN));
+    assert_eq!(r, [32767, -32767, 0, -16384, 16384, -8192, -1, 1]);
 }


### PR DESCRIPTION
We may switch to https://github.com/dtolnay/zmij for floating point formatting in the standard library (motivated in part by having to add an implementation for `f128`), and that implementation uses this intrinsic.

The LLVM IR for a manual implementation of this intrinsic is sufficiently complicated that I don't think LLVM can realistically match this pattern reliably, so it needs a custom implementation.

I've validated the tests on real hardware.