### PR TITLE
[Priroda] Show composite debug-info fragments in `locals`

### DIFF
--- a/priroda/src/main.rs
+++ b/priroda/src/main.rs
@@ -12,6 +12,7 @@ extern crate rustc_log;
 extern crate rustc_middle;
 extern crate rustc_session;
 extern crate rustc_span;
+extern crate rustc_type_ir;
 
 use std::collections::{HashMap, HashSet};
 use std::io::{self, Write};
@@ -22,9 +23,8 @@ use rustc_driver::Compilation;
 use rustc_hir::attrs::CrateType;
 use rustc_index::IndexVec;
 use rustc_interface::interface;
-use rustc_middle::mir;
-use rustc_middle::mir::{Local, VarDebugInfoContents};
-use rustc_middle::ty::TyCtxt;
+use rustc_middle::mir::{self, Local, ProjectionElem, VarDebugInfoContents, VarDebugInfoFragment};
+use rustc_middle::ty::{TyCtxt, TyKind};
 use rustc_session::EarlyDiagCtxt;
 use rustc_session::config::ErrorOutputType;
 use rustc_span::source_map::SourceMap;
@@ -133,8 +133,11 @@ struct PrirodaContext<'tcx> {
 }
 
 struct LocalDesc {
-    name: Option<Symbol>,
-    local: Local,
+    source_name: Option<Symbol>,
+    // Source-side projection from `VarDebugInfo::composite`. Each symbol is
+    // already rendered as one source projection segment, such as `.field` or `.0`.
+    source_projection: Option<Vec<Symbol>>,
+    local: Option<Local>,
     ty: String,
 }
 /// Controls when execution returns to the frontend.
@@ -365,24 +368,96 @@ impl<'tcx> PrirodaContext<'tcx> {
             .body()
             .local_decls
             .iter_enumerated()
-            .map(|(id, local_decl)| {
-                LocalDesc { name: None, local: id, ty: local_decl.ty.to_string() }
+            .map(|(local, local_decl)| {
+                LocalDesc {
+                    source_name: None,
+                    source_projection: None,
+                    local: Some(local),
+                    ty: local_decl.ty.to_string(),
+                }
             })
             .collect();
 
-        // FIXME: Some debug-info entries do not have a backing MIR local, for example
-        // because the source variable was optimized out or is represented as a
-        // projection. This local-indexed table cannot represent those entries yet;
-        // the final locals list should become a `Vec<LocalDesc>` with `id : Option<Local>`, `id`
-        // could be renamed to `local`.
+        // FIXME: Finish classifying `var_debug_info` by keeping the source path
+        // and MIR storage path separate:
+        //
+        // - source side: `var_debug_info.name` plus
+        //   `var_debug_info.composite.projection`
+        // - storage side: `VarDebugInfoContents::Place(place).local` plus
+        //   `place.projection`
+        //
+        // Already handled by the `place.as_local()` path below:
+        // - whole source variable -> whole MIR local:
+        //   `composite = None`, `Place(_N)` with empty projection.
+        // - source fragment -> whole MIR local:
+        //   `composite = Some(source_proj)`, `Place(_N)` with empty projection.
+        //
+        // Remaining cases to represent or explicitly defer:
+        // - whole source variable -> projected MIR storage:
+        //   `composite = None`, `Place(_N.proj)`.
+        // - source fragment -> projected MIR storage:
+        //   `composite = Some(source_proj)`, `Place(_N.storage_proj)`.
+        // - source variable/fragment -> constant:
+        //   `Const(...)`, with no MIR local id.
+        // - optimized-out/debug-only/unsupported shapes:
+        //   explicit deferred state, not silent discard.
+        //
+        // `list_locals` should collect this local-indexed table into a Vec,
+        // then append explicit deferred/debug-info-only rows where needed.
+        // Related: SROA can split a source local like `_slice: ExtraSlice` into
+        // field locals whose debug paths should be printed as `_slice._slice`
+        // and `_slice._extra`, not as two separate locals both named `_slice`.
 
         // Attach source names from debug info when the debug entry maps directly to a whole MIR local.
         for var_debug_info in &frame.body().var_debug_info {
-            if let VarDebugInfoContents::Place(place) = var_debug_info.value
+            if let VarDebugInfoContents::Place(place) = &var_debug_info.value
                 && let Some(local) = place.as_local()
-                && locals[local].name.is_none()
+                && locals[local].source_name.is_none()
             {
-                locals[local].name = Some(var_debug_info.name);
+                if let Some(VarDebugInfoFragment { ty, projection }) =
+                    var_debug_info.composite.as_deref()
+                {
+                    // Walk the source-side projection from the original
+                    // composite variable type. Each `Field` element stores the
+                    // resulting field type, so resolve the field name from the
+                    // current base type before advancing to `field_ty`.
+                    let mut projection_ty = ty;
+
+                    locals[local].source_projection = Some(
+                        projection
+                            .iter()
+                            .filter_map(|elem| {
+                                match elem {
+                                    ProjectionElem::Field(field_idx, field_ty) => {
+                                        let rendered = match projection_ty.kind() {
+                                            TyKind::Adt(adt_def, _args) if adt_def.is_struct() => {
+                                                let variant = adt_def.non_enum_variant();
+                                                let field = &variant.fields[*field_idx];
+                                                Symbol::intern(&format!(".{}", field.name))
+                                            }
+
+                                            TyKind::Tuple(_) =>
+                                                Symbol::intern(&format!(".{}", field_idx.index())),
+
+                                            _ => Symbol::intern(".<unexpected>"),
+                                        };
+
+                                        projection_ty = field_ty;
+
+                                        Some(rendered)
+                                    }
+                                    // Composite projections are currently
+                                    // expected to be field-only. Leave any
+                                    // unexpected shape for the later deferred
+                                    // debug-info representation instead of
+                                    // printing noise in the CLI.
+                                    _ => None,
+                                }
+                            })
+                            .collect(),
+                    );
+                };
+                locals[local].source_name = Some(var_debug_info.name);
             }
         }
 
@@ -450,15 +525,31 @@ impl Cli {
                             println!("no locals");
                         } else {
                             for local_desc in &locals_desc {
-                                let mut name_str = "None".to_string();
-                                if let Some(name) = local_desc.name {
-                                    name_str = name.to_string();
-                                }
+                                let source_projection = local_desc
+                                    .source_projection
+                                    .as_ref()
+                                    .map(|fields| {
+                                        fields
+                                            .iter()
+                                            .map(|field| field.to_string())
+                                            .collect::<String>()
+                                    })
+                                    .unwrap_or_default();
+
+                                let name = local_desc
+                                    .source_name
+                                    .map_or_else(|| "<none>".to_string(), |name| name.to_string());
+
+                                let display_name = format!("{name}{source_projection}");
+
+                                let local = local_desc.local.map_or_else(
+                                    || "<none>".to_string(),
+                                    |local| format!("_{}", local.index()),
+                                );
+
                                 println!(
-                                    "Name: {}, Id: _{}, Ty: {}",
-                                    name_str,
-                                    local_desc.local.index(),
-                                    local_desc.ty,
+                                    "Name: {}, Id: {}, Ty: {}",
+                                    display_name, local, local_desc.ty
                                 );
                             }
                         },

--- a/priroda/tests/ui/locals_access_field.rs
+++ b/priroda/tests/ui/locals_access_field.rs
@@ -1,0 +1,18 @@
+// Verifies that the `locals` command lists locals introduced by accessing
+// struct fields, including the original aggregate and each extracted field.
+struct ExtraSlice<'a> {
+    _slice: &'a [u8],
+    _extra: u32,
+}
+
+impl<'a> ExtraSlice<'a> {
+    fn new() -> ExtraSlice<'a> {
+        ExtraSlice { _slice: &[1; 0], _extra: 0 }
+    }
+}
+
+fn main() {
+    let extraslice = ExtraSlice::new();
+    let _slice = extraslice._slice;
+    let _extra = extraslice._extra;
+}

--- a/priroda/tests/ui/locals_access_field.stdin
+++ b/priroda/tests/ui/locals_access_field.stdin
@@ -1,0 +1,4 @@
+break tests/ui/locals_access_field.rs:14
+continue
+locals
+quit

--- a/priroda/tests/ui/locals_access_field.stdout
+++ b/priroda/tests/ui/locals_access_field.stdout
@@ -1,0 +1,8 @@
+(priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_access_field.rs:14
+(priroda) Hit breakpoint
+{MANIFEST_DIR}/tests/ui/locals_access_field.rs:14
+(priroda) Name: <none>, Id: _0, Ty: ()
+Name: extraslice, Id: _1, Ty: ExtraSlice<'_>
+Name: _slice, Id: _2, Ty: &[u8]
+Name: _extra, Id: _3, Ty: u32
+(priroda) quitting

--- a/priroda/tests/ui/locals_in_function.stdout
+++ b/priroda/tests/ui/locals_in_function.stdout
@@ -1,10 +1,10 @@
 (priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_in_function.rs:5
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_in_function.rs:5
-(priroda) Name: None, Id: _0, Ty: ()
+(priroda) Name: <none>, Id: _0, Ty: ()
 Name: x, Id: _1, Ty: i32
 Name: y, Id: _2, Ty: bool
-Name: None, Id: _3, Ty: (i32, bool)
-Name: None, Id: _4, Ty: i32
-Name: None, Id: _5, Ty: bool
+Name: <none>, Id: _3, Ty: (i32, bool)
+Name: <none>, Id: _4, Ty: i32
+Name: <none>, Id: _5, Ty: bool
 (priroda) quitting

--- a/priroda/tests/ui/locals_nested_field_fragment.rs
+++ b/priroda/tests/ui/locals_nested_field_fragment.rs
@@ -1,0 +1,13 @@
+//@ compile-flags: -Zmir-opt-level=0 -Zmir-enable-passes=+ScalarReplacementOfAggregates -Aunused
+
+struct Leaf {
+    field: u8,
+}
+
+struct Outer {
+    inner: (Leaf,),
+}
+
+fn main() {
+    let x = Outer { inner: (Leaf { field: 3 },) };
+}

--- a/priroda/tests/ui/locals_nested_field_fragment.stdin
+++ b/priroda/tests/ui/locals_nested_field_fragment.stdin
@@ -1,0 +1,4 @@
+break tests/ui/locals_nested_field_fragment.rs:12
+continue
+locals
+quit

--- a/priroda/tests/ui/locals_nested_field_fragment.stdout
+++ b/priroda/tests/ui/locals_nested_field_fragment.stdout
@@ -1,0 +1,14 @@
+(priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_nested_field_fragment.rs:12
+(priroda) Hit breakpoint
+{MANIFEST_DIR}/tests/ui/locals_nested_field_fragment.rs:12
+(priroda) Name: <none>, Id: _0, Ty: ()
+Name: <none>, Id: _1, Ty: Outer
+Name: <none>, Id: _2, Ty: (Leaf,)
+Name: <none>, Id: _3, Ty: Leaf
+Name: <none>, Id: _4, Ty: (Leaf,)
+Name: <none>, Id: _5, Ty: Leaf
+Name: <none>, Id: _6, Ty: Leaf
+Name: x.inner.0.field, Id: _7, Ty: u8
+Name: <none>, Id: _8, Ty: u8
+Name: <none>, Id: _9, Ty: u8
+(priroda) quitting

--- a/priroda/tests/ui/locals_sroa.rs
+++ b/priroda/tests/ui/locals_sroa.rs
@@ -1,0 +1,21 @@
+//@ compile-flags: -Zmir-opt-level=0 -Zmir-enable-passes=+ScalarReplacementOfAggregates
+
+// Source only declares `s` and `_slice` in `extra`. But after the
+// ScalarReplacementOfAggregates optimization, rustc splits the struct into fields. Priroda should
+// show those split field locals as separate MIR locals with the original `_slice` debug name.
+// FIXME: The CLI currently prints both split fields as `_slice`; it should preserve the projected
+// debug-info paths and show `_slice._slice` and `_slice._extra` instead.
+
+pub struct ExtraSlice<'a> {
+    _slice: &'a [u8],
+    _extra: u32,
+}
+
+pub fn extra(s: &[u8]) {
+    let _slice = ExtraSlice { _slice: s, _extra: s.len() as u32 };
+}
+
+fn main() {
+    let bytes = &[3, 3];
+    extra(bytes);
+}

--- a/priroda/tests/ui/locals_sroa.rs
+++ b/priroda/tests/ui/locals_sroa.rs
@@ -2,9 +2,7 @@
 
 // Source only declares `s` and `_slice` in `extra`. But after the
 // ScalarReplacementOfAggregates optimization, rustc splits the struct into fields. Priroda should
-// show those split field locals as separate MIR locals with the original `_slice` debug name.
-// FIXME: The CLI currently prints both split fields as `_slice`; it should preserve the projected
-// debug-info paths and show `_slice._slice` and `_slice._extra` instead.
+// show those split field locals as separate MIR locals with the projected source debug paths.
 
 pub struct ExtraSlice<'a> {
     _slice: &'a [u8],

--- a/priroda/tests/ui/locals_sroa.stdin
+++ b/priroda/tests/ui/locals_sroa.stdin
@@ -1,4 +1,4 @@
-break tests/ui/locals_sroa.rs:15
+break tests/ui/locals_sroa.rs:13
 continue
 locals
 quit

--- a/priroda/tests/ui/locals_sroa.stdin
+++ b/priroda/tests/ui/locals_sroa.stdin
@@ -1,0 +1,4 @@
+break tests/ui/locals_sroa.rs:15
+continue
+locals
+quit

--- a/priroda/tests/ui/locals_sroa.stdout
+++ b/priroda/tests/ui/locals_sroa.stdout
@@ -1,6 +1,6 @@
-(priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_sroa.rs:15
+(priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_sroa.rs:13
 (priroda) Hit breakpoint
-{MANIFEST_DIR}/tests/ui/locals_sroa.rs:15
+{MANIFEST_DIR}/tests/ui/locals_sroa.rs:13
 (priroda) Name: <none>, Id: _0, Ty: ()
 Name: s, Id: _1, Ty: &[u8]
 Name: <none>, Id: _2, Ty: ExtraSlice<'_>
@@ -8,6 +8,6 @@ Name: <none>, Id: _3, Ty: &[u8]
 Name: <none>, Id: _4, Ty: u32
 Name: <none>, Id: _5, Ty: usize
 Name: <none>, Id: _6, Ty: &[u8]
-Name: _slice, Id: _7, Ty: &[u8]
-Name: _slice, Id: _8, Ty: u32
+Name: _slice._slice, Id: _7, Ty: &[u8]
+Name: _slice._extra, Id: _8, Ty: u32
 (priroda) quitting

--- a/priroda/tests/ui/locals_sroa.stdout
+++ b/priroda/tests/ui/locals_sroa.stdout
@@ -1,0 +1,13 @@
+(priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_sroa.rs:15
+(priroda) Hit breakpoint
+{MANIFEST_DIR}/tests/ui/locals_sroa.rs:15
+(priroda) Name: <none>, Id: _0, Ty: ()
+Name: s, Id: _1, Ty: &[u8]
+Name: <none>, Id: _2, Ty: ExtraSlice<'_>
+Name: <none>, Id: _3, Ty: &[u8]
+Name: <none>, Id: _4, Ty: u32
+Name: <none>, Id: _5, Ty: usize
+Name: <none>, Id: _6, Ty: &[u8]
+Name: _slice, Id: _7, Ty: &[u8]
+Name: _slice, Id: _8, Ty: u32
+(priroda) quitting

--- a/priroda/tests/ui/locals_struct_field_fragment.rs
+++ b/priroda/tests/ui/locals_struct_field_fragment.rs
@@ -1,0 +1,13 @@
+//@ compile-flags: -Zmir-opt-level=0 -Zmir-enable-passes=+ScalarReplacementOfAggregates -Aunused
+
+struct Inner {
+    value: u8,
+}
+
+struct Outer {
+    inner: Inner,
+}
+
+fn main() {
+    let x = Outer { inner: Inner { value: 7 } };
+}

--- a/priroda/tests/ui/locals_struct_field_fragment.stdin
+++ b/priroda/tests/ui/locals_struct_field_fragment.stdin
@@ -1,0 +1,4 @@
+break tests/ui/locals_struct_field_fragment.rs:11
+continue
+locals
+quit

--- a/priroda/tests/ui/locals_struct_field_fragment.stdout
+++ b/priroda/tests/ui/locals_struct_field_fragment.stdout
@@ -1,0 +1,10 @@
+(priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_struct_field_fragment.rs:11
+(priroda) Hit breakpoint
+{MANIFEST_DIR}/tests/ui/locals_struct_field_fragment.rs:11
+(priroda) Name: <none>, Id: _0, Ty: ()
+Name: <none>, Id: _1, Ty: Outer
+Name: <none>, Id: _2, Ty: Inner
+Name: <none>, Id: _3, Ty: Inner
+Name: x.inner.value, Id: _4, Ty: u8
+Name: <none>, Id: _5, Ty: u8
+(priroda) quitting

--- a/priroda/tests/ui/locals_tuple_field_fragment.rs
+++ b/priroda/tests/ui/locals_tuple_field_fragment.rs
@@ -1,0 +1,5 @@
+//@ compile-flags: -Zmir-opt-level=0 -Zmir-enable-passes=+ScalarReplacementOfAggregates -Aunused
+
+fn main() {
+    let t = (10_u8, 20_u16);
+}

--- a/priroda/tests/ui/locals_tuple_field_fragment.stdin
+++ b/priroda/tests/ui/locals_tuple_field_fragment.stdin
@@ -1,0 +1,4 @@
+break tests/ui/locals_tuple_field_fragment.rs:4
+continue
+locals
+quit

--- a/priroda/tests/ui/locals_tuple_field_fragment.stdout
+++ b/priroda/tests/ui/locals_tuple_field_fragment.stdout
@@ -1,0 +1,8 @@
+(priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_tuple_field_fragment.rs:4
+(priroda) Hit breakpoint
+{MANIFEST_DIR}/tests/ui/locals_tuple_field_fragment.rs:4
+(priroda) Name: <none>, Id: _0, Ty: ()
+Name: <none>, Id: _1, Ty: (u8, u16)
+Name: t.0, Id: _2, Ty: u8
+Name: t.1, Id: _3, Ty: u16
+(priroda) quitting


### PR DESCRIPTION
This pr make  Priroda’s `locals` command to preserve source-side field fragments from `VarDebugInfo::composite`.

Previously, SROA-split locals could lose the projected source path and show duplicated base names, for example printing two `_slice` entries instead of `_slice._slice` and `_slice._extra`. The locals listing now keeps the source variable name separate from its composite projection and renders struct fields by source name, while falling back to tuple-style indices for unnamed fields.

## What changed

- Track source projections for locals described by `VarDebugInfoFragment`.
- Resolve struct field names from the projection base type.
- Render tuple fields as `.0`, `.1`, etc.
- Print `<none>` for MIR locals without a source name.
- Keep local IDs optional in the representation so future debug-info-only locals can be handled more naturally.

## Tests

Added UI coverage for:

- regular struct field fragments: `x.inner.value`
- tuple field fragments: `t.0` and `t.1`
- nested struct/tuple projections: `x.inner.0.field`
- SROA-split structs: `_slice._slice` and `_slice._extra`