### PR TITLE
run arch intrinsic tests natively

### DIFF
--- a/src/shims/x86/mod.rs
+++ b/src/shims/x86/mod.rs
@@ -879,33 +879,39 @@ fn mpsadbw<'tcx>(
     assert_eq!(left.layout.size, dest.layout.size);
 
     let (num_chunks, op_items_per_chunk, left) = split_simd_to_128bit_chunks(ecx, left)?;
+    assert!(num_chunks <= 2);
+
     let (_, _, right) = split_simd_to_128bit_chunks(ecx, right)?;
     let (_, dest_items_per_chunk, dest) = split_simd_to_128bit_chunks(ecx, dest)?;
 
     assert_eq!(op_items_per_chunk, dest_items_per_chunk.strict_mul(2));
 
     let imm = ecx.read_scalar(imm)?.to_uint(imm.layout.size)?;
-    // Bit 2 of `imm` specifies the offset for indices of `left`.
-    // The offset is 0 when the bit is 0 or 4 when the bit is 1.
-    let left_offset = u64::try_from((imm >> 2) & 1).unwrap().strict_mul(4);
-    // Bits 0..=1 of `imm` specify the offset for indices of
-    // `right` in blocks of 4 elements.
-    let right_offset = u64::try_from(imm & 0b11).unwrap().strict_mul(4);
 
     for i in 0..num_chunks {
         let left = ecx.project_index(&left, i)?;
         let right = ecx.project_index(&right, i)?;
         let dest = ecx.project_index(&dest, i)?;
 
+        // The first 128-bit chunk uses the low 3 bits of IMM, the second chunk uses bits 3..6.
+        let lane_imm = imm.strict_shr(i.strict_mul(3).try_into().unwrap());
+
+        // Bit 2 of `lane_imm` specifies the offset for indices of `left`.
+        // The offset is 0 when the bit is 0 or 4 when the bit is 1.
+        let left_base = u64::try_from((lane_imm >> 2) & 1).unwrap().strict_mul(4);
+        // Bits 0..=1 of `lane_imm` specify the offset for indices of
+        // `right` in blocks of 4 elements.
+        let right_base = u64::try_from(lane_imm & 0b11).unwrap().strict_mul(4);
+
         for j in 0..dest_items_per_chunk {
-            let left_offset = left_offset.strict_add(j);
+            let left_offset = left_base.strict_add(j);
             let mut res: u16 = 0;
             for k in 0..4 {
                 let left = ecx
                     .read_scalar(&ecx.project_index(&left, left_offset.strict_add(k))?)?
                     .to_u8()?;
                 let right = ecx
-                    .read_scalar(&ecx.project_index(&right, right_offset.strict_add(k))?)?
+                    .read_scalar(&ecx.project_index(&right, right_base.strict_add(k))?)?
                     .to_u8()?;
                 res = res.strict_add(left.abs_diff(right).into());
             }

--- a/tests/pass/shims/aarch64/intrinsics-aarch64-aes.rs
+++ b/tests/pass/shims/aarch64/intrinsics-aarch64-aes.rs
@@ -1,6 +1,7 @@
 // We're testing aarch64 AES target specific features.
 //@only-target: aarch64
 //@compile-flags: -C target-feature=+neon,+aes
+//@run-native
 
 use std::arch::aarch64::*;
 use std::arch::is_aarch64_feature_detected;

--- a/tests/pass/shims/aarch64/intrinsics-aarch64-crc32.rs
+++ b/tests/pass/shims/aarch64/intrinsics-aarch64-crc32.rs
@@ -1,6 +1,7 @@
 // We're testing aarch64 CRC32 target specific features
 //@only-target: aarch64
 //@compile-flags: -C target-feature=+crc
+//@run-native
 
 use std::arch::aarch64::*;
 use std::arch::is_aarch64_feature_detected;

--- a/tests/pass/shims/aarch64/intrinsics-aarch64-neon.rs
+++ b/tests/pass/shims/aarch64/intrinsics-aarch64-neon.rs
@@ -1,6 +1,7 @@
 // We're testing aarch64 target specific features
 //@only-target: aarch64
 //@compile-flags: -C target-feature=+neon
+//@run-native
 
 use std::arch::aarch64::*;
 use std::arch::is_aarch64_feature_detected;

--- a/tests/pass/shims/x86/intrinsics-sha.rs
+++ b/tests/pass/shims/x86/intrinsics-sha.rs
@@ -1,6 +1,7 @@
 // We're testing x86 target specific features
 //@only-target: x86_64 i686
 //@compile-flags: -C target-feature=+sha,+sse2,+ssse3,+sse4.1
+//@run-native
 
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;

--- a/tests/pass/shims/x86/intrinsics-x86-adx.rs
+++ b/tests/pass/shims/x86/intrinsics-x86-adx.rs
@@ -1,6 +1,7 @@
 // We're testing x86 target specific features
 //@only-target: x86_64 i686
 //@compile-flags: -C target-feature=+adx
+//@run-native
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod x86 {

--- a/tests/pass/shims/x86/intrinsics-x86-aes-vaes.rs
+++ b/tests/pass/shims/x86/intrinsics-x86-aes-vaes.rs
@@ -1,6 +1,7 @@
 // We're testing x86 target specific features
 //@only-target: x86_64 i686
 //@compile-flags: -C target-feature=+aes,+vaes,+avx512f
+//@run-native
 
 use core::mem::transmute;
 #[cfg(target_arch = "x86")]
@@ -11,7 +12,6 @@ use std::arch::x86_64::*;
 fn main() {
     assert!(is_x86_feature_detected!("aes"));
     assert!(is_x86_feature_detected!("vaes"));
-    assert!(is_x86_feature_detected!("avx512f"));
 
     unsafe {
         test_aes();
@@ -86,7 +86,7 @@ unsafe fn test_aes() {
 // be interpreted as integers; signedness does not make sense for them, but
 // __m128i happens to be defined in terms of signed integers.
 #[allow(overflowing_literals)]
-#[target_feature(enable = "vaes,avx512f")]
+#[target_feature(enable = "vaes")]
 unsafe fn test_vaes() {
     #[target_feature(enable = "avx")]
     unsafe fn get_a256() -> __m256i {
@@ -176,6 +176,12 @@ unsafe fn test_vaes() {
         }
     }
     test_mm256_aesenclast_epi128();
+
+    // The tests below require avx512.
+    if !is_x86_feature_detected!("avx512f") {
+        println!("warning: skipping avx512 tests");
+        return;
+    }
 
     #[target_feature(enable = "avx512f")]
     unsafe fn get_a512() -> __m512i {

--- a/tests/pass/shims/x86/intrinsics-x86-avx.rs
+++ b/tests/pass/shims/x86/intrinsics-x86-avx.rs
@@ -1,6 +1,7 @@
 // We're testing x86 target specific features
 //@only-target: x86_64 i686
 //@compile-flags: -C target-feature=+avx
+//@run-native
 
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;

--- a/tests/pass/shims/x86/intrinsics-x86-avx2.rs
+++ b/tests/pass/shims/x86/intrinsics-x86-avx2.rs
@@ -1,6 +1,7 @@
 // We're testing x86 target specific features
 //@only-target: x86_64 i686
 //@compile-flags: -C target-feature=+avx2
+//@run-native
 
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;

--- a/tests/pass/shims/x86/intrinsics-x86-avx2.rs
+++ b/tests/pass/shims/x86/intrinsics-x86-avx2.rs
@@ -1069,23 +1069,31 @@ unsafe fn test_avx2() {
             18, 20, 22, 24, 26, 28, 30,
         );
 
-        let r = _mm256_mpsadbw_epu8::<0b000>(a, a);
+        let r = _mm256_mpsadbw_epu8::<0b00000>(a, a);
         let e = _mm256_setr_epi16(0, 4, 8, 12, 16, 20, 24, 28, 0, 8, 16, 24, 32, 40, 48, 56);
         assert_eq_m256i(r, e);
 
-        let r = _mm256_mpsadbw_epu8::<0b001>(a, a);
+        let r = _mm256_mpsadbw_epu8::<0b001001>(a, a);
         let e = _mm256_setr_epi16(16, 12, 8, 4, 0, 4, 8, 12, 32, 24, 16, 8, 0, 8, 16, 24);
         assert_eq_m256i(r, e);
 
-        let r = _mm256_mpsadbw_epu8::<0b100>(a, a);
+        let r = _mm256_mpsadbw_epu8::<0b000001>(a, a);
+        let e = _mm256_setr_epi16(16, 12, 8, 4, 0, 4, 8, 12, 0, 8, 16, 24, 32, 40, 48, 56);
+        assert_eq_m256i(r, e);
+
+        let r = _mm256_mpsadbw_epu8::<0b001000>(a, a);
+        let e = _mm256_setr_epi16(0, 4, 8, 12, 16, 20, 24, 28, 32, 24, 16, 8, 0, 8, 16, 24);
+        assert_eq_m256i(r, e);
+
+        let r = _mm256_mpsadbw_epu8::<0b100100>(a, a);
         let e = _mm256_setr_epi16(16, 20, 24, 28, 32, 36, 40, 44, 32, 40, 48, 56, 64, 72, 80, 88);
         assert_eq_m256i(r, e);
 
-        let r = _mm256_mpsadbw_epu8::<0b101>(a, a);
+        let r = _mm256_mpsadbw_epu8::<0b101101>(a, a);
         let e = _mm256_setr_epi16(0, 4, 8, 12, 16, 20, 24, 28, 0, 8, 16, 24, 32, 40, 48, 56);
         assert_eq_m256i(r, e);
 
-        let r = _mm256_mpsadbw_epu8::<0b111>(a, a);
+        let r = _mm256_mpsadbw_epu8::<0b111111>(a, a);
         let e = _mm256_setr_epi16(32, 28, 24, 20, 16, 12, 8, 4, 64, 56, 48, 40, 32, 24, 16, 8);
         assert_eq_m256i(r, e);
     }

--- a/tests/pass/shims/x86/intrinsics-x86-avx512.rs
+++ b/tests/pass/shims/x86/intrinsics-x86-avx512.rs
@@ -1,6 +1,7 @@
 // We're testing x86 target specific features
 //@only-target: x86_64 i686
 //@compile-flags: -C target-feature=+avx512f,+avx512vl,+avx512bw,+avx512bitalg,+avx512vpopcntdq,+avx512vnni,+avx512vbmi
+//@run-native
 
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;
@@ -9,6 +10,13 @@ use std::arch::x86_64::*;
 use std::mem::transmute;
 
 fn main() {
+    if !is_x86_feature_detected!("avx512f") {
+        // GH runners don't have this, but we still want to run this natively if
+        // the machine happens to have gfni. So we bail out dynamically.
+        println!("warning: skipping AVX512 tests");
+        return;
+    }
+
     assert!(is_x86_feature_detected!("avx512f"));
     assert!(is_x86_feature_detected!("avx512vl"));
     assert!(is_x86_feature_detected!("avx512bw"));

--- a/tests/pass/shims/x86/intrinsics-x86-bmi.rs
+++ b/tests/pass/shims/x86/intrinsics-x86-bmi.rs
@@ -1,6 +1,7 @@
 // We're testing x86 target specific features
 //@only-target: x86_64 i686
 //@compile-flags: -C target-feature=+bmi1,+bmi2
+//@run-native
 
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;

--- a/tests/pass/shims/x86/intrinsics-x86-gfni.rs
+++ b/tests/pass/shims/x86/intrinsics-x86-gfni.rs
@@ -1,6 +1,7 @@
 // We're testing x86 target specific features
 //@only-target: x86_64 i686
 //@compile-flags: -C target-feature=+gfni,+avx512f
+//@run-native
 
 // The constants in the tests below are just bit patterns. They should not
 // be interpreted as integers; signedness does not make sense for them, but
@@ -20,8 +21,14 @@ const CONSTANT_BYTE: i32 = 0x63;
 fn main() {
     // Mostly copied from library/stdarch/crates/core_arch/src/x86/gfni.rs
 
-    assert!(is_x86_feature_detected!("avx512f"));
-    assert!(is_x86_feature_detected!("gfni"));
+    assert!(is_x86_feature_detected!("avx"));
+
+    if !is_x86_feature_detected!("gfni") {
+        // GH runners don't have this, but we still want to run this natively if
+        // the machine happens to have gfni. So we bail out dynamically.
+        println!("warning: skipping gfni tests");
+        return;
+    }
 
     unsafe {
         let byte_mul_test_data = generate_byte_mul_test_data();
@@ -29,15 +36,20 @@ fn main() {
         let affine_mul_test_data_constant = generate_affine_mul_test_data(CONSTANT_BYTE as u8);
         let inv_tests_data = generate_inv_tests_data();
 
-        test_mm512_gf2p8mul_epi8(&byte_mul_test_data);
         test_mm256_gf2p8mul_epi8(&byte_mul_test_data);
         test_mm_gf2p8mul_epi8(&byte_mul_test_data);
-        test_mm512_gf2p8affine_epi64_epi8(&byte_mul_test_data, &affine_mul_test_data_identity);
         test_mm256_gf2p8affine_epi64_epi8(&byte_mul_test_data, &affine_mul_test_data_identity);
         test_mm_gf2p8affine_epi64_epi8(&byte_mul_test_data, &affine_mul_test_data_identity);
-        test_mm512_gf2p8affineinv_epi64_epi8(&inv_tests_data, &affine_mul_test_data_constant);
         test_mm256_gf2p8affineinv_epi64_epi8(&inv_tests_data, &affine_mul_test_data_constant);
         test_mm_gf2p8affineinv_epi64_epi8(&inv_tests_data, &affine_mul_test_data_constant);
+
+        if is_x86_feature_detected!("avx512f") {
+            test_mm512_gf2p8mul_epi8(&byte_mul_test_data);
+            test_mm512_gf2p8affine_epi64_epi8(&byte_mul_test_data, &affine_mul_test_data_identity);
+            test_mm512_gf2p8affineinv_epi64_epi8(&inv_tests_data, &affine_mul_test_data_constant);
+        } else {
+            println!("warning: skipping avx512 tests");
+        }
     }
 }
 

--- a/tests/pass/shims/x86/intrinsics-x86-pclmulqdq.rs
+++ b/tests/pass/shims/x86/intrinsics-x86-pclmulqdq.rs
@@ -1,6 +1,7 @@
 // We're testing x86 target specific features
 //@only-target: x86_64 i686
 //@compile-flags: -C target-feature=+pclmulqdq
+//@run-native
 
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;

--- a/tests/pass/shims/x86/intrinsics-x86-sse.rs
+++ b/tests/pass/shims/x86/intrinsics-x86-sse.rs
@@ -1,5 +1,6 @@
 // We're testing x86 target specific features
 //@only-target: x86_64 i686
+//@run-native
 #![allow(unnecessary_transmutes)]
 
 #[cfg(target_arch = "x86")]

--- a/tests/pass/shims/x86/intrinsics-x86-sse2.rs
+++ b/tests/pass/shims/x86/intrinsics-x86-sse2.rs
@@ -1,5 +1,6 @@
 // We're testing x86 target specific features
 //@only-target: x86_64 i686
+//@run-native
 #![allow(unnecessary_transmutes)]
 
 #[cfg(target_arch = "x86")]

--- a/tests/pass/shims/x86/intrinsics-x86-sse3-ssse3.rs
+++ b/tests/pass/shims/x86/intrinsics-x86-sse3-ssse3.rs
@@ -2,6 +2,7 @@
 //@only-target: x86_64 i686
 // SSSE3 implicitly enables SSE3
 //@compile-flags: -C target-feature=+ssse3
+//@run-native
 
 use core::mem::transmute;
 #[cfg(target_arch = "x86")]

--- a/tests/pass/shims/x86/intrinsics-x86-sse41.rs
+++ b/tests/pass/shims/x86/intrinsics-x86-sse41.rs
@@ -1,6 +1,7 @@
 // We're testing x86 target specific features
 //@only-target: x86_64 i686
 //@compile-flags: -C target-feature=+sse4.1
+//@run-native
 
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;

--- a/tests/pass/shims/x86/intrinsics-x86-sse42.rs
+++ b/tests/pass/shims/x86/intrinsics-x86-sse42.rs
@@ -1,6 +1,7 @@
 // We're testing x86 target specific features
 //@only-target: x86_64 i686
 //@compile-flags: -C target-feature=+sse4.2
+//@run-native
 
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;

--- a/tests/pass/shims/x86/intrinsics-x86-vpclmulqdq.rs
+++ b/tests/pass/shims/x86/intrinsics-x86-vpclmulqdq.rs
@@ -3,6 +3,7 @@
 //@only-target: x86_64 i686
 //@[avx512]compile-flags: -C target-feature=+vpclmulqdq,+avx512f
 //@[avx]compile-flags: -C target-feature=+vpclmulqdq,+avx2
+//@run-native
 
 // The constants in the tests below are just bit patterns. They should not
 // be interpreted as integers; signedness does not make sense for them, but

--- a/tests/pass/shims/x86/intrinsics-x86.rs
+++ b/tests/pass/shims/x86/intrinsics-x86.rs
@@ -1,4 +1,6 @@
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+//@only-target: x86_64 i686
+//@run-native
+
 mod x86 {
     #[cfg(target_arch = "x86")]
     use core::arch::x86 as arch;
@@ -84,7 +86,6 @@ mod x86_64 {
 }
 
 fn main() {
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     x86::main();
     #[cfg(target_arch = "x86_64")]
     x86_64::main();


### PR DESCRIPTION
At least, most of them -- AVX512 is not available widely enough so we can't run those tests natively.