### PR TITLE
fix bug in `mpsadbw`

### DIFF
--- a/src/shims/x86/mod.rs
+++ b/src/shims/x86/mod.rs
@@ -879,33 +879,39 @@ fn mpsadbw<'tcx>(
     assert_eq!(left.layout.size, dest.layout.size);
 
     let (num_chunks, op_items_per_chunk, left) = split_simd_to_128bit_chunks(ecx, left)?;
+    assert!((1..=2).contains(&num_chunks));
+
     let (_, _, right) = split_simd_to_128bit_chunks(ecx, right)?;
     let (_, dest_items_per_chunk, dest) = split_simd_to_128bit_chunks(ecx, dest)?;
 
     assert_eq!(op_items_per_chunk, dest_items_per_chunk.strict_mul(2));
 
     let imm = ecx.read_scalar(imm)?.to_uint(imm.layout.size)?;
-    // Bit 2 of `imm` specifies the offset for indices of `left`.
-    // The offset is 0 when the bit is 0 or 4 when the bit is 1.
-    let left_offset = u64::try_from((imm >> 2) & 1).unwrap().strict_mul(4);
-    // Bits 0..=1 of `imm` specify the offset for indices of
-    // `right` in blocks of 4 elements.
-    let right_offset = u64::try_from(imm & 0b11).unwrap().strict_mul(4);
 
     for i in 0..num_chunks {
         let left = ecx.project_index(&left, i)?;
         let right = ecx.project_index(&right, i)?;
         let dest = ecx.project_index(&dest, i)?;
 
+        // The first 128-bit chunk uses the low 3 bits of IMM, the second chunk uses bits 3..6.
+        let lane_imm = imm.strict_shr(i.strict_mul(3).try_into().unwrap());
+
+        // Bit 2 of `lane_imm` specifies the offset for indices of `left`.
+        // The offset is 0 when the bit is 0 or 4 when the bit is 1.
+        let left_base = u64::try_from((lane_imm >> 2) & 1).unwrap().strict_mul(4);
+        // Bits 0..=1 of `lane_imm` specify the offset for indices of
+        // `right` in blocks of 4 elements.
+        let right_base = u64::try_from(lane_imm & 0b11).unwrap().strict_mul(4);
+
         for j in 0..dest_items_per_chunk {
-            let left_offset = left_offset.strict_add(j);
+            let left_offset = left_base.strict_add(j);
             let mut res: u16 = 0;
             for k in 0..4 {
                 let left = ecx
                     .read_scalar(&ecx.project_index(&left, left_offset.strict_add(k))?)?
                     .to_u8()?;
                 let right = ecx
-                    .read_scalar(&ecx.project_index(&right, right_offset.strict_add(k))?)?
+                    .read_scalar(&ecx.project_index(&right, right_base.strict_add(k))?)?
                     .to_u8()?;
                 res = res.strict_add(left.abs_diff(right).into());
             }

--- a/tests/pass/shims/x86/intrinsics-x86-avx2.rs
+++ b/tests/pass/shims/x86/intrinsics-x86-avx2.rs
@@ -1,6 +1,7 @@
 // We're testing x86 target specific features
 //@only-target: x86_64 i686
 //@compile-flags: -C target-feature=+avx2
+//@run-native
 
 #[cfg(target_arch = "x86")]
 use std::arch::x86::*;
@@ -1068,23 +1069,31 @@ unsafe fn test_avx2() {
             18, 20, 22, 24, 26, 28, 30,
         );
 
-        let r = _mm256_mpsadbw_epu8::<0b000>(a, a);
+        let r = _mm256_mpsadbw_epu8::<0b00000>(a, a);
         let e = _mm256_setr_epi16(0, 4, 8, 12, 16, 20, 24, 28, 0, 8, 16, 24, 32, 40, 48, 56);
         assert_eq_m256i(r, e);
 
-        let r = _mm256_mpsadbw_epu8::<0b001>(a, a);
+        let r = _mm256_mpsadbw_epu8::<0b001001>(a, a);
         let e = _mm256_setr_epi16(16, 12, 8, 4, 0, 4, 8, 12, 32, 24, 16, 8, 0, 8, 16, 24);
         assert_eq_m256i(r, e);
 
-        let r = _mm256_mpsadbw_epu8::<0b100>(a, a);
+        let r = _mm256_mpsadbw_epu8::<0b000001>(a, a);
+        let e = _mm256_setr_epi16(16, 12, 8, 4, 0, 4, 8, 12, 0, 8, 16, 24, 32, 40, 48, 56);
+        assert_eq_m256i(r, e);
+
+        let r = _mm256_mpsadbw_epu8::<0b001000>(a, a);
+        let e = _mm256_setr_epi16(0, 4, 8, 12, 16, 20, 24, 28, 32, 24, 16, 8, 0, 8, 16, 24);
+        assert_eq_m256i(r, e);
+
+        let r = _mm256_mpsadbw_epu8::<0b100100>(a, a);
         let e = _mm256_setr_epi16(16, 20, 24, 28, 32, 36, 40, 44, 32, 40, 48, 56, 64, 72, 80, 88);
         assert_eq_m256i(r, e);
 
-        let r = _mm256_mpsadbw_epu8::<0b101>(a, a);
+        let r = _mm256_mpsadbw_epu8::<0b101101>(a, a);
         let e = _mm256_setr_epi16(0, 4, 8, 12, 16, 20, 24, 28, 0, 8, 16, 24, 32, 40, 48, 56);
         assert_eq_m256i(r, e);
 
-        let r = _mm256_mpsadbw_epu8::<0b111>(a, a);
+        let r = _mm256_mpsadbw_epu8::<0b111111>(a, a);
         let e = _mm256_setr_epi16(32, 28, 24, 20, 16, 12, 8, 4, 64, 56, 48, 40, 32, 24, 16, 8);
         assert_eq_m256i(r, e);
     }


### PR DESCRIPTION
the 256-bit implementation actually takes a 6-bit IMM and uses the low 3 bits for the first 128-bit chunk, the next 3 bits for the second 128-bit chunk. Previously we only used the low 3 bits for both chunks.