### PR TITLE
shims: add a shim for gethostname

### DIFF
--- a/src/shims/unix/env.rs
+++ b/src/shims/unix/env.rs
@@ -6,8 +6,9 @@ use rustc_abi::{FieldIdx, Size};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_index::IndexVec;
 use rustc_middle::ty::Ty;
-use rustc_target::spec::Os;
+use rustc_target::spec::{Env, Os};
 
+use super::HOSTNAME;
 use crate::*;
 
 pub struct UnixEnvVars<'tcx> {
@@ -217,6 +218,81 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         }
 
         interp_ok(Pointer::null())
+    }
+
+    fn gethostname(
+        &mut self,
+        name_op: &OpTy<'tcx>,
+        len_op: &OpTy<'tcx>,
+    ) -> InterpResult<'tcx, Scalar> {
+        let this = self.eval_context_mut();
+        this.assert_target_os_is_unix("gethostname");
+
+        let name = this.read_pointer(name_op)?;
+        let len = this.read_target_usize(len_op)?;
+
+        // macOS makes a length of zero UB by writing to `name[namelen - 1]`:
+        // <https://github.com/apple-oss-distributions/Libc/blob/main/gen/FreeBSD/gethostname.c#L48-L60>
+        //
+        // Since POSIX does not clearly specify whether a zero length is valid, require the length
+        // argument to be non-zero on every platform. This cannot be folded into the access check
+        // below: `check_ptr_access` delegates to `check_and_deref_ptr`, which treats every
+        // zero-sized access as valid and returns before checking `name`. In particular, it would
+        // accept a null pointer here.
+        if len == 0 {
+            throw_ub_format!("`gethostname` called with a length of zero");
+        }
+        // The caller promises that `name` points to an array of `len` bytes, so validate that
+        // entire range up front. Since `len` is non-zero, this also rejects null and dangling
+        // pointers.
+        this.check_ptr_access(name, Size::from_bytes(len), CheckInAllocMsg::MemoryAccess)?;
+
+        if len > u64::try_from(HOSTNAME.len()).unwrap() {
+            let (written, _) = this.write_c_str(HOSTNAME, name, len)?;
+            assert!(written); // Value should fit.
+            return interp_ok(Scalar::from_i32(0));
+        }
+
+        // The exact behavior on a too short buffer differs by platform and even libc.
+        // POSIX says:
+        // > The returned name shall be null-terminated, except that if namelen is
+        // > an insufficient length to hold the host name, then the returned name
+        // > shall be truncated and it is unspecified whether the returned name is
+        // > null-terminated.
+        match (&this.tcx.sess.target.os, &this.tcx.sess.target.env) {
+            (Os::Android, _) => {
+                // Android violates POSIX and does not write anything:
+                // <https://raw.githubusercontent.com/aosp-mirror/platform_bionic/master/libc/bionic/gethostname.cpp>
+                this.set_errno_and_return_neg1_i32(LibcError("ENAMETOOLONG"))
+            }
+            (Os::Linux, Env::Gnu) | (Os::FreeBsd, _) => {
+                // Write what we can *without* trailing null.
+                let len: usize = len.try_into().unwrap();
+                this.write_bytes_ptr(name, HOSTNAME[..len].iter().copied())?;
+                this.set_errno_and_return_neg1_i32(LibcError("ENAMETOOLONG"))
+            }
+            (Os::Linux, _) | (Os::MacOs, _) | (Os::Solaris, _) | (Os::Illumos, _) => {
+                // Write what we can *with* trailing null.
+                let len: usize = len.try_into().unwrap();
+                let copy_len = len.strict_sub(1);
+                this.write_bytes_ptr(
+                    name,
+                    HOSTNAME[..copy_len].iter().copied().chain(std::iter::once(0)),
+                )?;
+
+                // These implementations report truncation as successful. POSIX requires
+                // truncation when `namelen` is insufficient, but does not require it
+                // to be reported as an error.
+                // musl: <https://git.musl-libc.org/cgit/musl/tree/src/unistd/gethostname.c>
+                // macOS: <https://github.com/apple-oss-distributions/Libc/blob/main/gen/FreeBSD/gethostname.c>
+                // Illumos: <https://github.com/illumos/illumos-gate/blob/master/usr/src/lib/libc/port/gen/gethostname.c>
+                // Solaris: <https://docs.oracle.com/cd/E88353_01/html/E37843/gethostname-3c.html>
+                interp_ok(Scalar::from_i32(0))
+            }
+            _ => {
+                throw_unsup_format!("`gethostname` is not supported on {}", this.tcx.sess.target.os)
+            }
+        }
     }
 
     fn chdir(&mut self, path_op: &OpTy<'tcx>) -> InterpResult<'tcx, Scalar> {

--- a/src/shims/unix/foreign_items.rs
+++ b/src/shims/unix/foreign_items.rs
@@ -164,6 +164,16 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let result = this.getcwd(buf, size)?;
                 this.write_pointer(result, dest)?;
             }
+            "gethostname" => {
+                let [name, len] = this.check_shim_sig(
+                    shim_sig!(extern "C" fn(*mut _, usize) -> i32),
+                    link_name,
+                    abi,
+                    args,
+                )?;
+                let result = this.gethostname(name, len)?;
+                this.write_scalar(result, dest)?;
+            }
             "chdir" => {
                 // FIXME: This does not have a direct test (#3179).
                 let [path] = this.check_shim_sig(

--- a/src/shims/unix/mod.rs
+++ b/src/shims/unix/mod.rs
@@ -33,3 +33,4 @@ pub use self::virtual_socket::EvalContextExt as _;
 
 // Make up some constants.
 const UID: u32 = 1000;
+const HOSTNAME: &[u8] = b"Miri";

--- a/tests/fail-dep/libc/libc-gethostname-length-exceeds-buffer.rs
+++ b/tests/fail-dep/libc/libc-gethostname-length-exceeds-buffer.rs
@@ -1,0 +1,8 @@
+//@ignore-target: windows # No libc
+
+fn main() {
+    let mut name = [0u8; 5];
+    unsafe {
+        libc::gethostname(name.as_mut_ptr().cast(), 6); //~ERROR: memory access
+    }
+}

--- a/tests/fail-dep/libc/libc-gethostname-length-exceeds-buffer.stderr
+++ b/tests/fail-dep/libc/libc-gethostname-length-exceeds-buffer.stderr
@@ -1,0 +1,18 @@
+error: Undefined Behavior: memory access failed: attempting to access 6 bytes, but got ALLOC which is only 5 bytes from the end of the allocation
+  --> tests/fail-dep/libc/libc-gethostname-length-exceeds-buffer.rs:LL:CC
+   |
+LL |         libc::gethostname(name.as_mut_ptr().cast(), 6);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+help: ALLOC was allocated here:
+  --> tests/fail-dep/libc/libc-gethostname-length-exceeds-buffer.rs:LL:CC
+   |
+LL |     let mut name = [0u8; 5];
+   |         ^^^^^^^^
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/tests/fail-dep/libc/libc-gethostname-null.rs
+++ b/tests/fail-dep/libc/libc-gethostname-null.rs
@@ -1,0 +1,10 @@
+//@ignore-target: windows # No libc
+
+fn main() {
+    // Some libc implementations dereference `name` in userspace. For example, glibc obtains the
+    // hostname with `uname` and then copies it into `name` with `memcpy`, so a null pointer is UB:
+    // <https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/posix/gethostname.c;h=b17671373ca1ac61e7346ae0dcdda22eff1d7fcd#l36>
+    unsafe {
+        libc::gethostname(std::ptr::null_mut(), 5); //~ERROR: null pointer
+    }
+}

--- a/tests/fail-dep/libc/libc-gethostname-null.stderr
+++ b/tests/fail-dep/libc/libc-gethostname-null.stderr
@@ -1,0 +1,13 @@
+error: Undefined Behavior: memory access failed: attempting to access 5 bytes, but got null pointer
+  --> tests/fail-dep/libc/libc-gethostname-null.rs:LL:CC
+   |
+LL |         libc::gethostname(std::ptr::null_mut(), 5);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/tests/fail-dep/libc/libc-gethostname-zero-length.rs
+++ b/tests/fail-dep/libc/libc-gethostname-zero-length.rs
@@ -1,0 +1,11 @@
+//@ignore-target: windows # No libc
+
+fn main() {
+    // MacOS unconditionally writes to `name[namelen - 1]`, so passing zero for `namelen`
+    // causes an out-of-bounds access. Miri requires a non-zero length on every target:
+    // <https://github.com/apple-oss-distributions/Libc/blob/main/gen/FreeBSD/gethostname.c#L48-L60>
+    let mut name = 0u8;
+    unsafe {
+        libc::gethostname((&mut name as *mut u8).cast(), 0); //~ERROR: length of zero
+    }
+}

--- a/tests/fail-dep/libc/libc-gethostname-zero-length.stderr
+++ b/tests/fail-dep/libc/libc-gethostname-zero-length.stderr
@@ -1,0 +1,13 @@
+error: Undefined Behavior: `gethostname` called with a length of zero
+  --> tests/fail-dep/libc/libc-gethostname-zero-length.rs:LL:CC
+   |
+LL |         libc::gethostname((&mut name as *mut u8).cast(), 0);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/tests/pass-dep/libc/libc-gethostname.rs
+++ b/tests/pass-dep/libc/libc-gethostname.rs
@@ -1,0 +1,66 @@
+//@ignore-target: windows # No libc
+//@run-native
+
+#[path = "../../utils/libc.rs"]
+mod libc_utils;
+
+use std::ffi::CStr;
+
+use libc_utils::*;
+
+fn main() {
+    test_ok();
+
+    test_too_small();
+}
+
+fn get_hostname() -> Vec<u8> {
+    let mut name = [0u8; 1024]; // We assume this is enough space.
+    errno_check(unsafe { libc::gethostname(name.as_mut_ptr().cast(), name.len()) });
+
+    let hostname = unsafe { CStr::from_ptr(name.as_ptr().cast()) }.to_bytes().to_owned();
+    assert!(!hostname.is_empty());
+    hostname
+}
+
+fn test_ok() {
+    let hostname = get_hostname();
+
+    if cfg!(miri) {
+        assert_eq!(hostname, b"Miri");
+    }
+}
+
+fn test_too_small() {
+    let hostname = get_hostname();
+
+    // Leave no room for the trailing null byte.
+    let mut name = vec![0u8; hostname.len()];
+    let result = unsafe { libc::gethostname(name.as_mut_ptr().cast(), name.len()) };
+    cfg_select! {
+        target_os = "android" => {
+            let err = errno_result(result).unwrap_err();
+            assert!(name.iter().all(|byte| *byte == 0));
+            assert_eq!(err.raw_os_error(), Some(libc::ENAMETOOLONG));
+        }
+        any(all(target_os = "linux", target_env = "gnu"), target_os = "freebsd") => {
+            let err = errno_result(result).unwrap_err();
+            assert_eq!(name, hostname);
+            assert_eq!(err.raw_os_error(), Some(libc::ENAMETOOLONG));
+        }
+        any(
+            all(target_os = "linux", not(target_env = "gnu")),
+            target_os = "macos",
+            target_os = "illumos",
+            target_os = "solaris",
+        ) => {
+            errno_check(result);
+            let mut expected = hostname.to_owned();
+            *expected.last_mut().unwrap() = 0;
+            assert_eq!(name, expected);
+        }
+        _ => {
+            compile_error!("unsupported target");
+        }
+    }
+}


### PR DESCRIPTION
Add a shim for gethostname().
Closes rust-lang/miri#5138.

Behavior differs between targets, so I had to match on Os *and* on Glibc/Musl. I don't know whether `throw_unsup_format!()` is the correct way of handling all other cases. 

I'm not *quite* sure how Solaris behaves, but I assume it matches the behavior of Illumos. Also not quite sure if MacOS behavior is correct. It *can* in theory return `ENAMETOOLONG`, but docs and source clash a bit here:

Manpage: 

>  [ENAMETOOLONG]     The current host name is longer than namelen.  (For gethostname() only.)

Source code:
```c
int
gethostname(char *name, size_t namelen)
{
	int mib[2];

	mib[0] = CTL_KERN;
	mib[1] = KERN_HOSTNAME;
	if (namelen < MAXHOSTNAMELEN + 1) {
		char local_buf[MAXHOSTNAMELEN + 1];
		size_t local_len = sizeof(local_buf);
		if (sysctl(mib, 2, local_buf, &local_len, NULL, 0) == -1) {
			if (errno == ENOMEM)
				errno = ENAMETOOLONG;
			return (-1);
		}
		strncpy(name, local_buf, namelen);
		name[namelen - 1] = 0;
	} else {
	if (sysctl(mib, 2, name, &namelen, NULL, 0) == -1) {
		if (errno == ENOMEM)
			errno = ENAMETOOLONG;
		return (-1);
		}
	}
	return (0);
}
```
As far as I can see, if `sysctl()` succeeds, i.e. the hostname is copied into `local_buf`, and `name` is too small, it still would put a NULL-terminated part of the hostname into `name` and return successfully.       

A few notes on the `match` statement:

@ Android

```rust
(Os::Android, _) => this.set_errno_and_return_neg1_i32(LibcError("ENAMETOOLONG")),
```

Android returns error code `ENAMETOOLONG` without writing anything to `name`, see [here](https://raw.githubusercontent.com/aosp-mirror/platform_bionic/master/libc/bionic/gethostname.cpp):

```c
int gethostname(char* buf, size_t n) {
  utsname name = {};
  uname(&name);

  size_t name_length = static_cast<size_t>(strlen(name.nodename) + 1);
  if (name_length > n) {
    errno = ENAMETOOLONG;
    return -1;
  }

  memcpy(buf, name.nodename, name_length);
  return 0;
}
```

@ GNU libc, FreeBSD

GNU libc and FreeBSD behave the same, see [libc source](https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/posix/gethostname.c;h=b17671373ca1ac61e7346ae0dcdda22eff1d7fcd;hb=HEAD) and [FreeBSD source](https://github.com/freebsd/freebsd-src/blob/main/lib/libc/gen/gethostname.c). Both GNU libc and FreeBSD write a trunctuated, _non-NULL-terminated_ prefix of the hostname before returning:

```rust
(Os::Linux, Env::Gnu) | (Os::FreeBsd, _) => {
    let len: usize = len.try_into().unwrap();
    this.write_bytes_ptr(name, hostname[..len].iter().copied())?;
    this.set_errno_and_return_neg1_i32(LibcError("ENAMETOOLONG"))
}
```

GNU libc:

```c
node_len = strlen (buf.nodename) + 1;
memcpy (name, buf.nodename, len < node_len ? len : node_len);

if (node_len > len)
  {
    __set_errno (ENAMETOOLONG);
    return -1;
  }
```

FreeBSD:

```c
int mib[2];

mib[0] = CTL_KERN;
mib[1] = KERN_HOSTNAME;
if (sysctl(mib, 2, name, &namelen, NULL, 0) == -1) {
	if (errno == ENOMEM)
		errno = ENAMETOOLONG;
	return (-1);
}
```

@ Musl, MacOS, Solaris, Illumos

```rust
(Os::Linux, _) | (Os::MacOs, _) | (Os::Solaris, _) | (Os::Illumos, _) => {
    if len > 0 {
        let len: usize = len.try_into().unwrap();
        this.write_bytes_ptr(
            name,
            hostname[..len - 1].iter().copied().chain(std::iter::once(0)),
        )?;
    }
    interp_ok(Scalar::from_i32(0))
}
```

[Musl libc](https://git.musl-libc.org/cgit/musl/tree/src/unistd/gethostname.c)'s implementation is actually different from GNU libc, it adds a NULL byte at the end:

```c
if (len > sizeof uts.nodename) len = sizeof uts.nodename;
for (i=0; i<len && (name[i] = uts.nodename[i]); i++);
if (i && i==len) name[i-1] = 0;
}
```

In cases where hostname length == buffer length, we get different behavior:

```sh
$ ./gethostname_musl.o
ret=0 errno=0 (No error information)
bytes=74 65 6d 00
chars=tem\0

$ ./gethostname_glibc.o
ret=-1 errno=36 (File name too long)
bytes=74 65 6d 70
chars=temp
```

MacOS [also NULL-terminates the name](https://github.com/apple-open-source/macos/blob/master/Libc/gen/FreeBSD/gethostname.c):

```c
char local_buf[MAXHOSTNAMELEN + 1];
size_t local_len = sizeof(local_buf);
if (sysctl(mib, 2, local_buf, &local_len, NULL, 0) == -1) {
	if (errno == ENOMEM)
		errno = ENAMETOOLONG;
	return (-1);
}
strncpy(name, local_buf, namelen);
name[namelen - 1] = 0;
```

Illumos [uses the systeminfo syscall](https://raw.githubusercontent.com/illumos/illumos-gate/master/usr/src/lib/libc/port/gen/gethostname.c):

```c
return (sysinfo(SI_HOSTNAME, name, namelen) == -1 ? -1 : 0);
```

And systeminfo also NULL-terminates the buffer when it's too small:

```c
if (kstr != NULL) {
		strcnt = strlen(kstr);
		if (count > 0) {
			if (count <= strcnt) {
				getcnt = count - 1;
				if (subyte(buf + getcnt, 0) < 0)
					return (set_errno(EFAULT));
			} else {
				getcnt = strcnt + 1;
			}
			if (copyout(kstr, buf, getcnt))
				return (set_errno(EFAULT));
		}
		return (strcnt + 1);
	}
```

Relevant manpages:
- MacOS: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/gethostname.3.html
- Linux: https://www.man7.org/linux/man-pages/man2/gethostname.2.html
- FreeBSD: https://man.freebsd.org/cgi/man.cgi?query=gethostname
- Solaris: https://docs.oracle.com/cd/E88353_01/html/E37843/gethostname-3c.html

