### PR TITLE
[Priroda] Handle projected debug-info locals

### DIFF
--- a/priroda/src/main.rs
+++ b/priroda/src/main.rs
@@ -131,6 +131,26 @@ struct PrirodaContext<'tcx> {
     last_location: Option<SourceLocation>,
 }
 
+enum StorageProj {
+    Field(usize),
+    Deref,
+    Downcast(Symbol),
+    Variant(usize),
+    Unsupported(String),
+}
+
+impl StorageProj {
+    fn render(&self) -> String {
+        match self {
+            StorageProj::Field(field_idx) => format!(".{field_idx}"),
+            StorageProj::Deref => format!(".*"),
+            StorageProj::Downcast(name) => format!(" as {name}"),
+            StorageProj::Variant(variant_idx) => format!(" as variant#{variant_idx}"),
+            StorageProj::Unsupported(unsop) => format!(".<unsupported:{unsop}>"),
+        }
+    }
+}
+
 struct LocalDesc {
     /// Source variable name from `VarDebugInfo`, if this row has one.
     source_name: Option<Symbol>,
@@ -140,6 +160,9 @@ struct LocalDesc {
 
     /// MIR storage local that backs this description, if any.
     local: Option<Local>,
+
+    /// rendered/debug MIR place projection for now
+    storage_projection: Vec<StorageProj>,
 
     /// Display-rendered type for this description.
     ty: String,
@@ -354,14 +377,79 @@ impl<'tcx> PrirodaContext<'tcx> {
 
     /// Returns structured descriptions for locals in the innermost stack frame.
     ///
-    /// Starts from all MIR locals, then enriches them with source names from
-    /// `var_debug_info` when a debug entry maps directly to a whole local.
+    /// Starts from all MIR locals, enriches whole-local debug entries in place,
+    /// and appends extra rows for projected debug-info storage.
     fn list_locals(&self) -> Vec<LocalDesc> {
         let Some(frame) = self.ecx.active_thread_stack().last() else {
             return Vec::new();
         };
 
         self.build_local_descs(frame)
+    }
+
+    /// Render the source-side path from composite debug info, such as `.field`.
+    fn render_source_projection(
+        fragment: Option<&VarDebugInfoFragment<'tcx>>,
+    ) -> Option<Vec<Symbol>> {
+        let Some(VarDebugInfoFragment { ty, projection }) = fragment else { return None };
+
+        // Walk the source-side projection from the original
+        // composite variable type. Each `Field` element stores the
+        // resulting field type, so resolve the field name from the
+        // current base type before advancing to `field_ty`.
+        let mut projection_ty = ty;
+
+        let source_projection = Some(
+            projection
+                .iter()
+                .map(|elem| {
+                    match elem {
+                        ProjectionElem::Field(field_idx, field_ty) => {
+                            let rendered = match projection_ty.kind() {
+                                TyKind::Adt(adt_def, _args) if adt_def.is_struct() => {
+                                    let variant = adt_def.non_enum_variant();
+                                    let field = &variant.fields[*field_idx];
+                                    Symbol::intern(&format!(".{}", field.name))
+                                }
+
+                                TyKind::Tuple(_) =>
+                                    Symbol::intern(&format!(".{}", field_idx.index())),
+
+                                _ => Symbol::intern(".<unexpected>"),
+                            };
+
+                            projection_ty = field_ty;
+
+                            rendered
+                        }
+                        // `VarDebugInfoFragment::projection` is expected to be
+                        // field-only. If that ever changes, keep the unexpected
+                        // segment visible instead of silently rendering a
+                        // misleading source path.
+                        other => Symbol::intern(&format!(".<unsupported:{other:?}>")),
+                    }
+                })
+                .collect(),
+        );
+        source_projection
+    }
+
+    /// Render the MIR storage-side path that backs a debug-info local.
+    fn render_storage_projection(projection: &[mir::PlaceElem<'tcx>]) -> Vec<StorageProj> {
+        let storage_proj = projection
+            .iter()
+            .map(|projection_elem| {
+                match projection_elem {
+                    ProjectionElem::Field(field_idx, _) => StorageProj::Field(field_idx.index()),
+                    ProjectionElem::Deref => StorageProj::Deref,
+                    ProjectionElem::Downcast(Some(name), _) => StorageProj::Downcast(*name),
+                    ProjectionElem::Downcast(None, variant_idx) =>
+                        StorageProj::Variant(variant_idx.index()),
+                    other => StorageProj::Unsupported(format!("{other:?}")),
+                }
+            })
+            .collect();
+        storage_proj
     }
 
     fn build_local_descs(
@@ -379,6 +467,7 @@ impl<'tcx> PrirodaContext<'tcx> {
                 source_name: None,
                 source_projection: None,
                 local: Some(local_idx),
+                storage_projection: Vec::new(),
                 ty: local_decl.ty.to_string(),
             });
         }
@@ -417,58 +506,25 @@ impl<'tcx> PrirodaContext<'tcx> {
         // Projected places and constants are handled separately/deferred.
         for var_debug_info in &frame.body().var_debug_info {
             if let VarDebugInfoContents::Place(place) = &var_debug_info.value {
-                if let Some(local_idx) = place.as_local() {
-                    if locals[local_idx.index()].source_name.is_none() {
-                        if let Some(VarDebugInfoFragment { ty, projection }) =
-                            var_debug_info.composite.as_deref()
-                        {
-                            // Walk the source-side projection from the original
-                            // composite variable type. Each `Field` element stores the
-                            // resulting field type, so resolve the field name from the
-                            // current base type before advancing to `field_ty`.
-                            let mut projection_ty = ty;
+                if let Some(local_idx) = place.as_local()
+                    && locals[local_idx.index()].source_name.is_none()
+                {
+                    let local_idx = local_idx.index();
+                    locals[local_idx].source_projection =
+                        Self::render_source_projection(var_debug_info.composite.as_deref());
+                    locals[local_idx].source_name = Some(var_debug_info.name);
+                } else if !place.projection.is_empty() {
+                    let storage_projection = Self::render_storage_projection(place.projection);
+                    let source_projection =
+                        Self::render_source_projection(var_debug_info.composite.as_deref());
 
-                            locals[local_idx.index()].source_projection = Some(
-                                projection
-                                    .iter()
-                                    .filter_map(|elem| {
-                                        match elem {
-                                            ProjectionElem::Field(field_idx, field_ty) => {
-                                                let rendered = match projection_ty.kind() {
-                                                    TyKind::Adt(adt_def, _args)
-                                                        if adt_def.is_struct() =>
-                                                    {
-                                                        let variant = adt_def.non_enum_variant();
-                                                        let field = &variant.fields[*field_idx];
-                                                        Symbol::intern(&format!(".{}", field.name))
-                                                    }
-
-                                                    TyKind::Tuple(_) =>
-                                                        Symbol::intern(&format!(
-                                                            ".{}",
-                                                            field_idx.index()
-                                                        )),
-
-                                                    _ => Symbol::intern(".<unexpected>"),
-                                                };
-
-                                                projection_ty = field_ty;
-
-                                                Some(rendered)
-                                            }
-                                            // Composite projections are currently
-                                            // expected to be field-only. Leave any
-                                            // unexpected shape for the later deferred
-                                            // debug-info representation instead of
-                                            // printing noise in the CLI.
-                                            _ => None,
-                                        }
-                                    })
-                                    .collect(),
-                            );
-                        }
-                    }
-                    locals[local_idx.index()].source_name = Some(var_debug_info.name);
+                    locals.push(LocalDesc {
+                        source_name: Some(var_debug_info.name),
+                        source_projection,
+                        local: Some(place.local),
+                        storage_projection,
+                        ty: place.ty(local_decls, self.ecx.tcx.tcx).ty.to_string(),
+                    });
                 }
             }
         }
@@ -559,9 +615,16 @@ impl Cli {
                                     |local_idx| format!("_{}", local_idx.index()),
                                 );
 
+                                let storage_projection = local_desc
+                                    .storage_projection
+                                    .iter()
+                                    .map(StorageProj::render)
+                                    .collect::<String>();
+
+                                let display_local_id = format!("{local_id}{storage_projection}");
                                 println!(
                                     "Name: {}, Id: {}, Ty: {}",
-                                    display_name, local_id, local_desc.ty
+                                    display_name, display_local_id, local_desc.ty
                                 );
                             }
                         },

--- a/priroda/src/main.rs
+++ b/priroda/src/main.rs
@@ -21,7 +21,6 @@ use std::path::PathBuf;
 use miri::*;
 use rustc_driver::Compilation;
 use rustc_hir::attrs::CrateType;
-use rustc_index::IndexVec;
 use rustc_interface::interface;
 use rustc_middle::mir::{self, Local, ProjectionElem, VarDebugInfoContents, VarDebugInfoFragment};
 use rustc_middle::ty::{TyCtxt, TyKind};
@@ -133,13 +132,19 @@ struct PrirodaContext<'tcx> {
 }
 
 struct LocalDesc {
+    /// Source variable name from `VarDebugInfo`, if this row has one.
     source_name: Option<Symbol>,
-    // Source-side projection from `VarDebugInfo::composite`. Each symbol is
-    // already rendered as one source projection segment, such as `.field` or `.0`.
+
+    /// Source-side projection from `VarDebugInfo::composite`, e.g. `.field` in source fragment `x.field`.
     source_projection: Option<Vec<Symbol>>,
+
+    /// MIR storage local that backs this description, if any.
     local: Option<Local>,
+
+    /// Display-rendered type for this description.
     ty: String,
 }
+
 /// Controls when execution returns to the frontend.
 enum ResumeMode {
     /// Stop at the next visible MIR instruction.
@@ -356,27 +361,27 @@ impl<'tcx> PrirodaContext<'tcx> {
             return Vec::new();
         };
 
-        self.local_desc_map(frame).into_iter().collect()
+        self.build_local_descs(frame)
     }
 
-    fn local_desc_map(
+    fn build_local_descs(
         &self,
         frame: &Frame<'tcx, Provenance, FrameExtra<'tcx>>,
-    ) -> IndexVec<Local, LocalDesc> {
-        // Initialize one description per MIR local so the table can be indexed by Local.
-        let mut locals: IndexVec<Local, LocalDesc> = frame
-            .body()
-            .local_decls
-            .iter_enumerated()
-            .map(|(local, local_decl)| {
-                LocalDesc {
-                    source_name: None,
-                    source_projection: None,
-                    local: Some(local),
-                    ty: local_decl.ty.to_string(),
-                }
-            })
-            .collect();
+    ) -> Vec<LocalDesc> {
+        let local_decls = &frame.body().local_decls;
+
+        let mut locals: Vec<LocalDesc> = Vec::with_capacity(local_decls.len());
+
+        // Create LocalDesc for every MIR local before processing debug info.
+        // Later debug-derived descriptions will be pushed back to LocalDesc list.
+        for (local_idx, local_decl) in local_decls.iter_enumerated() {
+            locals.push(LocalDesc {
+                source_name: None,
+                source_projection: None,
+                local: Some(local_idx),
+                ty: local_decl.ty.to_string(),
+            });
+        }
 
         // FIXME: Finish classifying `var_debug_info` by keeping the source path
         // and MIR storage path separate:
@@ -402,62 +407,69 @@ impl<'tcx> PrirodaContext<'tcx> {
         // - optimized-out/debug-only/unsupported shapes:
         //   explicit deferred state, not silent discard.
         //
-        // `list_locals` should collect this local-indexed table into a Vec,
+        // Final output should be produced by walking `Vec<LocalDesc>`,
         // then append explicit deferred/debug-info-only rows where needed.
         // Related: SROA can split a source local like `_slice: ExtraSlice` into
         // field locals whose debug paths should be printed as `_slice._slice`
         // and `_slice._extra`, not as two separate locals both named `_slice`.
 
-        // Attach source names from debug info when the debug entry maps directly to a whole MIR local.
+        // Whole-place debug entries enrich the direct storage-local description.
+        // Projected places and constants are handled separately/deferred.
         for var_debug_info in &frame.body().var_debug_info {
-            if let VarDebugInfoContents::Place(place) = &var_debug_info.value
-                && let Some(local) = place.as_local()
-                && locals[local].source_name.is_none()
-            {
-                if let Some(VarDebugInfoFragment { ty, projection }) =
-                    var_debug_info.composite.as_deref()
-                {
-                    // Walk the source-side projection from the original
-                    // composite variable type. Each `Field` element stores the
-                    // resulting field type, so resolve the field name from the
-                    // current base type before advancing to `field_ty`.
-                    let mut projection_ty = ty;
+            if let VarDebugInfoContents::Place(place) = &var_debug_info.value {
+                if let Some(local_idx) = place.as_local() {
+                    if locals[local_idx.index()].source_name.is_none() {
+                        if let Some(VarDebugInfoFragment { ty, projection }) =
+                            var_debug_info.composite.as_deref()
+                        {
+                            // Walk the source-side projection from the original
+                            // composite variable type. Each `Field` element stores the
+                            // resulting field type, so resolve the field name from the
+                            // current base type before advancing to `field_ty`.
+                            let mut projection_ty = ty;
 
-                    locals[local].source_projection = Some(
-                        projection
-                            .iter()
-                            .filter_map(|elem| {
-                                match elem {
-                                    ProjectionElem::Field(field_idx, field_ty) => {
-                                        let rendered = match projection_ty.kind() {
-                                            TyKind::Adt(adt_def, _args) if adt_def.is_struct() => {
-                                                let variant = adt_def.non_enum_variant();
-                                                let field = &variant.fields[*field_idx];
-                                                Symbol::intern(&format!(".{}", field.name))
+                            locals[local_idx.index()].source_projection = Some(
+                                projection
+                                    .iter()
+                                    .filter_map(|elem| {
+                                        match elem {
+                                            ProjectionElem::Field(field_idx, field_ty) => {
+                                                let rendered = match projection_ty.kind() {
+                                                    TyKind::Adt(adt_def, _args)
+                                                        if adt_def.is_struct() =>
+                                                    {
+                                                        let variant = adt_def.non_enum_variant();
+                                                        let field = &variant.fields[*field_idx];
+                                                        Symbol::intern(&format!(".{}", field.name))
+                                                    }
+
+                                                    TyKind::Tuple(_) =>
+                                                        Symbol::intern(&format!(
+                                                            ".{}",
+                                                            field_idx.index()
+                                                        )),
+
+                                                    _ => Symbol::intern(".<unexpected>"),
+                                                };
+
+                                                projection_ty = field_ty;
+
+                                                Some(rendered)
                                             }
-
-                                            TyKind::Tuple(_) =>
-                                                Symbol::intern(&format!(".{}", field_idx.index())),
-
-                                            _ => Symbol::intern(".<unexpected>"),
-                                        };
-
-                                        projection_ty = field_ty;
-
-                                        Some(rendered)
-                                    }
-                                    // Composite projections are currently
-                                    // expected to be field-only. Leave any
-                                    // unexpected shape for the later deferred
-                                    // debug-info representation instead of
-                                    // printing noise in the CLI.
-                                    _ => None,
-                                }
-                            })
-                            .collect(),
-                    );
-                };
-                locals[local].source_name = Some(var_debug_info.name);
+                                            // Composite projections are currently
+                                            // expected to be field-only. Leave any
+                                            // unexpected shape for the later deferred
+                                            // debug-info representation instead of
+                                            // printing noise in the CLI.
+                                            _ => None,
+                                        }
+                                    })
+                                    .collect(),
+                            );
+                        }
+                    }
+                    locals[local_idx.index()].source_name = Some(var_debug_info.name);
+                }
             }
         }
 
@@ -542,14 +554,14 @@ impl Cli {
 
                                 let display_name = format!("{name}{source_projection}");
 
-                                let local = local_desc.local.map_or_else(
+                                let local_id = local_desc.local.map_or_else(
                                     || "<none>".to_string(),
-                                    |local| format!("_{}", local.index()),
+                                    |local_idx| format!("_{}", local_idx.index()),
                                 );
 
                                 println!(
                                     "Name: {}, Id: {}, Ty: {}",
-                                    display_name, local, local_desc.ty
+                                    display_name, local_id, local_desc.ty
                                 );
                             }
                         },

--- a/priroda/tests/ui/locals_corpus_async.rs
+++ b/priroda/tests/ui/locals_corpus_async.rs
@@ -1,0 +1,88 @@
+//@ compile-flags: -Zmir-opt-level=0
+
+#![allow(internal_features)]
+#![feature(custom_mir, core_intrinsics)]
+
+extern crate core;
+use core::intrinsics::mir::*;
+
+// Source: adapted from rustc's MIR-opt custom debuginfo fixture:
+// `rust/tests/mir-opt/building/custom/debuginfo.rs`.
+//
+// Priroda uses this as a CLI locals corpus for projected debug-info storage:
+// tuple fields, struct fields, enum variant fields, variant-field derefs, and
+// constants.
+#[custom_mir(dialect = "built")]
+fn pointee(opt: &mut Option<i32>) {
+    mir! {
+        debug foo => Field::<i32>(Variant(*opt, 1), 0);
+        {
+            Return()
+        }
+    }
+}
+
+#[custom_mir(dialect = "analysis", phase = "post-cleanup")]
+fn numbered(i: (u32, i32)) {
+    mir! {
+        debug first => i.0;
+        debug second => i.1;
+        {
+            Return()
+        }
+    }
+}
+
+struct S {
+    x: f32,
+}
+
+#[custom_mir(dialect = "analysis", phase = "post-cleanup")]
+fn structured(i: S) {
+    mir! {
+        debug x => i.x;
+        {
+            Return()
+        }
+    }
+}
+
+#[custom_mir(dialect = "built")]
+fn variant(opt: Option<i32>) {
+    mir! {
+        debug inner => Field::<i32>(Variant(opt, 1), 0);
+        {
+            Return()
+        }
+    }
+}
+
+#[custom_mir(dialect = "built")]
+fn variant_deref(opt: Option<&i32>) {
+    mir! {
+        debug pointer => Field::<&i32>(Variant(opt, 1), 0);
+        debug deref => *Field::<&i32>(Variant(opt, 1), 0);
+        {
+            Return()
+        }
+    }
+}
+
+#[custom_mir(dialect = "built")]
+fn constant() {
+    mir!(
+        debug scalar => 5_usize;
+        {
+            Return()
+        }
+    )
+}
+
+fn main() {
+    numbered((5, 6));
+    structured(S { x: 5. });
+    variant(Some(5));
+    variant_deref(Some(&5));
+    pointee(&mut Some(5));
+    constant();
+}

--- a/priroda/tests/ui/locals_corpus_async.stdin
+++ b/priroda/tests/ui/locals_corpus_async.stdin
@@ -1,0 +1,19 @@
+break tests/ui/locals_corpus_async.rs:31
+break tests/ui/locals_corpus_async.rs:45
+break tests/ui/locals_corpus_async.rs:55
+break tests/ui/locals_corpus_async.rs:66
+break tests/ui/locals_corpus_async.rs:20
+break tests/ui/locals_corpus_async.rs:76
+continue
+locals
+continue
+locals
+continue
+locals
+continue
+locals
+continue
+locals
+continue
+locals
+quit

--- a/priroda/tests/ui/locals_corpus_async.stdout
+++ b/priroda/tests/ui/locals_corpus_async.stdout
@@ -8,22 +8,29 @@
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:31
 (priroda) Name: <none>, Id: _0, Ty: ()
 Name: <none>, Id: _1, Ty: (u32, i32)
+Name: first, Id: _1.0, Ty: u32
+Name: second, Id: _1.1, Ty: i32
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:45
 (priroda) Name: <none>, Id: _0, Ty: ()
 Name: <none>, Id: _1, Ty: S
+Name: x, Id: _1.0, Ty: f32
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:55
 (priroda) Name: <none>, Id: _0, Ty: ()
 Name: <none>, Id: _1, Ty: std::option::Option<i32>
+Name: inner, Id: _1 as variant#1.0, Ty: i32
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:66
 (priroda) Name: <none>, Id: _0, Ty: ()
 Name: <none>, Id: _1, Ty: std::option::Option<&i32>
+Name: pointer, Id: _1 as variant#1.0, Ty: &i32
+Name: deref, Id: _1 as variant#1.0.*, Ty: i32
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:20
 (priroda) Name: <none>, Id: _0, Ty: ()
 Name: <none>, Id: _1, Ty: &mut std::option::Option<i32>
+Name: foo, Id: _1.* as variant#1.0, Ty: i32
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:76
 (priroda) Name: <none>, Id: _0, Ty: ()

--- a/priroda/tests/ui/locals_corpus_async.stdout
+++ b/priroda/tests/ui/locals_corpus_async.stdout
@@ -1,0 +1,30 @@
+(priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:31
+(priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:45
+(priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:55
+(priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:66
+(priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:20
+(priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:76
+(priroda) Hit breakpoint
+{MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:31
+(priroda) Name: <none>, Id: _0, Ty: ()
+Name: <none>, Id: _1, Ty: (u32, i32)
+(priroda) Hit breakpoint
+{MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:45
+(priroda) Name: <none>, Id: _0, Ty: ()
+Name: <none>, Id: _1, Ty: S
+(priroda) Hit breakpoint
+{MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:55
+(priroda) Name: <none>, Id: _0, Ty: ()
+Name: <none>, Id: _1, Ty: std::option::Option<i32>
+(priroda) Hit breakpoint
+{MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:66
+(priroda) Name: <none>, Id: _0, Ty: ()
+Name: <none>, Id: _1, Ty: std::option::Option<&i32>
+(priroda) Hit breakpoint
+{MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:20
+(priroda) Name: <none>, Id: _0, Ty: ()
+Name: <none>, Id: _1, Ty: &mut std::option::Option<i32>
+(priroda) Hit breakpoint
+{MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:76
+(priroda) Name: <none>, Id: _0, Ty: ()
+(priroda) quitting


### PR DESCRIPTION
This patch keeps the existing MIR-local descriptions, but appends additional LocalDesc rows for projected debug-info places. Each projected row records both sides of the mapping:

- the source-facing name/projection from VarDebugInfo
- the MIR storage local
- the MIR storage projection
- the projected value type

This makes the locals command show debug-info-only projected entries instead of silently dropping them.

Changes:

- Adds a projected debug-info locals UI corpus covering tuple fields, struct fields, enum variant fields, derefs, and constants.
- Adds StorageProj to represent rendered MIR storage projections.
- Adds storage_projection to LocalDesc.
- Extracts source-side projection rendering into render_source_projection().
- Adds storage-side projection rendering in render_storage_projection().
- Appends projected VarDebugInfoContents::Place entries to the locals output.
- Renders unnamed enum downcasts as as variant#N instead of marking them unsupported.
- Updates locals_corpus_async.stdout to check projected debug-info output.
- Updates comments/docs around locals construction to match the new behavior.