### PR TITLE
Support `fallocate` on Linux

### DIFF
--- a/src/shims/io_error.rs
+++ b/src/shims/io_error.rs
@@ -283,15 +283,20 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         }
     }
 
-    /// Sets the last error variable.
-    fn set_last_error(&mut self, err: impl Into<IoError>) -> InterpResult<'tcx> {
+    fn io_error_to_errnum(&mut self, err: impl Into<IoError>) -> InterpResult<'tcx, Scalar> {
         let this = self.eval_context_mut();
-        let errno = match err.into() {
-            HostError(err) => this.io_error_to_errnum(err)?,
+        interp_ok(match err.into() {
+            HostError(err) => this.host_error_to_errnum(err)?,
             LibcError(name) => this.eval_libc(name),
             WindowsError(name) => this.eval_windows("c", name),
             Raw(val) => val,
-        };
+        })
+    }
+
+    /// Sets the last error variable.
+    fn set_last_error(&mut self, err: impl Into<IoError>) -> InterpResult<'tcx> {
+        let this = self.eval_context_mut();
+        let errno = this.io_error_to_errnum(err)?;
         let errno_place = this.last_error_place()?;
         this.write_scalar(errno, &errno_place)
     }
@@ -337,7 +342,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
     /// This function converts host errors to target errors. It tries to produce the most similar OS
     /// error from the `std::io::ErrorKind` as a platform-specific errnum.
-    fn io_error_to_errnum(&self, err: std::io::Error) -> InterpResult<'tcx, Scalar> {
+    fn host_error_to_errnum(&self, err: std::io::Error) -> InterpResult<'tcx, Scalar> {
         let this = self.eval_context_ref();
         let target = &this.tcx.sess.target;
 

--- a/src/shims/unix/fs.rs
+++ b/src/shims/unix/fs.rs
@@ -1319,7 +1319,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             }
             Some(Err(e)) => {
                 // return positive error number on error (do *not* set last error)
-                this.io_error_to_errnum(e)?
+                this.host_error_to_errnum(e)?
             }
         })
     }
@@ -1390,44 +1390,88 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return interp_ok(this.eval_libc("EBADF"));
         }
 
-        // EINVAL is returned when: "offset was less than 0, or len was less than or equal to 0".
-        if offset < 0 || len <= 0 {
-            return interp_ok(this.eval_libc("EINVAL"));
+        match this.fallocate_impl(fd_num, offset, len)? {
+            Ok(()) => interp_ok(Scalar::from_i32(0)),
+            Err(e) => this.io_error_to_errnum(e),
+        }
+    }
+
+    fn linux_fallocate(
+        &mut self,
+        fd: i32,
+        mode: i32,
+        offset: i64,
+        size: i64,
+    ) -> InterpResult<'tcx, Scalar> {
+        // This is mostly a copy of `posix_fallocate` except that errors are returned via errno.
+        let this = self.eval_context_mut();
+
+        // Reject if isolation is enabled.
+        if let IsolatedOp::Reject(reject_with) = this.machine.isolated_op {
+            this.reject_in_isolation("`fallocate`", reject_with)?;
+            // Set error code "EBADF" (bad fd).
+            return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
         }
 
-        // Get the file handle.
+        // We only support `fallocate` as a replacement for `posix_fallocate` on linux,
+        // so a non-default `mode` is not supported.
+        if mode != 0 {
+            throw_unsup_format!("unsupported flags for `fallocate` in `mode` argument: {mode}")
+        }
+
+        match this.fallocate_impl(fd, offset, size)? {
+            Ok(()) => interp_ok(Scalar::from_i32(0)),
+            Err(e) => this.set_errno_and_return_neg1_i32(e),
+        }
+    }
+
+    /// Shared logic between `posix_fallocate` and `linux_fallocate`.
+    fn fallocate_impl(
+        &mut self,
+        fd_num: i32,
+        offset: i64,
+        len: i64,
+    ) -> InterpResult<'tcx, Result<(), IoError>> {
+        let this = self.eval_context_mut();
+
+        // EINVAL is returned/set when: "offset was less than 0, or len was less than or equal to 0".
+        if offset < 0 || len <= 0 {
+            return interp_ok(Err(LibcError("EINVAL")));
+        }
+
         let Some(fd) = this.machine.fds.get(fd_num) else {
-            return interp_ok(this.eval_libc("EBADF"));
+            return interp_ok(Err(LibcError("EBADF")));
         };
         let Some(file) = fd.downcast::<FileHandle>() else {
             // Man page specifies to return ENODEV if `fd` is not a regular file.
-            return interp_ok(this.eval_libc("ENODEV"));
+            return interp_ok(Err(LibcError("ENODEV")));
         };
 
         if !file.writable {
-            // The file is not writable.
-            return interp_ok(this.eval_libc("EBADF"));
+            return interp_ok(Err(LibcError("EBADF")));
         }
 
         let current_size = match file.file.metadata() {
             Ok(metadata) => metadata.len(),
-            Err(err) => return this.io_error_to_errnum(err),
+            Err(err) => return interp_ok(Err(err.into())),
         };
+
         // Checked i64 addition, to ensure the result does not exceed the max file size.
         let new_size = match offset.checked_add(len) {
             // `new_size` is definitely non-negative, so we can cast to `u64`.
             Some(new_size) => u64::try_from(new_size).unwrap(),
-            None => return interp_ok(this.eval_libc("EFBIG")), // new size too big
+            None => return interp_ok(Err(LibcError("EFBIG"))), // new size too big
         };
-        // If the size of the file is less than offset+size, then the file is increased to this size;
-        // otherwise the file size is left unchanged.
+
+        // If the size of the file is less than offset+size, then the file is increased to this
+        // size; otherwise the file size is left unchanged.
         if current_size < new_size {
-            interp_ok(match file.file.set_len(new_size) {
-                Ok(()) => Scalar::from_i32(0),
-                Err(e) => this.io_error_to_errnum(e)?,
-            })
+            match file.file.set_len(new_size) {
+                Ok(()) => interp_ok(Ok(())),
+                Err(err) => interp_ok(Err(err.into())),
+            }
         } else {
-            interp_ok(Scalar::from_i32(0))
+            interp_ok(Ok(()))
         }
     }
 

--- a/src/shims/unix/linux/foreign_items.rs
+++ b/src/shims/unix/linux/foreign_items.rs
@@ -114,6 +114,43 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let result = this.posix_fallocate(fd, offset, len)?;
                 this.write_scalar(result, dest)?;
             }
+
+            "fallocate" => {
+                let [fd, mode, offset, len] = this.check_shim_sig(
+                    shim_sig!(extern "C" fn(i32, i32, libc::off_t, libc::off_t) -> i32),
+                    link_name,
+                    abi,
+                    args,
+                )?;
+
+                let fd = this.read_scalar(fd)?.to_i32()?;
+                let mode = this.read_scalar(mode)?.to_i32()?;
+                // We don't support platforms which have libc::off_t bigger than 64 bits.
+                let offset =
+                    i64::try_from(this.read_scalar(offset)?.to_int(offset.layout.size)?).unwrap();
+                let len = i64::try_from(this.read_scalar(len)?.to_int(len.layout.size)?).unwrap();
+
+                let result = this.linux_fallocate(fd, mode, offset, len)?;
+                this.write_scalar(result, dest)?;
+            }
+
+            "fallocate64" => {
+                let [fd, mode, offset, len] = this.check_shim_sig(
+                    shim_sig!(extern "C" fn(i32, i32, libc::off64_t, libc::off64_t) -> i32),
+                    link_name,
+                    abi,
+                    args,
+                )?;
+
+                let fd = this.read_scalar(fd)?.to_i32()?;
+                let mode = this.read_scalar(mode)?.to_i32()?;
+                let offset = this.read_scalar(offset)?.to_i64()?;
+                let len = this.read_scalar(len)?.to_i64()?;
+
+                let result = this.linux_fallocate(fd, mode, offset, len)?;
+                this.write_scalar(result, dest)?;
+            }
+
             "readdir64" => {
                 let [dirp] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
                 this.readdir(dirp, dest)?;

--- a/tests/pass-dep/libc/libc-fs.rs
+++ b/tests/pass-dep/libc/libc-fs.rs
@@ -43,6 +43,10 @@ fn main() {
     #[cfg(target_os = "linux")]
     test_posix_fallocate::<libc::off64_t>(libc::posix_fallocate64);
     #[cfg(target_os = "linux")]
+    test_fallocate::<libc::off_t>(libc::fallocate);
+    #[cfg(target_os = "linux")]
+    test_fallocate::<libc::off64_t>(libc::fallocate64);
+    #[cfg(target_os = "linux")]
     test_sync_file_range();
     test_fstat();
     test_stat();
@@ -602,6 +606,75 @@ fn test_posix_fallocate<T: From<i32>>(
 
     test_errors();
     test();
+}
+
+#[cfg(target_os = "linux")]
+fn test_fallocate<T: From<i32>>(
+    fallocate: unsafe extern "C" fn(
+        fd: libc::c_int,
+        mode: libc::c_int,
+        offset: T,
+        len: T,
+    ) -> libc::c_int,
+) {
+    use libc_utils::{errno_check, errno_result};
+
+    // -- Test errors ---
+    // libc::off_t is i32 in target i686-unknown-linux-gnu
+    // https://docs.rs/libc/latest/i686-unknown-linux-gnu/libc/type.off_t.html
+
+    // invalid fd
+    let err = errno_result(unsafe { fallocate(42, 0, T::from(0), T::from(10)) }).unwrap_err();
+    assert_eq!(err.raw_os_error().unwrap(), libc::EBADF);
+
+    let path = utils::prepare("miri_test_libc_fallocate_errors.txt");
+    let file = File::create(&path).unwrap();
+
+    // invalid offset
+    let err = errno_result(unsafe { fallocate(file.as_raw_fd(), 0, T::from(-10), T::from(10)) })
+        .unwrap_err();
+    assert_eq!(err.raw_os_error().unwrap(), libc::EINVAL);
+
+    // invalid len
+    let err = errno_result(unsafe { fallocate(file.as_raw_fd(), 0, T::from(0), T::from(-10)) })
+        .unwrap_err();
+    assert_eq!(err.raw_os_error().unwrap(), libc::EINVAL);
+
+    // fd not writable
+    let c_path = CString::new(path.as_os_str().as_bytes()).expect("CString::new failed");
+    let fd = errno_result(unsafe { libc::open(c_path.as_ptr(), libc::O_RDONLY) }).unwrap();
+    let err = errno_result(unsafe { fallocate(fd, 0, T::from(0), T::from(10)) }).unwrap_err();
+    assert_eq!(err.raw_os_error().unwrap(), libc::EBADF);
+
+    // --- Test correct behaviour ---
+    let bytes = b"hello";
+    let path = utils::prepare("miri_test_libc_fallocate.txt");
+    let mut file = File::create(&path).unwrap();
+    file.write_all(bytes).unwrap();
+    file.sync_all().unwrap();
+    assert_eq!(file.metadata().unwrap().len(), 5);
+
+    let c_path = CString::new(path.as_os_str().as_bytes()).expect("CString::new failed");
+    let fd = errno_result(unsafe { libc::open(c_path.as_ptr(), libc::O_RDWR) }).unwrap();
+
+    // Allocate to a bigger size from offset 0
+    errno_check(unsafe { fallocate(fd, 0, T::from(0), T::from(10)) });
+    assert_eq!(file.metadata().unwrap().len(), 10);
+
+    // Write after allocation
+    file.write(b"dup").unwrap();
+    file.sync_all().unwrap();
+    assert_eq!(file.metadata().unwrap().len(), 10);
+
+    // Can't truncate to a smaller size with fallocate
+    errno_check(unsafe { fallocate(fd, 0, T::from(0), T::from(3)) });
+    assert_eq!(file.metadata().unwrap().len(), 10);
+
+    // Allocate from offset
+    errno_check(unsafe { fallocate(fd, 0, T::from(7), T::from(7)) });
+    assert_eq!(file.metadata().unwrap().len(), 14);
+
+    remove_file(&path).unwrap();
 }
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
Closes rust-lang/miri#5137

This PR implements the linux syscall `fallocate` and its 64-bit version. It is an extended version of `posix_fallocate`. So for now this pr only implements the `posix_fallocate` behaviour as explained in the [man page](https://man7.org/linux/man-pages/man2/fallocate.2.html).

All other "features" are rather specific and I couldn't find a reliable way to mimic them in Miri, they also specify that they require file system support, so i have no clue there.

If needed, I can include them here or in a follow-up PR.