### PR TITLE
Use shared libc helpers in tests

### DIFF
--- a/tests/fail-dep/libc/eventfd_block_read_twice.rs
+++ b/tests/fail-dep/libc/eventfd_block_read_twice.rs
@@ -25,10 +25,8 @@ fn main() {
     let fd = errno_result(unsafe { libc::eventfd(0, flags) }).unwrap();
 
     let thread1 = thread::spawn(move || {
-        let mut buf: [u8; 8] = [0; 8];
         // This read will block initially.
-        let res: i64 = unsafe { libc::read(fd, buf.as_mut_ptr().cast(), 8).try_into().unwrap() };
-        assert_eq!(res, 8);
+        let buf: [u8; 8] = read_exact_array(fd).unwrap();
         let counter = u64::from_ne_bytes(buf);
         assert_eq!(counter, 1_u64);
     });
@@ -37,7 +35,7 @@ fn main() {
         let mut buf: [u8; 8] = [0; 8];
         // This read will block initially, then get unblocked by thread3, then get blocked again
         // because the `read` in thread1 executes first and set the counter to 0 again.
-        let res: i64 = unsafe { libc::read(fd, buf.as_mut_ptr().cast(), 8).try_into().unwrap() };
+        let res = errno_result(unsafe { libc::read(fd, buf.as_mut_ptr().cast(), 8) }).unwrap();
         //~^ERROR: deadlocked
         assert_eq!(res, 8);
         let counter = u64::from_ne_bytes(buf);
@@ -47,11 +45,8 @@ fn main() {
     let thread3 = thread::spawn(move || {
         let sized_8_data = 1_u64.to_ne_bytes();
         // Write 1 to the counter, so both thread1 and thread2 will unblock.
-        let res: i64 = unsafe {
-            libc::write(fd, sized_8_data.as_ptr() as *const libc::c_void, 8).try_into().unwrap()
-        };
         // Make sure that write is successful.
-        assert_eq!(res, 8);
+        write_all(fd, &sized_8_data).unwrap();
     });
 
     thread1.join().unwrap();

--- a/tests/fail-dep/libc/eventfd_block_read_twice.stderr
+++ b/tests/fail-dep/libc/eventfd_block_read_twice.stderr
@@ -18,8 +18,8 @@ LL |         let ret = unsafe { libc::pthread_join(id, ptr::null_mut()) };
 error: the evaluated program deadlocked
   --> tests/fail-dep/libc/eventfd_block_read_twice.rs:LL:CC
    |
-LL |         let res: i64 = unsafe { libc::read(fd, buf.as_mut_ptr().cast(), 8).try_into().unwrap() };
-   |                                                                          ^ thread got stuck here
+LL |         let res = errno_result(unsafe { libc::read(fd, buf.as_mut_ptr().cast(), 8) }).unwrap();
+   |                                                                                  ^ thread got stuck here
    |
    = note: this is on thread `unnamed-ID`
 note: the current function got called indirectly due to this code

--- a/tests/fail-dep/libc/eventfd_block_write_twice.rs
+++ b/tests/fail-dep/libc/eventfd_block_write_twice.rs
@@ -24,38 +24,31 @@ fn main() {
     let fd = errno_result(unsafe { libc::eventfd(0, flags) }).unwrap();
     // Write u64 - 1, so the all subsequent write will block.
     let sized_8_data: [u8; 8] = (u64::MAX - 1).to_ne_bytes();
-    let res: i64 = unsafe {
-        libc::write(fd, sized_8_data.as_ptr() as *const libc::c_void, 8).try_into().unwrap()
-    };
-    assert_eq!(res, 8);
+    write_all(fd, &sized_8_data).unwrap();
 
     let thread1 = thread::spawn(move || {
         let sized_8_data = (u64::MAX - 1).to_ne_bytes();
-        let res: i64 = unsafe {
-            libc::write(fd, sized_8_data.as_ptr() as *const libc::c_void, 8).try_into().unwrap()
-        };
         // Make sure that write is successful.
-        assert_eq!(res, 8);
+        write_all(fd, &sized_8_data).unwrap();
     });
 
     let thread2 = thread::spawn(move || {
         let sized_8_data = (u64::MAX - 1).to_ne_bytes();
         // Write u64::MAX - 1, so that all subsequent writes will block.
-        let res: i64 = unsafe {
+        let res = errno_result(unsafe {
             // This `write` will initially blocked, then get unblocked by thread3, then get blocked again
             // because the `write` in thread1 executes first.
-            libc::write(fd, sized_8_data.as_ptr() as *const libc::c_void, 8).try_into().unwrap()
+            libc::write(fd, sized_8_data.as_ptr() as *const libc::c_void, 8)
             //~^ERROR: deadlocked
-        };
+        })
+        .unwrap();
         // Make sure that write is successful.
         assert_eq!(res, 8);
     });
 
     let thread3 = thread::spawn(move || {
-        let mut buf: [u8; 8] = [0; 8];
         // This will unblock both `write` in thread1 and thread2.
-        let res: i64 = unsafe { libc::read(fd, buf.as_mut_ptr().cast(), 8).try_into().unwrap() };
-        assert_eq!(res, 8);
+        let buf: [u8; 8] = read_exact_array(fd).unwrap();
         let counter = u64::from_ne_bytes(buf);
         assert_eq!(counter, (u64::MAX - 1));
     });

--- a/tests/fail-dep/libc/eventfd_block_write_twice.stderr
+++ b/tests/fail-dep/libc/eventfd_block_write_twice.stderr
@@ -18,7 +18,7 @@ LL |         let ret = unsafe { libc::pthread_join(id, ptr::null_mut()) };
 error: the evaluated program deadlocked
   --> tests/fail-dep/libc/eventfd_block_write_twice.rs:LL:CC
    |
-LL |             libc::write(fd, sized_8_data.as_ptr() as *const libc::c_void, 8).try_into().unwrap()
+LL |             libc::write(fd, sized_8_data.as_ptr() as *const libc::c_void, 8)
    |                                                                            ^ thread got stuck here
    |
    = note: this is on thread `unnamed-ID`
@@ -29,7 +29,7 @@ LL |       let thread2 = thread::spawn(move || {
    |  ___________________^
 LL | |         let sized_8_data = (u64::MAX - 1).to_ne_bytes();
 LL | |         // Write u64::MAX - 1, so that all subsequent writes will block.
-LL | |         let res: i64 = unsafe {
+LL | |         let res = errno_result(unsafe {
 ...  |
 LL | |         assert_eq!(res, 8);
 LL | |     });


### PR DESCRIPTION
Related to rust-lang/miri#4725 .
Wraps the `libc::read/write()` calls in `errno_result`.