### PR TITLE
enable bors (for squashing only)

### DIFF
--- a/rust-bors.toml
+++ b/rust-bors.toml
@@ -1,0 +1,1 @@
+# This repo uses GH merge queues, bors is only enabled for squashing.


### PR DESCRIPTION
See discussion in https://rust-lang.zulipchat.com/#narrow/channel/496228-t-infra.2Fbors/topic/Squash-and-merge.3F/with/608090791

(This will not do anything on its own, it just means infra can toggle the switch whenever they think bors is ready for this.)