### PR TITLE
aarch64: extend tbl1 shim to support `vtbl1_s8`/`vtbl1_u8`

### DIFF
--- a/src/shims/aarch64.rs
+++ b/src/shims/aarch64.rs
@@ -1,3 +1,5 @@
+use std::assert_matches;
+
 use rustc_middle::mir::BinOp;
 use rustc_span::Symbol;
 
@@ -178,18 +180,23 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 }
             }
 
-            // Vector table lookup: each index selects a byte from the 16-byte table, out-of-range -> 0.
-            // Used to implement vtbl1_u8 function.
+            // Vector table lookup: each index selects a byte from the 8 or 16-byte table,
+            // out-of-range -> 0.
+            //
+            // Used to implement the vqtbl1 and vqtbl1q set of functions, e.g.:
+            //
+            // - https://developer.arm.com/architectures/instruction-sets/intrinsics/vtbl1_u8
+            // - https://developer.arm.com/architectures/instruction-sets/intrinsics/vqtbl1q_s8
+            //
             // LLVM does not have a portable shuffle that takes non-const indices
             // so we need to implement this ourselves.
-            // https://developer.arm.com/architectures/instruction-sets/intrinsics/vtbl1_u8
-            "neon.tbl1.v16i8" => {
+            "neon.tbl1.v8i8" | "neon.tbl1.v16i8" => {
                 let [table, indices] = this.check_shim_sig_unadjusted(link_name, args)?;
 
                 let (table, table_len) = this.project_to_simd(table)?;
                 let (indices, idx_len) = this.project_to_simd(indices)?;
                 let (dest, dest_len) = this.project_to_simd(dest)?;
-                assert_eq!(table_len, 16);
+                assert_matches!(table_len, 8 | 16);
                 assert_eq!(idx_len, dest_len);
 
                 for i in 0..dest_len {

--- a/tests/pass/shims/aarch64/intrinsics-aarch64-neon.rs
+++ b/tests/pass/shims/aarch64/intrinsics-aarch64-neon.rs
@@ -12,7 +12,7 @@ fn main() {
 
     unsafe {
         test_vpmaxq_u8();
-        test_tbl1_v16i8_basic();
+        test_tbl1_basic();
         test_vpadd();
         test_vpaddl();
         test_vqdmulh();
@@ -46,7 +46,27 @@ unsafe fn test_vpmaxq_u8() {
 }
 
 #[target_feature(enable = "neon")]
-fn test_tbl1_v16i8_basic() {
+fn test_tbl1_basic() {
+    unsafe {
+        // table = 0..7
+        let table: uint8x8_t = transmute::<[u8; 8], _>([0, 1, 2, 3, 4, 5, 6, 7]);
+
+        // indices
+        let idx: uint8x8_t = transmute::<[u8; 8], _>([0, 1, 2, 3, 4, 5, 6, 7]);
+        let got = vtbl1_u8(table, idx);
+        let got_arr: [u8; 8] = transmute(got);
+        assert_eq!(got_arr, [0, 1, 2, 3, 4, 5, 6, 7]);
+
+        // Also try different order and out-of-range indices (8, 255).
+        let idx2: uint8x8_t = transmute::<[u8; 8], _>([7, 8, 255, 0, 1, 2, 3, 4]);
+        let got2 = vtbl1_u8(table, idx2);
+        let got2_arr: [u8; 8] = transmute(got2);
+        assert_eq!(got2_arr[0], 7);
+        assert_eq!(got2_arr[1], 0); // out-of-range
+        assert_eq!(got2_arr[2], 0); // out-of-range
+        assert_eq!(&got2_arr[3..8], &[0, 1, 2, 3, 4][..]);
+    }
+
     unsafe {
         // table = 0..15
         let table: uint8x16_t =
@@ -69,6 +89,7 @@ fn test_tbl1_v16i8_basic() {
         assert_eq!(&got2_arr[3..16], &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12][..]);
     }
 }
+
 #[target_feature(enable = "neon")]
 unsafe fn test_vpadd() {
     let a = vld1_s8([1, 2, 3, 4, 5, 6, 7, 8].as_ptr());


### PR DESCRIPTION
cc https://github.com/rust-lang/portable-simd/issues/524