### PR TITLE
remove -Zmiri-force-intrinsic-fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,9 +461,6 @@ to Miri failing to detect cases of undefined behavior in a program.
   disables the randomization of the next thread to be picked, instead fixing a round-robin schedule.
   Note however that other aspects of Miri's concurrency behavior are still randomize; use
   `-Zmiri-deterministic-concurrency` to disable them all.
-* `-Zmiri-force-intrinsic-fallback` forces the use of the "fallback" body for all intrinsics that
-  have one. This is useful to test the fallback bodies, but should not be used otherwise. It is
-  **unsound** since the fallback body might not be checking for all UB.
 * `-Zmiri-native-lib=<path to a shared object file or folder>` is an experimental flag for providing
   support for calling native functions from inside the interpreter via FFI. The flag is supported
   only on Unix systems. Functions not provided by that file are still executed via the usual Miri

--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -536,8 +536,6 @@ fn main() -> ExitCode {
         } else if arg == "-Zmiri-ignore-leaks" {
             miri_config.ignore_leaks = true;
             miri_config.collect_leak_backtraces = false;
-        } else if arg == "-Zmiri-force-intrinsic-fallback" {
-            miri_config.force_intrinsic_fallback = true;
         } else if arg == "-Zmiri-deterministic-floats" {
             miri_config.float_nondet = false;
         } else if arg == "-Zmiri-no-extra-rounding-error" {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -162,8 +162,6 @@ pub struct MiriConfig {
     pub address_reuse_cross_thread_rate: f64,
     /// Round Robin scheduling with no preemption.
     pub fixed_scheduling: bool,
-    /// Always prefer the intrinsic fallback body over the native Miri implementation.
-    pub force_intrinsic_fallback: bool,
     /// Whether floating-point operations can behave non-deterministically.
     pub float_nondet: bool,
     /// Whether floating-point operations can have a non-deterministic rounding error.
@@ -210,7 +208,6 @@ impl Default for MiriConfig {
             address_reuse_rate: 0.5,
             address_reuse_cross_thread_rate: 0.1,
             fixed_scheduling: false,
-            force_intrinsic_fallback: false,
             float_nondet: true,
             float_rounding_error: FloatRoundingErrorMode::Random,
             short_fd_operations: true,

--- a/src/intrinsics/mod.rs
+++ b/src/intrinsics/mod.rs
@@ -46,16 +46,6 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     ) -> InterpResult<'tcx, Option<ty::Instance<'tcx>>> {
         let this = self.eval_context_mut();
 
-        // Force use of fallback body, if available.
-        if this.machine.force_intrinsic_fallback
-            && !this.tcx.intrinsic(instance.def_id()).unwrap().must_be_overridden
-        {
-            return interp_ok(Some(ty::Instance {
-                def: ty::InstanceKind::Item(instance.def_id()),
-                args: instance.args,
-            }));
-        }
-
         // See if the core engine can handle this intrinsic.
         if this.eval_intrinsic(instance, args, dest, ret)? {
             return interp_ok(None);

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -657,9 +657,6 @@ pub struct MiriMachine<'tcx> {
     /// Cache for `mangle_internal_symbol`.
     pub(crate) mangle_internal_symbol_cache: FxHashMap<&'static str, String>,
 
-    /// Always prefer the intrinsic fallback body over the native Miri implementation.
-    pub force_intrinsic_fallback: bool,
-
     /// Whether floating-point operations can behave non-deterministically.
     pub float_nondet: bool,
     /// Whether floating-point operations can have a non-deterministic rounding error.
@@ -838,7 +835,6 @@ impl<'tcx> MiriMachine<'tcx> {
             pthread_condvar_sanity: Cell::new(false),
             allocator_shim_symbols: Self::allocator_shim_symbols(tcx),
             mangle_internal_symbol_cache: Default::default(),
-            force_intrinsic_fallback: config.force_intrinsic_fallback,
             float_nondet: config.float_nondet,
             float_rounding_error: config.float_rounding_error,
             short_fd_operations: config.short_fd_operations,
@@ -1074,7 +1070,6 @@ impl VisitProvenance for MiriMachine<'_> {
             pthread_condvar_sanity: _,
             allocator_shim_symbols: _,
             mangle_internal_symbol_cache: _,
-            force_intrinsic_fallback: _,
             float_nondet: _,
             float_rounding_error: _,
             short_fd_operations: _,

--- a/tests/pass/c-variadic.rs
+++ b/tests/pass/c-variadic.rs
@@ -121,13 +121,6 @@ fn equal_up_to_free_lifetime() {
 }
 
 fn clone() {
-    if cfg!(force_intrinsic_fallback) {
-        // Skip this test when we use the fallback bodies. The fallback body does
-        // not hook into the Miri allocation bookkeeping for variable argument lists
-        // and would would falsely report UB.
-        return;
-    }
-
     unsafe extern "C" fn clone_the_va_list(args: ...) {
         // The implicit `drop` will catch a `VaList` that isn't properly initialized.
         let _ = args.clone();
@@ -137,13 +130,6 @@ fn clone() {
 }
 
 fn clone_and_advance() {
-    if cfg!(force_intrinsic_fallback) {
-        // Skip this test when we use the fallback bodies. The fallback body does
-        // not hook into the Miri allocation bookkeeping for variable argument lists
-        // and would would falsely report UB.
-        return;
-    }
-
     unsafe extern "C" fn variadic(mut a: ...) {
         unsafe {
             let mut b = a.clone();

--- a/tests/pass/float.rs
+++ b/tests/pass/float.rs
@@ -1529,12 +1529,6 @@ fn test_fmuladd() {
 }
 
 fn test_non_determinism() {
-    if cfg!(force_intrinsic_fallback) {
-        // Skip this test when we use the fallback bodies, as that one is deterministic.
-        // (CI sets `--cfg force_intrinsic_fallback` together with `-Zmiri-force-intrinsic-fallback`.)
-        return;
-    }
-
     use std::intrinsics::{
         fadd_algebraic, fadd_fast, fdiv_algebraic, fdiv_fast, fmul_algebraic, fmul_fast,
         frem_algebraic, frem_fast, fsub_algebraic, fsub_fast,

--- a/tests/pass/float_nan.rs
+++ b/tests/pass/float_nan.rs
@@ -541,12 +541,6 @@ fn test_simd() {
 }
 
 fn main() {
-    if cfg!(force_intrinsic_fallback) {
-        // Skip this test when we use the fallback bodies, as that one is deterministic.
-        // (CI sets `--cfg force_intrinsic_fallback` together with `-Zmiri-force-intrinsic-fallback`.)
-        return;
-    }
-
     // Check our constants against std, just to be sure.
     // We add 1 since our numbers are the number of bits stored
     // to represent the value, and std has the precision of the value,

--- a/tests/pass/intrinsics/intrinsics.rs
+++ b/tests/pass/intrinsics/intrinsics.rs
@@ -37,11 +37,7 @@ fn main() {
     assert_eq!(intrinsics::likely(false), false);
     assert_eq!(intrinsics::unlikely(true), true);
 
-    // Skip this test when we use the fallback bodies, as that one is deterministic.
-    // (CI sets `--cfg force_intrinsic_fallback` together with `-Zmiri-force-intrinsic-fallback`.)
-    if !cfg!(force_intrinsic_fallback) {
-        check_nondet(|| intrinsics::is_val_statically_known(0));
-    }
+    check_nondet(|| intrinsics::is_val_statically_known(0));
 
     intrinsics::forget(Bomb);
 


### PR DESCRIPTION
It's getting increasingly burdensome to keep Miri's tests work in this mode.
So we're moving that test coverage elsewhere: https://github.com/rust-lang/rust/pull/158377.

Blocked on https://github.com/rust-lang/rust/pull/150946 so that the rustc repo does not rely on this any more.