### PR TITLE
Implement `recv` and `send` for virtual sockets

### DIFF
--- a/src/shims/unix/fd.rs
+++ b/src/shims/unix/fd.rs
@@ -77,11 +77,12 @@ pub trait UnixFileDescription: FileDescription {
         throw_unsup_format!("cannot use ioctl on {}", self.name());
     }
 
+    /// Returns this file description as a Unix socket, if it represents one.
     fn as_socket<'tcx>(
         self: FileDescriptionRef<Self>,
         _ecx: &MiriInterpCx<'tcx>,
-    ) -> FileDescriptionRef<dyn UnixSocketFileDescription> {
-        panic!("Not a unix socket file descriptor: {}", self.name());
+    ) -> Option<FileDescriptionRef<dyn UnixSocketFileDescription>> {
+        None
     }
 }
 

--- a/src/shims/unix/socket.rs
+++ b/src/shims/unix/socket.rs
@@ -70,10 +70,10 @@ pub trait UnixSocketFileDescription: UnixFileDescription {
         throw_unsup_format!("cannot connect {}", self.name());
     }
 
-    /// Recieve data on the socket into the given buffer `ptr`.
+    /// Receive data on the socket into the given buffer `ptr`.
     /// `len` indicates how many bytes we should try to receive.
     /// `is_peek` specifies whether the receive removes the bytes from the receive buffer
-    /// ([`false`]) or leaves them in the reiceve buffer ([`true`]).
+    /// ([`false`]) or leaves them in the receive buffer ([`true`]).
     /// `is_non_block` specifies whether the receive operation is non-blocking.
     /// After a successful receive, `finish` should be called with the amount of bytes received.
     fn recv<'tcx>(
@@ -254,7 +254,10 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
         };
 
-        let socket = fd.as_unix(this).as_socket(this);
+        let Some(socket) = fd.as_unix(this).as_socket(this) else {
+            return this.set_errno_and_return_neg1_i32(LibcError("ENOTSOCK"));
+        };
+
         match socket.bind(this.machine.communicate(), address, this)? {
             Ok(_) => interp_ok(Scalar::from_i32(0)),
             Err(e) => this.set_errno_and_return_neg1_i32(e),
@@ -272,7 +275,10 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
         };
 
-        let socket = fd.as_unix(this).as_socket(this);
+        let Some(socket) = fd.as_unix(this).as_socket(this) else {
+            return this.set_errno_and_return_neg1_i32(LibcError("ENOTSOCK"));
+        };
+
         match socket.listen(this.machine.communicate(), backlog, this)? {
             Ok(_) => interp_ok(Scalar::from_i32(0)),
             Err(e) => this.set_errno_and_return_neg1_i32(e),
@@ -303,7 +309,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return this.set_errno_and_return_neg1(LibcError("EBADF"), dest);
         };
 
-        let socket = fd.as_unix(this).as_socket(this);
+        let Some(socket) = fd.as_unix(this).as_socket(this) else {
+            return this.set_errno_and_return_neg1(LibcError("ENOTSOCK"), dest);
+        };
 
         let mut is_client_sock_nonblock = false;
 
@@ -388,7 +396,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return this.set_errno_and_return_neg1(LibcError("EBADF"), dest);
         };
 
-        let socket = fd.as_unix(this).as_socket(this);
+        let Some(socket) = fd.as_unix(this).as_socket(this) else {
+            return this.set_errno_and_return_neg1(LibcError("ENOTSOCK"), dest);
+        };
 
         let dest = dest.clone();
 
@@ -432,7 +442,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return this.set_errno_and_return_neg1(LibcError("EBADF"), dest);
         };
 
-        let socket = fd.as_unix(this).as_socket(this);
+        let Some(socket) = fd.as_unix(this).as_socket(this) else {
+            return this.set_errno_and_return_neg1(LibcError("ENOTSOCK"), dest);
+        };
 
         let mut is_non_block = false;
 
@@ -509,7 +521,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return this.set_errno_and_return_neg1(LibcError("EBADF"), dest);
         };
 
-        let socket = fd.as_unix(this).as_socket(this);
+        let Some(socket) = fd.as_unix(this).as_socket(this) else {
+            return this.set_errno_and_return_neg1(LibcError("ENOTSOCK"), dest);
+        };
 
         let mut is_peek = false;
         let mut is_non_block = false;
@@ -599,7 +613,10 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
         };
 
-        let socket = fd.as_unix(this).as_socket(this);
+        let Some(socket) = fd.as_unix(this).as_socket(this) else {
+            return this.set_errno_and_return_neg1_i32(LibcError("ENOTSOCK"));
+        };
+
         let result = socket.setsockopt(level, option_name, option_value_ptr, option_len, this)?;
         match result {
             Ok(_) => interp_ok(Scalar::from_i32(0)),
@@ -633,7 +650,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
         };
 
-        let socket = fd.as_unix(this).as_socket(this);
+        let Some(socket) = fd.as_unix(this).as_socket(this) else {
+            return this.set_errno_and_return_neg1_i32(LibcError("ENOTSOCK"));
+        };
 
         if option_value_ptr == Pointer::null() || option_len_ptr == Pointer::null() {
             // This socket option returns a value and thus we need to return EFAULT
@@ -699,7 +718,10 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
         };
 
-        let socket = fd.as_unix(this).as_socket(this);
+        let Some(socket) = fd.as_unix(this).as_socket(this) else {
+            return this.set_errno_and_return_neg1_i32(LibcError("ENOTSOCK"));
+        };
+
         let address = match socket.getsockname(this.machine.communicate(), this)? {
             Ok(address) => address,
             Err(e) => return this.set_errno_and_return_neg1_i32(e),
@@ -728,7 +750,10 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return this.set_errno_and_return_neg1(LibcError("EBADF"), dest);
         };
 
-        let socket = fd.as_unix(this).as_socket(this);
+        let Some(socket) = fd.as_unix(this).as_socket(this) else {
+            return this.set_errno_and_return_neg1(LibcError("ENOTSOCK"), dest);
+        };
+
         let dest = dest.clone();
 
         socket.getpeername(
@@ -768,7 +793,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
         };
 
-        let socket = fd.as_unix(this).as_socket(this);
+        let Some(socket) = fd.as_unix(this).as_socket(this) else {
+            return this.set_errno_and_return_neg1_i32(LibcError("ENOTSOCK"));
+        };
 
         let is_read_shutdown = how == this.eval_libc_i32("SHUT_RD");
         let is_write_shutdown = how == this.eval_libc_i32("SHUT_WR");

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -238,8 +238,8 @@ impl UnixFileDescription for TcpSocket {
     fn as_socket<'tcx>(
         self: FileDescriptionRef<Self>,
         _ecx: &MiriInterpCx<'tcx>,
-    ) -> FileDescriptionRef<dyn UnixSocketFileDescription> {
-        self
+    ) -> Option<FileDescriptionRef<dyn UnixSocketFileDescription>> {
+        Some(self)
     }
 }
 

--- a/src/shims/unix/virtual_socket.rs
+++ b/src/shims/unix/virtual_socket.rs
@@ -13,6 +13,7 @@ use crate::shims::files::{
     EvalContextExt as _, FdId, FileDescription, FileDescriptionRef, WeakFileDescriptionRef,
 };
 use crate::shims::unix::UnixFileDescription;
+use crate::shims::unix::socket::UnixSocketFileDescription;
 use crate::*;
 
 /// The maximum capacity of the socketpair buffer in bytes.
@@ -120,7 +121,7 @@ impl FileDescription for VirtualSocket {
         ecx: &mut MiriInterpCx<'tcx>,
         finish: DynMachineCallback<'tcx, Result<usize, IoError>>,
     ) -> InterpResult<'tcx> {
-        ecx.virtual_socket_read(self, ptr, len, finish)
+        ecx.virtual_socket_read(self, ptr, len, /* is_non_block */ false, finish)
     }
 
     fn write<'tcx>(
@@ -131,7 +132,7 @@ impl FileDescription for VirtualSocket {
         ecx: &mut MiriInterpCx<'tcx>,
         finish: DynMachineCallback<'tcx, Result<usize, IoError>>,
     ) -> InterpResult<'tcx> {
-        ecx.virtual_socket_write(self, ptr, len, finish)
+        ecx.virtual_socket_write(self, ptr, len, /* is_non_block */ false, finish)
     }
 
     fn short_fd_operations(&self) -> bool {
@@ -248,18 +249,107 @@ impl FileDescription for VirtualSocket {
     }
 }
 
-impl UnixFileDescription for VirtualSocket {}
+impl UnixFileDescription for VirtualSocket {
+    fn ioctl<'tcx>(
+        &self,
+        op: Scalar,
+        arg: Option<&OpTy<'tcx>>,
+        ecx: &mut MiriInterpCx<'tcx>,
+    ) -> InterpResult<'tcx, i32> {
+        match self.fd_type {
+            VirtualSocketType::Socketpair => { /* fall-through to below */ }
+            VirtualSocketType::PipeRead | VirtualSocketType::PipeWrite => {
+                // The standard library only uses ioctl for changing the blocking mode
+                // of Unix sockets. Thus, since using ioctl isn't the preferred way of
+                // changing the blocking mode, we don't support it on pipes.
+                throw_unsup_format!("cannot use ioctl on pipe");
+            }
+        }
+
+        let fionbio = ecx.eval_libc("FIONBIO");
+
+        if op == fionbio {
+            // On these OSes, Rust uses the ioctl, so we trust that it is reasonable and controls
+            // the same internal flag as fcntl.
+            if !matches!(ecx.tcx.sess.target.os, Os::Linux | Os::Android | Os::MacOs | Os::FreeBsd)
+            {
+                // FIONBIO cannot be used to change the blocking mode of a socket on solarish targets:
+                // <https://github.com/rust-lang/rust/commit/dda5c97675b4f5b1f6fdab64606c8a1f21021b0a>
+                // Since there might be more targets which do weird things with this option, we use
+                // an allowlist instead of just denying solarish targets.
+                throw_unsup_format!(
+                    "ioctl: setting FIONBIO on sockets is unsupported on target {}",
+                    ecx.tcx.sess.target.os
+                );
+            }
+
+            let Some(value_ptr) = arg else {
+                throw_ub_format!("ioctl: setting FIONBIO on sockets requires a third argument");
+            };
+            let value = ecx.deref_pointer_as(value_ptr, ecx.machine.layouts.i32)?;
+            let non_block = ecx.read_scalar(&value)?.to_i32()? != 0;
+            self.is_nonblock.set(non_block);
+            return interp_ok(0);
+        }
+
+        throw_unsup_format!("ioctl: unsupported operation {op:#x} on socket");
+    }
+
+    fn as_socket<'tcx>(
+        self: FileDescriptionRef<Self>,
+        _ecx: &MiriInterpCx<'tcx>,
+    ) -> Option<FileDescriptionRef<dyn UnixSocketFileDescription>> {
+        match self.fd_type {
+            VirtualSocketType::Socketpair => Some(self),
+            VirtualSocketType::PipeRead | VirtualSocketType::PipeWrite => None,
+        }
+    }
+}
+
+impl UnixSocketFileDescription for VirtualSocket {
+    fn send<'tcx>(
+        self: FileDescriptionRef<Self>,
+        _communicate_allowed: bool,
+        ptr: Pointer,
+        len: usize,
+        is_non_block: bool,
+        ecx: &mut MiriInterpCx<'tcx>,
+        finish: DynMachineCallback<'tcx, Result<usize, IoError>>,
+    ) -> InterpResult<'tcx> {
+        ecx.virtual_socket_write(self, ptr, len, is_non_block, finish)
+    }
+
+    fn recv<'tcx>(
+        self: FileDescriptionRef<Self>,
+        _communicate_allowed: bool,
+        ptr: Pointer,
+        len: usize,
+        is_peek: bool,
+        is_non_block: bool,
+        ecx: &mut MiriInterpCx<'tcx>,
+        finish: DynMachineCallback<'tcx, Result<usize, IoError>>,
+    ) -> InterpResult<'tcx> {
+        if is_peek {
+            throw_unsup_format!("socketpair: virtual sockets don't support peeking")
+        }
+
+        ecx.virtual_socket_read(self, ptr, len, is_non_block, finish)
+    }
+}
 
 impl<'tcx> EvalContextPrivExt<'tcx> for crate::MiriInterpCx<'tcx> {}
 trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     /// Attempt two write `len` bytes from the buffer pointed to by `ptr` into the
-    /// virtual socket `socket`. After a successful write, `finish` is called with
-    /// the amount of bytes written.
+    /// virtual socket `socket`.
+    /// `is_non_block` specifies whether the operation should be performed as if the
+    /// socket was non-blocking.
+    /// After a successful write, `finish` is called with the amount of bytes written.
     fn virtual_socket_write(
         &mut self,
         socket: FileDescriptionRef<VirtualSocket>,
         ptr: Pointer,
         len: usize,
+        is_non_block: bool,
         finish: DynMachineCallback<'tcx, Result<usize, IoError>>,
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
@@ -286,7 +376,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let available_space =
             MAX_SOCKETPAIR_BUFFER_CAPACITY.strict_sub(writebuf.borrow().buf.len());
         if available_space == 0 {
-            if socket.is_nonblock.get() {
+            if socket.is_nonblock.get() || is_non_block {
                 // Non-blocking socketpair with a full buffer.
                 return finish.call(this, Err(ErrorKind::WouldBlock.into()));
             } else {
@@ -302,6 +392,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                             weak_socket: WeakFileDescriptionRef<VirtualSocket>,
                             ptr: Pointer,
                             len: usize,
+                            is_non_block: bool,
                             finish: DynMachineCallback<'tcx, Result<usize, IoError>>,
                         }
                         |this, unblock: UnblockKind| {
@@ -309,7 +400,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                             // If we got unblocked, then our peer successfully upgraded its weak
                             // ref to us. That means we can also upgrade our weak ref.
                             let socket = weak_socket.upgrade().unwrap();
-                            this.virtual_socket_write(socket, ptr, len, finish)
+                            this.virtual_socket_write(socket, ptr, len, is_non_block, finish)
                         }
                     ),
                 );
@@ -348,13 +439,16 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     }
 
     /// Attempt to read `len` bytes from the virtual socket `socket` into the buffer
-    /// pointed to by `ptr`. After a successful read, `finish` is called with the
-    /// amount of bytes read.
+    /// pointed to by `ptr`.
+    /// `is_non_block` specifies whether the operation should be performed as if the
+    /// socket was non-blocking.
+    /// After a successful read, `finish` is called with the amount of bytes read.
     fn virtual_socket_read(
         &mut self,
         socket: FileDescriptionRef<VirtualSocket>,
         ptr: Pointer,
         len: usize,
+        is_non_block: bool,
         finish: DynMachineCallback<'tcx, Result<usize, IoError>>,
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
@@ -375,7 +469,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // Socketpair with no peer and empty buffer.
                 // 0 bytes successfully read indicates end-of-file.
                 return finish.call(this, Ok(0));
-            } else if socket.is_nonblock.get() {
+            } else if socket.is_nonblock.get() || is_non_block {
                 // Non-blocking socketpair with writer and empty buffer.
                 // https://linux.die.net/man/2/read
                 // EAGAIN or EWOULDBLOCK can be returned for socket,
@@ -395,6 +489,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                             weak_socket: WeakFileDescriptionRef<VirtualSocket>,
                             ptr: Pointer,
                             len: usize,
+                            is_non_block: bool,
                             finish: DynMachineCallback<'tcx, Result<usize, IoError>>,
                         }
                         |this, unblock: UnblockKind| {
@@ -402,7 +497,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                             // If we got unblocked, then our peer successfully upgraded its weak
                             // ref to us. That means we can also upgrade our weak ref.
                             let socket = weak_socket.upgrade().unwrap();
-                            this.virtual_socket_read(socket, ptr, len, finish)
+                            this.virtual_socket_read(socket, ptr, len, is_non_block, finish)
                         }
                     ),
                 );
@@ -475,8 +570,12 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
         // Interpret the flag. Every flag we recognize is "subtracted" from `flags`, so
         // if there is anything left at the end, that's an unsupported flag.
-        if matches!(this.tcx.sess.target.os, Os::Linux | Os::Android) {
-            // SOCK_NONBLOCK only exists on Linux.
+        if matches!(
+            this.tcx.sess.target.os,
+            Os::Linux | Os::Android | Os::FreeBsd | Os::Solaris | Os::Illumos
+        ) {
+            // SOCK_NONBLOCK and SOCK_CLOEXEC only exist on Linux, Android, FreeBSD,
+            // Solaris, and Illumos targets.
             let sock_nonblock = this.eval_libc_i32("SOCK_NONBLOCK");
             let sock_cloexec = this.eval_libc_i32("SOCK_CLOEXEC");
             if flags & sock_nonblock == sock_nonblock {

--- a/tests/pass-dep/libc/libc-pipe.rs
+++ b/tests/pass-dep/libc/libc-pipe.rs
@@ -24,6 +24,7 @@ fn main() {
     test_pipe2();
     test_pipe_setfl_getfl();
     test_pipe_fcntl_threaded();
+    test_send_recv();
 }
 
 fn test_pipe() {
@@ -197,4 +198,26 @@ fn test_pipe_fcntl_threaded() {
     let buf = read_exact_array::<5>(fds[0]).unwrap();
     thread1.join().unwrap();
     assert_eq!(&buf, b"abcde");
+}
+
+/// `send` and `recv` should fail on pipes as they are not sockets.
+/// Since pipes are implemented using virtual sockets in Miri, we test
+/// that those operations correctly fail.
+fn test_send_recv() {
+    let mut fds = [-1, -1];
+    errno_check(unsafe { libc::pipe(fds.as_mut_ptr()) });
+
+    let mut buffer = [1u8; 16];
+
+    let err = unsafe {
+        errno_result(libc::send(fds[0], buffer.as_mut_ptr().cast(), buffer.len(), 0)).unwrap_err()
+    };
+    // `send` should fail because the pipe isn't a socket.
+    assert_eq!(err.raw_os_error(), Some(libc::ENOTSOCK));
+
+    let err = unsafe {
+        errno_result(libc::recv(fds[0], buffer.as_mut_ptr().cast(), buffer.len(), 0)).unwrap_err()
+    };
+    // `recv` should fail because the pipe isn't a socket.
+    assert_eq!(err.raw_os_error(), Some(libc::ENOTSOCK));
 }

--- a/tests/pass-dep/libc/libc-socketpair-no-blocking.rs
+++ b/tests/pass-dep/libc/libc-socketpair-no-blocking.rs
@@ -1,0 +1,414 @@
+//@ignore-target: windows # No libc socketpair on Windows
+//@run-native
+
+#[path = "../../utils/libc.rs"]
+mod libc_utils;
+
+use std::io::ErrorKind;
+use std::thread;
+use std::time::Duration;
+
+use libc_utils::*;
+
+const TEST_BYTES: &[u8] = b"these are some test bytes!";
+
+fn main() {
+    test_fcntl_nonblock_opt();
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "solaris",
+        target_os = "illumos"
+    ))]
+    test_sock_nonblock_opt();
+    #[cfg(not(any(target_os = "solaris", target_os = "illumos")))]
+    test_ioctl_fionbio_op();
+
+    test_send_recv_nonblock();
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "solaris",
+        target_os = "illumos"
+    ))]
+    test_send_recv_dontwait();
+    test_write_read_nonblock();
+}
+
+/// Test that setting the O_NONBLOCK flag changes the blocking state of a socket
+/// from a socket pair.
+fn test_fcntl_nonblock_opt() {
+    let mut fds = [-1, -1];
+    errno_check(unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) });
+
+    // Initially, both sides should have O_RDWR and nothing else.
+    assert_eq!(errno_result(unsafe { libc::fcntl(fds[0], libc::F_GETFL) }).unwrap(), libc::O_RDWR);
+    assert_eq!(errno_result(unsafe { libc::fcntl(fds[1], libc::F_GETFL) }).unwrap(), libc::O_RDWR);
+
+    // Change socket to be non-blocking.
+    unsafe { errno_check(libc::fcntl(fds[0], libc::F_SETFL, libc::O_NONBLOCK)) };
+
+    let flags_sock1 = unsafe { errno_result(libc::fcntl(fds[0], libc::F_GETFL, 0)).unwrap() };
+    let flags_sock2 = unsafe { errno_result(libc::fcntl(fds[1], libc::F_GETFL, 0)).unwrap() };
+    // Ensure that the socket is really non-blocking.
+    assert_eq!(flags_sock1 & libc::O_NONBLOCK, libc::O_NONBLOCK);
+    // Ensure that the other socket is still blocking.
+    assert_eq!(flags_sock2 & libc::O_NONBLOCK, 0);
+
+    // Change socket back to be blocking.
+    unsafe { errno_check(libc::fcntl(fds[0], libc::F_SETFL, 0)) };
+
+    let flags = unsafe { errno_result(libc::fcntl(fds[0], libc::F_GETFL, 0)).unwrap() };
+    // Ensure that the socket is really blocking.
+    assert_eq!(flags & libc::O_NONBLOCK, 0);
+}
+
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "solaris",
+    target_os = "illumos"
+))]
+/// Test creating a pair of non-blocking sockets by using the SOCK_NONBLOCK option
+/// for the `socketpair` syscall.
+fn test_sock_nonblock_opt() {
+    let mut fds = [-1, -1];
+    errno_check(unsafe {
+        libc::socketpair(
+            libc::AF_UNIX,
+            libc::SOCK_STREAM | libc::SOCK_NONBLOCK,
+            0,
+            fds.as_mut_ptr(),
+        )
+    });
+
+    let flags_sock1 = unsafe { errno_result(libc::fcntl(fds[0], libc::F_GETFL, 0)).unwrap() };
+    let flags_sock2 = unsafe { errno_result(libc::fcntl(fds[1], libc::F_GETFL, 0)).unwrap() };
+    // Ensure that both sockets are really non-blocking.
+    assert_eq!(flags_sock1 & libc::O_NONBLOCK, libc::O_NONBLOCK);
+    assert_eq!(flags_sock2 & libc::O_NONBLOCK, libc::O_NONBLOCK);
+}
+
+#[cfg(not(any(target_os = "solaris", target_os = "illumos")))]
+/// Test changing the blocking state of a socket from a socket pair using the
+/// `ioctl(fd, FIONBIO, ...)` syscall.
+fn test_ioctl_fionbio_op() {
+    let mut fds = [-1, -1];
+    errno_check(unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) });
+
+    unsafe {
+        // Change socket to be non-blocking.
+        let mut value = 1 as libc::c_int;
+        errno_check(libc::ioctl(fds[0], libc::FIONBIO, &mut value));
+    }
+
+    let flags_sock1 = unsafe { errno_result(libc::fcntl(fds[0], libc::F_GETFL, 0)).unwrap() };
+    let flags_sock2 = unsafe { errno_result(libc::fcntl(fds[1], libc::F_GETFL, 0)).unwrap() };
+    // Ensure that the socket is really non-blocking.
+    assert_eq!(flags_sock1 & libc::O_NONBLOCK, libc::O_NONBLOCK);
+    // Ensure that the other socket is still blocking.
+    assert_eq!(flags_sock2 & libc::O_NONBLOCK, 0);
+
+    unsafe {
+        // Change socket back to be blocking.
+        let mut value = 0 as libc::c_int;
+        errno_check(libc::ioctl(fds[0], libc::FIONBIO, &mut value));
+    }
+
+    let flags = unsafe { errno_result(libc::fcntl(fds[0], libc::F_GETFL, 0)).unwrap() };
+    // Ensure that the socket is really blocking.
+    assert_eq!(flags & libc::O_NONBLOCK, 0);
+}
+
+/// Test sending bytes into and receiving bytes from a connected stream without blocking.
+fn test_send_recv_nonblock() {
+    let mut fds = [-1, -1];
+    errno_check(unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) });
+    let sock1fd = fds[0]; // our client socket.
+    let sock2fd = fds[1]; // our peer socket on the "server" which is connected to the client socket.
+
+    // Change client socket to be non-blocking.
+    unsafe { errno_check(libc::fcntl(sock1fd, libc::F_SETFL, libc::O_NONBLOCK)) };
+
+    // Spawn the "server" thread. The main thread is the "client" thread.
+    let server_thread = thread::spawn(move || {
+        // `sock2fd` is a blocking socket now. But that's okay, the client still does non-blocking
+        // reads/writes.
+
+        // Yield back to client so that it starts receiving before we start sending.
+        thread::sleep(Duration::from_millis(10));
+
+        unsafe {
+            libc_utils::write_all_generic(
+                TEST_BYTES.as_ptr().cast(),
+                TEST_BYTES.len(),
+                libc_utils::NoRetry,
+                |buf, count| libc::send(sock2fd, buf, count, 0),
+            )
+            .unwrap()
+        };
+
+        // The buffer should contain `TEST_BYTES` at the beginning.
+        // This will block until the client sent us this data.
+        let mut buffer = [0; TEST_BYTES.len()];
+        unsafe {
+            libc_utils::read_exact_generic(
+                buffer.as_mut_ptr().cast(),
+                buffer.len(),
+                libc_utils::NoRetry,
+                |buf, count| libc::recv(sock2fd, buf, count, 0),
+            )
+            .unwrap()
+        };
+        assert_eq!(&buffer, TEST_BYTES);
+    });
+
+    let mut buffer = [0; TEST_BYTES.len()];
+    // Receiving from a socket when the peer is not writing is
+    // not possible without blocking.
+    let err = unsafe {
+        errno_result(libc::recv(sock1fd, buffer.as_mut_ptr().cast(), buffer.len(), 0)).unwrap_err()
+    };
+    assert_eq!(err.kind(), ErrorKind::WouldBlock);
+
+    // Try to receive bytes from the peer socket without blocking.
+    // Since the peer socket might do partial writes, we might need to
+    // sleep multiple times until we received everything.
+
+    unsafe {
+        libc_utils::read_exact_generic(
+            buffer.as_mut_ptr().cast(),
+            buffer.len(),
+            libc_utils::RetryAfter(Duration::from_millis(10)),
+            |buf, count| libc::recv(sock1fd, buf, count, 0),
+        )
+        .unwrap()
+    };
+    assert_eq!(&buffer, TEST_BYTES);
+
+    // Test non-blocking writing.
+
+    // Sending into the empty buffer should succeed without blocking.
+    unsafe {
+        libc_utils::write_all_generic(
+            TEST_BYTES.as_ptr().cast(),
+            TEST_BYTES.len(),
+            libc_utils::NoRetry,
+            |buf, count| libc::send(sock1fd, buf, count, 0),
+        )
+        .unwrap()
+    };
+
+    let fill_buf = [1u8; 32_000];
+    // Keep sending data until the buffer is full and we would block.
+    loop {
+        let result = unsafe {
+            libc_utils::write_all_generic(
+                fill_buf.as_ptr().cast(),
+                fill_buf.len(),
+                libc_utils::NoRetry,
+                |buf, count| libc::send(sock1fd, buf, count, 0),
+            )
+        };
+
+        match result {
+            Ok(_) => { /* continue to fill buffer */ }
+            Err(err) if err.kind() == ErrorKind::WouldBlock => break,
+            Err(err) => panic!("unexpected error whilst filling up buffer: {err}"),
+        }
+    }
+
+    server_thread.join().unwrap();
+}
+
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "solaris",
+    target_os = "illumos"
+))]
+/// Test sending bytes into and receiving bytes from a par of stream sockets without blocking.
+/// Instead of using non-blocking sockets, we test whether it works with blocking sockets
+/// when passing the `libc::MSG_DONTWAIT` flag to the send and receive calls.
+fn test_send_recv_dontwait() {
+    let mut fds = [-1, -1];
+    errno_check(unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) });
+    let sock1fd = fds[0]; // our client socket.
+    let sock2fd = fds[1]; // our peer socket on the "server" which is connected to the client socket.
+
+    // Spawn the "server" thread. The main thread is the "client" thread.
+    let server_thread = thread::spawn(move || {
+        // Similar to above we use blocking operations on the server side.
+
+        // Yield back to client so that it starts receiving before we start sending.
+        thread::sleep(Duration::from_millis(10));
+
+        unsafe {
+            libc_utils::write_all_generic(
+                TEST_BYTES.as_ptr().cast(),
+                TEST_BYTES.len(),
+                libc_utils::NoRetry,
+                |buf, count| libc::send(sock2fd, buf, count, 0),
+            )
+            .unwrap()
+        };
+
+        // The buffer should contain `TEST_BYTES` at the beginning.
+        // This will block until the client sent us this data.
+        let mut buffer = [0; TEST_BYTES.len()];
+        unsafe {
+            libc_utils::read_exact_generic(
+                buffer.as_mut_ptr().cast(),
+                buffer.len(),
+                libc_utils::NoRetry,
+                |buf, count| libc::recv(sock2fd, buf, count, 0),
+            )
+            .unwrap()
+        };
+        assert_eq!(&buffer, TEST_BYTES);
+    });
+
+    let mut buffer = [0; TEST_BYTES.len()];
+    // Receiving from a socket when the peer is not writing is
+    // not possible without blocking.
+    let err = unsafe {
+        errno_result(libc::recv(
+            sock1fd,
+            buffer.as_mut_ptr().cast(),
+            buffer.len(),
+            libc::MSG_DONTWAIT,
+        ))
+        .unwrap_err()
+    };
+    assert_eq!(err.kind(), ErrorKind::WouldBlock);
+
+    // Try to receive bytes from the peer socket without blocking.
+    // Since the peer socket might do partial writes, we might need to
+    // sleep multiple times until we received everything.
+
+    unsafe {
+        libc_utils::read_exact_generic(
+            buffer.as_mut_ptr().cast(),
+            buffer.len(),
+            libc_utils::RetryAfter(Duration::from_millis(10)),
+            |buf, count| libc::recv(sock1fd, buf, count, libc::MSG_DONTWAIT),
+        )
+        .unwrap()
+    };
+    assert_eq!(&buffer, TEST_BYTES);
+
+    // Test non-blocking writing.
+
+    // Sending into the empty buffer should succeed without blocking.
+    unsafe {
+        libc_utils::write_all_generic(
+            TEST_BYTES.as_ptr().cast(),
+            TEST_BYTES.len(),
+            libc_utils::NoRetry,
+            |buf, count| libc::send(sock1fd, buf, count, libc::MSG_DONTWAIT),
+        )
+        .unwrap()
+    };
+
+    let fill_buf = [1u8; 32_000];
+    // Keep sending data until the buffer is full and we would block.
+    loop {
+        let result = unsafe {
+            libc_utils::write_all_generic(
+                fill_buf.as_ptr().cast(),
+                fill_buf.len(),
+                libc_utils::NoRetry,
+                |buf, count| libc::send(sock1fd, buf, count, libc::MSG_DONTWAIT),
+            )
+        };
+
+        match result {
+            Ok(_) => { /* continue to fill buffer */ }
+            Err(err) if err.kind() == ErrorKind::WouldBlock => break,
+            Err(err) => panic!("unexpected error whilst filling up buffer: {err}"),
+        }
+    }
+
+    server_thread.join().unwrap();
+}
+
+/// Test writing bytes into and reading bytes from a stream socket pair without blocking.
+fn test_write_read_nonblock() {
+    let mut fds = [-1, -1];
+    errno_check(unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) });
+    let sock1fd = fds[0]; // our client socket.
+    let sock2fd = fds[1]; // our peer socket on the "server" which is connected to the client socket.
+
+    // Change client socket to be non-blocking.
+    unsafe { errno_check(libc::fcntl(sock1fd, libc::F_SETFL, libc::O_NONBLOCK)) };
+
+    // Spawn the "server" thread. The main thread is the "client" thread.
+    let server_thread = thread::spawn(move || {
+        // Similar to above we use blocking operations on the server side.
+
+        // Yield back to client so that it starts receiving before we start sending.
+        thread::sleep(Duration::from_millis(10));
+
+        libc_utils::write_all(sock2fd, TEST_BYTES).unwrap();
+
+        // The buffer should contain `TEST_BYTES` at the beginning.
+        // This will block until the client sent us this data.
+        let mut buffer = [0; TEST_BYTES.len()];
+        libc_utils::read_exact(sock2fd, &mut buffer).unwrap();
+        assert_eq!(&buffer, TEST_BYTES);
+    });
+
+    let mut buffer = [0; TEST_BYTES.len()];
+    // Reading from a socket when the peer is not writing is
+    // not possible without blocking.
+    let err = unsafe {
+        errno_result(libc::read(sock1fd, buffer.as_mut_ptr() as *mut libc::c_void, buffer.len()))
+            .unwrap_err()
+    };
+    assert_eq!(err.kind(), ErrorKind::WouldBlock);
+
+    // Try to read bytes from the peer socket without blocking.
+    // Since the peer socket might do partial writes, we might need to
+    // sleep multiple times until we read everything.
+
+    unsafe {
+        libc_utils::read_exact_generic(
+            buffer.as_mut_ptr().cast(),
+            buffer.len(),
+            libc_utils::RetryAfter(Duration::from_millis(10)),
+            |buf, count| libc::read(sock1fd, buf, count),
+        )
+        .unwrap()
+    };
+    assert_eq!(&buffer, TEST_BYTES);
+
+    // Now we test non-blocking writing.
+
+    // Writing into the empty buffer should succeed without blocking.
+    libc_utils::write_all(sock1fd, TEST_BYTES).unwrap();
+
+    let fill_buf = [1u8; 32_000];
+    // Keep sending data until the buffer is full and we would block.
+    loop {
+        let result = unsafe {
+            libc_utils::write_all_generic(
+                fill_buf.as_ptr().cast(),
+                fill_buf.len(),
+                libc_utils::NoRetry,
+                |buf, count| libc::write(sock1fd, buf, count),
+            )
+        };
+
+        match result {
+            Ok(_) => { /* continue to fill buffer */ }
+            Err(err) if err.kind() == ErrorKind::WouldBlock => break,
+            Err(err) => panic!("unexpected error whilst filling up buffer: {err}"),
+        }
+    }
+
+    server_thread.join().unwrap();
+}

--- a/tests/pass-dep/libc/libc-socketpair.rs
+++ b/tests/pass-dep/libc/libc-socketpair.rs
@@ -18,7 +18,6 @@ fn main() {
     test_race();
     test_blocking_read();
     test_blocking_write();
-    test_socketpair_setfl_getfl();
 }
 
 fn test_socketpair() {
@@ -30,6 +29,30 @@ fn test_socketpair() {
     write_all(fds[0], data).unwrap();
     let buf = read_exact_array::<5>(fds[1]).unwrap();
     assert_eq!(&buf, data);
+
+    // Test reading and writing using `send` and `recv` instead of
+    // `write` and `read`.
+    let data = b"some data";
+    unsafe {
+        libc_utils::write_all_generic(
+            data.as_ptr().cast(),
+            data.len(),
+            libc_utils::NoRetry,
+            |buf, count| libc::send(fds[1], buf, count, 0),
+        )
+        .unwrap()
+    };
+    let mut buffer = [0u8; 9];
+    unsafe {
+        libc_utils::read_exact_generic(
+            buffer.as_mut_ptr().cast(),
+            buffer.len(),
+            libc_utils::NoRetry,
+            |buf, count| libc::recv(fds[0], buf, count, 0),
+        )
+        .unwrap()
+    };
+    assert_eq!(&buffer, data);
 
     // Read size > data available in buffer.
     let data = b"abc";
@@ -154,31 +177,4 @@ fn test_blocking_write() {
     });
     thread1.join().unwrap();
     thread2.join().unwrap();
-}
-
-/// Basic test for socketpair fcntl's F_SETFL and F_GETFL flag.
-fn test_socketpair_setfl_getfl() {
-    // Initialise socketpair fds.
-    let mut fds = [-1, -1];
-    errno_check(unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) });
-
-    // Test if both sides have O_RDWR.
-    assert_eq!(errno_result(unsafe { libc::fcntl(fds[0], libc::F_GETFL) }).unwrap(), libc::O_RDWR);
-    assert_eq!(errno_result(unsafe { libc::fcntl(fds[1], libc::F_GETFL) }).unwrap(), libc::O_RDWR);
-
-    // Add the O_NONBLOCK flag with F_SETFL.
-    errno_check(unsafe { libc::fcntl(fds[0], libc::F_SETFL, libc::O_NONBLOCK) });
-
-    // Test if the O_NONBLOCK flag is successfully added.
-    assert_eq!(
-        errno_result(unsafe { libc::fcntl(fds[0], libc::F_GETFL) }).unwrap(),
-        libc::O_RDWR | libc::O_NONBLOCK
-    );
-
-    // The other side remains unchanged.
-    assert_eq!(errno_result(unsafe { libc::fcntl(fds[1], libc::F_GETFL) }).unwrap(), libc::O_RDWR);
-
-    // Test if O_NONBLOCK flag can be unset.
-    errno_check(unsafe { libc::fcntl(fds[0], libc::F_SETFL, 0) });
-    assert_eq!(errno_result(unsafe { libc::fcntl(fds[0], libc::F_GETFL) }).unwrap(), libc::O_RDWR);
 }

--- a/tests/pass/shims/unix-socket.rs
+++ b/tests/pass/shims/unix-socket.rs
@@ -1,0 +1,34 @@
+//@ignore-target: windows
+
+use std::io::{ErrorKind, Read, Write};
+use std::os::unix::net::UnixStream;
+
+const TEST_BYTES: &[u8] = b"these are some test bytes!";
+
+fn main() {
+    test_send_recv();
+    test_change_blocking_mode();
+}
+
+/// Test sending and receiving data on a pair of sockets.
+fn test_send_recv() {
+    let (mut sock1, mut sock2) = UnixStream::pair().unwrap();
+    sock1.write_all(TEST_BYTES).unwrap();
+    drop(sock1); // close it so that the other side gets an EOF.
+
+    let mut response = String::new();
+    sock2.read_to_string(&mut response).unwrap();
+    assert_eq!(response.as_bytes(), TEST_BYTES);
+}
+
+/// Test changing the blocking mode of a socket from a socket pair.
+fn test_change_blocking_mode() {
+    let (mut sock1, _sock2) = UnixStream::pair().unwrap();
+    // Change the blocking mode of one of the sockets.
+    sock1.set_nonblocking(true).unwrap();
+
+    let mut buffer = [0u8; 1];
+    // Reading from the socket should block because the peer didn't write anything.
+    let err = sock1.read(&mut buffer).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::WouldBlock);
+}


### PR DESCRIPTION
This pull request adds a basic implementation for `recv` and `send` from `UnixSocketFileDescription` for the virtual socket shim.
Additionally, it also adds support for non-blocking read/write operations to virtual sockets.

I didn't add support for peeking as this isn't as straightforward with `VecDeque`s as I had hoped it was. We would need to manually use `copy_from_slice` on the front slice returned from `as_slices`. Instead, I'm considering opening a PR on the standard library to add a peek implementation there -- however, I'm not sure whether this is enough of an use-cse to be part of the standard library. 

Also, is there a reason why the buffer is implemented using a `VecDeque` instead of just using a `Vec`? I couldn't find where the queue property was needed.

Close rust-lang/miri#4958