### PR TITLE
[Priroda] Add runtime local state classification

### DIFF
--- a/priroda/src/main.rs
+++ b/priroda/src/main.rs
@@ -375,8 +375,65 @@ impl<'tcx> PrirodaContext<'tcx> {
             DebuggerCommand::Breakpoint(path, line) =>
                 interp_ok(CommandResult::BreakpointResult(self.set_breakpoint(path, line))),
             DebuggerCommand::ListLocals => interp_ok(CommandResult::Locals(self.list_locals())),
+            DebuggerCommand::Print(local) =>
+                interp_ok(CommandResult::SingleLocal(self.get_local(local))),
             DebuggerCommand::TerminateSession => interp_ok(CommandResult::TerminateSession),
         }
+    }
+
+    fn get_local(&self, local: usize) -> Option<LocalDesc> {
+        let Some(frame) = self.ecx.active_thread_stack().last() else {
+            return None;
+        };
+
+        let local = mir::Local::from_usize(local);
+        let Some(local_decl) = &frame.body().local_decls.get(local) else {
+            return None;
+        };
+
+        // Create LocalDesc for MIR local before processing debug info.
+        // Later debug-derived descriptions will be pushed back to LocalDesc list.
+        let mut local_desc = LocalDesc {
+            source_name: None,
+            source_projection: None,
+            local: Some(local),
+            storage_projection: Vec::new(),
+            ty: local_decl.ty.to_string(),
+            // FIXME: projection not handled yet.
+            value: "<unsupported>".to_string(),
+        };
+
+        if let Some(local) = local_desc.local {
+            if local_desc.storage_projection.is_empty() {
+                match &frame.locals[local].as_mplace_or_imm() {
+                    None => {
+                        local_desc.value = "<dead>".to_string();
+                    }
+                    Some(Either::Left(_)) => {
+                        local_desc.value = "<indirect>".to_string();
+                    }
+                    Some(Either::Right(imm)) => {
+                        match imm {
+                            Scalar(_) => {
+                                local_desc.value = "<immediate>".to_string();
+                            }
+                            ScalarPair(_, _) => {
+                                local_desc.value = "<immediate-pair>".to_string();
+                            }
+
+                            Uninit => {
+                                local_desc.value = "<uninit>".to_string();
+                            }
+                        };
+                    }
+                };
+            } else {
+                // FIXME: projection not handled yet.
+                local_desc.value = "<unsupported-projection>".to_string();
+            }
+        }
+
+        Some(local_desc)
     }
 
     /// Returns structured descriptions for locals in the innermost stack frame.
@@ -580,6 +637,7 @@ enum DebuggerCommand {
     Continue,
     Breakpoint(PathBuf, usize),
     ListLocals,
+    Print(usize),
 }
 
 enum BreakpointSetResult {
@@ -592,6 +650,7 @@ enum CommandResult {
     ExecutionStopped(StepResult),
     BreakpointResult(BreakpointSetResult),
     Locals(Vec<LocalDesc>),
+    SingleLocal(Option<LocalDesc>),
     // FIXME: distinguish terminating the debugger session from disconnecting a
     // frontend and terminating the interpreted program once multiple frontends exist.
     TerminateSession,
@@ -668,6 +727,18 @@ impl Cli {
                                 );
                             }
                         },
+                    CommandResult::SingleLocal(local_desc) =>
+                        match local_desc {
+                            Some(local_desc) => {
+                                println!(
+                                    "Id: _{}, Ty: {}, Value: {}",
+                                    local_desc.local.unwrap().index(),
+                                    local_desc.ty,
+                                    local_desc.value
+                                );
+                            }
+                            None => println!("no local for this id"),
+                        },
                     CommandResult::TerminateSession => {
                         println!("quitting");
                         return interp_ok(());
@@ -699,6 +770,7 @@ impl Cli {
             "c" | "continue" => Some(DebuggerCommand::Continue),
             "b" | "break" => self.parse_breakpoint(args),
             "l" | "locals" => Some(DebuggerCommand::ListLocals),
+            "p" | "print" => self.parse_print_local(args),
             _ => None,
         }
     }
@@ -725,5 +797,10 @@ impl Cli {
         let line = line.parse().ok()?;
 
         Some(DebuggerCommand::Breakpoint(PathBuf::from(path), line))
+    }
+
+    fn parse_print_local(&self, input: &str) -> Option<DebuggerCommand> {
+        let local = input.parse().ok()?;
+        Some(DebuggerCommand::Print(local))
     }
 }

--- a/priroda/src/main.rs
+++ b/priroda/src/main.rs
@@ -382,64 +382,15 @@ impl<'tcx> PrirodaContext<'tcx> {
     }
 
     fn get_local(&self, local: usize) -> Option<LocalDesc> {
-        let Some(frame) = self.ecx.active_thread_stack().last() else {
-            return None;
-        };
+        let frame = self.ecx.active_thread_stack().last()?;
 
-        let local = mir::Local::from_usize(local);
-        let Some(local_decl) = &frame.body().local_decls.get(local) else {
-            return None;
-        };
-
-        // Create LocalDesc for MIR local before processing debug info.
-        // Later debug-derived descriptions will be pushed back to LocalDesc list.
-        let mut local_desc = LocalDesc {
-            source_name: None,
-            source_projection: None,
-            local: Some(local),
-            storage_projection: Vec::new(),
-            ty: local_decl.ty.to_string(),
-            // FIXME: projection not handled yet.
-            value: "<unsupported>".to_string(),
-        };
-
-        if let Some(local) = local_desc.local {
-            if local_desc.storage_projection.is_empty() {
-                match &frame.locals[local].as_mplace_or_imm() {
-                    None => {
-                        local_desc.value = "<dead>".to_string();
-                    }
-                    Some(Either::Left(_)) => {
-                        local_desc.value = "<indirect>".to_string();
-                    }
-                    Some(Either::Right(imm)) => {
-                        match imm {
-                            Scalar(_) => {
-                                local_desc.value = "<immediate>".to_string();
-                            }
-                            ScalarPair(_, _) => {
-                                local_desc.value = "<immediate-pair>".to_string();
-                            }
-
-                            Uninit => {
-                                local_desc.value = "<uninit>".to_string();
-                            }
-                        };
-                    }
-                };
-            } else {
-                // FIXME: projection not handled yet.
-                local_desc.value = "<unsupported-projection>".to_string();
-            }
-        }
-
-        Some(local_desc)
+        self.make_mir_local_desc(frame, local)
     }
 
     /// Returns structured descriptions for locals in the innermost stack frame.
     ///
-    /// Starts from all MIR locals, enriches whole-local debug entries in place,
-    /// and appends extra rows for projected debug-info storage.
+    /// Starts from all MIR locals, then enriches them with source names from
+    /// `var_debug_info` when a debug entry maps directly to a whole local.
     fn list_locals(&self) -> Vec<LocalDesc> {
         let Some(frame) = self.ecx.active_thread_stack().last() else {
             return Vec::new();
@@ -452,7 +403,7 @@ impl<'tcx> PrirodaContext<'tcx> {
     fn render_source_projection(
         fragment: Option<&VarDebugInfoFragment<'tcx>>,
     ) -> Option<Vec<Symbol>> {
-        let Some(VarDebugInfoFragment { ty, projection }) = fragment else { return None };
+        let VarDebugInfoFragment { ty, projection } = fragment?;
 
         // Walk the source-side projection from the original
         // composite variable type. Each `Field` element stores the
@@ -460,7 +411,7 @@ impl<'tcx> PrirodaContext<'tcx> {
         // current base type before advancing to `field_ty`.
         let mut projection_ty = ty;
 
-        let source_projection = Some(
+        Some(
             projection
                 .iter()
                 .map(|elem| {
@@ -491,13 +442,12 @@ impl<'tcx> PrirodaContext<'tcx> {
                     }
                 })
                 .collect(),
-        );
-        source_projection
+        )
     }
 
     /// Render the MIR storage-side path that backs a debug-info local.
     fn render_storage_projection(projection: &[mir::PlaceElem<'tcx>]) -> Vec<StorageProj> {
-        let storage_proj = projection
+        projection
             .iter()
             .map(|projection_elem| {
                 match projection_elem {
@@ -509,8 +459,53 @@ impl<'tcx> PrirodaContext<'tcx> {
                     other => StorageProj::Unsupported(format!("{other:?}")),
                 }
             })
-            .collect();
-        storage_proj
+            .collect()
+    }
+
+    /// Builds the baseline debugger row for one MIR local without scanning debug info.
+    fn make_mir_local_desc(
+        &self,
+        frame: &Frame<'tcx, Provenance, FrameExtra<'tcx>>,
+        local: usize,
+    ) -> Option<LocalDesc> {
+        let local = mir::Local::from_usize(local);
+        let local_decl = frame.body().local_decls.get(local)?;
+
+        // Create LocalDesc for MIR local before processing debug info.
+        // Debug-info enrichment is layered on by build_local_descs.
+        let mut local_desc = LocalDesc {
+            source_name: None,
+            source_projection: None,
+            local: Some(local),
+            storage_projection: Vec::new(),
+            ty: local_decl.ty.to_string(),
+            value: "<unsupported>".to_string(),
+        };
+
+        match &frame.locals[local].as_mplace_or_imm() {
+            None => {
+                local_desc.value = "<dead>".to_string();
+            }
+            Some(Either::Left(_)) => {
+                local_desc.value = "<indirect>".to_string();
+            }
+            Some(Either::Right(imm)) => {
+                match imm {
+                    Scalar(_) => {
+                        local_desc.value = "<immediate>".to_string();
+                    }
+                    ScalarPair(_, _) => {
+                        local_desc.value = "<immediate-pair>".to_string();
+                    }
+
+                    Uninit => {
+                        local_desc.value = "<uninit>".to_string();
+                    }
+                };
+            }
+        };
+
+        Some(local_desc)
     }
 
     fn build_local_descs(
@@ -519,20 +514,11 @@ impl<'tcx> PrirodaContext<'tcx> {
     ) -> Vec<LocalDesc> {
         let local_decls = &frame.body().local_decls;
 
-        let mut locals: Vec<LocalDesc> = Vec::with_capacity(local_decls.len());
+        let mut local_descs: Vec<LocalDesc> = Vec::with_capacity(local_decls.len());
 
-        // Create LocalDesc for every MIR local before processing debug info.
-        // Later debug-derived descriptions will be pushed back to LocalDesc list.
-        for (local_idx, local_decl) in local_decls.iter_enumerated() {
-            locals.push(LocalDesc {
-                source_name: None,
-                source_projection: None,
-                local: Some(local_idx),
-                storage_projection: Vec::new(),
-                ty: local_decl.ty.to_string(),
-                // FIXME: projection not handled yet.
-                value: "<unsupported>".to_string(),
-            });
+        // Start with one baseline row for every MIR local, then layer debug info on top.
+        for (local_idx, _) in local_decls.iter_enumerated() {
+            local_descs.push(self.make_mir_local_desc(frame, local_idx.index()).unwrap());
         }
 
         // FIXME: Finish classifying `var_debug_info` by keeping the source path
@@ -570,63 +556,31 @@ impl<'tcx> PrirodaContext<'tcx> {
         for var_debug_info in &frame.body().var_debug_info {
             if let VarDebugInfoContents::Place(place) = &var_debug_info.value {
                 if let Some(local_idx) = place.as_local()
-                    && locals[local_idx.index()].source_name.is_none()
+                    && local_descs[local_idx.index()].source_name.is_none()
                 {
                     let local_idx = local_idx.index();
-                    locals[local_idx].source_projection =
+                    local_descs[local_idx].source_projection =
                         Self::render_source_projection(var_debug_info.composite.as_deref());
-                    locals[local_idx].source_name = Some(var_debug_info.name);
+                    local_descs[local_idx].source_name = Some(var_debug_info.name);
                 } else if !place.projection.is_empty() {
                     let storage_projection = Self::render_storage_projection(place.projection);
                     let source_projection =
                         Self::render_source_projection(var_debug_info.composite.as_deref());
 
-                    locals.push(LocalDesc {
+                    local_descs.push(LocalDesc {
                         source_name: Some(var_debug_info.name),
                         source_projection,
                         local: Some(place.local),
                         storage_projection,
                         ty: place.ty(local_decls, self.ecx.tcx.tcx).ty.to_string(),
                         // FIXME: projection not handled yet.
-                        value: "<unsupported>".to_string(),
+                        value: "<unsupported-projection>".to_string(),
                     });
                 }
             }
         }
 
-        for local_desc in &mut locals {
-            if let Some(local) = local_desc.local {
-                if local_desc.storage_projection.is_empty() {
-                    match &frame.locals[local].as_mplace_or_imm() {
-                        None => {
-                            local_desc.value = "<dead>".to_string();
-                        }
-                        Some(Either::Left(_)) => {
-                            local_desc.value = "<indirect>".to_string();
-                        }
-                        Some(Either::Right(imm)) => {
-                            match imm {
-                                Scalar(_) => {
-                                    local_desc.value = "<immediate>".to_string();
-                                }
-                                ScalarPair(_, _) => {
-                                    local_desc.value = "<immediate-pair>".to_string();
-                                }
-
-                                Uninit => {
-                                    local_desc.value = "<uninit>".to_string();
-                                }
-                            };
-                        }
-                    };
-                } else {
-                    // FIXME: projection not handled yet.
-                    local_desc.value = "<unsupported-projection>".to_string();
-                }
-            }
-        }
-
-        locals
+        local_descs
     }
 }
 

--- a/priroda/src/main.rs
+++ b/priroda/src/main.rs
@@ -18,6 +18,7 @@ use std::collections::{HashMap, HashSet};
 use std::io::{self, Write};
 use std::path::PathBuf;
 
+use miri::Immediate::{Scalar, ScalarPair, Uninit};
 use miri::*;
 use rustc_driver::Compilation;
 use rustc_hir::attrs::CrateType;
@@ -166,6 +167,9 @@ struct LocalDesc {
 
     /// Display-rendered type for this description.
     ty: String,
+
+    /// Run-time state for now; will be expanded later
+    value: String,
 }
 
 /// Controls when execution returns to the frontend.
@@ -469,6 +473,8 @@ impl<'tcx> PrirodaContext<'tcx> {
                 local: Some(local_idx),
                 storage_projection: Vec::new(),
                 ty: local_decl.ty.to_string(),
+                // FIXME: projection not handled yet.
+                value: "<unsupported>".to_string(),
             });
         }
 
@@ -524,7 +530,41 @@ impl<'tcx> PrirodaContext<'tcx> {
                         local: Some(place.local),
                         storage_projection,
                         ty: place.ty(local_decls, self.ecx.tcx.tcx).ty.to_string(),
+                        // FIXME: projection not handled yet.
+                        value: "<unsupported>".to_string(),
                     });
+                }
+            }
+        }
+
+        for local_desc in &mut locals {
+            if let Some(local) = local_desc.local {
+                if local_desc.storage_projection.is_empty() {
+                    match &frame.locals[local].as_mplace_or_imm() {
+                        None => {
+                            local_desc.value = "<dead>".to_string();
+                        }
+                        Some(Either::Left(_)) => {
+                            local_desc.value = "<indirect>".to_string();
+                        }
+                        Some(Either::Right(imm)) => {
+                            match imm {
+                                Scalar(_) => {
+                                    local_desc.value = "<immediate>".to_string();
+                                }
+                                ScalarPair(_, _) => {
+                                    local_desc.value = "<immediate-pair>".to_string();
+                                }
+
+                                Uninit => {
+                                    local_desc.value = "<uninit>".to_string();
+                                }
+                            };
+                        }
+                    };
+                } else {
+                    // FIXME: projection not handled yet.
+                    local_desc.value = "<unsupported-projection>".to_string();
                 }
             }
         }
@@ -623,8 +663,8 @@ impl Cli {
 
                                 let display_local_id = format!("{local_id}{storage_projection}");
                                 println!(
-                                    "Name: {}, Id: {}, Ty: {}",
-                                    display_name, display_local_id, local_desc.ty
+                                    "Name: {}, Id: {}, Ty: {}, Value: {}",
+                                    display_name, display_local_id, local_desc.ty, local_desc.value
                                 );
                             }
                         },

--- a/priroda/tests/ui/locals_access_field.stdin
+++ b/priroda/tests/ui/locals_access_field.stdin
@@ -1,4 +1,10 @@
 break tests/ui/locals_access_field.rs:14
 continue
 locals
+print 0
+print 1
+print 2
+print 3
+print 4
+print 555
 quit

--- a/priroda/tests/ui/locals_access_field.stdout
+++ b/priroda/tests/ui/locals_access_field.stdout
@@ -5,4 +5,10 @@
 Name: extraslice, Id: _1, Ty: ExtraSlice<'_>, Value: <indirect>
 Name: _slice, Id: _2, Ty: &[u8], Value: <immediate-pair>
 Name: _extra, Id: _3, Ty: u32, Value: <immediate>
+(priroda) Id: _0, Ty: (), Value: <uninit>
+(priroda) Id: _1, Ty: ExtraSlice<'_>, Value: <indirect>
+(priroda) Id: _2, Ty: &[u8], Value: <immediate-pair>
+(priroda) Id: _3, Ty: u32, Value: <immediate>
+(priroda) no local for this id
+(priroda) no local for this id
 (priroda) quitting

--- a/priroda/tests/ui/locals_access_field.stdout
+++ b/priroda/tests/ui/locals_access_field.stdout
@@ -1,8 +1,8 @@
 (priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_access_field.rs:14
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_access_field.rs:14
-(priroda) Name: <none>, Id: _0, Ty: ()
-Name: extraslice, Id: _1, Ty: ExtraSlice<'_>
-Name: _slice, Id: _2, Ty: &[u8]
-Name: _extra, Id: _3, Ty: u32
+(priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
+Name: extraslice, Id: _1, Ty: ExtraSlice<'_>, Value: <indirect>
+Name: _slice, Id: _2, Ty: &[u8], Value: <immediate-pair>
+Name: _extra, Id: _3, Ty: u32, Value: <immediate>
 (priroda) quitting

--- a/priroda/tests/ui/locals_corpus_async.stdout
+++ b/priroda/tests/ui/locals_corpus_async.stdout
@@ -6,32 +6,32 @@
 (priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:76
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:31
-(priroda) Name: <none>, Id: _0, Ty: ()
-Name: <none>, Id: _1, Ty: (u32, i32)
-Name: first, Id: _1.0, Ty: u32
-Name: second, Id: _1.1, Ty: i32
+(priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
+Name: <none>, Id: _1, Ty: (u32, i32), Value: <immediate-pair>
+Name: first, Id: _1.0, Ty: u32, Value: <unsupported-projection>
+Name: second, Id: _1.1, Ty: i32, Value: <unsupported-projection>
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:45
-(priroda) Name: <none>, Id: _0, Ty: ()
-Name: <none>, Id: _1, Ty: S
-Name: x, Id: _1.0, Ty: f32
+(priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
+Name: <none>, Id: _1, Ty: S, Value: <immediate>
+Name: x, Id: _1.0, Ty: f32, Value: <unsupported-projection>
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:55
-(priroda) Name: <none>, Id: _0, Ty: ()
-Name: <none>, Id: _1, Ty: std::option::Option<i32>
-Name: inner, Id: _1 as variant#1.0, Ty: i32
+(priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
+Name: <none>, Id: _1, Ty: std::option::Option<i32>, Value: <indirect>
+Name: inner, Id: _1 as variant#1.0, Ty: i32, Value: <unsupported-projection>
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:66
-(priroda) Name: <none>, Id: _0, Ty: ()
-Name: <none>, Id: _1, Ty: std::option::Option<&i32>
-Name: pointer, Id: _1 as variant#1.0, Ty: &i32
-Name: deref, Id: _1 as variant#1.0.*, Ty: i32
+(priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
+Name: <none>, Id: _1, Ty: std::option::Option<&i32>, Value: <indirect>
+Name: pointer, Id: _1 as variant#1.0, Ty: &i32, Value: <unsupported-projection>
+Name: deref, Id: _1 as variant#1.0.*, Ty: i32, Value: <unsupported-projection>
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:20
-(priroda) Name: <none>, Id: _0, Ty: ()
-Name: <none>, Id: _1, Ty: &mut std::option::Option<i32>
-Name: foo, Id: _1.* as variant#1.0, Ty: i32
+(priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
+Name: <none>, Id: _1, Ty: &mut std::option::Option<i32>, Value: <immediate>
+Name: foo, Id: _1.* as variant#1.0, Ty: i32, Value: <unsupported-projection>
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:76
-(priroda) Name: <none>, Id: _0, Ty: ()
+(priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
 (priroda) quitting

--- a/priroda/tests/ui/locals_in_function.stdout
+++ b/priroda/tests/ui/locals_in_function.stdout
@@ -1,10 +1,10 @@
 (priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_in_function.rs:5
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_in_function.rs:5
-(priroda) Name: <none>, Id: _0, Ty: ()
-Name: x, Id: _1, Ty: i32
-Name: y, Id: _2, Ty: bool
-Name: <none>, Id: _3, Ty: (i32, bool)
-Name: <none>, Id: _4, Ty: i32
-Name: <none>, Id: _5, Ty: bool
+(priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
+Name: x, Id: _1, Ty: i32, Value: <immediate>
+Name: y, Id: _2, Ty: bool, Value: <dead>
+Name: <none>, Id: _3, Ty: (i32, bool), Value: <dead>
+Name: <none>, Id: _4, Ty: i32, Value: <dead>
+Name: <none>, Id: _5, Ty: bool, Value: <dead>
 (priroda) quitting

--- a/priroda/tests/ui/locals_nested_field_fragment.stdout
+++ b/priroda/tests/ui/locals_nested_field_fragment.stdout
@@ -1,14 +1,14 @@
 (priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_nested_field_fragment.rs:12
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_nested_field_fragment.rs:12
-(priroda) Name: <none>, Id: _0, Ty: ()
-Name: <none>, Id: _1, Ty: Outer
-Name: <none>, Id: _2, Ty: (Leaf,)
-Name: <none>, Id: _3, Ty: Leaf
-Name: <none>, Id: _4, Ty: (Leaf,)
-Name: <none>, Id: _5, Ty: Leaf
-Name: <none>, Id: _6, Ty: Leaf
-Name: x.inner.0.field, Id: _7, Ty: u8
-Name: <none>, Id: _8, Ty: u8
-Name: <none>, Id: _9, Ty: u8
+(priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
+Name: <none>, Id: _1, Ty: Outer, Value: <uninit>
+Name: <none>, Id: _2, Ty: (Leaf,), Value: <uninit>
+Name: <none>, Id: _3, Ty: Leaf, Value: <uninit>
+Name: <none>, Id: _4, Ty: (Leaf,), Value: <uninit>
+Name: <none>, Id: _5, Ty: Leaf, Value: <uninit>
+Name: <none>, Id: _6, Ty: Leaf, Value: <uninit>
+Name: x.inner.0.field, Id: _7, Ty: u8, Value: <dead>
+Name: <none>, Id: _8, Ty: u8, Value: <dead>
+Name: <none>, Id: _9, Ty: u8, Value: <dead>
 (priroda) quitting

--- a/priroda/tests/ui/locals_sroa.stdout
+++ b/priroda/tests/ui/locals_sroa.stdout
@@ -1,13 +1,13 @@
 (priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_sroa.rs:13
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_sroa.rs:13
-(priroda) Name: <none>, Id: _0, Ty: ()
-Name: s, Id: _1, Ty: &[u8]
-Name: <none>, Id: _2, Ty: ExtraSlice<'_>
-Name: <none>, Id: _3, Ty: &[u8]
-Name: <none>, Id: _4, Ty: u32
-Name: <none>, Id: _5, Ty: usize
-Name: <none>, Id: _6, Ty: &[u8]
-Name: _slice._slice, Id: _7, Ty: &[u8]
-Name: _slice._extra, Id: _8, Ty: u32
+(priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
+Name: s, Id: _1, Ty: &[u8], Value: <immediate-pair>
+Name: <none>, Id: _2, Ty: ExtraSlice<'_>, Value: <uninit>
+Name: <none>, Id: _3, Ty: &[u8], Value: <dead>
+Name: <none>, Id: _4, Ty: u32, Value: <dead>
+Name: <none>, Id: _5, Ty: usize, Value: <dead>
+Name: <none>, Id: _6, Ty: &[u8], Value: <dead>
+Name: _slice._slice, Id: _7, Ty: &[u8], Value: <dead>
+Name: _slice._extra, Id: _8, Ty: u32, Value: <dead>
 (priroda) quitting

--- a/priroda/tests/ui/locals_struct_field_fragment.stdout
+++ b/priroda/tests/ui/locals_struct_field_fragment.stdout
@@ -1,10 +1,10 @@
 (priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_struct_field_fragment.rs:11
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_struct_field_fragment.rs:11
-(priroda) Name: <none>, Id: _0, Ty: ()
-Name: <none>, Id: _1, Ty: Outer
-Name: <none>, Id: _2, Ty: Inner
-Name: <none>, Id: _3, Ty: Inner
-Name: x.inner.value, Id: _4, Ty: u8
-Name: <none>, Id: _5, Ty: u8
+(priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
+Name: <none>, Id: _1, Ty: Outer, Value: <uninit>
+Name: <none>, Id: _2, Ty: Inner, Value: <uninit>
+Name: <none>, Id: _3, Ty: Inner, Value: <uninit>
+Name: x.inner.value, Id: _4, Ty: u8, Value: <immediate>
+Name: <none>, Id: _5, Ty: u8, Value: <dead>
 (priroda) quitting

--- a/priroda/tests/ui/locals_tuple_field_fragment.stdout
+++ b/priroda/tests/ui/locals_tuple_field_fragment.stdout
@@ -1,8 +1,8 @@
 (priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_tuple_field_fragment.rs:4
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_tuple_field_fragment.rs:4
-(priroda) Name: <none>, Id: _0, Ty: ()
-Name: <none>, Id: _1, Ty: (u8, u16)
-Name: t.0, Id: _2, Ty: u8
-Name: t.1, Id: _3, Ty: u16
+(priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
+Name: <none>, Id: _1, Ty: (u8, u16), Value: <uninit>
+Name: t.0, Id: _2, Ty: u8, Value: <dead>
+Name: t.1, Id: _3, Ty: u16, Value: <dead>
 (priroda) quitting


### PR DESCRIPTION
Add the first runtime-state and single-local inspection pieces for Priroda.

This PR:
- classifies whole MIR locals as dead, uninit, immediate, immediate-pair, or indirect
- keeps projected-storage rows explicit as unsupported projections
- adds `print <local>` / `p <local>` for baseline info about one MIR local
- shares the baseline MIR-local description logic between `locals` and `print`

`print` intentionally avoids building the full `locals` table or scanning `var_debug_info`.


- Updated and added Priroda UI expectations for locals state output and single-local printing.