### PR TITLE
threads: do not keep reference in BlockReason

### DIFF
--- a/src/concurrency/blocking_io.rs
+++ b/src/concurrency/blocking_io.rs
@@ -192,14 +192,6 @@ impl BlockingIoManager {
         interp_ok(Ok(()))
     }
 
-    /// Return whether a source file description is currently registered in the
-    /// blocking I/O poll.
-    /// This can also be used to check whether a file description is a host
-    /// I/O source.
-    pub fn contains_source(&self, source_id: &FdId) -> bool {
-        self.sources.contains_key(source_id)
-    }
-
     /// Register a source file description to the blocking I/O poll.
     pub fn register(&mut self, source_fd: FileDescriptionRef<dyn SourceFileDescription>) {
         let poll =
@@ -353,5 +345,15 @@ pub trait EvalContextExt<'tcx>: MiriInterpCxExt<'tcx> {
             // reachable when a system resource error (e.g. ENOMEM or ENOSPC) occurred.
             Err(e) => panic!("unexpected error while polling: {e}"),
         }
+    }
+
+    /// Returns whether there exists any thread that is blocked on host I/O.
+    fn any_thread_blocked_on_host(&self) -> bool {
+        let this = self.eval_context_ref();
+        this.machine.blocking_io.sources.iter().any(|(&fd_id, source)| {
+            // There's two ways something could be blocked on this: directly,
+            // or indirectly via a readiness watcher.
+            source.blocked_threads.len() > 0 || this.has_watcher_with_blocked_threads(fd_id)
+        })
     }
 }

--- a/src/concurrency/blocking_io.rs
+++ b/src/concurrency/blocking_io.rs
@@ -353,7 +353,7 @@ pub trait EvalContextExt<'tcx>: MiriInterpCxExt<'tcx> {
         this.machine.blocking_io.sources.iter().any(|(&fd_id, source)| {
             // There's two ways something could be blocked on this: directly,
             // or indirectly via a readiness watcher.
-            source.blocked_threads.len() > 0 || this.has_watcher_with_blocked_threads(fd_id)
+            source.blocked_threads.len() > 0 || this.has_watcher_with_blocked_thread(fd_id)
         })
     }
 }

--- a/src/concurrency/thread.rs
+++ b/src/concurrency/thread.rs
@@ -1,7 +1,6 @@
 //! Implements threads.
 
 use std::mem;
-use std::rc::Rc;
 use std::sync::atomic::Ordering::Relaxed;
 use std::task::Poll;
 use std::time::{Duration, SystemTime};
@@ -91,7 +90,7 @@ impl From<ThreadId> for u64 {
 }
 
 /// Keeps track of what the thread is blocked on.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum BlockReason {
     /// The thread tried to join the specified thread and is blocked until that
     /// thread terminates.
@@ -108,8 +107,8 @@ pub enum BlockReason {
     Futex,
     /// Blocked on an InitOnce.
     InitOnce,
-    /// Blocked until a file description readiness is satisfied.
-    Readiness { watcher: Rc<ReadinessWatcher> },
+    /// Blocked until a file description readiness is satisfied (e.g. epoll).
+    Readiness,
     /// Blocked on eventfd.
     Eventfd,
     /// Blocked on virtual socket.
@@ -774,26 +773,13 @@ trait EvalContextPrivExt<'tcx>: MiriInterpCxExt<'tcx> {
             // timeout_callbacks, which may unblock some of the threads. Hence,
             // sleep until the first callback.
             interp_ok(SchedulingAction::SleepAndWaitForIo(Some(sleep_time)))
-        } else if threads.iter().any(|thread| this.is_thread_blocked_on_host(thread)) {
+        } else if this.any_thread_blocked_on_host() {
             // At least one thread doesn't have a timeout set, and is blocked on host I/O or is waiting on an
             // epoll instance which contains a host source interest. Hence, we sleep indefinitely in the
             // hope that eventually an I/O event happens.
             interp_ok(SchedulingAction::SleepAndWaitForIo(None))
         } else {
             throw_machine_stop!(TerminationInfo::GlobalDeadlock);
-        }
-    }
-
-    /// Check whether the provided thread is currently blocked on host I/O.
-    /// This means, it's either blocked on an I/O operation directly or it's
-    /// blocked on an epoll instance which contains a host source interest.
-    fn is_thread_blocked_on_host(&self, thread: &Thread<'tcx>) -> bool {
-        let this = self.eval_context_ref();
-        match &thread.state {
-            ThreadState::Blocked { reason: BlockReason::IO, .. } => true,
-            ThreadState::Blocked { reason: BlockReason::Readiness { watcher }, .. } =>
-                this.has_watcher_host_interests(watcher),
-            _ => false,
         }
     }
 
@@ -1057,7 +1043,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             .map(|(id, _)| id)
             .collect::<Vec<_>>();
         for thread in joining_threads {
-            this.unblock_thread(thread, unblock_reason.clone())?;
+            this.unblock_thread(thread, unblock_reason)?;
         }
 
         interp_ok(())

--- a/src/shims/readiness.rs
+++ b/src/shims/readiness.rs
@@ -93,6 +93,8 @@ impl ReadinessInterest {
     }
 }
 
+type ReadinessWatcherId = usize;
+
 /// A struct which stores [`ReadinessInterest`]s for a set of file descriptions
 /// together with which interests are currently satisfied, and a list of
 /// threads which should be unblocked once a [`ReadinessInterest`] of the
@@ -100,7 +102,7 @@ impl ReadinessInterest {
 #[derive(Debug)]
 pub struct ReadinessWatcher {
     /// Globally unique identifier of the watcher.
-    id: usize,
+    id: ReadinessWatcherId,
     /// A map of [`ReadinessInterest`]s registered for this watcher. Each entry is
     /// identified using a [`FdId`] [`FdNum`] tuple.
     interests: RefCell<BTreeMap<ReadinessInterestKey, ReadinessInterest>>,
@@ -338,12 +340,13 @@ impl VisitProvenance for ReadinessWatcher {
 pub struct ReadinessInterestTable {
     /// The id of the next [`ReadinessWatcher`] created through
     /// [`ReadinessInterestTable::new_watcher`].
-    next_watcher_id: usize,
+    next_watcher_id: ReadinessWatcherId,
     /// Maps each file description (identified by its [`FdId`]) to the list of watchers that are
     /// interested in that FD. We also store the [`ReadinessWatcher`]s ID
     /// separately so we can access it without calling `upgrade`. The list
-    /// is sorted by that id.
-    interests: BTreeMap<FdId, Vec<(usize, Weak<ReadinessWatcher>)>>,
+    /// is sorted by that id. We use an ID so that we can identify the watcher even after it has
+    /// been moved, e.g. in [`ReadinessWatcher::destroy`].
+    interests: BTreeMap<FdId, Vec<(ReadinessWatcherId, Weak<ReadinessWatcher>)>>,
 }
 
 impl ReadinessInterestTable {
@@ -420,8 +423,8 @@ impl ReadinessInterestTable {
 
 impl<'tcx> EvalContextExt<'tcx> for MiriInterpCx<'tcx> {}
 pub trait EvalContextExt<'tcx>: MiriInterpCxExt<'tcx> {
-    /// Returns whether the given FD has any readiness watcher with blocked threads watching it.
-    fn has_watcher_with_blocked_threads(&self, fd_id: FdId) -> bool {
+    /// Returns whether the given FD has any readiness watcher with a blocked thread watching it.
+    fn has_watcher_with_blocked_thread(&self, fd_id: FdId) -> bool {
         let this = self.eval_context_ref();
         let Some(mut watchers) = this.machine.readiness_interests.get_watchers_for_fd(fd_id) else {
             return false;

--- a/src/shims/readiness.rs
+++ b/src/shims/readiness.rs
@@ -328,14 +328,6 @@ impl ReadinessWatcher {
     }
 }
 
-impl PartialEq for ReadinessWatcher {
-    fn eq(&self, other: &Self) -> bool {
-        self.id == other.id
-    }
-}
-
-impl Eq for ReadinessWatcher {}
-
 impl VisitProvenance for ReadinessWatcher {
     fn visit_provenance(&self, _visit: &mut VisitWith<'_>) {}
 }
@@ -393,18 +385,16 @@ impl ReadinessInterestTable {
 
     /// Get all watchers which have a registered interest in the file description
     /// with id `fd_id`.
-    fn get_watchers_for_fd(&mut self, fd_id: &FdId) -> Option<Vec<Rc<ReadinessWatcher>>> {
-        let watchers = self.interests.get_mut(fd_id)?;
-        Some(
-            watchers
-                .iter()
-                .map(|(_id, watcher)| {
-                    watcher.upgrade().expect(
-                        "someone forgot to remove the garbage from `machine.readiness_interests`",
-                    )
-                })
-                .collect(),
-        )
+    fn get_watchers_for_fd(
+        &self,
+        fd_id: FdId,
+    ) -> Option<impl Iterator<Item = Rc<ReadinessWatcher>>> {
+        let watchers = self.interests.get(&fd_id)?;
+        Some(watchers.iter().map(|(_id, watcher)| {
+            watcher
+                .upgrade()
+                .expect("someone forgot to remove the garbage from `machine.readiness_interests`")
+        }))
     }
 
     /// Remove all watchers for the file description with id `fd_id`.
@@ -430,15 +420,14 @@ impl ReadinessInterestTable {
 
 impl<'tcx> EvalContextExt<'tcx> for MiriInterpCx<'tcx> {}
 pub trait EvalContextExt<'tcx>: MiriInterpCxExt<'tcx> {
-    /// Recursively check whether the [`ReadinessWatcher`] contains
-    /// interests which are host I/O source file descriptions.
-    fn has_watcher_host_interests(&self, watcher: &ReadinessWatcher) -> bool {
+    /// Returns whether the given FD has any readiness watcher with blocked threads watching it.
+    fn has_watcher_with_blocked_threads(&self, fd_id: FdId) -> bool {
         let this = self.eval_context_ref();
-        watcher.interests().keys().any(|(fd_id, _fd_num)| {
-            // By looking up whether the file description is currently registered,
-            // we get whether it's a host I/O source file description.
-            this.machine.blocking_io.contains_source(fd_id)
-        })
+        let Some(mut watchers) = this.machine.readiness_interests.get_watchers_for_fd(fd_id) else {
+            return false;
+        };
+        // See if any of those watchers has a blocked thread.
+        watchers.any(|w| w.queue.borrow().len() > 0)
     }
 
     /// For a specific file description, get its current readiness and send it to everyone who
@@ -455,9 +444,10 @@ pub trait EvalContextExt<'tcx>: MiriInterpCxExt<'tcx> {
         let this = self.eval_context_mut();
         let fd_id = fd.id();
 
-        let Some(watchers) = this.machine.readiness_interests.get_watchers_for_fd(&fd_id) else {
+        let Some(watchers) = this.machine.readiness_interests.get_watchers_for_fd(fd_id) else {
             return interp_ok(());
         };
+        let watchers = watchers.collect::<Vec<_>>(); // need to make a copy so below we can unblock threads
         let active_readiness = fd.readiness()?;
         for watcher in watchers {
             this.update_readiness(&watcher, active_readiness.clone(), force_edge, |callback| {
@@ -526,7 +516,7 @@ pub trait EvalContextPrivExt<'tcx>: MiriInterpCxExt<'tcx> {
             && let Some(thread_id) = watcher.queue.borrow_mut().pop_front()
         {
             drop(ready);
-            this.unblock_thread(thread_id, BlockReason::Readiness { watcher: watcher.clone() })?;
+            this.unblock_thread(thread_id, BlockReason::Readiness)?;
             ready = watcher.ready.borrow_mut();
         }
         interp_ok(())

--- a/src/shims/unix/linux_like/epoll.rs
+++ b/src/shims/unix/linux_like/epoll.rs
@@ -309,7 +309,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             // This means there'll be a leak if we never wake up, but that anyway would imply
             // a thread is permanently blocked so this is fine.
             this.block_thread(
-                BlockReason::Readiness { watcher: epfd.watcher.clone() },
+                BlockReason::Readiness,
                 deadline,
                 callback!(
                     @capture<'tcx> {


### PR DESCRIPTION
Helps a bit with https://github.com/rust-lang/miri/issues/5152 by reducing the number of references that are being kept.

@WhySoBad does this look reasonable?