### PR TITLE
Lazily destroy readiness watchers

### DIFF
--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1795,12 +1795,14 @@ impl<'tcx> Machine<'tcx> for MiriMachine<'tcx> {
         }
 
         // Search for BorTags to find all live pointers, then remove all other tags from borrow
-        // stacks.
+        // stacks. Also clean up dropped readiness watchers from the global readiness interest
+        // table.
         // When debug assertions are enabled, run the GC as often as possible so that any cases
         // where it mistakenly removes an important tag become visible.
         if ecx.machine.gc_interval > 0 && ecx.machine.since_gc >= ecx.machine.gc_interval {
             ecx.machine.since_gc = 0;
             ecx.run_provenance_gc();
+            ecx.machine.readiness_interests.run_gc();
         }
 
         // These are our preemption points.

--- a/src/shims/readiness.rs
+++ b/src/shims/readiness.rs
@@ -327,21 +327,6 @@ impl ReadinessWatcher {
 
         interp_ok(ready_interests)
     }
-
-    /// Destroy the watcher instance.
-    ///
-    /// This also deregisters all interests of the watcher
-    /// from the global readiness interest table.
-    pub fn destroy<'tcx>(self, ecx: &mut MiriInterpCx<'tcx>) {
-        // If we were interested in some FDs, we can remove that now.
-        let mut ids = self.interests.borrow().keys().map(|(id, _num)| *id).collect::<Vec<_>>();
-        // Because the ids come out of the map sorted,
-        // deduping only keeps all unique entries.
-        ids.dedup();
-        for id in ids {
-            ecx.machine.readiness_interests.remove(id, &self);
-        }
-    }
 }
 
 impl VisitProvenance for ReadinessWatcher {
@@ -359,7 +344,7 @@ pub struct ReadinessInterestTable {
     /// interested in that FD. We also store the [`ReadinessWatcher`]s ID
     /// separately so we can access it without calling `upgrade`. The list
     /// is sorted by that id. We use an ID so that we can identify the watcher even after it has
-    /// been moved, e.g. in [`ReadinessWatcher::destroy`].
+    /// been dropped.
     interests: BTreeMap<FdId, Vec<(ReadinessWatcherId, Weak<ReadinessWatcher>)>>,
 }
 
@@ -407,11 +392,9 @@ impl ReadinessInterestTable {
         fd_id: FdId,
     ) -> Option<impl Iterator<Item = Rc<ReadinessWatcher>>> {
         let watchers = self.interests.get(&fd_id)?;
-        Some(watchers.iter().map(|(_id, watcher)| {
-            watcher
-                .upgrade()
-                .expect("someone forgot to remove the garbage from `machine.readiness_interests`")
-        }))
+        // Ignore weak refs that cannot be upgraded -- those correspond to closed
+        // file descriptions and will be cleaned up by the GC eventually.
+        Some(watchers.iter().filter_map(|(_id, watcher)| watcher.upgrade()))
     }
 
     /// Remove all watchers for the file description with id `fd_id`.
@@ -432,6 +415,13 @@ impl ReadinessInterestTable {
             // Remove the ready interests for this file description.
             watcher.ready.borrow_mut().retain(|(id, _)| id != &fd_id);
         }
+    }
+
+    /// Run garbage collector to remove all dropped watchers from the interests map.
+    pub fn run_gc(&mut self) {
+        self.interests
+            .values_mut()
+            .for_each(|watchers| watchers.retain(|(_id, watcher)| watcher.strong_count() > 0));
     }
 }
 

--- a/src/shims/unix/linux_like/epoll.rs
+++ b/src/shims/unix/linux_like/epoll.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use rustc_abi::FieldIdx;
 
-use crate::shims::files::{FdId, FileDescription, FileDescriptionRef};
+use crate::shims::files::{FileDescription, FileDescriptionRef};
 use crate::shims::unix::UnixFileDescription;
 use crate::*;
 
@@ -32,18 +32,6 @@ impl FileDescription for Epoll {
     ) -> InterpResult<'tcx, Either<io::Result<std::fs::Metadata>, &'static str>> {
         // On Linux, epoll is an "anonymous inode" reported as S_IFREG.
         interp_ok(Either::Right("S_IFREG"))
-    }
-
-    fn destroy<'tcx>(
-        self,
-        _self_id: FdId,
-        _communicate_allowed: bool,
-        ecx: &mut MiriInterpCx<'tcx>,
-    ) -> InterpResult<'tcx, io::Result<()>> {
-        let watcher = Rc::into_inner(self.watcher)
-            .expect("Epoll instance should contain the only strong reference to the watcher");
-        watcher.destroy(ecx);
-        interp_ok(Ok(()))
     }
 
     fn as_unix<'tcx>(

--- a/src/shims/unix/poll.rs
+++ b/src/shims/unix/poll.rs
@@ -102,15 +102,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             // Some interests are already fulfilled or a zero timeout was provided.
             // We thus don't need to block the thread and can just return here.
 
-            let count = this.write_ready_events(watcher.clone(), interests)?;
+            let count = this.write_ready_events(watcher, interests)?;
             // The Linux implementation also counts invalid interests as fulfilled.
             let total = count.strict_add(invalid_interests);
-
-            // FIXME: Until <https://github.com/rust-lang/miri/issues/5152> is fixed,
-            // we destroy the watcher here instead of in `write_ready_events` because
-            // here we know that we only have a single strong reference.
-            let inner = Rc::into_inner(watcher).unwrap();
-            inner.destroy(this);
 
             return this.write_scalar(Scalar::from_u32(total), dest);
         }
@@ -138,8 +132,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     dest: MPlaceTy<'tcx>,
                 } |this, reason: UnblockKind| {
                     if let UnblockKind::TimedOut = reason {
-                        // FIXME(miri#5152): we are not destroying the watcher.
-                        return this.write_null(&dest);
+                        return this.write_scalar(Scalar::from_u32(0), &dest);
                     }
 
                     let count = this.write_ready_events(watcher, interests)?;
@@ -177,10 +170,6 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             let poll_events = this.readiness_to_poll_bitflag(ready.active());
             this.write_scalar(Scalar::from_u16(poll_events), &interest.revents_place)?;
         }
-
-        // FIXME: At this point the watcher should be destroyed. However, because
-        // multiple strong references still exist at this point, that is impossible.
-        // See <https://github.com/rust-lang/miri/issues/5152>
 
         interp_ok(fulfilled_interests)
     }

--- a/tests/pass-dep/libc/libc-epoll-blocking.rs
+++ b/tests/pass-dep/libc/libc-epoll-blocking.rs
@@ -25,6 +25,7 @@ fn main() {
     test_epoll_race();
     wakeup_on_new_interest();
     multiple_events_wake_multiple_threads();
+    waiting_threads_unblocked_after_epoll_close();
 }
 
 // This test allows edge-triggered epoll_wait to block and then unblock
@@ -224,4 +225,35 @@ fn multiple_events_wake_multiple_threads() {
 
     // In both modes we should get both events across the two threads.
     assert!(expected == [e1, e2] || expected == [e2, e1]);
+}
+
+/// Test that threads which are waiting on an epoll are unblocked when a registered interest
+/// is fulfilled, even when the epoll file _descriptor_ they block on got closed in the
+/// mean time.
+fn waiting_threads_unblocked_after_epoll_close() {
+    // Create an epoll instance.
+    let epfd = errno_result(unsafe { libc::epoll_create1(0) }).unwrap();
+
+    // Create a socketpair instance.
+    let mut fds = [-1, -1];
+    errno_check(unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) });
+
+    // Add `fds[0]` to epoll with readable interest.
+    epoll_ctl_add(epfd, fds[0], EPOLLIN | EPOLLET_OR_ZERO).unwrap();
+
+    let t1 = thread::spawn(move || {
+        // Sleep 10ms to make sure the other thread is blocked.
+        thread::sleep(Duration::from_millis(10));
+
+        // Close epoll file descriptor.
+        unsafe { errno_check(libc::close(epfd)) };
+
+        // Write some data into `fds[1]` which should make `fds[0]` readable.
+        write_all(fds[1], b"abcde").unwrap();
+    });
+
+    // Indefinitely block until `fds[0]` becomes readable.
+    check_epoll_wait(epfd, &[Ev { events: EPOLLIN, data: fds[0] }], -1);
+
+    t1.join().unwrap();
 }

--- a/tests/pass-dep/libc/libc-poll.rs
+++ b/tests/pass-dep/libc/libc-poll.rs
@@ -19,6 +19,7 @@ fn main() {
     test_poll_negative_fd_interest();
     test_poll_invalid_non_negative_fd_interest();
     test_poll_zero_timeout();
+    test_readiness_event_after_poll_blocked();
 }
 
 /// Test that the readiness written into the `revents` field on an interest
@@ -158,4 +159,36 @@ fn test_poll_zero_timeout() {
     // The `poll` should not block; since CI can be slow
     // we just assert that it didn't block for more than 100ms.
     assert!(before.elapsed() < Duration::from_millis(100))
+}
+
+/// Before <https://github.com/rust-lang/miri/pull/5172> Miri would ICE when
+/// any file description readiness is updated after a `poll` invocation has
+/// blocked.
+fn test_readiness_event_after_poll_blocked() {
+    let mut fds = [-1, -1];
+    unsafe { errno_check(libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr())) };
+
+    let t1 = thread::spawn(move || {
+        // Yield to main thread to ensure it's blocked on `poll` before
+        // we write into the socket.
+        thread::sleep(Duration::from_millis(10));
+
+        unsafe {
+            errno_result(libc::write(fds[1], TEST_BYTES.as_ptr().cast(), TEST_BYTES.len())).unwrap()
+        }
+    });
+
+    let mut interests = [libc::pollfd { fd: fds[0], events: libc::POLLIN, revents: 1 }];
+    let ready = unsafe {
+        errno_result(libc::poll(interests.as_mut_ptr(), interests.len() as libc::nfds_t, -1))
+            .unwrap()
+    };
+    assert_eq!(ready, 1);
+
+    // Update the file description readiness of `fds[0]` and `fds[1]`. This is used to ICE.
+    unsafe {
+        errno_result(libc::write(fds[0], TEST_BYTES.as_ptr().cast(), TEST_BYTES.len())).unwrap()
+    };
+
+    t1.join().unwrap();
 }


### PR DESCRIPTION
This pull request resolves the problem mentioned in https://github.com/rust-lang/miri/issues/5152#issuecomment-4925373676.

The `ReadinessWatcher`s no longer need to be destroyed explicitly, instead they are lazily destroyed when the stored weak reference can no longer be upgraded.

By this, Tokio now works fine using the `poll` selector. To verify the Tokio support, I've ran the Tokio test suite on the `x86_64-pc-solaris` target (which for now still uses the `poll` selector by default) and all tests passed, except the `io_async_fd` ones. However, as mentioned in https://github.com/rust-lang/miri/issues/5173#issuecomment-4948059337, this seems to be a Tokio bug rather than a Miri bug.