### PR TITLE
remove bogus sanity check from weak memory mixed-size logic

### DIFF
--- a/src/concurrency/data_race.rs
+++ b/src/concurrency/data_race.rs
@@ -740,6 +740,8 @@ pub trait EvalContextExt<'tcx>: MiriInterpCxExt<'tcx> {
             );
         }
 
+        trace!("read_scalar_atomic({:?}, {} bytes)", place.ptr(), place.layout.size.bytes());
+
         let scalar = this.allow_data_races_ref(move |this| this.read_scalar(place))?;
         let buffered_scalar = this.buffered_atomic_read(place, atomic, scalar, |sync_clock| {
             this.validate_atomic_load(place, atomic, sync_clock)
@@ -757,9 +759,13 @@ pub trait EvalContextExt<'tcx>: MiriInterpCxExt<'tcx> {
         let this = self.eval_context_mut();
         this.atomic_access_check(dest, AtomicAccessType::Store)?;
 
+        // Read the previous value so we can put it in the store buffer later.
+        // Both GenMC and Miri need this. This value is nonsense if there are concurrent writes
+        // but the code consuming the value is aware of that.
+        let old_val = this.run_for_validation_ref(|this| this.read_scalar(dest)).discard_err();
+
         // Inform GenMC about the atomic store.
         if let Some(genmc_ctx) = this.machine.data_race.as_genmc_ref() {
-            let old_val = this.run_for_validation_ref(|this| this.read_scalar(dest)).discard_err();
             if genmc_ctx.atomic_store(
                 this,
                 dest.ptr().addr(),
@@ -775,8 +781,8 @@ pub trait EvalContextExt<'tcx>: MiriInterpCxExt<'tcx> {
             return interp_ok(());
         }
 
-        // Read the previous value so we can put it in the store buffer later.
-        let old_val = this.get_latest_nonatomic_val(dest);
+        trace!("write_scalar_atomic({:?}, {} bytes)", dest.ptr(), dest.layout.size.bytes());
+
         this.allow_data_races_mut(move |this| this.write_scalar(val, dest))?;
         this.validate_atomic_store(dest, atomic)?;
         this.buffered_atomic_write(val, dest, atomic, old_val)
@@ -813,6 +819,8 @@ pub trait EvalContextExt<'tcx>: MiriInterpCxExt<'tcx> {
             return interp_ok(ImmTy::from_scalar(old_val, old.layout));
         }
 
+        trace!("atomic_rmw({:?}, {} bytes)", place.ptr(), place.layout.size.bytes());
+
         let val = match atomic_op {
             AtomicRmwOp::MirOp { op, neg } => {
                 let val = this.binary_op(op, &old, rhs)?;
@@ -829,9 +837,7 @@ pub trait EvalContextExt<'tcx>: MiriInterpCxExt<'tcx> {
         };
 
         this.allow_data_races_mut(|this| this.write_immediate(*val, place))?;
-
         this.validate_atomic_rmw(place, ord)?;
-
         this.buffered_atomic_rmw(val.to_scalar(), place, ord, old.to_scalar())?;
         interp_ok(old)
     }
@@ -848,7 +854,6 @@ pub trait EvalContextExt<'tcx>: MiriInterpCxExt<'tcx> {
         this.atomic_access_check(place, AtomicAccessType::Rmw)?;
 
         let old = this.allow_data_races_mut(|this| this.read_scalar(place))?;
-        this.allow_data_races_mut(|this| this.write_scalar(new, place))?;
 
         // Inform GenMC about the atomic atomic exchange.
         if let Some(genmc_ctx) = this.machine.data_race.as_genmc_ref() {
@@ -868,8 +873,10 @@ pub trait EvalContextExt<'tcx>: MiriInterpCxExt<'tcx> {
             return interp_ok(old_val);
         }
 
-        this.validate_atomic_rmw(place, atomic)?;
+        trace!("atomic_exchange_scalar({:?}, {} bytes)", place.ptr(), place.layout.size.bytes());
 
+        this.allow_data_races_mut(|this| this.write_scalar(new, place))?;
+        this.validate_atomic_rmw(place, atomic)?;
         this.buffered_atomic_rmw(new, place, atomic, old)?;
         interp_ok(old)
     }
@@ -928,6 +935,13 @@ pub trait EvalContextExt<'tcx>: MiriInterpCxExt<'tcx> {
                 true
             };
         let res = Immediate::ScalarPair(old.to_scalar(), Scalar::from_bool(cmpxchg_success));
+
+        trace!(
+            "atomic_compare_exchange_scalar({:?}, {} bytes, success = {})",
+            place.ptr(),
+            place.layout.size.bytes(),
+            cmpxchg_success,
+        );
 
         // Update ptr depending on comparison.
         // if successful, perform a full rw-atomic validation
@@ -1538,35 +1552,6 @@ trait EvalContextPrivExt<'tcx>: MiriInterpCxExt<'tcx> {
                 }
             },
         )
-    }
-
-    /// Returns the most recent *non-atomic* value stored in the given place.
-    /// Errors if we don't need that (because we don't do store buffering) or if
-    /// the most recent value is in fact atomic.
-    fn get_latest_nonatomic_val(&self, place: &MPlaceTy<'tcx>) -> Result<Option<Scalar>, ()> {
-        let this = self.eval_context_ref();
-        // These cannot fail because `atomic_access_check` was done first.
-        let (alloc_id, offset, _prov) = this.ptr_get_alloc_id(place.ptr(), 0).unwrap();
-        let alloc_meta = &this.get_alloc_extra(alloc_id).unwrap().data_race;
-        if alloc_meta.as_weak_memory_ref().is_none() {
-            // No reason to read old value if we don't track store buffers.
-            return Err(());
-        }
-        let data_race = alloc_meta.as_vclocks_ref().unwrap();
-        // Only read old value if this is currently a non-atomic location.
-        for (_range, clocks) in data_race.alloc_ranges.borrow_mut().iter(offset, place.layout.size)
-        {
-            // If this had an atomic write that's not before the non-atomic write, that should
-            // already be in the store buffer. Initializing the store buffer now would use the
-            // wrong `sync_clock` so we better make sure that does not happen.
-            if clocks.atomic().is_some_and(|atomic| !(atomic.write_vector <= clocks.write())) {
-                return Err(());
-            }
-        }
-        // The program didn't actually do a read, so suppress the memory access hooks.
-        // This is also a very special exception where we just ignore an error -- if this read
-        // was UB e.g. because the memory is uninitialized, we don't want to know!
-        Ok(this.run_for_validation_ref(|this| this.read_scalar(place)).discard_err())
     }
 
     /// Generic atomic operation implementation

--- a/src/concurrency/data_race.rs
+++ b/src/concurrency/data_race.rs
@@ -637,7 +637,7 @@ impl MemoryCellClocks {
 
     /// Detect races for non-atomic read operations at the current memory cell
     /// returns true if a data-race is detected.
-    fn read_race_detect(
+    fn non_atomic_read_detect(
         &mut self,
         thread_clocks: &mut ThreadClockSet,
         index: VectorIdx,
@@ -664,7 +664,7 @@ impl MemoryCellClocks {
 
     /// Detect races for non-atomic write operations at the current memory cell
     /// returns true if a data-race is detected.
-    fn write_race_detect(
+    fn non_atomic_write_detect(
         &mut self,
         thread_clocks: &mut ThreadClockSet,
         index: VectorIdx,
@@ -1233,9 +1233,12 @@ impl VClockAlloc {
         for (mem_clocks_range, mem_clocks) in
             alloc_ranges.iter_mut(access_range.start, access_range.size)
         {
-            if let Err(DataRace) =
-                mem_clocks.read_race_detect(&mut thread_clocks, index, read_type, current_span)
-            {
+            if let Err(DataRace) = mem_clocks.non_atomic_read_detect(
+                &mut thread_clocks,
+                index,
+                read_type,
+                current_span,
+            ) {
                 drop(thread_clocks);
                 // Report data-race.
                 return Self::report_data_race(
@@ -1274,9 +1277,12 @@ impl VClockAlloc {
         for (mem_clocks_range, mem_clocks) in
             self.alloc_ranges.borrow_mut().iter_mut(access_range.start, access_range.size)
         {
-            if let Err(DataRace) =
-                mem_clocks.write_race_detect(&mut thread_clocks, index, write_type, current_span)
-            {
+            if let Err(DataRace) = mem_clocks.non_atomic_write_detect(
+                &mut thread_clocks,
+                index,
+                write_type,
+                current_span,
+            ) {
                 drop(thread_clocks);
                 // Report data-race
                 return Self::report_data_race(

--- a/src/concurrency/weak_memory.rs
+++ b/src/concurrency/weak_memory.rs
@@ -227,23 +227,23 @@ impl StoreBufferAlloc {
     fn get_or_create_store_buffer_mut<'tcx>(
         &mut self,
         range: AllocRange,
-        init: Result<Option<Scalar>, ()>,
+        init: Option<Scalar>,
     ) -> InterpResult<'tcx, &mut StoreBuffer> {
         let buffers = self.store_buffers.get_mut();
         let access_type = buffers.access_type(range);
         let pos = match access_type {
             AccessType::PerfectlyOverlapping(pos) => pos,
             AccessType::Empty(pos) => {
-                let init =
-                    init.expect("cannot have empty store buffer when previous write was atomic");
+                // We can use `init` for a new store buffer (with a default `sync_clock` that
+                // acquires nothing) because there was no data race and no previous atomic write
+                // either.
                 buffers.insert_at_pos(pos, range, StoreBuffer::new(init));
                 pos
             }
             AccessType::ImperfectlyOverlapping(pos_range) => {
-                // Once we reach here we would've already checked that this access is not racy.
-                let init = init.expect(
-                    "cannot have partially overlapping store buffer when previous write was atomic",
-                );
+                // We can use `init` for a new store buffer (with a default `sync_clock` that
+                // acquires nothing) because there was no data race and all previous atomic writes
+                // are fully synchronized (as otherwise the imperfect overlap would be UB).
                 buffers.remove_pos_range(pos_range.clone());
                 buffers.insert_at_pos(pos_range.start, range, StoreBuffer::new(init));
                 pos_range.start
@@ -511,7 +511,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             }
             let range = alloc_range(base_offset, place.layout.size);
             let sync_clock = data_race_clocks.sync_clock(range);
-            let buffer = alloc_buffers.get_or_create_store_buffer_mut(range, Ok(Some(init)))?;
+            let buffer = alloc_buffers.get_or_create_store_buffer_mut(range, Some(init))?;
             // The RMW always reads from the most recent store.
             buffer.read_from_last_store(global, threads, atomic == AtomicRwOrd::SeqCst);
             buffer.buffered_write(
@@ -575,10 +575,11 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     }
 
     /// Add the given write to the store buffer. (Does not change machine memory.)
+    /// Must only be called after we determined that there is no data race or mixed-size race.
     ///
     /// `init` says with which value to initialize the store buffer in case there wasn't a store
-    /// buffer for this memory range before. `Err(())` means the value is not available;
-    /// `Ok(None)` means the memory does not contain a valid scalar.
+    /// buffer for this memory range before. `None` means the memory does not contain a valid
+    /// scalar.
     ///
     /// Must be called *after* `validate_atomic_store` to ensure that `sync_clock` is up-to-date.
     fn buffered_atomic_write(
@@ -586,7 +587,7 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         val: Scalar,
         dest: &MPlaceTy<'tcx>,
         atomic: AtomicWriteOrd,
-        init: Result<Option<Scalar>, ()>,
+        init: Option<Scalar>,
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
         let (alloc_id, base_offset, ..) = this.ptr_get_alloc_id(dest.ptr(), 0)?;

--- a/src/concurrency/weak_memory.rs
+++ b/src/concurrency/weak_memory.rs
@@ -244,6 +244,12 @@ impl StoreBufferAlloc {
                 // We can use `init` for a new store buffer (with a default `sync_clock` that
                 // acquires nothing) because there was no data race and all previous atomic writes
                 // are fully synchronized (as otherwise the imperfect overlap would be UB).
+                // It is tempting to try to sanity-check this against the data race clock view of
+                // whether there was any overlap, but that is very tricky: because we are skipping
+                // clock tracking until the first thread is spawned, we don't actually have a good
+                // view of whether a given atomic access "creates a new atomic object" or not.
+                // A sanity check would require is to always track clocks for atomic accesses, which
+                // does show up in benchmarks so we don't do it.
                 buffers.remove_pos_range(pos_range.clone());
                 buffers.insert_at_pos(pos_range.start, range, StoreBuffer::new(init));
                 pos_range.start

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ pub use rustc_const_eval::interpret::*;
 #[doc(no_inline)]
 pub use rustc_const_eval::interpret::{self, AllocMap, Provenance as _};
 pub use rustc_data_structures::either::Either;
-pub use rustc_log::tracing::{self, info, trace};
+pub use rustc_log::tracing::{self, info, trace, warn};
 pub use rustc_middle::{bug, span_bug};
 
 #[cfg(all(feature = "native-lib", unix))]

--- a/tests/pass/concurrency/data_race.rs
+++ b/tests/pass/concurrency/data_race.rs
@@ -10,6 +10,10 @@ struct EvilSend<T>(pub T);
 unsafe impl<T> Send for EvilSend<T> {}
 unsafe impl<T> Sync for EvilSend<T> {}
 
+unsafe fn split_atomic(a: &AtomicU16) -> &[AtomicU8; 2] {
+    unsafe { std::mem::transmute(a) }
+}
+
 fn test_fence_sync() {
     static SYNC: AtomicUsize = AtomicUsize::new(0);
 
@@ -179,13 +183,9 @@ fn test_read_read_race2() {
 }
 
 fn mixed_size_read_read() {
-    fn convert(a: &AtomicU16) -> &[AtomicU8; 2] {
-        unsafe { std::mem::transmute(a) }
-    }
-
     let a = AtomicU16::new(0);
     let a16 = &a;
-    let a8 = convert(a16);
+    let a8 = unsafe { split_atomic(a16) };
 
     // Just two different-sized atomic reads without any writes are fine.
     thread::scope(|s| {

--- a/tests/pass/concurrency/issue-miri-5185-same-thread-mixed-size-writes.rs
+++ b/tests/pass/concurrency/issue-miri-5185-same-thread-mixed-size-writes.rs
@@ -1,0 +1,22 @@
+use std::sync::atomic::Ordering::Relaxed;
+use std::sync::atomic::*;
+
+unsafe fn split_atomic(a: &AtomicU16) -> &[AtomicU8; 2] {
+    unsafe { std::mem::transmute(a) }
+}
+
+fn main() {
+    std::thread::spawn(move || {
+        let a: AtomicU16 = 0.into();
+
+        // Bump our vector clock so the non-atomic initializing write above is separate
+        // from the first relaxed store below. Or something like that.
+        AtomicU16::new(0).store(0, Relaxed);
+
+        a.store(0, Relaxed);
+        let parts = unsafe { split_atomic(&a) };
+        parts[0].store(0, Relaxed);
+    })
+    .join()
+    .unwrap();
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/miri/issues/5185

I added this check in `get_latest_nonatomic_val` because I was concerned about using this value in a way that's wrong... but turns out the sanity check was itself wrong. The correct sanity check would just duplicate the data race & mixed-size race detection logic so that does not seem worth it.