### PR TITLE
Lazily destroy source file descriptions

### DIFF
--- a/src/concurrency/blocking_io.rs
+++ b/src/concurrency/blocking_io.rs
@@ -147,9 +147,9 @@ impl BlockingIoManager {
                     .sources
                     .get(&fd_id)
                     .expect("Source should be registered");
-                let fd = source.fd.upgrade().expect(
-                    "Source file description shouldn't be destroyed whilst being registered",
-                );
+                let Some(fd) = source.fd.upgrade() else {
+                    panic!("Should not receive readiness event for closed source file description")
+                };
 
                 assert_eq!(fd.id(), fd_id);
                 // Update the readiness of the source.
@@ -165,10 +165,9 @@ impl BlockingIoManager {
             // Update readiness for the `fd` source.
             ecx.update_fd_readiness(fd.clone(), false)?;
 
-            let source =
-                ecx.machine.blocking_io.sources.get(&fd.id()).expect(
-                    "Source file description shouldn't be destroyed whilst being registered",
-                );
+            // The `update_fd_readiness` can't cause the source to be deregistered since we still
+            // hold a strong reference to the file description with `fd`.
+            let source = ecx.machine.blocking_io.sources.get(&fd.id()).unwrap();
 
             // List of all thread id's whose interests are currently fulfilled
             // and which are blocked on the `fd` source. This also includes
@@ -222,31 +221,6 @@ impl BlockingIoManager {
             .unwrap_or_else(|_| panic!("Source should not already be registered"));
     }
 
-    /// Deregister a source file description from the blocking I/O poll.
-    ///
-    /// It's assumed that the file description with id `source_id` is already
-    /// removed from the file description table.
-    pub fn deregister(&mut self, source_id: FdId, source: impl SourceFileDescription) {
-        let poll =
-            self.poll.as_ref().expect("Blocking I/O should not be called with isolation enabled");
-
-        let stored_source = self.sources.remove(&source_id).expect("Source should be registered");
-        // Ensure that the source file description is already removed from the file
-        // description table.
-        assert!(
-            stored_source.fd.upgrade().is_none(),
-            "Sources must only be deregistered when they are destroyed"
-        );
-
-        // Because we only store `WeakFileDescriptionRef`s and the `stored_source` file description
-        // is already destroyed, the weak reference can no longer be upgraded. Thus, we cannot use
-        // it to deregister the source from the poll and instead use the `source` argument to deregister.
-
-        // Treat errors from deregistering as fatal. On UNIX hosts this can only
-        // fail due to system resource errors (e.g. ENOMEM or ENOSPC).
-        source.with_source(&mut |source| poll.registry().deregister(source)).unwrap();
-    }
-
     /// Add a new blocked thread to a registered source. The thread gets unblocked
     /// once its [`BlockingIoInterest`] is fulfilled when calling
     /// [`BlockingIoManager::poll`].
@@ -276,6 +250,17 @@ impl BlockingIoManager {
     pub fn remove_blocked_thread(&mut self, source_id: FdId, thread_id: ThreadId) {
         let source = self.sources.get_mut(&source_id).expect("Source should be registered");
         source.blocked_threads.remove(&thread_id).expect("Thread should be blocked on source");
+    }
+
+    /// Run garbage collector on blocking I/O manager to remove all closed source file
+    /// descriptions from the registered sources map.
+    pub fn run_gc(&mut self) {
+        // For hosts where mio uses `kqueue`, `epoll` or `IOCP` (Windows), we know that
+        // the source doesn't need to be deregistered from the `Poll` before being dropped:
+        // See <https://github.com/tokio-rs/mio/issues/1972>
+        // Thus, just removing the closed source file descriptions from the `sources` map
+        // is enough.
+        self.sources.retain(|_id, source| !source.fd.is_closed());
     }
 }
 

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1792,13 +1792,14 @@ impl<'tcx> Machine<'tcx> for MiriMachine<'tcx> {
 
         // Search for BorTags to find all live pointers, then remove all other tags from borrow
         // stacks. Also clean up dropped readiness watchers from the global readiness interest
-        // table.
+        // table and closed source file descriptions in the blocking I/O manager.
         // When debug assertions are enabled, run the GC as often as possible so that any cases
         // where it mistakenly removes an important tag become visible.
         if ecx.machine.gc_interval > 0 && ecx.machine.since_gc >= ecx.machine.gc_interval {
             ecx.machine.since_gc = 0;
             ecx.run_provenance_gc();
             ecx.machine.readiness_interests.run_gc();
+            ecx.machine.blocking_io.run_gc();
         }
 
         // These are our preemption points.

--- a/src/shims/files.rs
+++ b/src/shims/files.rs
@@ -89,6 +89,12 @@ impl<T: ?Sized> WeakFileDescriptionRef<T> {
     pub fn upgrade(&self) -> Option<FileDescriptionRef<T>> {
         self.0.upgrade().map(FileDescriptionRef)
     }
+
+    /// Returns whether the file description that this weak reference points to
+    /// has been closed, i.e., there are no more strong references.
+    pub fn is_closed(&self) -> bool {
+        self.0.strong_count() == 0
+    }
 }
 
 impl<T> VisitProvenance for WeakFileDescriptionRef<T> {

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -11,7 +11,7 @@ use rustc_const_eval::interpret::{InterpResult, interp_ok};
 use rustc_middle::throw_unsup_format;
 use rustc_target::spec::Os;
 
-use crate::shims::files::{EvalContextExt as _, FdId, FdNum, FileDescription, FileDescriptionRef};
+use crate::shims::files::{EvalContextExt as _, FdNum, FileDescription, FileDescriptionRef};
 use crate::shims::unix::UnixFileDescription;
 use crate::shims::unix::socket::{SocketFamily, UnixSocketFileDescription};
 use crate::*;
@@ -89,29 +89,6 @@ impl TcpSocket {
 impl FileDescription for TcpSocket {
     fn name(&self) -> &'static str {
         "socket"
-    }
-
-    fn destroy<'tcx>(
-        self,
-        self_id: FdId,
-        communicate_allowed: bool,
-        ecx: &mut MiriInterpCx<'tcx>,
-    ) -> InterpResult<'tcx, io::Result<()>> {
-        assert!(communicate_allowed, "cannot have `TcpSocket` with isolation enabled!");
-
-        if matches!(
-            &*self.state.borrow(),
-            SocketState::Listening(_)
-                | SocketState::Connecting(_)
-                | SocketState::Connected(_)
-                | SocketState::ConnectionFailed(_)
-        ) {
-            // There exists an associated host socket so we need to deregister it
-            // from the blocking I/O manager.
-            ecx.machine.blocking_io.deregister(self_id, self)
-        };
-
-        interp_ok(Ok(()))
     }
 
     fn read<'tcx>(
@@ -995,6 +972,9 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         finish: DynMachineCallback<'tcx, Result<(FdNum, SocketAddr), IoError>>,
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
+        // Since the callback holds a strong reference to the socket, the file description
+        // won't be closed as long as some thread is blocked on it. While this reflects
+        // what Linux does, for other Unix systems this might differ from the native behavior.
         this.block_thread_for_io(
             socket.clone(),
             BlockingIoInterest::Read,
@@ -1094,6 +1074,9 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         finish: DynMachineCallback<'tcx, Result<usize, IoError>>,
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
+        // Since the callback holds a strong reference to the socket, the file description
+        // won't be closed as long as some thread is blocked on it. While this reflects
+        // what Linux does, for other Unix systems this might differ from the native behavior.
         this.block_thread_for_io(
             socket.clone(),
             BlockingIoInterest::Write,
@@ -1224,6 +1207,9 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         finish: DynMachineCallback<'tcx, Result<usize, IoError>>,
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
+        // Since the callback holds a strong reference to the socket, the file description
+        // won't be closed as long as some thread is blocked on it. While this reflects
+        // what Linux does, for other Unix systems this might differ from the native behavior.
         this.block_thread_for_io(
             socket.clone(),
             BlockingIoInterest::Read,

--- a/tests/pass-dep/libc/libc-socket.rs
+++ b/tests/pass-dep/libc/libc-socket.rs
@@ -59,6 +59,8 @@ fn main() {
 
     test_sockopt_sndtimeo();
     test_sockopt_rcvtimeo();
+
+    test_unblock_after_socket_close();
 }
 
 /// Test creating a socket and then closing it afterwards.
@@ -900,4 +902,41 @@ fn test_sockopt_rcvtimeo() {
     assert_eq!(err.kind(), ErrorKind::WouldBlock);
     // Ensure that we blocked for at least 40 milliseconds.
     assert!(before.elapsed() >= Duration::from_millis(40))
+}
+
+/// Test that a thread which is blocked on a socket gets unblocked once
+/// the operation is finished, even when the socket file _descriptor_ gets
+/// closed in the mean time.
+fn test_unblock_after_socket_close() {
+    // MacOS behaves different (`read` errors with EBADFD when the file description is closed)
+    // so we skip the test when we are run on a native macOS target.
+    if cfg!(not(miri)) && cfg!(target_os = "macos") {
+        return;
+    }
+
+    let (server_sockfd, addr) = net::make_listener_ipv4().unwrap();
+    let client_sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+
+    net::connect_ipv4(client_sockfd, addr).unwrap();
+    let (peerfd, _) = net::accept_ipv4(server_sockfd).unwrap();
+
+    // Spawn server thread.
+    let server_thread = thread::spawn(move || {
+        // Ensure main thread is blocked on reading from
+        // the client socket.
+        thread::sleep(Duration::from_millis(50));
+
+        unsafe { errno_check(libc::close(client_sockfd)) };
+
+        // Writing data into the peer socket should unblock
+        // the main thread.
+        libc_utils::write_all(peerfd, TEST_BYTES).unwrap();
+    });
+
+    let mut buffer = [0u8; TEST_BYTES.len()];
+    libc_utils::read_exact(client_sockfd, &mut buffer).unwrap();
+    assert_eq!(&buffer, TEST_BYTES);
+
+    server_thread.join().unwrap();
 }


### PR DESCRIPTION
This pull request removes the explicit destructor for the TCP socket shim. 
Registered source file descriptions are now lazily deregistered from the blocking I/O manager when the garbage collector runs.