### PR TITLE
move scheduler into its own file

### DIFF
--- a/priroda/src/main.rs
+++ b/priroda/src/main.rs
@@ -301,7 +301,7 @@ impl<'tcx> PrirodaContext<'tcx> {
         // claiming support for multi-threaded interpreted programs.
 
         // State inspection should happen only after a successful step.
-        self.ecx.miri_step()?;
+        self.ecx.step_current_thread()?;
         self.last_location = self.current_location.take();
         self.current_location = self.resolve_current_location();
         interp_ok(())

--- a/src/concurrency/mod.rs
+++ b/src/concurrency/mod.rs
@@ -3,6 +3,7 @@ pub mod cpu_affinity;
 pub mod data_race;
 mod data_race_handler;
 pub mod init_once;
+pub mod scheduler;
 pub mod sync;
 pub mod thread;
 mod vector_clock;

--- a/src/concurrency/scheduler.rs
+++ b/src/concurrency/scheduler.rs
@@ -1,0 +1,214 @@
+//! This file contains Miri's scheduler, which is in charge of picking the next thread to run when
+//! the current thread blocks/yields. It also manages timeouts and runs an async event loop
+//! to deal with host I/O. In GenMC mode, it handles delegating schedule control to GenMC.
+
+use std::sync::atomic::Ordering;
+use std::task::Poll;
+use std::time::Duration;
+
+use rand::seq::IteratorRandom;
+use rustc_const_eval::CTRL_C_RECEIVED;
+use rustc_index::Idx;
+use rustc_span::DUMMY_SP;
+
+use crate::*;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum SchedulingAction {
+    /// Execute step on the active thread.
+    ExecuteStep,
+    /// Wait for a bit, but at most as long as the duration specified.
+    /// We wake up early if an I/O event happened.
+    /// If the duration is [`None`], we sleep indefinitely. This is
+    /// only allowed when isolation is disabled and there are threads waiting for I/O!
+    SleepAndWaitForIo(Option<Duration>),
+}
+
+impl<'tcx> EvalContextPrivExt<'tcx> for MiriInterpCx<'tcx> {}
+trait EvalContextPrivExt<'tcx>: MiriInterpCxExt<'tcx> {
+    #[inline]
+    fn run_on_stack_empty(&mut self) -> InterpResult<'tcx, Poll<()>> {
+        let this = self.eval_context_mut();
+        let active_thread = this.active_thread_mut();
+        active_thread.origin_span = DUMMY_SP; // reset, the old value no longer applied
+        let mut callback = active_thread
+            .on_stack_empty
+            .take()
+            .expect("`on_stack_empty` not set up, or already running");
+        let res = callback(this)?;
+        this.active_thread_mut().on_stack_empty = Some(callback);
+        interp_ok(res)
+    }
+
+    /// Decide which action to take next and on which thread.
+    ///
+    /// The currently implemented scheduling policy is the one that is commonly
+    /// used in stateless model checkers such as Loom: run the active thread as
+    /// long as we can and switch only when we have to (the active thread was
+    /// blocked, terminated, or has explicitly asked to be preempted).
+    ///
+    /// If GenMC mode is active, the scheduling is instead handled by GenMC.
+    fn schedule(&mut self) -> InterpResult<'tcx, SchedulingAction> {
+        let this = self.eval_context_mut();
+
+        // In GenMC mode, we let GenMC do the scheduling.
+        if this.machine.data_race.as_genmc_ref().is_some() {
+            loop {
+                let genmc_ctx = this.machine.data_race.as_genmc_ref().unwrap();
+                let Some(next_thread_id) = genmc_ctx.schedule_thread(this)? else {
+                    return interp_ok(SchedulingAction::ExecuteStep);
+                };
+                // If a thread is blocked on GenMC, we have to implicitly unblock it when it gets scheduled again.
+                if this.machine.threads.thread_ref(next_thread_id).is_blocked_on(BlockReason::Genmc)
+                {
+                    info!(
+                        "GenMC: scheduling blocked thread {next_thread_id:?}, so we unblock it now."
+                    );
+                    this.unblock_thread(next_thread_id, BlockReason::Genmc)?;
+                }
+                // The thread we just unblocked may have been blocked again during the unblocking callback.
+                // In that case, we need to ask for a different thread to run next.
+                let thread_manager = &mut this.machine.threads;
+                if thread_manager.thread_ref(next_thread_id).is_enabled() {
+                    // Set the new active thread.
+                    thread_manager.set_active_thread(next_thread_id);
+                    return interp_ok(SchedulingAction::ExecuteStep);
+                }
+            }
+        }
+
+        // We are not in GenMC mode, so we control the scheduling.
+        let thread_manager = &this.machine.threads;
+        // This thread and the program can keep going.
+        if thread_manager.active_thread_ref().is_enabled() && !thread_manager.yield_active_thread {
+            // The currently active thread is still enabled, just continue with it.
+            return interp_ok(SchedulingAction::ExecuteStep);
+        }
+
+        // The active thread yielded or got terminated. Let's see if there are any I/O events
+        // or timeouts to take care of.
+
+        if this.machine.communicate() {
+            // When isolation is disabled we need to check for events for threads
+            // which are blocked on host I/O. Unlike the `poll_and_unblock` before
+            // any foreign item, the call here is needed to ensure that threads which
+            // are blocked on host I/O are woken up even if no shimmed functions are
+            // executed afterwards.
+            // We do this before running any other threads such that the threads
+            // which received events are available for scheduling afterwards.
+
+            // Perform a non-blocking poll for newly available I/O events from the OS.
+            this.poll_and_unblock(Some(Duration::ZERO))?;
+        }
+
+        // We also check timeouts before running any other thread, to ensure that timeouts
+        // "in the past" fire before any other thread can take an action. This ensures that for
+        // `pthread_cond_timedwait`, "an error is returned if [...] the absolute time specified by
+        // abstime has already been passed at the time of the call".
+        // <https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_cond_timedwait.html>
+        let potential_sleep_time = this.unblock_expired_deadlines()?;
+
+        let thread_manager = &mut this.machine.threads;
+        let rng = this.machine.rng.get_mut();
+
+        // No callbacks immediately scheduled, pick a regular thread to execute.
+        // The active thread blocked or yielded. So we go search for another enabled thread.
+        // We build the list of threads by starting with the threads after the current one, followed by
+        // the threads before the current one and then the current thread itself (i.e., this iterator acts
+        // like `threads.rotate_left(self.active_thread.index() + 1)`. This ensures that if we pick the first
+        // eligible thread, we do regular round-robin scheduling, and all threads get a chance to take a step.
+        let mut threads_iter = thread_manager
+            .all_threads()
+            .skip(thread_manager.active_thread().index() + 1)
+            .chain(thread_manager.all_threads().take(thread_manager.active_thread().index() + 1))
+            .filter(|(_id, thread)| thread.is_enabled());
+        // Pick a new thread, and switch to it.
+        let new_thread = if thread_manager.fixed_scheduling() {
+            let next = threads_iter.next();
+            drop(threads_iter);
+            next
+        } else {
+            threads_iter.choose(rng)
+        };
+
+        if let Some((id, _thread)) = new_thread {
+            if thread_manager.active_thread() != id {
+                thread_manager.set_active_thread(id);
+            }
+        }
+        // This completes the `yield`, if any was requested.
+        thread_manager.yield_active_thread = false;
+
+        if thread_manager.active_thread_ref().is_enabled() {
+            return interp_ok(SchedulingAction::ExecuteStep);
+        }
+
+        // We have not found a thread to execute.
+        if this.machine.threads.all_threads().all(|(_id, thread)| thread.is_terminated()) {
+            unreachable!("all threads terminated without the main thread terminating?!");
+        } else if let Some(sleep_time) = potential_sleep_time {
+            // All threads are currently blocked, but we have unexecuted
+            // timeout_callbacks, which may unblock some of the threads. Hence,
+            // sleep until the first callback.
+            interp_ok(SchedulingAction::SleepAndWaitForIo(Some(sleep_time)))
+        } else if this.any_thread_blocked_on_host() {
+            // At least one thread doesn't have a timeout set, and is blocked on host I/O or is waiting on an
+            // epoll instance which contains a host source interest. Hence, we sleep indefinitely in the
+            // hope that eventually an I/O event happens.
+            interp_ok(SchedulingAction::SleepAndWaitForIo(None))
+        } else {
+            throw_machine_stop!(TerminationInfo::GlobalDeadlock);
+        }
+    }
+}
+
+impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
+pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
+    /// Public because this is used by Priroda.
+    fn step_current_thread(&mut self) -> InterpResult<'tcx> {
+        let this = self.eval_context_mut();
+
+        if !this.step()? {
+            // See if this thread can do something else.
+            match this.run_on_stack_empty()? {
+                Poll::Pending => {} // keep going
+                Poll::Ready(()) => {
+                    this.terminate_active_thread(TlsAllocAction::Deallocate)?;
+                }
+            }
+        }
+
+        interp_ok(())
+    }
+
+    /// Run the core interpreter loop. Returns only when an interrupt occurs (an error or program
+    /// termination).
+    fn run_threads(&mut self) -> InterpResult<'tcx, !> {
+        let this = self.eval_context_mut();
+        loop {
+            if CTRL_C_RECEIVED.load(Ordering::Relaxed) {
+                this.machine.handle_abnormal_termination();
+                throw_machine_stop!(TerminationInfo::Interrupted);
+            }
+            match this.schedule()? {
+                SchedulingAction::ExecuteStep => {
+                    this.step_current_thread()?;
+                }
+                SchedulingAction::SleepAndWaitForIo(duration) => {
+                    if this.machine.communicate() {
+                        // When we're running with isolation disabled, instead of
+                        // strictly sleeping the duration we allow waking up
+                        // early for I/O events from the OS.
+
+                        this.poll_and_unblock(duration)?;
+                    } else {
+                        let duration = duration.expect(
+                            "Infinite sleep should not be triggered when isolation is enabled",
+                        );
+                        this.machine.monotonic_clock.sleep(duration);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/concurrency/thread.rs
+++ b/src/concurrency/thread.rs
@@ -1,14 +1,11 @@
 //! Implements threads.
 
 use std::mem;
-use std::sync::atomic::Ordering::Relaxed;
 use std::task::Poll;
 use std::time::{Duration, SystemTime};
 
 use rand::RngExt;
-use rand::seq::IteratorRandom;
 use rustc_abi::ExternAbi;
-use rustc_const_eval::CTRL_C_RECEIVED;
 use rustc_data_structures::either::Either;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_hir::def_id::DefId;
@@ -21,17 +18,6 @@ use rustc_target::spec::Os;
 use crate::concurrency::GlobalDataRaceHandler;
 use crate::shims::tls;
 use crate::*;
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-enum SchedulingAction {
-    /// Execute step on the active thread.
-    ExecuteStep,
-    /// Wait for a bit, but at most as long as the duration specified.
-    /// We wake up early if an I/O event happened.
-    /// If the duration is [`None`], we sleep indefinitely. This is
-    /// only allowed when isolation is disabled and there are threads waiting for I/O!
-    SleepAndWaitForIo(Option<Duration>),
-}
 
 /// What to do with TLS allocations from terminated threads
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -154,8 +140,8 @@ impl<'tcx> ThreadState<'tcx> {
         matches!(self, ThreadState::Terminated)
     }
 
-    fn is_blocked_on(&self, reason: &BlockReason) -> bool {
-        matches!(self, ThreadState::Blocked { reason: actual_reason, .. } if actual_reason == reason)
+    fn is_blocked_on(&self, reason: BlockReason) -> bool {
+        matches!(self, ThreadState::Blocked { reason: actual_reason, .. } if *actual_reason == reason)
     }
 }
 
@@ -226,6 +212,14 @@ impl<'tcx> Thread<'tcx> {
     /// Return whether this thread is enabled or not.
     pub fn is_enabled(&self) -> bool {
         self.state.is_enabled()
+    }
+
+    pub fn is_terminated(&self) -> bool {
+        self.state.is_terminated()
+    }
+
+    pub fn is_blocked_on(&self, reason: BlockReason) -> bool {
+        self.state.is_blocked_on(reason)
     }
 
     /// Get the name of the current thread for display purposes; will include thread ID if not set.
@@ -400,7 +394,7 @@ pub struct ThreadManager<'tcx> {
     thread_local_allocs: FxHashMap<(DefId, ThreadId), StrictPointer>,
     /// A flag that indicates that we should change the active thread.
     /// Completely ignored in GenMC mode.
-    yield_active_thread: bool,
+    pub(super) yield_active_thread: bool,
     /// A flag that indicates that we should do round robin scheduling of threads else randomized scheduling is used.
     fixed_scheduling: bool,
 }
@@ -495,6 +489,10 @@ impl<'tcx> ThreadManager<'tcx> {
         &mut self.threads[self.active_thread].stack
     }
 
+    pub(super) fn all_threads(&self) -> impl Iterator<Item = (ThreadId, &Thread<'tcx>)> {
+        self.threads.iter_enumerated()
+    }
+
     pub fn all_blocked_stacks(
         &self,
     ) -> impl Iterator<Item = (ThreadId, &[Frame<'tcx, Provenance, FrameExtra<'tcx>>])> {
@@ -512,7 +510,7 @@ impl<'tcx> ThreadManager<'tcx> {
     }
 
     /// Set an active thread and return the id of the thread that was active before.
-    fn set_active_thread_id(&mut self, id: ThreadId) -> ThreadId {
+    pub(super) fn set_active_thread(&mut self, id: ThreadId) -> ThreadId {
         assert!(id.index() < self.threads.len());
         info!(
             "---------- Now executing on thread `{}` (previous: `{}`) ----------------------------------------",
@@ -620,246 +618,14 @@ impl<'tcx> ThreadManager<'tcx> {
         *state = ThreadState::Blocked { reason, deadline, callback }
     }
 
-    /// Change the active thread to some enabled thread.
-    fn yield_active_thread(&mut self) {
-        // We do not yield immediately, as swapping out the current stack while executing a MIR statement
-        // could lead to all sorts of confusion.
-        // We should only switch stacks between steps.
-        self.yield_active_thread = true;
-    }
-}
-
-impl<'tcx> EvalContextPrivExt<'tcx> for MiriInterpCx<'tcx> {}
-trait EvalContextPrivExt<'tcx>: MiriInterpCxExt<'tcx> {
-    #[inline]
-    fn run_on_stack_empty(&mut self) -> InterpResult<'tcx, Poll<()>> {
-        let this = self.eval_context_mut();
-        let active_thread = this.active_thread_mut();
-        active_thread.origin_span = DUMMY_SP; // reset, the old value no longer applied
-        let mut callback = active_thread
-            .on_stack_empty
-            .take()
-            .expect("`on_stack_empty` not set up, or already running");
-        let res = callback(this)?;
-        this.active_thread_mut().on_stack_empty = Some(callback);
-        interp_ok(res)
-    }
-
-    /// Decide which action to take next and on which thread.
-    ///
-    /// The currently implemented scheduling policy is the one that is commonly
-    /// used in stateless model checkers such as Loom: run the active thread as
-    /// long as we can and switch only when we have to (the active thread was
-    /// blocked, terminated, or has explicitly asked to be preempted).
-    ///
-    /// If GenMC mode is active, the scheduling is instead handled by GenMC.
-    fn schedule(&mut self) -> InterpResult<'tcx, SchedulingAction> {
-        let this = self.eval_context_mut();
-
-        // In GenMC mode, we let GenMC do the scheduling.
-        if this.machine.data_race.as_genmc_ref().is_some() {
-            loop {
-                let genmc_ctx = this.machine.data_race.as_genmc_ref().unwrap();
-                let Some(next_thread_id) = genmc_ctx.schedule_thread(this)? else {
-                    return interp_ok(SchedulingAction::ExecuteStep);
-                };
-                // If a thread is blocked on GenMC, we have to implicitly unblock it when it gets scheduled again.
-                if this.machine.threads.threads[next_thread_id]
-                    .state
-                    .is_blocked_on(&BlockReason::Genmc)
-                {
-                    info!(
-                        "GenMC: scheduling blocked thread {next_thread_id:?}, so we unblock it now."
-                    );
-                    this.unblock_thread(next_thread_id, BlockReason::Genmc)?;
-                }
-                // The thread we just unblocked may have been blocked again during the unblocking callback.
-                // In that case, we need to ask for a different thread to run next.
-                let thread_manager = &mut this.machine.threads;
-                if thread_manager.threads[next_thread_id].state.is_enabled() {
-                    // Set the new active thread.
-                    thread_manager.active_thread = next_thread_id;
-                    return interp_ok(SchedulingAction::ExecuteStep);
-                }
-            }
-        }
-
-        // We are not in GenMC mode, so we control the scheduling.
-        let thread_manager = &this.machine.threads;
-        // This thread and the program can keep going.
-        if thread_manager.threads[thread_manager.active_thread].state.is_enabled()
-            && !thread_manager.yield_active_thread
-        {
-            // The currently active thread is still enabled, just continue with it.
-            return interp_ok(SchedulingAction::ExecuteStep);
-        }
-
-        // The active thread yielded or got terminated. Let's see if there are any I/O events
-        // or timeouts to take care of.
-
-        if this.machine.communicate() {
-            // When isolation is disabled we need to check for events for threads
-            // which are blocked on host I/O. Unlike the `poll_and_unblock` before
-            // any foreign item, the call here is needed to ensure that threads which
-            // are blocked on host I/O are woken up even if no shimmed functions are
-            // executed afterwards.
-            // We do this before running any other threads such that the threads
-            // which received events are available for scheduling afterwards.
-
-            // Perform a non-blocking poll for newly available I/O events from the OS.
-            this.poll_and_unblock(Some(Duration::ZERO))?;
-        }
-
-        // We also check timeouts before running any other thread, to ensure that timeouts
-        // "in the past" fire before any other thread can take an action. This ensures that for
-        // `pthread_cond_timedwait`, "an error is returned if [...] the absolute time specified by
-        // abstime has already been passed at the time of the call".
-        // <https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_cond_timedwait.html>
-        let potential_sleep_time = this.unblock_expired_deadlines()?;
-
-        let thread_manager = &mut this.machine.threads;
-        let rng = this.machine.rng.get_mut();
-
-        // No callbacks immediately scheduled, pick a regular thread to execute.
-        // The active thread blocked or yielded. So we go search for another enabled thread.
-        // We build the list of threads by starting with the threads after the current one, followed by
-        // the threads before the current one and then the current thread itself (i.e., this iterator acts
-        // like `threads.rotate_left(self.active_thread.index() + 1)`. This ensures that if we pick the first
-        // eligible thread, we do regular round-robin scheduling, and all threads get a chance to take a step.
-        let mut threads_iter = thread_manager
-            .threads
-            .iter_enumerated()
-            .skip(thread_manager.active_thread.index() + 1)
-            .chain(
-                thread_manager
-                    .threads
-                    .iter_enumerated()
-                    .take(thread_manager.active_thread.index() + 1),
-            )
-            .filter(|(_id, thread)| thread.state.is_enabled());
-        // Pick a new thread, and switch to it.
-        let new_thread = if thread_manager.fixed_scheduling {
-            let next = threads_iter.next();
-            drop(threads_iter);
-            next
-        } else {
-            threads_iter.choose(rng)
-        };
-
-        if let Some((id, _thread)) = new_thread {
-            if thread_manager.active_thread != id {
-                info!(
-                    "---------- Now executing on thread `{}` (previous: `{}`) ----------------------------------------",
-                    thread_manager.get_thread_display_name(id),
-                    thread_manager.get_thread_display_name(thread_manager.active_thread)
-                );
-                thread_manager.active_thread = id;
-            }
-        }
-        // This completes the `yield`, if any was requested.
-        thread_manager.yield_active_thread = false;
-
-        if thread_manager.threads[thread_manager.active_thread].state.is_enabled() {
-            return interp_ok(SchedulingAction::ExecuteStep);
-        }
-
-        // We have not found a thread to execute.
-        let threads = &this.machine.threads.threads;
-
-        if threads.iter().all(|thread| thread.state.is_terminated()) {
-            unreachable!("all threads terminated without the main thread terminating?!");
-        } else if let Some(sleep_time) = potential_sleep_time {
-            // All threads are currently blocked, but we have unexecuted
-            // timeout_callbacks, which may unblock some of the threads. Hence,
-            // sleep until the first callback.
-            interp_ok(SchedulingAction::SleepAndWaitForIo(Some(sleep_time)))
-        } else if this.any_thread_blocked_on_host() {
-            // At least one thread doesn't have a timeout set, and is blocked on host I/O or is waiting on an
-            // epoll instance which contains a host source interest. Hence, we sleep indefinitely in the
-            // hope that eventually an I/O event happens.
-            interp_ok(SchedulingAction::SleepAndWaitForIo(None))
-        } else {
-            throw_machine_stop!(TerminationInfo::GlobalDeadlock);
-        }
-    }
-
-    /// Find all threads with expired timeouts, unblock them and execute their timeout callbacks.
-    ///
-    /// This method returns the minimum duration until the next thread deadline.
-    /// If all ready threads have no deadline set, [`None`] is returned.
-    fn unblock_expired_deadlines(&mut self) -> InterpResult<'tcx, Option<Duration>> {
-        let this = self.eval_context_mut();
-        let communicate = this.machine.communicate();
-
-        let mut min_wait_time = Option::<Duration>::None;
-        let mut callbacks = Vec::new();
-
-        for (id, thread) in this.machine.threads.threads.iter_enumerated_mut() {
-            match &thread.state {
-                ThreadState::Blocked { deadline: Some(deadline), .. } => {
-                    let wait_time = match deadline {
-                        Deadline::Monotonic(instant) =>
-                            instant.duration_since(this.machine.monotonic_clock.now()),
-                        Deadline::RealTime(time) => {
-                            assert!(communicate, "cannot have `RealTime` timeout with isolation");
-                            time.duration_since(SystemTime::now()).unwrap_or(Duration::ZERO)
-                        }
-                    };
-
-                    if wait_time.is_zero() {
-                        // The timeout expired for this thread.
-                        let old_state = mem::replace(&mut thread.state, ThreadState::Enabled);
-                        let ThreadState::Blocked { callback, .. } = old_state else {
-                            unreachable!()
-                        };
-                        // Add callback to list to be run after this loop because of borrow-checking.
-                        callbacks.push((id, callback));
-                    } else {
-                        // Update `min_wait_time` to contain the smallest duration until
-                        // the next timeout expires.
-                        min_wait_time = Some(wait_time.min(min_wait_time.unwrap_or(Duration::MAX)));
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        for (thread, callback) in callbacks {
-            // This back-and-forth with `set_active_thread` is here because of two
-            // design decisions:
-            // 1. Make the caller and not the callback responsible for changing
-            //    thread.
-            // 2. Make the scheduler the only place that can change the active
-            //    thread.
-            let old_thread = this.machine.threads.set_active_thread_id(thread);
-            callback.call(this, UnblockKind::TimedOut)?;
-            this.machine.threads.set_active_thread_id(old_thread);
-        }
-
-        interp_ok(min_wait_time)
+    pub fn fixed_scheduling(&self) -> bool {
+        self.fixed_scheduling
     }
 }
 
 // Public interface to thread management.
 impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
 pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
-    /// Public because this is used by Priroda.
-    fn miri_step(&mut self) -> InterpResult<'tcx> {
-        let this = self.eval_context_mut();
-
-        if !this.step()? {
-            // See if this thread can do something else.
-            match this.run_on_stack_empty()? {
-                Poll::Pending => {} //keep going
-                Poll::Ready(()) => {
-                    this.terminate_active_thread(TlsAllocAction::Deallocate)?;
-                }
-            }
-        }
-
-        interp_ok(())
-    }
-
     #[inline]
     fn thread_id_try_from(&self, id: impl TryInto<u32>) -> Result<ThreadId, ThreadLookupError> {
         self.eval_context_ref().machine.threads.thread_id_try_from(id)
@@ -948,7 +714,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
         // Finally switch to new thread so that we can push the first stackframe.
         // After this all accesses will be treated as occurring in the new thread.
-        let old_thread_id = this.machine.threads.set_active_thread_id(new_thread_id);
+        let old_thread_id = this.machine.threads.set_active_thread(new_thread_id);
 
         // The child inherits its parent's cpu affinity.
         // Skips this if `machine.thread_cpu_affinity` is not initialized.
@@ -975,7 +741,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         )?;
 
         // Restore the old active thread frame.
-        this.machine.threads.set_active_thread_id(old_thread_id);
+        this.machine.threads.set_active_thread(old_thread_id);
 
         interp_ok(new_thread_id)
     }
@@ -1039,7 +805,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let threads = &this.machine.threads.threads;
         let joining_threads = threads
             .iter_enumerated()
-            .filter(|(_, thread)| thread.state.is_blocked_on(&unblock_reason))
+            .filter(|(_, thread)| thread.state.is_blocked_on(unblock_reason))
             .map(|(id, _)| id)
             .collect::<Vec<_>>();
         for thread in joining_threads {
@@ -1085,10 +851,66 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             _ => panic!("unblock_thread: thread was not blocked"),
         };
         // The callback must be executed in the previously blocked thread.
-        let old_thread = this.machine.threads.set_active_thread_id(thread);
+        let old_thread = this.machine.threads.set_active_thread(thread);
         callback.call(this, UnblockKind::Ready)?;
-        this.machine.threads.set_active_thread_id(old_thread);
+        this.machine.threads.set_active_thread(old_thread);
         interp_ok(())
+    }
+
+    /// Find all threads with expired timeouts, unblock them and execute their timeout callbacks.
+    ///
+    /// This method returns the minimum duration until the next thread deadline.
+    /// If all ready threads have no deadline set, [`None`] is returned.
+    fn unblock_expired_deadlines(&mut self) -> InterpResult<'tcx, Option<Duration>> {
+        let this = self.eval_context_mut();
+        let communicate = this.machine.communicate();
+
+        let mut min_wait_time = Option::<Duration>::None;
+        let mut callbacks = Vec::new();
+
+        for (id, thread) in this.machine.threads.threads.iter_enumerated_mut() {
+            match &thread.state {
+                ThreadState::Blocked { deadline: Some(deadline), .. } => {
+                    let wait_time = match deadline {
+                        Deadline::Monotonic(instant) =>
+                            instant.duration_since(this.machine.monotonic_clock.now()),
+                        Deadline::RealTime(time) => {
+                            assert!(communicate, "cannot have `RealTime` timeout with isolation");
+                            time.duration_since(SystemTime::now()).unwrap_or(Duration::ZERO)
+                        }
+                    };
+
+                    if wait_time.is_zero() {
+                        // The timeout expired for this thread.
+                        let old_state = mem::replace(&mut thread.state, ThreadState::Enabled);
+                        let ThreadState::Blocked { callback, .. } = old_state else {
+                            unreachable!()
+                        };
+                        // Add callback to list to be run after this loop because of borrow-checking.
+                        callbacks.push((id, callback));
+                    } else {
+                        // Update `min_wait_time` to contain the smallest duration until
+                        // the next timeout expires.
+                        min_wait_time = Some(wait_time.min(min_wait_time.unwrap_or(Duration::MAX)));
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        for (thread, callback) in callbacks {
+            // This back-and-forth with `set_active_thread` is here because of two
+            // design decisions:
+            // 1. Make the caller and not the callback responsible for changing
+            //    thread.
+            // 2. Make the scheduler the only place that can change the active
+            //    thread.
+            let old_thread = this.machine.threads.set_active_thread(thread);
+            callback.call(this, UnblockKind::TimedOut)?;
+            this.machine.threads.set_active_thread(old_thread);
+        }
+
+        interp_ok(min_wait_time)
     }
 
     #[inline]
@@ -1194,9 +1016,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
         // Sanity check `join_status`.
         assert!(
-            threads.iter().all(|thread| {
-                !thread.state.is_blocked_on(&BlockReason::Join(joined_thread_id))
-            }),
+            threads
+                .iter()
+                .all(|thread| { !thread.state.is_blocked_on(BlockReason::Join(joined_thread_id)) }),
             "this thread already has threads waiting for its termination"
         );
 
@@ -1269,7 +1091,10 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
     #[inline]
     fn yield_active_thread(&mut self) {
-        self.eval_context_mut().machine.threads.yield_active_thread();
+        // We do not yield immediately, as swapping out the current stack while executing a MIR statement
+        // could lead to all sorts of confusion.
+        // We should only switch stacks between steps.
+        self.eval_context_mut().machine.threads.yield_active_thread = true;
     }
 
     #[inline]
@@ -1279,37 +1104,6 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             && this.machine.rng.get_mut().random_bool(this.machine.preemption_rate)
         {
             this.yield_active_thread();
-        }
-    }
-
-    /// Run the core interpreter loop. Returns only when an interrupt occurs (an error or program
-    /// termination).
-    fn run_threads(&mut self) -> InterpResult<'tcx, !> {
-        let this = self.eval_context_mut();
-        loop {
-            if CTRL_C_RECEIVED.load(Relaxed) {
-                this.machine.handle_abnormal_termination();
-                throw_machine_stop!(TerminationInfo::Interrupted);
-            }
-            match this.schedule()? {
-                SchedulingAction::ExecuteStep => {
-                    this.miri_step()?;
-                }
-                SchedulingAction::SleepAndWaitForIo(duration) => {
-                    if this.machine.communicate() {
-                        // When we're running with isolation disabled, instead of
-                        // strictly sleeping the duration we allow waking up
-                        // early for I/O events from the OS.
-
-                        this.poll_and_unblock(duration)?;
-                    } else {
-                        let duration = duration.expect(
-                            "Infinite sleep should not be triggered when isolation is enabled",
-                        );
-                        this.machine.monotonic_clock.sleep(duration);
-                    }
-                }
-            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,7 @@ pub use crate::concurrency::data_race::{
     AtomicFenceOrd, AtomicReadOrd, AtomicRwOrd, AtomicWriteOrd, EvalContextExt as _,
 };
 pub use crate::concurrency::init_once::{EvalContextExt as _, InitOnceRef};
+pub use crate::concurrency::scheduler::EvalContextExt as _;
 pub use crate::concurrency::sync::{CondvarRef, EvalContextExt as _, MutexRef, RwLockRef};
 pub use crate::concurrency::thread::{
     BlockReason, DynUnblockCallback, EvalContextExt as _, StackEmptyCallback, ThreadId,


### PR DESCRIPTION
The scheduler has grown to considerate complexity over the years. Let's move it into its own file so it's easier to find and look at separate from all the general thread management infrastructure.