### PR TITLE
remove FileDescription::destroy

### DIFF
--- a/src/concurrency/blocking_io.rs
+++ b/src/concurrency/blocking_io.rs
@@ -63,10 +63,9 @@ impl From<&mio::event::Event> for Readiness {
 }
 
 struct BlockingIoSource {
-    /// The source file description which is registered into the poll.
-    /// We only store weak references such that source file descriptions
-    /// can be destroyed whilst they are registered. However, they are required
-    /// to deregister themselves when [`FileDescription::destroy`] is called.
+    /// The source file description which is registered into the poll. We only store weak references
+    /// such that source file descriptions can be destroyed whilst they are registered. They will
+    /// later be cleaned up on the next GC run.
     fd: WeakFileDescriptionRef<dyn SourceFileDescription>,
     /// The threads which are blocked on the I/O source, and the interest indicating
     /// when they should be unblocked.

--- a/src/concurrency/scheduler.rs
+++ b/src/concurrency/scheduler.rs
@@ -11,6 +11,7 @@ use rustc_const_eval::CTRL_C_RECEIVED;
 use rustc_index::Idx;
 use rustc_span::DUMMY_SP;
 
+use crate::shims::readiness::DelayedReadinessUpdates;
 use crate::*;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -87,6 +88,9 @@ trait EvalContextPrivExt<'tcx>: MiriInterpCxExt<'tcx> {
 
         // The active thread yielded or got terminated. Let's see if there are any I/O events
         // or timeouts to take care of.
+
+        // There may be delayed readiness updates we have to process.
+        DelayedReadinessUpdates::process(this)?;
 
         if this.machine.communicate() {
             // When isolation is disabled we need to check for events for threads

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -41,6 +41,7 @@ use crate::concurrency::{
     AllocDataRaceHandler, GenmcCtx, GenmcEvalContextExt as _, GlobalDataRaceHandler, weak_memory,
 };
 use crate::helpers::is_no_core;
+use crate::shims::readiness::DelayedReadinessUpdates;
 use crate::*;
 
 /// First real-time signal.
@@ -534,6 +535,7 @@ pub struct MiriMachine<'tcx> {
 
     /// The table of all active [`ReadinessWatcher`]s.
     pub(crate) readiness_interests: ReadinessInterestTable,
+    pub(crate) delayed_readiness_updates: Rc<DelayedReadinessUpdates>,
 
     /// This machine's monotone clock.
     pub(crate) monotonic_clock: MonotonicClock,
@@ -767,6 +769,7 @@ impl<'tcx> MiriMachine<'tcx> {
             validation: config.validation,
             fds: shims::FdTable::init(config.mute_stdout_stderr),
             readiness_interests: ReadinessInterestTable::new(),
+            delayed_readiness_updates: Rc::new(DelayedReadinessUpdates::default()),
             dirs: Default::default(),
             layouts,
             threads,
@@ -1027,6 +1030,7 @@ impl VisitProvenance for MiriMachine<'_> {
             fds,
             blocking_io:_,
             readiness_interests: _,
+            delayed_readiness_updates: _,
             tcx: _,
             isolated_op: _,
             validation: _,

--- a/src/shims/files.rs
+++ b/src/shims/files.rs
@@ -109,11 +109,10 @@ impl<T> VisitProvenance for FileDescriptionRef<T> {
 pub trait FileDescriptionExt: 'static {
     fn into_rc_any(self: FileDescriptionRef<Self>) -> Rc<dyn Any>;
 
-    /// We wrap the regular `close` function generically, so both handle `Rc::into_inner`
+    /// We wrap the regular `close` function generically, to both handle `Rc::into_inner`
     /// and epoll interest management.
     fn close_ref<'tcx>(
         self: FileDescriptionRef<Self>,
-        communicate_allowed: bool,
         ecx: &mut MiriInterpCx<'tcx>,
     ) -> InterpResult<'tcx, io::Result<()>>;
 }
@@ -125,15 +124,17 @@ impl<T: FileDescription + 'static> FileDescriptionExt for T {
 
     fn close_ref<'tcx>(
         self: FileDescriptionRef<Self>,
-        communicate_allowed: bool,
         ecx: &mut MiriInterpCx<'tcx>,
     ) -> InterpResult<'tcx, io::Result<()>> {
         match Rc::into_inner(self.0) {
             Some(fd) => {
+                // This was the last strong reference.
                 // There might have been readiness watchers interested in this FD. Remove them.
+                // FIXME: this isn't actually reliable, we don't always call `close_ref` when
+                // a FileDescriptionRef gets dropped!
                 ecx.machine.readiness_interests.remove_watchers_for_fd(fd.id);
 
-                fd.inner.destroy(fd.id, communicate_allowed, ecx)
+                interp_ok(Ok(()))
             }
             None => {
                 // Not the last reference.
@@ -204,22 +205,6 @@ pub trait FileDescription: std::fmt::Debug + FileDescriptionExt {
         _offset: SeekFrom,
     ) -> InterpResult<'tcx, io::Result<u64>> {
         throw_unsup_format!("cannot seek on {}", self.name());
-    }
-
-    /// Destroys the file description. Only called when the last duplicate file descriptor is closed.
-    ///
-    /// Note that if you do anything here you must also make sure that any time you drop
-    /// a `FileDescriptionRef` for your description type, that is dropped via `close_ref`!
-    fn destroy<'tcx>(
-        self,
-        _self_id: FdId,
-        _communicate_allowed: bool,
-        _ecx: &mut MiriInterpCx<'tcx>,
-    ) -> InterpResult<'tcx, io::Result<()>>
-    where
-        Self: Sized,
-    {
-        interp_ok(Ok(()))
     }
 
     /// Returns the metadata for this FD, if available.

--- a/src/shims/files.rs
+++ b/src/shims/files.rs
@@ -408,33 +408,6 @@ impl FileDescription for FileHandle {
         interp_ok((&mut &self.file).seek(offset))
     }
 
-    fn destroy<'tcx>(
-        self,
-        _self_id: FdId,
-        communicate_allowed: bool,
-        _ecx: &mut MiriInterpCx<'tcx>,
-    ) -> InterpResult<'tcx, io::Result<()>> {
-        assert!(communicate_allowed, "isolation should have prevented even opening a file");
-        // We sync the file if it was opened in a mode different than read-only.
-        if self.writable {
-            // `File::sync_all` does the checks that are done when closing a file. We do this to
-            // to handle possible errors correctly.
-            let result = self.file.sync_all();
-            // Now we actually close the file and return the result.
-            drop(self.file);
-            interp_ok(result)
-        } else {
-            // We drop the file, this closes it but ignores any errors
-            // produced when closing it. This is done because
-            // `File::sync_all` cannot be done over files like
-            // `/dev/urandom` which are read-only. Check
-            // https://github.com/rust-lang/miri/issues/999#issuecomment-568920439
-            // for a deeper discussion.
-            drop(self.file);
-            interp_ok(Ok(()))
-        }
-    }
-
     fn metadata<'tcx>(&self) -> InterpResult<'tcx, Either<io::Result<fs::Metadata>, &'static str>> {
         interp_ok(Either::Left(self.file.metadata()))
     }

--- a/src/shims/readiness.rs
+++ b/src/shims/readiness.rs
@@ -426,6 +426,32 @@ impl ReadinessInterestTable {
     }
 }
 
+/// If a file description's readiness is known to change but we don't have an `ecx` around to update
+/// it immediately, we arange for a referene to the delayed readiness updates queue to be available
+/// and perform the update on the next scheduler call.
+#[derive(Default, Debug)]
+pub struct DelayedReadinessUpdates {
+    to_update: RefCell<Vec<DynFileDescriptionRef>>,
+}
+
+impl DelayedReadinessUpdates {
+    pub fn add(&self, fd: DynFileDescriptionRef) {
+        self.to_update.borrow_mut().push(fd);
+    }
+
+    pub fn process<'tcx>(ecx: &mut MiriInterpCx<'tcx>) -> InterpResult<'tcx> {
+        loop {
+            // Avoid keeping the RefCell open over the `update_fd_readiness` as that can invoke
+            // arbitrary code via the unblock callback.
+            let Some(fd) = ecx.machine.delayed_readiness_updates.to_update.borrow_mut().pop()
+            else {
+                return interp_ok(());
+            };
+            ecx.update_fd_readiness(fd, /* force_edge */ false)?;
+        }
+    }
+}
+
 impl<'tcx> EvalContextExt<'tcx> for MiriInterpCx<'tcx> {}
 pub trait EvalContextExt<'tcx>: MiriInterpCxExt<'tcx> {
     /// Returns whether the given FD has any readiness watcher with a blocked thread watching it.

--- a/src/shims/unix/fd.rs
+++ b/src/shims/unix/fd.rs
@@ -108,7 +108,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             // If old_fd and new_fd point to the same description, then `dup_fd` ensures we keep the underlying file description alive.
             if let Some(old_new_fd) = this.machine.fds.fds.insert(new_fd_num, fd) {
                 // Ignore close error (not interpreter's) according to dup2() doc.
-                old_new_fd.close_ref(this.machine.communicate(), this)?.ok();
+                old_new_fd.close_ref(this)?.ok();
             }
         }
         interp_ok(Scalar::from_i32(new_fd_num))
@@ -286,7 +286,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let Some(fd) = this.machine.fds.remove(fd_num) else {
             return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
         };
-        let result = fd.close_ref(this.machine.communicate(), this)?;
+        let result = fd.close_ref(this)?;
         // return `0` if close is successful
         let result = result.map(|()| 0i32);
         interp_ok(Scalar::from_i32(this.try_unwrap_io_result(result)?))

--- a/src/shims/unix/virtual_socket.rs
+++ b/src/shims/unix/virtual_socket.rs
@@ -5,13 +5,15 @@
 use std::cell::{Cell, OnceCell, RefCell};
 use std::collections::VecDeque;
 use std::io::{self, ErrorKind, Read};
+use std::rc::Rc;
 
 use rustc_target::spec::Os;
 
 use crate::concurrency::VClock;
 use crate::shims::files::{
-    EvalContextExt as _, FdId, FileDescription, FileDescriptionRef, WeakFileDescriptionRef,
+    EvalContextExt as _, FileDescription, FileDescriptionRef, WeakFileDescriptionRef,
 };
+use crate::shims::readiness::DelayedReadinessUpdates;
 use crate::shims::unix::UnixFileDescription;
 use crate::shims::unix::socket::UnixSocketFileDescription;
 use crate::*;
@@ -53,8 +55,11 @@ struct VirtualSocket {
     blocked_write_tid: RefCell<Vec<ThreadId>>,
     /// Whether this fd is non-blocking or not.
     is_nonblock: Cell<bool>,
-    // Differentiate between different virtual socket fd types.
+    /// Differentiate between different virtual socket fd types.
     fd_type: VirtualSocketType,
+    /// We need to update the peer_fd readiness when we get dropped, so we keep a reference
+    /// to the readiness update queue
+    delayed_readiness_updates: Rc<DelayedReadinessUpdates>,
 }
 
 #[derive(Debug)]
@@ -75,6 +80,22 @@ impl VirtualSocket {
     }
 }
 
+impl Drop for VirtualSocket {
+    fn drop(&mut self) {
+        if let Some(peer_fd) = self.peer_fd().upgrade() {
+            // If the current readbuf is non-empty when the file description is closed,
+            // notify the peer that data lost has happened in current file description.
+            if let Some(readbuf) = &self.readbuf {
+                if !readbuf.borrow().buf.is_empty() {
+                    peer_fd.peer_lost_data.set(true);
+                }
+            }
+            // Notify peer fd that close has happened, since that can unblock reads and writes.
+            self.delayed_readiness_updates.add(peer_fd);
+        }
+    }
+}
+
 impl FileDescription for VirtualSocket {
     fn name(&self) -> &'static str {
         match self.fd_type {
@@ -91,26 +112,6 @@ impl FileDescription for VirtualSocket {
             VirtualSocketType::PipeRead | VirtualSocketType::PipeWrite => "S_IFIFO",
         };
         interp_ok(Either::Right(mode_name))
-    }
-
-    fn destroy<'tcx>(
-        self,
-        _self_id: FdId,
-        _communicate_allowed: bool,
-        ecx: &mut MiriInterpCx<'tcx>,
-    ) -> InterpResult<'tcx, io::Result<()>> {
-        if let Some(peer_fd) = self.peer_fd().upgrade() {
-            // If the current readbuf is non-empty when the file description is closed,
-            // notify the peer that data lost has happened in current file description.
-            if let Some(readbuf) = &self.readbuf {
-                if !readbuf.borrow().buf.is_empty() {
-                    peer_fd.peer_lost_data.set(true);
-                }
-            }
-            // Notify peer fd that close has happened, since that can unblock reads and writes.
-            ecx.update_fd_readiness(peer_fd, /* force_edge */ false)?;
-        }
-        interp_ok(Ok(()))
     }
 
     fn read<'tcx>(
@@ -607,6 +608,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             blocked_write_tid: RefCell::new(Vec::new()),
             is_nonblock: Cell::new(is_sock_nonblock),
             fd_type: VirtualSocketType::Socketpair,
+            delayed_readiness_updates: Rc::clone(&this.machine.delayed_readiness_updates),
         });
         let fd1 = fds.new_ref(VirtualSocket {
             readbuf: Some(RefCell::new(Buffer::new())),
@@ -616,6 +618,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             blocked_write_tid: RefCell::new(Vec::new()),
             is_nonblock: Cell::new(is_sock_nonblock),
             fd_type: VirtualSocketType::Socketpair,
+            delayed_readiness_updates: Rc::clone(&this.machine.delayed_readiness_updates),
         });
 
         // Make the file descriptions point to each other.
@@ -677,6 +680,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             blocked_write_tid: RefCell::new(Vec::new()),
             is_nonblock: Cell::new(is_nonblock),
             fd_type: VirtualSocketType::PipeRead,
+            delayed_readiness_updates: Rc::clone(&this.machine.delayed_readiness_updates),
         });
         let fd1 = fds.new_ref(VirtualSocket {
             readbuf: None,
@@ -686,6 +690,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             blocked_write_tid: RefCell::new(Vec::new()),
             is_nonblock: Cell::new(is_nonblock),
             fd_type: VirtualSocketType::PipeWrite,
+            delayed_readiness_updates: Rc::clone(&this.machine.delayed_readiness_updates),
         });
 
         // Make the file descriptions point to each other.

--- a/src/shims/windows/handle.rs
+++ b/src/shims/windows/handle.rs
@@ -342,7 +342,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             }
             Handle::File(fd_num) =>
                 if let Some(fd) = this.machine.fds.remove(fd_num) {
-                    let err = fd.close_ref(this.machine.communicate(), this)?;
+                    let err = fd.close_ref(this)?;
                     if let Err(e) = err {
                         this.set_last_error(e)?;
                         this.eval_windows("c", "FALSE")

--- a/tests/pass-dep/libc/libc-epoll-blocking.rs
+++ b/tests/pass-dep/libc/libc-epoll-blocking.rs
@@ -1,9 +1,9 @@
 //@only-target: linux android illumos
-// test_epoll_block_then_unblock and test_epoll_race depend on a deterministic schedule.
 //@revisions: edge_triggered level_triggered
 //@run-native
 
 use std::convert::TryInto;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::Duration;
 
@@ -26,6 +26,7 @@ fn main() {
     wakeup_on_new_interest();
     multiple_events_wake_multiple_threads();
     waiting_threads_unblocked_after_epoll_close();
+    waiting_threads_unblocked_after_socketpair_close();
 }
 
 // This test allows edge-triggered epoll_wait to block and then unblock
@@ -125,7 +126,7 @@ fn test_notification_after_timeout() {
     check_epoll_wait(epfd, &[Ev { events: EPOLLIN | EPOLLOUT, data: fds[0] }], 10);
 }
 
-// This test shows a data race before epoll had vector clocks added.
+// This test shows that there is no data race when synchronizing through an epoll wakeup.
 fn test_epoll_race() {
     // Create an epoll instance.
     let epfd = errno_result(unsafe { libc::epoll_create1(0) }).unwrap();
@@ -256,4 +257,48 @@ fn waiting_threads_unblocked_after_epoll_close() {
     check_epoll_wait(epfd, &[Ev { events: EPOLLIN, data: fds[0] }], -1);
 
     t1.join().unwrap();
+}
+
+/// Check correct behavior when a socketpair FD is closed while a thread blocks on it.
+/// That thread keeps a reference so it is only really closed when that thread wakes up
+/// again, and at that point an epoll notification should be triggered.
+fn waiting_threads_unblocked_after_socketpair_close() {
+    // Create an epoll instance.
+    let epfd = errno_result(unsafe { libc::epoll_create1(0) }).unwrap();
+
+    // Create a socketpair instance.
+    let mut fds = [-1, -1];
+    errno_check(unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) });
+
+    // And an atomic variable for synchronization.
+    let flag = AtomicBool::new(false);
+
+    thread::scope(|s| {
+        // Thread 1 will block reading on fds[0], thread 2 blocks on epoll for fds[1].
+        s.spawn(|| {
+            let data = read_exact_array::<4>(fds[0]).unwrap();
+            assert_eq!(&data, b"1234");
+            flag.store(true, Ordering::Relaxed);
+        });
+        s.spawn(|| {
+            // Indefinitely block until `fds[1]` becomes readable.
+            epoll_ctl_add(epfd, fds[1], EPOLLIN | EPOLLET_OR_ZERO).unwrap();
+            check_epoll_wait(epfd, &[Ev { events: EPOLLIN | EPOLLHUP, data: fds[1] }], -1);
+            flag.store(true, Ordering::Relaxed);
+        });
+
+        // Let the threads go and do their setup.
+        thread::sleep(Duration::from_millis(10));
+
+        // Once they did their setup, close fds[0] (will not really be closed since there is a thread
+        // blocked on it).
+        unsafe { errno_check(libc::close(fds[0])) };
+
+        // This should *not* yet wake up anyone. So we wait a bit and check the flag.
+        thread::sleep(Duration::from_millis(10));
+        assert_eq!(flag.load(Ordering::Relaxed), false);
+
+        // ... and then write to fds[1] to make it readable.
+        write_all(fds[1], b"1234").unwrap();
+    });
 }

--- a/tests/pass-dep/libc/libc-socketpair.rs
+++ b/tests/pass-dep/libc/libc-socketpair.rs
@@ -205,10 +205,10 @@ fn test_unblock_after_socket_close() {
         unsafe { errno_check(libc::close(client_fd)) };
 
         // Writing data into the peer socket should unblock the main thread.
-        libc_utils::write_all(server_fd, b"1234").unwrap();
+        write_all(server_fd, b"1234").unwrap();
     });
 
-    let data = libc_utils::read_exact_array::<4>(client_fd).unwrap();
+    let data = read_exact_array::<4>(client_fd).unwrap();
     assert_eq!(&data, b"1234");
 
     server_thread.join().unwrap();


### PR DESCRIPTION
The idea of `FileDescription::destroy` was that we'd call it when the refcount of a file handle reaches 0. But that requires reliably instrumenting every place where a file handle is destroyed, which is simply not practical and we already got it wrong in a bunch of ways. (Things would be a lot easier if we only ever held weak references in blocked thread callbacks, but then we couldn't faithfully implement the Linux behavior where it apparently keeps file descriptions alive when there is a thread still blocked on them.)

This gets rid of the last two file handle types that have a `destroy`:
- VirtualSocket, which now uses a new "delayed readiness update" system to make sure that it's peer socket readiness is updated correctly.
- FileHandle, where we just remove the `destroy` since anyway errors are [not reliably reported on close](https://github.com/rust-lang/rust/issues/98338).