### PR TITLE
Re-do how we handle closing FDs that epoll is watching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,13 +65,14 @@ jobs:
       - name: install multiarch
         if: ${{ matrix.multiarch != '' }}
         run: |
+          set -x
           # armhf, s390x, ppc64el, riscv64 need Ubuntu Ports to be in the mirror list
           sudo bash -c "echo 'https://ports.ubuntu.com/	priority:4' >> /etc/apt/apt-mirrors.txt"
           # Add architecture
           sudo dpkg --add-architecture ${{ matrix.multiarch }}
           # Ubuntu Ports often has outdated mirrors so try a few times to get the apt repo
           for TRY in $(seq 3); do
-            { sudo apt update && break; } || sleep 60
+            { sudo apt update -o APT::Update::Error-Mode=any && break; } || sleep 60
           done
           # Install needed packages
           sudo apt install $(echo "libatomic1: zlib1g-dev:" | sed 's/:/:${{ matrix.multiarch }}/g')

--- a/src/concurrency/scheduler.rs
+++ b/src/concurrency/scheduler.rs
@@ -80,7 +80,7 @@ trait EvalContextPrivExt<'tcx>: MiriInterpCxExt<'tcx> {
 
         // We are not in GenMC mode, so we control the scheduling.
         let thread_manager = &this.machine.threads;
-        // This thread and the program can keep going.
+        // Check if we can just keep running the current thread.
         if thread_manager.active_thread_ref().is_enabled() && !thread_manager.yield_active_thread {
             // The currently active thread is still enabled, just continue with it.
             return interp_ok(SchedulingAction::ExecuteStep);
@@ -89,7 +89,9 @@ trait EvalContextPrivExt<'tcx>: MiriInterpCxExt<'tcx> {
         // The active thread yielded or got terminated. Let's see if there are any I/O events
         // or timeouts to take care of.
 
-        // There may be delayed readiness updates we have to process.
+        // There may be delayed readiness updates we have to process. We only care about this
+        // if it may unblock other threads, or if someone calls `epoll_wait`, and for the latter
+        // case there is another call in `ReadinessWatcher::get_ready_interests`.
         DelayedReadinessUpdates::process(this)?;
 
         if this.machine.communicate() {

--- a/src/shims/files.rs
+++ b/src/shims/files.rs
@@ -40,6 +40,7 @@ struct FdIdWith<T: ?Sized> {
 /// globally unique ID of this file description.
 #[repr(transparent)]
 #[derive(CoercePointee, Debug)]
+// Sadly `CoercePointee` does not let us keep the `FdId` *outside* the `Rc`.
 pub struct FileDescriptionRef<T: ?Sized>(Rc<FdIdWith<T>>);
 
 impl<T: ?Sized> Clone for FileDescriptionRef<T> {
@@ -145,6 +146,7 @@ impl<T: FileDescription + 'static> FileDescriptionExt for T {
 }
 
 pub type DynFileDescriptionRef = FileDescriptionRef<dyn FileDescription>;
+pub type WeakDynFileDescriptionRef = WeakFileDescriptionRef<dyn FileDescription>;
 
 impl FileDescriptionRef<dyn FileDescription> {
     pub fn downcast<T: FileDescription + 'static>(self) -> Option<FileDescriptionRef<T>> {

--- a/src/shims/files.rs
+++ b/src/shims/files.rs
@@ -109,39 +109,11 @@ impl<T> VisitProvenance for FileDescriptionRef<T> {
 /// but that does not allow upcasting.
 pub trait FileDescriptionExt: 'static {
     fn into_rc_any(self: FileDescriptionRef<Self>) -> Rc<dyn Any>;
-
-    /// We wrap the regular `close` function generically, to both handle `Rc::into_inner`
-    /// and epoll interest management.
-    fn close_ref<'tcx>(
-        self: FileDescriptionRef<Self>,
-        ecx: &mut MiriInterpCx<'tcx>,
-    ) -> InterpResult<'tcx, io::Result<()>>;
 }
 
 impl<T: FileDescription + 'static> FileDescriptionExt for T {
     fn into_rc_any(self: FileDescriptionRef<Self>) -> Rc<dyn Any> {
         self.0
-    }
-
-    fn close_ref<'tcx>(
-        self: FileDescriptionRef<Self>,
-        ecx: &mut MiriInterpCx<'tcx>,
-    ) -> InterpResult<'tcx, io::Result<()>> {
-        match Rc::into_inner(self.0) {
-            Some(fd) => {
-                // This was the last strong reference.
-                // There might have been readiness watchers interested in this FD. Remove them.
-                // FIXME: this isn't actually reliable, we don't always call `close_ref` when
-                // a FileDescriptionRef gets dropped!
-                ecx.machine.readiness_interests.remove_watchers_for_fd(fd.id);
-
-                interp_ok(Ok(()))
-            }
-            None => {
-                // Not the last reference.
-                interp_ok(Ok(()))
-            }
-        }
     }
 }
 

--- a/src/shims/readiness.rs
+++ b/src/shims/readiness.rs
@@ -81,6 +81,8 @@ fn range_for_id(id: FdId) -> std::ops::RangeInclusive<ReadinessInterestKey> {
 
 #[derive(Debug, Clone)]
 pub struct ReadinessInterest {
+    /// The FD we are interested in.
+    watched_fd: WeakDynFileDescriptionRef,
     /// The mask of events the interest is interested in
     /// for this file descriptor.
     pub relevant: Readiness,
@@ -159,6 +161,7 @@ impl ReadinessWatcher {
         let key = (fd_id, fd_num);
 
         let interest = ReadinessInterest {
+            watched_fd: FileDescriptionRef::downgrade(&fd_ref),
             active: Readiness::EMPTY,
             clock: VClock::default(),
             relevant,
@@ -278,7 +281,7 @@ impl ReadinessWatcher {
         self.ready.borrow().len()
     }
 
-    /// Get at most the first `count` ready interests from the ready queue.
+    /// Get at most the first `max` ready interests from the ready queue.
     ///
     /// If the interest is a level-triggered interest, it's automatically
     /// added to the end of the queue again such that it will only be reported
@@ -289,10 +292,16 @@ impl ReadinessWatcher {
     /// are level-triggered interests.
     pub fn get_ready_interests<'tcx>(
         &self,
-        count: usize,
+        max: usize,
         ecx: &mut MiriInterpCx<'tcx>,
     ) -> InterpResult<'tcx, Vec<ReadinessInterest>> {
+        // The goal below is to do work proportyional to how much we're actually reporting to the
+        // client, i.e., how many interests of this watcher are ready. In particular, we do *not*
+        // iterate over all interests of this watcher, or all watchers, or all FDs being watched, or
+        // anything like that.
+
         // Process delayed readiness updates, to ensure we have fully up-to-date information.
+        // This is almost always a NOP.
         DelayedReadinessUpdates::process(ecx)?;
 
         let interests = self.interests.borrow();
@@ -300,34 +309,42 @@ impl ReadinessWatcher {
 
         // Sanity-check to ensure that all event info is up-to-date.
         if cfg!(debug_assertions) {
-            for (key, interest) in interests.iter() {
-                // Ensure this matches the latest readiness of this FD.
-                // We have to do an FD lookup by ID for this. The FdNum might be already closed.
-                let fd = ecx.machine.fds.fds.values().find(|fd| fd.id() == key.0).unwrap();
+            for interest in interests.values() {
+                // Ensure this matches the latest readiness of this FD, if the FD is still open.
+                let Some(fd) = interest.watched_fd.upgrade() else { continue };
                 let current_active = fd.readiness()?;
                 assert_eq!(interest.active(), &(current_active & interest.relevant.clone()));
             }
         }
 
-        // Compute how many events we can actually return.
-        let count = count.min(ready.len());
-        let mut ready_interests = Vec::with_capacity(count);
+        let mut ready_interests = Vec::with_capacity(max.min(ready.len()));
+        let mut re_add_interests = Vec::new();
 
-        // We have to bound this iterator by `count`. Iterating until `ready` is empty would not
-        // work since we are re-adding level-triggered events to `ready` during the loop.
-        while ready_interests.len() < count {
-            let key = ready.pop_front().unwrap();
+        // Continue while we haven't yet gotten `max` events, and while there are more to add.
+        while ready_interests.len() < max
+            && let Some(key) = ready.pop_front()
+        {
             let interest = interests.get(&key).expect("non-existing interest in ready set");
+            if interest.watched_fd.is_closed() {
+                // "A file descriptor is removed from an interest list only after all the file
+                // descriptors referring to the underlying open file description have been closed."
+                // So, we should have removed this FD from the interest list, we just didn't get
+                // around to that yet. Pretend it does not exist. It will not be re-added to the
+                // ready list, and it will eventually be cleaned up by the GC.
+                continue;
+            }
 
             if !interest.is_edge_triggered {
-                // This is a level-triggered interest, so we need to re-add the event
-                // at the end of the ready queue like Linux does with epoll:
-                // <https://github.com/torvalds/linux/blob/HEAD/fs/eventpoll.c#L1835-L1847>
-                ready.push_back(key);
+                // This is a level-triggered interest, so we need to re-add the event:
+                // <https://github.com/torvalds/linux/blob/HEAD/fs/eventpoll.c#L1835-L1847>.
+                // We delay adding them back so they do not get picked up by later loop iterations.
+                re_add_interests.push(key);
             }
 
             ready_interests.push(interest.clone());
         }
+        // Add back the level-triggered ones.
+        ready.extend(re_add_interests);
 
         interp_ok(ready_interests)
     }
@@ -351,6 +368,8 @@ pub struct ReadinessInterestTable {
     /// been dropped.
     /// We also store a weak reference to the watched file description, so we can clean them up
     /// when they get freed.
+    /// FIXME: a better place to store this would probably be the relevant FD itself. Experiment
+    /// with delegation to easily do that for all FD types, once that is ready.
     interests: BTreeMap<
         FdId,
         (WeakDynFileDescriptionRef, Vec<(ReadinessWatcherId, Weak<ReadinessWatcher>)>),
@@ -378,67 +397,62 @@ impl ReadinessInterestTable {
 
     /// Add an interest for `watcher` for the `watched_fd` file description.
     fn insert(&mut self, watched_fd: &DynFileDescriptionRef, watcher: &Rc<ReadinessWatcher>) {
-        let watchers = self
+        let (_watched, watchers) = self
             .interests
             .entry(watched_fd.id())
             .or_insert_with(|| (FileDescriptionRef::downgrade(watched_fd), Vec::new()));
         let idx = watchers
-            .1
             .binary_search_by_key(&watcher.id, |&(id, _)| id)
             .expect_err("watcher already has a registered interest in the provided watched fd");
-        watchers.1.insert(idx, (watcher.id, Rc::downgrade(watcher)));
+        watchers.insert(idx, (watcher.id, Rc::downgrade(watcher)));
     }
 
     /// Remove the interest of `watcher` for the file description with id `fd_id`.
     fn remove(&mut self, watched_fd: FdId, watcher: &ReadinessWatcher) {
-        let watchers = self
+        let (_watched, watchers) = self
             .interests
             .get_mut(&watched_fd)
             .expect("watcher has no registered interest in the provided watched fd");
         let idx = watchers
-            .1
             .binary_search_by_key(&watcher.id, |&(id, _)| id)
             .expect("watcher has no registered interest in the provided watched fd");
-        watchers.1.remove(idx);
+        watchers.remove(idx);
     }
 
-    /// Get all watchers which have a registered interest in the file description
-    /// with id `fd_id`.
+    /// Get all watchers which have a registered interest in the file description with id `fd_id`.
     fn get_watchers_for_fd(
         &self,
         fd_id: FdId,
     ) -> Option<impl Iterator<Item = Rc<ReadinessWatcher>>> {
-        let watchers = self.interests.get(&fd_id)?;
+        let (_watched, watchers) = self.interests.get(&fd_id)?;
         // Ignore weak refs that cannot be upgraded -- those correspond to closed
         // file descriptions and will be cleaned up by the GC eventually.
-        Some(watchers.1.iter().filter_map(|(_id, watcher)| watcher.upgrade()))
+        Some(watchers.iter().filter_map(|(_id, watcher)| watcher.upgrade()))
     }
 
-    /// Remove all watchers for the file description with id `fd_id`.
-    pub fn remove_watchers_for_fd(&mut self, fd_id: FdId) {
-        let Some(watchers) = self.interests.remove(&fd_id) else {
-            return;
-        };
-
-        for watcher in watchers.1.iter().filter_map(|(_id, watcher)| Weak::upgrade(watcher)) {
-            // This is a still-live watcher with interest in this FD. Remove all
-            // relevant interests (including from the ready set).
-            watcher
-                .interests
-                .borrow_mut()
-                .extract_if(range_for_id(fd_id), |_, _| true)
-                // Consume the iterator.
-                .for_each(drop);
-            // Remove the ready interests for this file description.
-            watcher.ready.borrow_mut().retain(|(id, _)| id != &fd_id);
-        }
-    }
-
-    /// Run garbage collector to remove all dropped watchers from the interests map.
+    /// Run garbage collector to remove all dropped watchers and dropped watched FDs.
     pub fn run_gc(&mut self) {
-        self.interests
-            .values_mut()
-            .for_each(|watchers| watchers.1.retain(|(_id, watcher)| watcher.strong_count() > 0));
+        self.interests.retain(|&fd_id, (watched, watchers)| {
+            if watched.is_closed() {
+                // An FD we were watching got closed. Remove it from the watcher as well.
+                for watcher in watchers.iter().filter_map(|(_id, watcher)| Weak::upgrade(watcher)) {
+                    // This is a still-live watcher with interest in this FD. Remove all
+                    // relevant interests (including from the ready set).
+                    watcher
+                        .interests
+                        .borrow_mut()
+                        .extract_if(range_for_id(fd_id), |_, _| true)
+                        // Consume the iterator.
+                        .for_each(drop);
+                    // Remove the ready interests for this file description.
+                    watcher.ready.borrow_mut().retain(|(id, _)| id != &fd_id);
+                }
+                return false; // delete this one
+            }
+            // Keep this one, but clean up the watchers.
+            watchers.retain(|(_id, watcher)| watcher.strong_count() > 0);
+            true
+        });
     }
 }
 
@@ -547,7 +561,7 @@ pub trait EvalContextPrivExt<'tcx>: MiriInterpCxExt<'tcx> {
 
                 // We need to ensure that this event is not already part of the `ready` queue
                 // before enqueueing, as Linux does it with epoll:
-                // <https://github.com/torvalds/linux/blob/HEAD/fs/eventpoll.c#L1292-L1296>
+                // <https://github.com/torvalds/linux/blob/13dce771bbad42da6ecf086446d8ddfd1fce3a1b/fs/eventpoll.c#L1290-L1293>
                 if !ready.contains(&key) {
                     ready.push_back(key);
                 }

--- a/src/shims/readiness.rs
+++ b/src/shims/readiness.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, VecDeque};
 use std::rc::{Rc, Weak};
 
 use crate::concurrency::VClock;
-use crate::shims::files::{DynFileDescriptionRef, FdNum};
+use crate::shims::files::{DynFileDescriptionRef, FdNum, WeakDynFileDescriptionRef};
 use crate::shims::*;
 use crate::*;
 
@@ -170,7 +170,7 @@ impl ReadinessWatcher {
             // This is the first time this FD got added to the watcher.
             // We need to remember that in the global list such that we
             // get notified about FD events.
-            ecx.machine.readiness_interests.insert(fd_id, self);
+            ecx.machine.readiness_interests.insert(&fd_ref, self);
         }
         if interests.try_insert(key, interest).is_err() {
             return interp_ok(Err(()));
@@ -349,7 +349,12 @@ pub struct ReadinessInterestTable {
     /// separately so we can access it without calling `upgrade`. The list
     /// is sorted by that id. We use an ID so that we can identify the watcher even after it has
     /// been dropped.
-    interests: BTreeMap<FdId, Vec<(ReadinessWatcherId, Weak<ReadinessWatcher>)>>,
+    /// We also store a weak reference to the watched file description, so we can clean them up
+    /// when they get freed.
+    interests: BTreeMap<
+        FdId,
+        (WeakDynFileDescriptionRef, Vec<(ReadinessWatcherId, Weak<ReadinessWatcher>)>),
+    >,
 }
 
 impl ReadinessInterestTable {
@@ -371,22 +376,30 @@ impl ReadinessInterestTable {
         }
     }
 
-    /// Add an interest for `watcher` for the file description with id `fd_id`.
-    fn insert(&mut self, fd_id: FdId, watcher: &Rc<ReadinessWatcher>) {
-        let watchers = self.interests.entry(fd_id).or_default();
+    /// Add an interest for `watcher` for the `watched_fd` file description.
+    fn insert(&mut self, watched_fd: &DynFileDescriptionRef, watcher: &Rc<ReadinessWatcher>) {
+        let watchers = self
+            .interests
+            .entry(watched_fd.id())
+            .or_insert_with(|| (FileDescriptionRef::downgrade(watched_fd), Vec::new()));
         let idx = watchers
+            .1
             .binary_search_by_key(&watcher.id, |&(id, _)| id)
-            .expect_err("watcher already has a registered interest in the provided fd");
-        watchers.insert(idx, (watcher.id, Rc::downgrade(watcher)));
+            .expect_err("watcher already has a registered interest in the provided watched fd");
+        watchers.1.insert(idx, (watcher.id, Rc::downgrade(watcher)));
     }
 
     /// Remove the interest of `watcher` for the file description with id `fd_id`.
-    fn remove(&mut self, fd_id: FdId, watcher: &ReadinessWatcher) {
-        let watchers = self.interests.entry(fd_id).or_default();
+    fn remove(&mut self, watched_fd: FdId, watcher: &ReadinessWatcher) {
+        let watchers = self
+            .interests
+            .get_mut(&watched_fd)
+            .expect("watcher has no registered interest in the provided watched fd");
         let idx = watchers
+            .1
             .binary_search_by_key(&watcher.id, |&(id, _)| id)
-            .expect("watcher has no registered interest in the provided fd");
-        watchers.remove(idx);
+            .expect("watcher has no registered interest in the provided watched fd");
+        watchers.1.remove(idx);
     }
 
     /// Get all watchers which have a registered interest in the file description
@@ -398,7 +411,7 @@ impl ReadinessInterestTable {
         let watchers = self.interests.get(&fd_id)?;
         // Ignore weak refs that cannot be upgraded -- those correspond to closed
         // file descriptions and will be cleaned up by the GC eventually.
-        Some(watchers.iter().filter_map(|(_id, watcher)| watcher.upgrade()))
+        Some(watchers.1.iter().filter_map(|(_id, watcher)| watcher.upgrade()))
     }
 
     /// Remove all watchers for the file description with id `fd_id`.
@@ -407,7 +420,7 @@ impl ReadinessInterestTable {
             return;
         };
 
-        for watcher in watchers.iter().filter_map(|(_id, watcher)| Weak::upgrade(watcher)) {
+        for watcher in watchers.1.iter().filter_map(|(_id, watcher)| Weak::upgrade(watcher)) {
             // This is a still-live watcher with interest in this FD. Remove all
             // relevant interests (including from the ready set).
             watcher
@@ -425,7 +438,7 @@ impl ReadinessInterestTable {
     pub fn run_gc(&mut self) {
         self.interests
             .values_mut()
-            .for_each(|watchers| watchers.retain(|(_id, watcher)| watcher.strong_count() > 0));
+            .for_each(|watchers| watchers.1.retain(|(_id, watcher)| watcher.strong_count() > 0));
     }
 }
 

--- a/src/shims/readiness.rs
+++ b/src/shims/readiness.rs
@@ -292,6 +292,9 @@ impl ReadinessWatcher {
         count: usize,
         ecx: &mut MiriInterpCx<'tcx>,
     ) -> InterpResult<'tcx, Vec<ReadinessInterest>> {
+        // Process delayed readiness updates, to ensure we have fully up-to-date information.
+        DelayedReadinessUpdates::process(ecx)?;
+
         let interests = self.interests.borrow();
         let mut ready = self.ready.borrow_mut();
 

--- a/src/shims/readiness.rs
+++ b/src/shims/readiness.rs
@@ -1,3 +1,4 @@
+use std::assert_matches;
 use std::cell::{Ref, RefCell};
 use std::collections::{BTreeMap, VecDeque};
 use std::rc::{Rc, Weak};
@@ -109,16 +110,12 @@ impl ReadinessInterest {
     }
 }
 
-type ReadinessWatcherId = usize;
-
 /// A struct which stores [`ReadinessInterest`]s for a set of file descriptions
 /// together with which interests are currently satisfied, and a list of
 /// threads which should be unblocked once a [`ReadinessInterest`] of the
 /// watcher is fulfilled.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ReadinessWatcher {
-    /// Globally unique identifier of the watcher.
-    id: ReadinessWatcherId,
     /// A map of [`ReadinessInterest`]s registered for this watcher. Each entry is
     /// identified using a [`FdId`] [`FdNum`] tuple.
     interests: RefCell<BTreeMap<ReadinessInterestKey, ReadinessInterest>>,
@@ -358,41 +355,18 @@ impl VisitProvenance for ReadinessWatcher {
 /// This tracks, for each file description, which watchers have an interest in events
 /// for this file description.
 pub struct ReadinessInterestTable {
-    /// The id of the next [`ReadinessWatcher`] created through
-    /// [`ReadinessInterestTable::new_watcher`].
-    next_watcher_id: ReadinessWatcherId,
     /// Maps each file description (identified by its [`FdId`]) to the list of watchers that are
-    /// interested in that FD. We also store the [`ReadinessWatcher`]s ID
-    /// separately so we can access it without calling `upgrade`. The list
-    /// is sorted by that id. We use an ID so that we can identify the watcher even after it has
-    /// been dropped.
+    /// interested in that FD.
     /// We also store a weak reference to the watched file description, so we can clean them up
     /// when they get freed.
     /// FIXME: a better place to store this would probably be the relevant FD itself. Experiment
     /// with delegation to easily do that for all FD types, once that is ready.
-    interests: BTreeMap<
-        FdId,
-        (WeakDynFileDescriptionRef, Vec<(ReadinessWatcherId, Weak<ReadinessWatcher>)>),
-    >,
+    interests: BTreeMap<FdId, (WeakDynFileDescriptionRef, Vec<Weak<ReadinessWatcher>>)>,
 }
 
 impl ReadinessInterestTable {
     pub(crate) fn new() -> Self {
-        ReadinessInterestTable { interests: BTreeMap::new(), next_watcher_id: 0 }
-    }
-
-    /// Create a new [`ReadinessWatcher`] with a globally unique id.
-    /// Every watcher gets a sequentially increasing id such that no two
-    /// watchers ever get the same id.
-    pub fn new_watcher(&mut self) -> ReadinessWatcher {
-        let id = self.next_watcher_id;
-        self.next_watcher_id = id.strict_add(1);
-        ReadinessWatcher {
-            id,
-            interests: RefCell::new(BTreeMap::new()),
-            ready: RefCell::new(VecDeque::new()),
-            queue: RefCell::new(VecDeque::new()),
-        }
+        ReadinessInterestTable { interests: BTreeMap::new() }
     }
 
     /// Add an interest for `watcher` for the `watched_fd` file description.
@@ -401,20 +375,29 @@ impl ReadinessInterestTable {
             .interests
             .entry(watched_fd.id())
             .or_insert_with(|| (FileDescriptionRef::downgrade(watched_fd), Vec::new()));
-        let idx = watchers
-            .binary_search_by_key(&watcher.id, |&(id, _)| id)
-            .expect_err("watcher already has a registered interest in the provided watched fd");
-        watchers.insert(idx, (watcher.id, Rc::downgrade(watcher)));
+        if cfg!(debug_assertions) {
+            // Ensure uniqueness.
+            assert_matches!(
+                watchers.iter().find(|elem| elem.as_ptr() == Rc::as_ptr(watcher)),
+                None,
+                "watcher has already been added to this watched fd",
+            );
+        }
+        watchers.push(Rc::downgrade(watcher));
     }
 
     /// Remove the interest of `watcher` for the file description with id `fd_id`.
-    fn remove(&mut self, watched_fd: FdId, watcher: &ReadinessWatcher) {
+    fn remove(&mut self, watched_fd: FdId, watcher: &Rc<ReadinessWatcher>) {
         let (_watched, watchers) = self
             .interests
             .get_mut(&watched_fd)
             .expect("watcher has no registered interest in the provided watched fd");
+        // We need to do a linear scan to find the watcher to remove. That's not ideal, but removing
+        // a watched FD from an epoll is rare so it's not worth the non-trivial effort it would take
+        // to make this more efficient.
         let idx = watchers
-            .binary_search_by_key(&watcher.id, |&(id, _)| id)
+            .iter()
+            .position(|elem| elem.as_ptr() == Rc::as_ptr(watcher))
             .expect("watcher has no registered interest in the provided watched fd");
         watchers.remove(idx);
     }
@@ -427,7 +410,7 @@ impl ReadinessInterestTable {
         let (_watched, watchers) = self.interests.get(&fd_id)?;
         // Ignore weak refs that cannot be upgraded -- those correspond to closed
         // file descriptions and will be cleaned up by the GC eventually.
-        Some(watchers.iter().filter_map(|(_id, watcher)| watcher.upgrade()))
+        Some(watchers.iter().filter_map(|watcher| watcher.upgrade()))
     }
 
     /// Run garbage collector to remove all dropped watchers and dropped watched FDs.
@@ -435,7 +418,7 @@ impl ReadinessInterestTable {
         self.interests.retain(|&fd_id, (watched, watchers)| {
             if watched.is_closed() {
                 // An FD we were watching got closed. Remove it from the watcher as well.
-                for watcher in watchers.iter().filter_map(|(_id, watcher)| Weak::upgrade(watcher)) {
+                for watcher in watchers.iter().filter_map(Weak::upgrade) {
                     // This is a still-live watcher with interest in this FD. Remove all
                     // relevant interests (including from the ready set).
                     watcher
@@ -450,7 +433,7 @@ impl ReadinessInterestTable {
                 return false; // delete this one
             }
             // Keep this one, but clean up the watchers.
-            watchers.retain(|(_id, watcher)| watcher.strong_count() > 0);
+            watchers.retain(|watcher| watcher.strong_count() > 0);
             true
         });
     }

--- a/src/shims/unix/fd.rs
+++ b/src/shims/unix/fd.rs
@@ -107,8 +107,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             // Close new_fd if it is previously opened.
             // If old_fd and new_fd point to the same description, then `dup_fd` ensures we keep the underlying file description alive.
             if let Some(old_new_fd) = this.machine.fds.fds.insert(new_fd_num, fd) {
-                // Ignore close error (not interpreter's) according to dup2() doc.
-                old_new_fd.close_ref(this)?.ok();
+                drop(old_new_fd);
             }
         }
         interp_ok(Scalar::from_i32(new_fd_num))
@@ -286,10 +285,10 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let Some(fd) = this.machine.fds.remove(fd_num) else {
             return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
         };
-        let result = fd.close_ref(this)?;
-        // return `0` if close is successful
-        let result = result.map(|()| 0i32);
-        interp_ok(Scalar::from_i32(this.try_unwrap_io_result(result)?))
+        drop(fd);
+        // Our close is always successful. Close does not reliably return errors anyway so it is
+        // not worth the effort to try and return anything here.
+        interp_ok(Scalar::from_i32(0))
     }
 
     /// Read data from `fd` into buffer specified by `buf` and `count`.

--- a/src/shims/unix/linux_like/epoll.rs
+++ b/src/shims/unix/linux_like/epoll.rs
@@ -60,10 +60,8 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             );
         }
 
-        let fd = this
-            .machine
-            .fds
-            .insert_new(Epoll { watcher: Rc::new(this.machine.readiness_interests.new_watcher()) });
+        let fd =
+            this.machine.fds.insert_new(Epoll { watcher: Rc::new(ReadinessWatcher::default()) });
         interp_ok(Scalar::from_i32(fd))
     }
 

--- a/src/shims/unix/poll.rs
+++ b/src/shims/unix/poll.rs
@@ -45,7 +45,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         // a positive file descriptor that doesn't exist.
         let mut invalid_interests = 0u32;
 
-        let watcher = Rc::new(this.machine.readiness_interests.new_watcher());
+        let watcher = Rc::new(ReadinessWatcher::default());
 
         // We iterate over the fds array of the `poll` syscall. For each fd, we check its
         // output field, the relevant events, and whether they are currently fulfilled.

--- a/src/shims/windows/handle.rs
+++ b/src/shims/windows/handle.rs
@@ -342,13 +342,8 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             }
             Handle::File(fd_num) =>
                 if let Some(fd) = this.machine.fds.remove(fd_num) {
-                    let err = fd.close_ref(this)?;
-                    if let Err(e) = err {
-                        this.set_last_error(e)?;
-                        this.eval_windows("c", "FALSE")
-                    } else {
-                        this.eval_windows("c", "TRUE")
-                    }
+                    drop(fd);
+                    this.eval_windows("c", "TRUE")
                 } else {
                     this.invalid_handle("CloseHandle")?
                 },

--- a/tests/pass-dep/libc/libc-epoll-blocking.rs
+++ b/tests/pass-dep/libc/libc-epoll-blocking.rs
@@ -7,7 +7,7 @@
 use std::convert::TryInto;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 #[path = "../../utils/libc.rs"]
 mod libc_utils;
@@ -29,6 +29,7 @@ fn main() {
     multiple_events_wake_multiple_threads();
     waiting_threads_unblocked_after_epoll_close();
     waiting_threads_unblocked_after_socketpair_close();
+    epoll_blocking_watching_fd_that_is_being_closed();
 }
 
 // This test allows edge-triggered epoll_wait to block and then unblock
@@ -42,6 +43,16 @@ fn test_epoll_block_without_notification() {
     let flags = libc::EFD_NONBLOCK | libc::EFD_CLOEXEC;
     let fd = errno_result(unsafe { libc::eventfd(0, flags) }).unwrap();
 
+    // Wait for EPOLLIN (it will not happen).
+    epoll_ctl_add(epfd, fd, EPOLLIN | EPOLLET_OR_ZERO).unwrap();
+    let start = Instant::now();
+    check_epoll_wait(epfd, &[], 10);
+    assert!(start.elapsed() >= Duration::from_millis(10));
+
+    // The second test behaves differently between level- and edge-triggered epoll.
+    // We get a new epoll instance for this.
+    let epfd = errno_result(unsafe { libc::epoll_create1(0) }).unwrap();
+
     // Register eventfd with epoll.
     epoll_ctl_add(epfd, fd, EPOLLIN | EPOLLOUT | EPOLLET_OR_ZERO).unwrap();
 
@@ -50,7 +61,9 @@ fn test_epoll_block_without_notification() {
 
     if cfg!(edge_triggered) {
         // This epoll wait blocks, and timeout without notification.
-        check_epoll_wait(epfd, &[], 5);
+        let start = Instant::now();
+        check_epoll_wait(epfd, &[], 10);
+        assert!(start.elapsed() >= Duration::from_millis(10));
     } else {
         // In level-triggered mode we should receive the same events
         // as before without timing out.
@@ -327,4 +340,31 @@ fn waiting_threads_unblocked_after_socketpair_close() {
             }
         });
     }
+}
+
+/// Ensure correct behavior when we block on epoll watching an FD that is being closed.
+fn epoll_blocking_watching_fd_that_is_being_closed() {
+    // Create an epoll instance.
+    let epfd = errno_result(unsafe { libc::epoll_create1(0) }).unwrap();
+
+    // Create an eventfd instance and register it with epoll.
+    let fd = errno_result(unsafe { libc::eventfd(0, 0) }).unwrap();
+    epoll_ctl_add(epfd, fd, EPOLLIN | EPOLLET_OR_ZERO).unwrap();
+
+    thread::scope(|s| {
+        s.spawn(|| {
+            // Block on the epoll.
+            let start = Instant::now();
+            check_epoll_wait(epfd, &[], 10);
+            assert!(start.elapsed() >= Duration::from_millis(10));
+        });
+
+        // Let the thread go and do its setup.
+        thread::sleep(Duration::from_millis(10));
+
+        // Now that the thread is blocked, close the eventfd.
+        unsafe { errno_check(libc::close(fd)) };
+
+        // The epoll_wait above should time out. Being closed does not generate any events.
+    });
 }

--- a/tests/pass-dep/libc/libc-epoll-blocking.rs
+++ b/tests/pass-dep/libc/libc-epoll-blocking.rs
@@ -1,5 +1,7 @@
 //@only-target: linux android illumos
 //@revisions: edge_triggered level_triggered
+// We need to control yielding.
+//@compile-flags: -Zmiri-deterministic-concurrency
 //@run-native
 
 use std::convert::TryInto;
@@ -263,42 +265,66 @@ fn waiting_threads_unblocked_after_epoll_close() {
 /// That thread keeps a reference so it is only really closed when that thread wakes up
 /// again, and at that point an epoll notification should be triggered.
 fn waiting_threads_unblocked_after_socketpair_close() {
-    // Create an epoll instance.
-    let epfd = errno_result(unsafe { libc::epoll_create1(0) }).unwrap();
-
-    // Create a socketpair instance.
-    let mut fds = [-1, -1];
-    errno_check(unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr()) });
-
-    // And an atomic variable for synchronization.
-    let flag = AtomicBool::new(false);
-
-    thread::scope(|s| {
-        // Thread 1 will block reading on fds[0], thread 2 blocks on epoll for fds[1].
-        s.spawn(|| {
-            let data = read_exact_array::<4>(fds[0]).unwrap();
-            assert_eq!(&data, b"1234");
-            flag.store(true, Ordering::Relaxed);
-        });
-        s.spawn(|| {
-            // Indefinitely block until `fds[1]` becomes readable.
-            epoll_ctl_add(epfd, fds[1], EPOLLIN | EPOLLET_OR_ZERO).unwrap();
-            check_epoll_wait(epfd, &[Ev { events: EPOLLIN | EPOLLHUP, data: fds[1] }], -1);
-            flag.store(true, Ordering::Relaxed);
+    // There are multiple variants of this test.
+    for variant in 0..=1 {
+        // Create a socketpair instance.
+        let mut fds = [-1, -1];
+        errno_check(unsafe {
+            libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr())
         });
 
-        // Let the threads go and do their setup.
-        thread::sleep(Duration::from_millis(10));
+        // Create an epoll instance, register `fds[1]`.
+        let epfd = errno_result(unsafe { libc::epoll_create1(0) }).unwrap();
+        epoll_ctl_add(epfd, fds[1], EPOLLIN | EPOLLET_OR_ZERO).unwrap();
 
-        // Once they did their setup, close fds[0] (will not really be closed since there is a thread
-        // blocked on it).
-        unsafe { errno_check(libc::close(fds[0])) };
+        // And an atomic variable for synchronization.
+        let flag = AtomicBool::new(false);
 
-        // This should *not* yet wake up anyone. So we wait a bit and check the flag.
-        thread::sleep(Duration::from_millis(10));
-        assert_eq!(flag.load(Ordering::Relaxed), false);
+        thread::scope(|s| {
+            // Thread 1 will block reading on fds[0], thread 2 blocks on epoll for fds[1].
+            s.spawn(|| {
+                let data = read_exact_array::<4>(fds[0]).unwrap();
+                assert_eq!(&data, b"1234");
+                flag.store(true, Ordering::Relaxed);
+            });
+            if variant == 0 {
+                // In variant 1, the event is consumed below (for edge-triggered).
+                s.spawn(|| {
+                    // Indefinitely block until `fds[1]` becomes readable.
+                    check_epoll_wait(epfd, &[Ev { events: EPOLLIN | EPOLLHUP, data: fds[1] }], -1);
+                    flag.store(true, Ordering::Relaxed);
+                });
+            }
 
-        // ... and then write to fds[1] to make it readable.
-        write_all(fds[1], b"1234").unwrap();
-    });
+            // Let the threads go and do their setup.
+            thread::sleep(Duration::from_millis(10));
+
+            // Once they did their setup, close fds[0] (will not really be closed since there is a
+            // thread blocked on it).
+            unsafe { errno_check(libc::close(fds[0])) };
+
+            // This should *not* yet wake up anyone. So we wait a bit and check the flag.
+            thread::sleep(Duration::from_millis(10));
+            assert_eq!(flag.load(Ordering::Relaxed), false);
+
+            // ... and then write to fds[1] to make it readable.
+            write_all(fds[1], b"1234").unwrap();
+
+            // We want to both test "delayed readiness processed by scheduler" and "delayed
+            // readiness processed by epoll_wait", so we have two variants of this test.
+            if variant == 1 {
+                // Now readiness should be updated, even before we schedule to another thread. Needs to be
+                // non-blocking to hit what used to be a buggy codepath! Interestingly, we do *not* always
+                // immediately see the new events on native runs -- it's almost as if Linux also delays
+                // updating the readiness. We still want to update readiness immediately in Miri as
+                // otherwise we'd have to give up on a nice strong invariant and disable a sanity check.
+                // So we give the native kernel a bit of time to update the readiness.
+                if !cfg!(miri) {
+                    // Give the kernel some time to process.
+                    thread::sleep(Duration::from_millis(10));
+                }
+                check_epoll_wait_noblock(epfd, &[Ev { events: EPOLLIN | EPOLLHUP, data: fds[1] }]);
+            }
+        });
+    }
 }

--- a/tests/pass-dep/libc/libc-epoll-blocking.rs
+++ b/tests/pass-dep/libc/libc-epoll-blocking.rs
@@ -287,7 +287,7 @@ fn waiting_threads_unblocked_after_socketpair_close() {
                 assert_eq!(&data, b"1234");
                 flag.store(true, Ordering::Relaxed);
             });
-            if variant == 0 {
+            if cfg!(level_triggered) || variant == 0 {
                 // In variant 1, the event is consumed below (for edge-triggered).
                 s.spawn(|| {
                     // Indefinitely block until `fds[1]` becomes readable.

--- a/tests/pass-dep/libc/libc-eventfd.rs
+++ b/tests/pass-dep/libc/libc-eventfd.rs
@@ -24,6 +24,7 @@ fn main() {
     test_blocking_write();
     test_two_threads_blocked_on_eventfd();
     test_close_while_blocked();
+    test_initval();
 }
 
 // We want to do individual read/write calls here so we avoid read_exact/write_all.
@@ -190,4 +191,10 @@ fn test_close_while_blocked() {
     assert_eq!(val, 1);
 
     server_thread.join().unwrap();
+}
+
+fn test_initval() {
+    let fd = errno_result(unsafe { libc::eventfd(10, 0) }).unwrap();
+    let val = eventfd::read_val(fd).unwrap();
+    assert_eq!(val, 10);
 }

--- a/tests/utils/libc.rs
+++ b/tests/utils/libc.rs
@@ -164,7 +164,7 @@ pub mod epoll {
         epoll_ctl(epfd, EPOLL_CTL_ADD, fd, Ev { events, data: fd })
     }
 
-    /// Call `epoll_wait` on `epfd` with the provided `timeout`.
+    /// Call `epoll_wait` on `epfd` with the provided `timeout` (in milliseconds).
     /// It fetches at most `max_events` events from `epfd` and
     /// ensures that the returned events match the `expected` events.
     #[track_caller]
@@ -182,7 +182,7 @@ pub mod epoll {
         assert_eq!(got, expected, "got wrong ready events");
     }
 
-    /// Call `epoll_wait` on `epfd` with the provided `timeout` and ensure
+    /// Call `epoll_wait` on `epfd` with the provided `timeout` (in milliseconds) and ensure
     /// that the set of *all* ready events matches `expected`.
     #[track_caller]
     pub fn check_epoll_wait(epfd: i32, expected: &[Ev], timeout: i32) {


### PR DESCRIPTION
We used to rely on `close_ref` to clean them up, but it's hard to make sure we reliably call `close_ref`. So instead we add some weak refs and delay cleaning up the readiness and interest for watched FDs that are being closed.

Fixes https://github.com/rust-lang/miri/issues/5203