### PR TITLE
replace global readiness watcher table by per-FD state

### DIFF
--- a/src/concurrency/blocking_io.rs
+++ b/src/concurrency/blocking_io.rs
@@ -162,7 +162,7 @@ impl BlockingIoManager {
         // unblock the threads which are blocked on such a source and whose interests are now fulfilled.
         for fd in event_fds.into_iter() {
             // Update readiness for the `fd` source.
-            ecx.update_fd_readiness(fd.clone(), false)?;
+            ecx.update_fd_readiness(fd.clone(), /* force_edge */ false)?;
 
             // The `update_fd_readiness` can't cause the source to be deregistered since we still
             // hold a strong reference to the file description with `fd`.

--- a/src/concurrency/blocking_io.rs
+++ b/src/concurrency/blocking_io.rs
@@ -334,10 +334,13 @@ pub trait EvalContextExt<'tcx>: MiriInterpCxExt<'tcx> {
     /// Returns whether there exists any thread that is blocked on host I/O.
     fn any_thread_blocked_on_host(&self) -> bool {
         let this = self.eval_context_ref();
-        this.machine.blocking_io.sources.iter().any(|(&fd_id, source)| {
+        this.machine.blocking_io.sources.values().any(|source| {
             // There's two ways something could be blocked on this: directly,
             // or indirectly via a readiness watcher.
-            source.blocked_threads.len() > 0 || this.has_watcher_with_blocked_thread(fd_id)
+            source.blocked_threads.len() > 0
+                || source.fd.upgrade().is_some_and(|fd| {
+                    fd.readiness_watched().is_some_and(|w| w.has_watcher_with_blocked_thread())
+                })
         })
     }
 }

--- a/src/concurrency/blocking_io.rs
+++ b/src/concurrency/blocking_io.rs
@@ -161,8 +161,9 @@ impl BlockingIoManager {
         // Update the readiness for all source file descriptions which received an event. Also,
         // unblock the threads which are blocked on such a source and whose interests are now fulfilled.
         for fd in event_fds.into_iter() {
-            // Update readiness for the `fd` source.
-            ecx.update_fd_readiness(fd.clone(), /* force_edge */ false)?;
+            // Update readiness for the `fd` source. This is no a "release" event since it was
+            // not triggered by the current thread, it was triggered by the outside world.
+            ecx.update_fd_readiness(fd.clone(), ReadinessUpdateFlags::NO_RELEASE_CLOCK)?;
 
             // The `update_fd_readiness` can't cause the source to be deregistered since we still
             // hold a strong reference to the file description with `fd`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,7 @@ pub use crate::shims::io_error::{EvalContextExt as _, IoError, LibcError};
 pub use crate::shims::os_str::EvalContextExt as _;
 pub use crate::shims::panic::EvalContextExt as _;
 pub use crate::shims::readiness::{
-    EvalContextExt as _, Readiness, ReadinessInterest, ReadinessInterestKey, ReadinessWatched,
+    EvalContextExt as _, Readiness, ReadinessInterest, ReadinessUpdateFlags, ReadinessWatched,
     ReadinessWatcher,
 };
 pub use crate::shims::sig::EvalContextExt as _;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,8 +170,8 @@ pub use crate::shims::io_error::{EvalContextExt as _, IoError, LibcError};
 pub use crate::shims::os_str::EvalContextExt as _;
 pub use crate::shims::panic::EvalContextExt as _;
 pub use crate::shims::readiness::{
-    EvalContextExt as _, Readiness, ReadinessInterest, ReadinessInterestKey,
-    ReadinessInterestTable, ReadinessWatcher,
+    EvalContextExt as _, Readiness, ReadinessInterest, ReadinessInterestKey, ReadinessWatched,
+    ReadinessWatcher,
 };
 pub use crate::shims::sig::EvalContextExt as _;
 pub use crate::shims::time::EvalContextExt as _;

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -533,8 +533,7 @@ pub struct MiriMachine<'tcx> {
     /// The table of directory descriptors.
     pub(crate) dirs: shims::DirTable,
 
-    /// The table of all active [`ReadinessWatcher`]s.
-    pub(crate) readiness_interests: ReadinessInterestTable,
+    /// Managing file descriptors whose readiness needs to be updated.
     pub(crate) delayed_readiness_updates: Rc<DelayedReadinessUpdates>,
 
     /// This machine's monotone clock.
@@ -768,7 +767,6 @@ impl<'tcx> MiriMachine<'tcx> {
             isolated_op: config.isolated_op,
             validation: config.validation,
             fds: shims::FdTable::init(config.mute_stdout_stderr),
-            readiness_interests: ReadinessInterestTable::new(),
             delayed_readiness_updates: Rc::new(DelayedReadinessUpdates::default()),
             dirs: Default::default(),
             layouts,
@@ -1029,7 +1027,6 @@ impl VisitProvenance for MiriMachine<'_> {
             alloc_addresses,
             fds,
             blocking_io:_,
-            readiness_interests: _,
             delayed_readiness_updates: _,
             tcx: _,
             isolated_op: _,
@@ -1813,7 +1810,6 @@ impl<'tcx> Machine<'tcx> for MiriMachine<'tcx> {
         if ecx.machine.gc_interval > 0 && ecx.machine.since_gc >= ecx.machine.gc_interval {
             ecx.machine.since_gc = 0;
             ecx.run_provenance_gc();
-            ecx.machine.readiness_interests.run_gc();
             ecx.machine.blocking_io.run_gc();
         }
 

--- a/src/shims/files.rs
+++ b/src/shims/files.rs
@@ -216,9 +216,14 @@ pub trait FileDescription: std::fmt::Debug + FileDescriptionExt {
         throw_unsup_format!("fcntl: {} is not supported for F_SETFL", self.name());
     }
 
+    /// Get the `ReadinessWatched` of the file description.
+    fn readiness_watched(&self) -> Option<&ReadinessWatched> {
+        None
+    }
+
     /// Get the current I/O readiness of the file description.
-    fn readiness<'tcx>(&self) -> InterpResult<'tcx, Readiness> {
-        throw_unsup_format!("{}: this file description doesn't support I/O readiness", self.name());
+    fn readiness(&self) -> Readiness {
+        panic!("FD type {} implements `readiness_watched` but not `readiness`", self.name());
     }
 }
 
@@ -480,6 +485,7 @@ impl FdTable {
         self.insert(fd_ref)
     }
 
+    /// Insert an alias to an existing file description to the FdTable.
     pub fn insert(&mut self, fd_ref: DynFileDescriptionRef) -> FdNum {
         self.insert_with_min_num(fd_ref, 0)
     }

--- a/src/shims/files.rs
+++ b/src/shims/files.rs
@@ -444,7 +444,7 @@ pub type FdNum = i32;
 /// The file descriptor table
 #[derive(Debug)]
 pub struct FdTable {
-    pub fds: BTreeMap<FdNum, DynFileDescriptionRef>,
+    fds: BTreeMap<FdNum, DynFileDescriptionRef>,
     /// Unique identifier for file description, used to differentiate between various file description.
     next_file_description_id: FdId,
 }

--- a/src/shims/files.rs
+++ b/src/shims/files.rs
@@ -490,29 +490,21 @@ impl FdTable {
         file_handle: DynFileDescriptionRef,
         min_fd_num: FdNum,
     ) -> FdNum {
-        // Find the lowest unused FD, starting from min_fd. If the first such unused FD is in
-        // between used FDs, the find_map combinator will return it. If the first such unused FD
-        // is after all other used FDs, the find_map combinator will return None, and we will use
-        // the FD following the greatest FD thus far.
-        let candidate_new_fd =
-            self.fds.range(min_fd_num..).zip(min_fd_num..).find_map(|((fd_num, _fd), counter)| {
-                if *fd_num != counter {
-                    // There was a gap in the fds stored, return the first unused one
-                    // (note that this relies on BTreeMap iterating in key order)
-                    Some(counter)
-                } else {
-                    // This fd is used, keep going
-                    None
-                }
-            });
-        let new_fd_num = candidate_new_fd.unwrap_or_else(|| {
-            // find_map ran out of BTreeMap entries before finding a free fd, use one plus the
-            // maximum fd in the map
-            self.fds.last_key_value().map(|(fd_num, _)| fd_num.strict_add(1)).unwrap_or(min_fd_num)
-        });
+        let mut candidate = min_fd_num;
+        for (&fd_num, _) in self.fds.range(min_fd_num..) {
+            if fd_num == candidate {
+                // This one is taken. Try the next one.
+                candidate = candidate.strict_add(1);
+            } else {
+                // We found a gap! Use this candidate.
+                break;
+            }
+        }
+        // If we exhaust the loop, the table is a solid block starting at `min_fd_num` until the
+        // end, and `candidate` is now the first number after that block -- exactly what we need.
 
-        self.fds.try_insert(new_fd_num, file_handle).unwrap();
-        new_fd_num
+        self.fds.try_insert(candidate, file_handle).unwrap();
+        candidate
     }
 
     pub fn get(&self, fd_num: FdNum) -> Option<DynFileDescriptionRef> {

--- a/src/shims/readiness.rs
+++ b/src/shims/readiness.rs
@@ -96,17 +96,11 @@ pub struct ReadinessInterest {
     pub data: u64,
     /// The currently active readiness for this file descriptor.
     active: Readiness,
-    /// The vector clock for wakeups.
-    clock: VClock,
 }
 
 impl ReadinessInterest {
     pub fn active(&self) -> &Readiness {
         &self.active
-    }
-
-    pub fn clock(&self) -> &VClock {
-        &self.clock
     }
 }
 
@@ -180,7 +174,6 @@ impl ReadinessWatcher {
         let interest = ReadinessInterest {
             watched_fd: FileDescriptionRef::downgrade(&fd_ref),
             active: Readiness::EMPTY,
-            clock: VClock::default(),
             relevant,
             is_edge_triggered,
             data,
@@ -343,14 +336,14 @@ impl ReadinessWatcher {
             && let Some(key) = ready.pop_front()
         {
             let interest = interests.get(&key).expect("non-existing interest in ready set");
-            if interest.watched_fd.is_closed() {
+            let Some(fd) = interest.watched_fd.upgrade() else {
                 // "A file descriptor is removed from an interest list only after all the file
                 // descriptors referring to the underlying open file description have been closed."
                 // So, we should have removed this FD from the interest list, we just didn't get
                 // around to that yet. Pretend it does not exist. It will not be re-added to the
                 // ready list, and it will eventually be cleaned up by the GC.
                 continue;
-            }
+            };
 
             if !interest.is_edge_triggered {
                 // This is a level-triggered interest, so we need to re-add the event:
@@ -360,6 +353,8 @@ impl ReadinessWatcher {
             }
 
             ready_interests.push(interest.clone());
+            // We now "see" the readiness of this FD, so make the data race system aware of that.
+            ecx.acquire_clock(&fd.readiness_watched().unwrap().ready_clock.borrow())?;
         }
         // Add back the level-triggered ones.
         ready.extend(re_add_interests);
@@ -378,6 +373,9 @@ impl VisitProvenance for ReadinessWatcher {
 pub struct ReadinessWatched {
     /// List of readiness watchers that are interested in us.
     watchers: RefCell<Vec<Weak<ReadinessWatcher>>>,
+    /// Vector clock for the most recent change to our readiness.
+    /// (Ideally this would be one clock per readiness flag, but we're not bothering with that.)
+    ready_clock: RefCell<VClock>,
 }
 
 impl ReadinessWatched {
@@ -461,8 +459,16 @@ pub trait EvalContextExt<'tcx>: MiriInterpCxExt<'tcx> {
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
         let fd_id = fd.id();
+        let watched = fd.readiness_watched().unwrap();
 
-        let watchers_ref = fd.readiness_watched().unwrap().watchers.borrow();
+        // We always capture a vector clock, since someone might get interested in the future
+        // and then synchronize with this event.
+        // FIXME: currently we do this even if the readiness did not change!
+        this.release_clock(|clock| {
+            watched.ready_clock.borrow_mut().join(clock);
+        })?;
+
+        let watchers_ref = watched.watchers.borrow();
         // Need to make a copy so below we can unblock threads which may need the same `RefCell`.
         let watchers =
             watchers_ref.iter().map(|w| w.upgrade().expect("dead watcher?")).collect::<Vec<_>>();
@@ -524,12 +530,6 @@ pub trait EvalContextPrivExt<'tcx>: MiriInterpCxExt<'tcx> {
                 if !ready.contains(&key) {
                     ready.push_back(key);
                 }
-
-                // No matter whether this is newly ready or just re-triggered,
-                // the waiter fetching this event should sync with the current thread.
-                this.release_clock(|clock| {
-                    interest.clock.join(clock);
-                })?;
             }
             interp_ok(())
         })?;

--- a/src/shims/readiness.rs
+++ b/src/shims/readiness.rs
@@ -137,7 +137,8 @@ impl Drop for ReadinessWatcher {
             if let Some(fd) = interest.watched_fd.upgrade() {
                 // We can't easily figure out who in that list is us, but we can just remove
                 // everything that has no more strong refs.
-                fd.readiness_watched().unwrap().run_gc();
+                let mut watchers = fd.readiness_watched().unwrap().watchers.borrow_mut();
+                watchers.retain(|w| w.strong_count() > 0);
             }
         }
     }
@@ -253,10 +254,7 @@ impl ReadinessWatcher {
             // We did not have interest in this.
             return None;
         };
-        let Some(fd_ref) = interest.watched_fd.upgrade() else {
-            // The FD is already gone, nothing to do.
-            return None;
-        };
+        let fd_ref = interest.watched_fd.upgrade().expect("dead watched");
 
         // Remove the ready event for this key, should one exist.
         let mut ready_events = self.ready.borrow_mut();
@@ -321,8 +319,8 @@ impl ReadinessWatcher {
         // Sanity-check to ensure that all event info is up-to-date.
         if cfg!(debug_assertions) {
             for interest in interests.values() {
-                // Ensure this matches the latest readiness of this FD, if the FD is still open.
-                let Some(fd) = interest.watched_fd.upgrade() else { continue };
+                // Ensure this matches the latest readiness of this FD.
+                let fd = interest.watched_fd.upgrade().expect("dead watched");
                 let current_active = fd.readiness();
                 assert_eq!(interest.active(), &(current_active & interest.relevant.clone()));
             }
@@ -336,14 +334,7 @@ impl ReadinessWatcher {
             && let Some(key) = ready.pop_front()
         {
             let interest = interests.get(&key).expect("non-existing interest in ready set");
-            let Some(fd) = interest.watched_fd.upgrade() else {
-                // "A file descriptor is removed from an interest list only after all the file
-                // descriptors referring to the underlying open file description have been closed."
-                // So, we should have removed this FD from the interest list, we just didn't get
-                // around to that yet. Pretend it does not exist. It will not be re-added to the
-                // ready list, and it will eventually be cleaned up by the GC.
-                continue;
-            };
+            let fd = interest.watched_fd.upgrade().expect("dead watched");
 
             if !interest.is_edge_triggered {
                 // This is a level-triggered interest, so we need to re-add the event:
@@ -378,6 +369,32 @@ pub struct ReadinessWatched {
     ready_clock: RefCell<VClock>,
 }
 
+impl Drop for ReadinessWatched {
+    fn drop(&mut self) {
+        // "A file descriptor is removed from an interest list only after all the file
+        // descriptors referring to the underlying open file description have been closed."
+        // So, remove ourselves from all interest lists.
+        for watcher in self.watchers.borrow().iter() {
+            // If the watcher still exists, remove ourselves from it.
+            let Some(watcher) = watcher.upgrade() else { continue };
+            // We can't easily figure out who in that list is us, but we can just remove everything
+            // that has no more strong refs.
+            let mut ready_events = watcher.ready.borrow_mut();
+            watcher.interests.borrow_mut().retain(|key, interest| {
+                if interest.watched_fd.is_closed() {
+                    // We'll remove this one. Also remove it from the ready queue if applicable!
+                    if let Some(idx) = ready_events.iter().position(|k| k == key) {
+                        ready_events.remove(idx);
+                    }
+                    false // do not retain
+                } else {
+                    true // do retain
+                }
+            });
+        }
+    }
+}
+
 impl ReadinessWatched {
     fn insert(&self, watcher: &Rc<ReadinessWatcher>) {
         let mut watchers = self.watchers.borrow_mut();
@@ -408,13 +425,7 @@ impl ReadinessWatched {
     pub fn has_watcher_with_blocked_thread(&self) -> bool {
         let watchers = self.watchers.borrow();
         // See if any of those watchers has a blocked thread.
-        watchers.iter().any(|w| w.upgrade().expect("dead watcher?").queue.borrow().len() > 0)
-    }
-
-    /// Cleans up references to dead watchers.
-    pub fn run_gc(&self) {
-        let mut watchers = self.watchers.borrow_mut();
-        watchers.retain(|w| w.strong_count() > 0);
+        watchers.iter().any(|w| w.upgrade().expect("dead watcher").queue.borrow().len() > 0)
     }
 }
 
@@ -471,7 +482,7 @@ pub trait EvalContextExt<'tcx>: MiriInterpCxExt<'tcx> {
         let watchers_ref = watched.watchers.borrow();
         // Need to make a copy so below we can unblock threads which may need the same `RefCell`.
         let watchers =
-            watchers_ref.iter().map(|w| w.upgrade().expect("dead watcher?")).collect::<Vec<_>>();
+            watchers_ref.iter().map(|w| w.upgrade().expect("dead watcher")).collect::<Vec<_>>();
         if watchers.is_empty() {
             return interp_ok(());
         };

--- a/src/shims/readiness.rs
+++ b/src/shims/readiness.rs
@@ -1,5 +1,5 @@
 use std::assert_matches;
-use std::cell::{Ref, RefCell};
+use std::cell::RefCell;
 use std::collections::{BTreeMap, VecDeque};
 use std::rc::{Rc, Weak};
 
@@ -145,12 +145,6 @@ impl Drop for ReadinessWatcher {
 }
 
 impl ReadinessWatcher {
-    /// Get a reference to the map of registered interests of the watcher
-    /// together with their keys.
-    pub fn interests(&self) -> Ref<'_, BTreeMap<ReadinessInterestKey, ReadinessInterest>> {
-        self.interests.borrow()
-    }
-
     /// Add an interest for the file description to which the file descriptor
     /// `fd_num` belongs.
     /// `relevant` contains the readiness mask of relevant events.
@@ -426,6 +420,19 @@ impl ReadinessWatched {
         let watchers = self.watchers.borrow();
         // See if any of those watchers has a blocked thread.
         watchers.iter().any(|w| w.upgrade().expect("dead watcher").queue.borrow().len() > 0)
+    }
+
+    /// Remove all interes in the given file descriptor, which must refer to the file description
+    /// that contains `self`.
+    pub fn remove_file_num_interests(&self, fd_id: FdId, fd_num: FdNum) {
+        // We make a copy since `remove_interest` may want to mutate `watchers`. This is not
+        // very efficient, but this code anyway only runs on `close` on Illumos.
+        let watchers = self.watchers.borrow().clone();
+        for watcher in watchers.iter() {
+            let watcher = watcher.upgrade().expect("dead watcher");
+            // Remove this interest, if it exists.
+            watcher.remove_interest((fd_id, fd_num));
+        }
     }
 }
 

--- a/src/shims/readiness.rs
+++ b/src/shims/readiness.rs
@@ -9,7 +9,7 @@ use crate::shims::*;
 use crate::*;
 
 /// Struct reflecting the readiness of a file description.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Readiness {
     /// Boolean whether the file description is readable.
     pub readable: bool,
@@ -73,7 +73,20 @@ impl Readiness {
     };
 }
 
-pub type ReadinessInterestKey = (FdId, FdNum);
+bitflags::bitflags! {
+    #[derive(Debug, Copy, Clone, PartialEq)]
+    pub struct ReadinessUpdateFlags: u32 {
+        const DEFAULT = 0;
+        /// Trigger edge-triggered even if the set of ready events did not change. This can lead to
+        /// spurious wakeups. Use with caution!
+        const FORCE_EDGE = 1 << 0;
+        /// Do not treat this as a release event from the current thread. This can lead to incorrect
+        /// data race reports. Use with caution!
+        const NO_RELEASE_CLOCK = 1 << 1;
+    }
+}
+
+type ReadinessInterestKey = (FdId, FdNum);
 
 /// Returns the range of all [`ReadinessInterestKey`] for the given FD ID.
 fn range_for_id(id: FdId) -> std::ops::RangeInclusive<ReadinessInterestKey> {
@@ -316,7 +329,7 @@ impl ReadinessWatcher {
                 // Ensure this matches the latest readiness of this FD.
                 let fd = interest.watched_fd.upgrade().expect("dead watched");
                 let current_active = fd.readiness();
-                assert_eq!(interest.active(), &(current_active & interest.relevant.clone()));
+                assert_eq!(interest.active(), &(current_active & interest.relevant));
             }
         }
 
@@ -457,7 +470,7 @@ impl DelayedReadinessUpdates {
             else {
                 return interp_ok(());
             };
-            ecx.update_fd_readiness(fd, /* force_edge */ false)?;
+            ecx.update_fd_readiness(fd, ReadinessUpdateFlags::DEFAULT)?;
         }
     }
 }
@@ -467,24 +480,23 @@ pub trait EvalContextExt<'tcx>: MiriInterpCxExt<'tcx> {
     /// For a specific file description, get its current readiness and send it to everyone who
     /// registered interest in this FD. This function must be called whenever the result of
     /// `FileDescription::readiness` might change.
-    ///
-    /// If `force_edge` is set, edge-triggered interests will be triggered even if the set of
-    /// ready events did not change. This can lead to spurious wakeups. Use with caution!
     fn update_fd_readiness(
         &mut self,
         fd: DynFileDescriptionRef,
-        force_edge: bool,
+        flags: ReadinessUpdateFlags,
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
         let fd_id = fd.id();
         let watched = fd.readiness_watched().unwrap();
 
-        // We always capture a vector clock, since someone might get interested in the future
-        // and then synchronize with this event.
-        // FIXME: currently we do this even if the readiness did not change!
-        this.release_clock(|clock| {
-            watched.ready_clock.borrow_mut().join(clock);
-        })?;
+        if !flags.contains(ReadinessUpdateFlags::NO_RELEASE_CLOCK) {
+            // We capture a vector clock even if there is nobody watching, since someone might get
+            // interested in the future and then synchronize with this event.
+            // FIXME: currently we do this even if the readiness did not change!
+            this.release_clock(|clock| {
+                watched.ready_clock.borrow_mut().join(clock);
+            })?;
+        }
 
         let watchers_ref = watched.watchers.borrow();
         // Need to make a copy so below we can unblock threads which may need the same `RefCell`.
@@ -497,14 +509,19 @@ pub trait EvalContextExt<'tcx>: MiriInterpCxExt<'tcx> {
 
         let active_readiness = fd.readiness();
         for watcher in watchers {
-            this.update_readiness(&watcher, active_readiness.clone(), force_edge, |callback| {
-                for (&key, interest) in
-                    watcher.interests.borrow_mut().range_mut(range_for_id(fd_id))
-                {
-                    callback(key, interest)?;
-                }
-                interp_ok(())
-            })?;
+            this.update_readiness(
+                &watcher,
+                active_readiness,
+                flags.contains(ReadinessUpdateFlags::FORCE_EDGE),
+                |callback| {
+                    for (&key, interest) in
+                        watcher.interests.borrow_mut().range_mut(range_for_id(fd_id))
+                    {
+                        callback(key, interest)?;
+                    }
+                    interp_ok(())
+                },
+            )?;
         }
 
         interp_ok(())
@@ -531,14 +548,14 @@ pub trait EvalContextPrivExt<'tcx>: MiriInterpCxExt<'tcx> {
         let this = self.eval_context_mut();
         let mut ready = watcher.ready.borrow_mut();
         for_each_interest(&mut |key, interest| {
-            let new_readiness = interest.relevant.clone() & active.clone();
-            let prev_readiness = std::mem::replace(&mut interest.active, new_readiness.clone());
+            let new_readiness = interest.relevant & active;
+            let prev_readiness = std::mem::replace(&mut interest.active, new_readiness);
             if new_readiness == Readiness::EMPTY {
                 // Un-trigger this, there's nothing left to report here.
                 if let Some(idx) = ready.iter().position(|k| k == &key) {
                     ready.remove(idx);
                 }
-            } else if force_edge || new_readiness != prev_readiness & new_readiness.clone() {
+            } else if force_edge || new_readiness != prev_readiness & new_readiness {
                 // Either we force an "edge" to be detected or there's a bit set in `new_readiness`
                 // that was not set in `prev_readiness`. In both cases, this is ready now.
 

--- a/src/shims/readiness.rs
+++ b/src/shims/readiness.rs
@@ -129,6 +129,26 @@ pub struct ReadinessWatcher {
     queue: RefCell<VecDeque<ThreadId>>,
 }
 
+impl Drop for ReadinessWatcher {
+    fn drop(&mut self) {
+        // Remove ourselves from the FDs we were interested in, at most once per description.
+        let mut last_id = None;
+        for ((id, _fd_num), interest) in self.interests.borrow().iter() {
+            // We'll see interested sorted by ID. Only do something once for each ID.
+            if Some(id) == last_id {
+                continue;
+            }
+            last_id = Some(id);
+            // If the FD still exists, remove ourselves from it.
+            if let Some(fd) = interest.watched_fd.upgrade() {
+                // We can't easily figure out who in that list is us, but we can just remove
+                // everything that has no more strong refs.
+                fd.readiness_watched().unwrap().run_gc();
+            }
+        }
+    }
+}
+
 impl ReadinessWatcher {
     /// Get a reference to the map of registered interests of the watcher
     /// together with their keys.
@@ -168,9 +188,11 @@ impl ReadinessWatcher {
         let mut interests = self.interests.borrow_mut();
         if interests.range(range_for_id(fd_id)).next().is_none() {
             // This is the first time this FD got added to the watcher.
-            // We need to remember that in the global list such that we
-            // get notified about FD events.
-            ecx.machine.readiness_interests.insert(&fd_ref, self);
+            // Let's make sure it can be watched, and add ourselves to its list.
+            let watched = fd_ref.readiness_watched().ok_or_else(|| {
+                err_unsup_format!("I/O readiness watching not supported for {}", fd_ref.name())
+            })?;
+            watched.insert(self);
         }
         if interests.try_insert(key, interest).is_err() {
             return interp_ok(Err(()));
@@ -181,7 +203,7 @@ impl ReadinessWatcher {
 
         ecx.update_readiness(
             self,
-            fd_ref.readiness()?,
+            fd_ref.readiness(),
             /* force_edge */ true,
             move |callback| {
                 // Need to release the RefCell when this closure returns, so we have to move
@@ -215,7 +237,7 @@ impl ReadinessWatcher {
         let fd_ref = ecx.machine.fds.get(key.1).expect("File description should exist");
         ecx.update_readiness(
             self,
-            fd_ref.readiness()?,
+            fd_ref.readiness(),
             /* force_edge */ true,
             move |callback| {
                 // Need to release the RefCell when this closure returns, so we have to move
@@ -231,18 +253,17 @@ impl ReadinessWatcher {
     ///
     /// This function returns [`None`] when no interest is registered
     /// for the specified `key`.
-    pub fn remove_interest<'tcx>(
-        self: &Rc<ReadinessWatcher>,
-        key: ReadinessInterestKey,
-        ecx: &mut MiriInterpCx<'tcx>,
-    ) -> Option<()> {
+    pub fn remove_interest(self: &Rc<ReadinessWatcher>, key: ReadinessInterestKey) -> Option<()> {
         let mut interests = self.interests.borrow_mut();
 
-        #[allow(clippy::question_mark)] // avoid hidden control flow
-        if interests.remove(&key).is_none() {
+        let Some(interest) = interests.remove(&key) else {
             // We did not have interest in this.
             return None;
-        }
+        };
+        let Some(fd_ref) = interest.watched_fd.upgrade() else {
+            // The FD is already gone, nothing to do.
+            return None;
+        };
 
         // Remove the ready event for this key, should one exist.
         let mut ready_events = self.ready.borrow_mut();
@@ -252,7 +273,7 @@ impl ReadinessWatcher {
         // If this was the last interest in this FD, remove us from the global list
         // of who is interested in this FD.
         if interests.range(range_for_id(key.0)).next().is_none() {
-            ecx.machine.readiness_interests.remove(key.0, self);
+            fd_ref.readiness_watched()?.remove(self);
         }
 
         Some(())
@@ -309,7 +330,7 @@ impl ReadinessWatcher {
             for interest in interests.values() {
                 // Ensure this matches the latest readiness of this FD, if the FD is still open.
                 let Some(fd) = interest.watched_fd.upgrade() else { continue };
-                let current_active = fd.readiness()?;
+                let current_active = fd.readiness();
                 assert_eq!(interest.active(), &(current_active & interest.relevant.clone()));
             }
         }
@@ -351,30 +372,17 @@ impl VisitProvenance for ReadinessWatcher {
     fn visit_provenance(&self, _visit: &mut VisitWith<'_>) {}
 }
 
-/// The table with all [`ReadinessWatcher`]s.
-/// This tracks, for each file description, which watchers have an interest in events
-/// for this file description.
-pub struct ReadinessInterestTable {
-    /// Maps each file description (identified by its [`FdId`]) to the list of watchers that are
-    /// interested in that FD.
-    /// We also store a weak reference to the watched file description, so we can clean them up
-    /// when they get freed.
-    /// FIXME: a better place to store this would probably be the relevant FD itself. Experiment
-    /// with delegation to easily do that for all FD types, once that is ready.
-    interests: BTreeMap<FdId, (WeakDynFileDescriptionRef, Vec<Weak<ReadinessWatcher>>)>,
+/// Data about a file descriptiobn that can be watched for readiness
+/// (meant to be stored inside said file description).
+#[derive(Debug, Default)]
+pub struct ReadinessWatched {
+    /// List of readiness watchers that are interested in us.
+    watchers: RefCell<Vec<Weak<ReadinessWatcher>>>,
 }
 
-impl ReadinessInterestTable {
-    pub(crate) fn new() -> Self {
-        ReadinessInterestTable { interests: BTreeMap::new() }
-    }
-
-    /// Add an interest for `watcher` for the `watched_fd` file description.
-    fn insert(&mut self, watched_fd: &DynFileDescriptionRef, watcher: &Rc<ReadinessWatcher>) {
-        let (_watched, watchers) = self
-            .interests
-            .entry(watched_fd.id())
-            .or_insert_with(|| (FileDescriptionRef::downgrade(watched_fd), Vec::new()));
+impl ReadinessWatched {
+    fn insert(&self, watcher: &Rc<ReadinessWatcher>) {
+        let mut watchers = self.watchers.borrow_mut();
         if cfg!(debug_assertions) {
             // Ensure uniqueness.
             assert_matches!(
@@ -386,12 +394,8 @@ impl ReadinessInterestTable {
         watchers.push(Rc::downgrade(watcher));
     }
 
-    /// Remove the interest of `watcher` for the file description with id `fd_id`.
-    fn remove(&mut self, watched_fd: FdId, watcher: &Rc<ReadinessWatcher>) {
-        let (_watched, watchers) = self
-            .interests
-            .get_mut(&watched_fd)
-            .expect("watcher has no registered interest in the provided watched fd");
+    fn remove(&self, watcher: &Rc<ReadinessWatcher>) {
+        let mut watchers = self.watchers.borrow_mut();
         // We need to do a linear scan to find the watcher to remove. That's not ideal, but removing
         // a watched FD from an epoll is rare so it's not worth the non-trivial effort it would take
         // to make this more efficient.
@@ -402,40 +406,17 @@ impl ReadinessInterestTable {
         watchers.remove(idx);
     }
 
-    /// Get all watchers which have a registered interest in the file description with id `fd_id`.
-    fn get_watchers_for_fd(
-        &self,
-        fd_id: FdId,
-    ) -> Option<impl Iterator<Item = Rc<ReadinessWatcher>>> {
-        let (_watched, watchers) = self.interests.get(&fd_id)?;
-        // Ignore weak refs that cannot be upgraded -- those correspond to closed
-        // file descriptions and will be cleaned up by the GC eventually.
-        Some(watchers.iter().filter_map(|watcher| watcher.upgrade()))
+    /// Returns whether the watched FD has any readiness watcher with a blocked thread watching it.
+    pub fn has_watcher_with_blocked_thread(&self) -> bool {
+        let watchers = self.watchers.borrow();
+        // See if any of those watchers has a blocked thread.
+        watchers.iter().any(|w| w.upgrade().expect("dead watcher?").queue.borrow().len() > 0)
     }
 
-    /// Run garbage collector to remove all dropped watchers and dropped watched FDs.
-    pub fn run_gc(&mut self) {
-        self.interests.retain(|&fd_id, (watched, watchers)| {
-            if watched.is_closed() {
-                // An FD we were watching got closed. Remove it from the watcher as well.
-                for watcher in watchers.iter().filter_map(Weak::upgrade) {
-                    // This is a still-live watcher with interest in this FD. Remove all
-                    // relevant interests (including from the ready set).
-                    watcher
-                        .interests
-                        .borrow_mut()
-                        .extract_if(range_for_id(fd_id), |_, _| true)
-                        // Consume the iterator.
-                        .for_each(drop);
-                    // Remove the ready interests for this file description.
-                    watcher.ready.borrow_mut().retain(|(id, _)| id != &fd_id);
-                }
-                return false; // delete this one
-            }
-            // Keep this one, but clean up the watchers.
-            watchers.retain(|watcher| watcher.strong_count() > 0);
-            true
-        });
+    /// Cleans up references to dead watchers.
+    pub fn run_gc(&self) {
+        let mut watchers = self.watchers.borrow_mut();
+        watchers.retain(|w| w.strong_count() > 0);
     }
 }
 
@@ -467,16 +448,6 @@ impl DelayedReadinessUpdates {
 
 impl<'tcx> EvalContextExt<'tcx> for MiriInterpCx<'tcx> {}
 pub trait EvalContextExt<'tcx>: MiriInterpCxExt<'tcx> {
-    /// Returns whether the given FD has any readiness watcher with a blocked thread watching it.
-    fn has_watcher_with_blocked_thread(&self, fd_id: FdId) -> bool {
-        let this = self.eval_context_ref();
-        let Some(mut watchers) = this.machine.readiness_interests.get_watchers_for_fd(fd_id) else {
-            return false;
-        };
-        // See if any of those watchers has a blocked thread.
-        watchers.any(|w| w.queue.borrow().len() > 0)
-    }
-
     /// For a specific file description, get its current readiness and send it to everyone who
     /// registered interest in this FD. This function must be called whenever the result of
     /// `FileDescription::readiness` might change.
@@ -491,11 +462,16 @@ pub trait EvalContextExt<'tcx>: MiriInterpCxExt<'tcx> {
         let this = self.eval_context_mut();
         let fd_id = fd.id();
 
-        let Some(watchers) = this.machine.readiness_interests.get_watchers_for_fd(fd_id) else {
+        let watchers_ref = fd.readiness_watched().unwrap().watchers.borrow();
+        // Need to make a copy so below we can unblock threads which may need the same `RefCell`.
+        let watchers =
+            watchers_ref.iter().map(|w| w.upgrade().expect("dead watcher?")).collect::<Vec<_>>();
+        if watchers.is_empty() {
             return interp_ok(());
         };
-        let watchers = watchers.collect::<Vec<_>>(); // need to make a copy so below we can unblock threads
-        let active_readiness = fd.readiness()?;
+        drop(watchers_ref);
+
+        let active_readiness = fd.readiness();
         for watcher in watchers {
             this.update_readiness(&watcher, active_readiness.clone(), force_edge, |callback| {
                 for (&key, interest) in

--- a/src/shims/unix/fd.rs
+++ b/src/shims/unix/fd.rs
@@ -9,7 +9,7 @@ use rustc_abi::{Align, Size};
 use rustc_target::spec::Os;
 
 use crate::shims::FileDescriptionRef;
-use crate::shims::files::{DynFileDescriptionRef, FileDescription};
+use crate::shims::files::{DynFileDescriptionRef, FdNum, FileDescription};
 use crate::shims::sig::check_min_vararg_count;
 use crate::shims::unix::socket::UnixSocketFileDescription;
 use crate::shims::unix::*;
@@ -88,7 +88,35 @@ pub trait UnixFileDescription: FileDescription {
 
 impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
 pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
-    fn dup(&mut self, old_fd_num: i32) -> InterpResult<'tcx, Scalar> {
+    fn close(&mut self, fd_num: FdNum) -> InterpResult<'tcx, Scalar> {
+        let this = self.eval_context_mut();
+
+        let Some(fd) = this.machine.fds.remove(fd_num) else {
+            return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
+        };
+        if this.tcx.sess.target.os == Os::Illumos {
+            // Illumos didn't like the Linux semantics of epoll tracking file *descriptions*
+            // rather than file *descriptors*. So on Illumos, when a file description is closed,
+            // de-register it from everything watching it.
+            // > While a best effort has been made to mimic the Linux semantics, there are
+            // > some semantics that are too peculiar or ill-conceived to merit
+            // > accommodation. In particular, the Linux epoll facility will -- by design
+            // > -- continue to generate events for closed file descriptors where/when the
+            // > underlying file description remains open. [...]
+            // > This epoll facility refuses to honor these semantics;
+            // > closing the EPOLL_CTL_ADD'd file descriptor will always result in no
+            // > further events being generated for that event description.
+            if let Some(watched) = fd.readiness_watched() {
+                watched.remove_file_num_interests(fd.id(), fd_num);
+            }
+        }
+        drop(fd);
+        // Our close is always successful. Close does not reliably return errors anyway so it is
+        // not worth the effort to try and return anything here.
+        interp_ok(Scalar::from_i32(0))
+    }
+
+    fn dup(&mut self, old_fd_num: FdNum) -> InterpResult<'tcx, Scalar> {
         let this = self.eval_context_mut();
 
         let Some(fd) = this.machine.fds.get(old_fd_num) else {
@@ -97,23 +125,26 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         interp_ok(Scalar::from_i32(this.machine.fds.insert(fd)))
     }
 
-    fn dup2(&mut self, old_fd_num: i32, new_fd_num: i32) -> InterpResult<'tcx, Scalar> {
+    fn dup2(&mut self, old_fd_num: FdNum, new_fd_num: FdNum) -> InterpResult<'tcx, Scalar> {
         let this = self.eval_context_mut();
 
         let Some(fd) = this.machine.fds.get(old_fd_num) else {
             return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
         };
         if new_fd_num != old_fd_num {
-            // Close new_fd if it is previously opened.
-            // If old_fd and new_fd point to the same description, then `dup_fd` ensures we keep the underlying file description alive.
-            if let Some(old_new_fd) = this.machine.fds.fds.insert(new_fd_num, fd) {
-                drop(old_new_fd);
+            if this.machine.fds.get(new_fd_num).is_some() {
+                // Close the FD currently holding this spot.
+                let ret = this.close(new_fd_num)?;
+                assert!(ret.to_i32().unwrap() == 0);
             }
+            // Insert new FD in this spot.
+            let actual_fd_num = this.machine.fds.insert_with_min_num(fd, new_fd_num);
+            assert_eq!(actual_fd_num, new_fd_num);
         }
         interp_ok(Scalar::from_i32(new_fd_num))
     }
 
-    fn flock(&mut self, fd_num: i32, op: i32) -> InterpResult<'tcx, Scalar> {
+    fn flock(&mut self, fd_num: FdNum, op: i32) -> InterpResult<'tcx, Scalar> {
         let this = self.eval_context_mut();
         let Some(fd) = this.machine.fds.get(fd_num) else {
             return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
@@ -275,20 +306,6 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 throw_unsup_format!("fcntl: unsupported command {cmd:#x}");
             }
         }
-    }
-
-    fn close(&mut self, fd_op: &OpTy<'tcx>) -> InterpResult<'tcx, Scalar> {
-        let this = self.eval_context_mut();
-
-        let fd_num = this.read_scalar(fd_op)?.to_i32()?;
-
-        let Some(fd) = this.machine.fds.remove(fd_num) else {
-            return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
-        };
-        drop(fd);
-        // Our close is always successful. Close does not reliably return errors anyway so it is
-        // not worth the effort to try and return anything here.
-        interp_ok(Scalar::from_i32(0))
     }
 
     /// Read data from `fd` into buffer specified by `buf` and `count`.

--- a/src/shims/unix/foreign_items.rs
+++ b/src/shims/unix/foreign_items.rs
@@ -320,6 +320,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     abi,
                     args,
                 )?;
+                let fd = this.read_scalar(fd)?.to_i32()?;
                 let result = this.close(fd)?;
                 this.write_scalar(result, dest)?;
             }

--- a/src/shims/unix/linux_like/epoll.rs
+++ b/src/shims/unix/linux_like/epoll.rs
@@ -398,8 +398,6 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 &slot,
             )?;
             num_of_events = num_of_events.strict_add(1);
-            // Synchronize receiving thread with the event of interest.
-            this.acquire_clock(interest.clock())?;
         }
         this.write_int(num_of_events, dest)?;
         interp_ok(num_of_events)

--- a/src/shims/unix/linux_like/epoll.rs
+++ b/src/shims/unix/linux_like/epoll.rs
@@ -187,7 +187,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 }
             }
         } else if op == epoll_ctl_del {
-            if epfd.watcher.remove_interest(interest_key, this).is_none() {
+            if epfd.watcher.remove_interest(interest_key).is_none() {
                 // We did not have interest in this.
                 return this.set_errno_and_return_neg1_i32(LibcError("ENOENT"));
             };

--- a/src/shims/unix/linux_like/eventfd.rs
+++ b/src/shims/unix/linux_like/eventfd.rs
@@ -228,7 +228,7 @@ fn eventfd_write<'tcx>(
             // Linux seems to cause spurious wakeups here, and Tokio seems to rely on that
             // (see <https://github.com/rust-lang/miri/pull/4676#discussion_r2510528994>
             // and also <https://www.illumos.org/issues/16700>).
-            ecx.update_fd_readiness(eventfd, /* force_edge */ true)?;
+            ecx.update_fd_readiness(eventfd, ReadinessUpdateFlags::FORCE_EDGE)?;
 
             // Return how many bytes we consumed from the user-provided buffer.
             return finish.call(ecx, Ok(buf_place.layout.size.bytes_usize()));
@@ -316,7 +316,7 @@ fn eventfd_read<'tcx>(
         // The state changed; we check and update the status of all supported event
         // types for current file description.
         // Linux seems to always emit do notifications here, even if we were already writable.
-        ecx.update_fd_readiness(eventfd, /* force_edge */ true)?;
+        ecx.update_fd_readiness(eventfd, ReadinessUpdateFlags::FORCE_EDGE)?;
 
         // Tell userspace how many bytes we put into the buffer.
         return finish.call(ecx, Ok(buf_place.layout.size.bytes_usize()));

--- a/src/shims/unix/linux_like/eventfd.rs
+++ b/src/shims/unix/linux_like/eventfd.rs
@@ -29,6 +29,8 @@ struct EventFd {
     blocked_read_tid: RefCell<Vec<ThreadId>>,
     /// A list of thread ids blocked on eventfd::write.
     blocked_write_tid: RefCell<Vec<ThreadId>>,
+    /// State for being watched by epoll.
+    watched: ReadinessWatched,
 }
 
 impl FileDescription for EventFd {
@@ -99,15 +101,19 @@ impl FileDescription for EventFd {
         eventfd_write(buf_place, self, ecx, finish)
     }
 
-    fn readiness<'tcx>(&self) -> InterpResult<'tcx, Readiness> {
+    fn readiness_watched(&self) -> Option<&ReadinessWatched> {
+        Some(&self.watched)
+    }
+
+    fn readiness(&self) -> Readiness {
         // We only check the "readable" and "writable" readiness for eventfd. If other event flags
         // need to be supported in the future, the check should be added here.
 
-        interp_ok(Readiness {
+        Readiness {
             readable: self.counter.get() != 0,
             writable: self.counter.get() != MAX_COUNTER,
             ..Readiness::EMPTY
-        })
+        }
     }
 
     fn as_unix<'tcx>(
@@ -175,6 +181,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             clock: RefCell::new(VClock::default()),
             blocked_read_tid: RefCell::new(Vec::new()),
             blocked_write_tid: RefCell::new(Vec::new()),
+            watched: ReadinessWatched::default(),
         });
 
         interp_ok(Scalar::from_i32(fd_value))

--- a/src/shims/unix/macos/foreign_items.rs
+++ b/src/shims/unix/macos/foreign_items.rs
@@ -42,8 +42,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
             // File related shims
             "close$NOCANCEL" => {
-                let [result] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
-                let result = this.close(result)?;
+                let [fd] = this.check_shim_sig_lenient(abi, CanonAbi::C, link_name, args)?;
+                let fd = this.read_scalar(fd)?.to_i32()?;
+                let result = this.close(fd)?;
                 this.write_scalar(result, dest)?;
             }
             "stat$INODE64" => {

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -177,7 +177,7 @@ impl FileDescription for TcpSocket {
     }
 
     fn readiness(&self) -> Readiness {
-        self.io_readiness.borrow().clone()
+        *self.io_readiness.borrow()
     }
 }
 
@@ -703,7 +703,7 @@ impl UnixSocketFileDescription for TcpSocket {
                 // We know there is no longer an async error and thus we need to update the
                 // I/O and fd readiness of the socket.
                 self.io_readiness.borrow_mut().error = false;
-                ecx.update_fd_readiness(self, /* force_edge */ false)?;
+                ecx.update_fd_readiness(self, ReadinessUpdateFlags::DEFAULT)?;
 
                 // Allocate new buffer on the stack with the `i32` layout.
                 let value_buffer = ecx.allocate(ecx.machine.layouts.i32, MemoryKind::Stack)?;
@@ -934,7 +934,7 @@ impl UnixSocketFileDescription for TcpSocket {
         drop(readiness);
 
         // Update the readiness for the socket.
-        ecx.update_fd_readiness(self, /* force_edge */ false)?;
+        ecx.update_fd_readiness(self, ReadinessUpdateFlags::DEFAULT)?;
 
         interp_ok(Ok(()))
     }
@@ -1037,7 +1037,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
                 // We know that the source is not readable so we need to update its readiness.
                 socket.io_readiness.borrow_mut().readable = false;
-                this.update_fd_readiness(socket.clone(), /* force_edge */ false)?;
+                this.update_fd_readiness(socket.clone(), ReadinessUpdateFlags::DEFAULT)?;
 
                 return interp_ok(Err(IoError::HostError(e)));
             }
@@ -1149,7 +1149,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             {
                 // We know that the source is not writable so we need to update its readiness.
                 socket.io_readiness.borrow_mut().writable = false;
-                this.update_fd_readiness(socket.clone(), /* force_edge */ false)?;
+                this.update_fd_readiness(socket.clone(), ReadinessUpdateFlags::DEFAULT)?;
 
                 // On Windows hosts, `send` can return WSAENOTCONN where EAGAIN or EWOULDBLOCK
                 // would be returned on UNIX-like systems. We thus remap this error to an EWOULDBLOCK.
@@ -1179,7 +1179,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     target_os = "watchos",
                 )) {
                     socket.io_readiness.borrow_mut().writable = false;
-                    this.update_fd_readiness(socket.clone(), /* force_edge */ false)?;
+                    this.update_fd_readiness(socket.clone(), ReadinessUpdateFlags::DEFAULT)?;
                 } else {
                     // On hosts which don't use the `epoll` or `kqueue` backends, a short write
                     // doesn't imply a full write buffer. However, the target we are emulating might
@@ -1190,7 +1190,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     // This results in an unrealistic execution but we don't have another way of
                     // finding out whether the write buffer is full. The "default case" of linux
                     // host and linux target isn't affected by this.
-                    this.update_fd_readiness(socket.clone(), /* force_edge */ true)?;
+                    this.update_fd_readiness(socket.clone(), ReadinessUpdateFlags::FORCE_EDGE)?;
                 }
                 interp_ok(result)
             }
@@ -1285,7 +1285,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             {
                 // We know that the source is not readable so we need to update its readiness.
                 socket.io_readiness.borrow_mut().readable = false;
-                this.update_fd_readiness(socket.clone(), /* force_edge */ false)?;
+                this.update_fd_readiness(socket.clone(), ReadinessUpdateFlags::DEFAULT)?;
 
                 // On Windows hosts, `recv` can return WSAENOTCONN where EAGAIN or EWOULDBLOCK
                 // would be returned on UNIX-like systems. We thus remap this error to an EWOULDBLOCK.
@@ -1324,7 +1324,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     target_os = "watchos",
                 )) {
                     socket.io_readiness.borrow_mut().readable = false;
-                    this.update_fd_readiness(socket.clone(), /* force_edge */ false)?;
+                    this.update_fd_readiness(socket.clone(), ReadinessUpdateFlags::DEFAULT)?;
                 } else {
                     // On hosts which don't use the `epoll` or `kqueue` backends, a short read
                     // doesn't imply an empty read buffer. However, the target we are emulating
@@ -1335,7 +1335,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     // This results in an unrealistic execution but we don't have another way of
                     // finding out whether the read buffer is empty. The "default case" of linux
                     // host and linux target isn't affected by this.
-                    this.update_fd_readiness(socket.clone(), /* force_edge */ true)?;
+                    this.update_fd_readiness(socket.clone(), ReadinessUpdateFlags::FORCE_EDGE)?;
                 }
                 interp_ok(result)
             }

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -70,6 +70,8 @@ pub(super) struct TcpSocket {
     /// for relative timeouts).
     /// This is ignored when the socket is non-blocking.
     write_timeout: Cell<Option<Duration>>,
+    /// State for being watched by epoll.
+    watched: ReadinessWatched,
 }
 
 impl TcpSocket {
@@ -82,6 +84,7 @@ impl TcpSocket {
             error: RefCell::new(None),
             read_timeout: Cell::new(None),
             write_timeout: Cell::new(None),
+            watched: ReadinessWatched::default(),
         }
     }
 }
@@ -169,8 +172,12 @@ impl FileDescription for TcpSocket {
         interp_ok(Scalar::from_i32(0))
     }
 
-    fn readiness<'tcx>(&self) -> InterpResult<'tcx, Readiness> {
-        interp_ok(self.io_readiness.borrow().clone())
+    fn readiness_watched(&self) -> Option<&ReadinessWatched> {
+        Some(&self.watched)
+    }
+
+    fn readiness(&self) -> Readiness {
+        self.io_readiness.borrow().clone()
     }
 }
 
@@ -1050,6 +1057,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             error: RefCell::new(None),
             read_timeout: Cell::new(None),
             write_timeout: Cell::new(None),
+            watched: ReadinessWatched::default(),
         });
         // Register the socket to the blocking I/O manager because
         // there is an associated host socket.

--- a/src/shims/unix/virtual_socket.rs
+++ b/src/shims/unix/virtual_socket.rs
@@ -431,8 +431,8 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             // Notify readiness watchers: we might be no longer writable, peer might now be readable.
             // The notification to the peer seems to be always sent on Linux, even if the
             // FD was readable before.
-            this.update_fd_readiness(socket, /* force_edge */ false)?;
-            this.update_fd_readiness(peer_fd, /* force_edge */ true)?;
+            this.update_fd_readiness(socket, ReadinessUpdateFlags::DEFAULT)?;
+            this.update_fd_readiness(peer_fd, ReadinessUpdateFlags::FORCE_EDGE)?;
 
             return finish.call(this, Ok(write_size));
         }
@@ -531,10 +531,17 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // Linux seems to always notify the peer if the read buffer is now empty.
                 // (Linux also does that if this was a "big" read, but to avoid some arbitrary
                 // threshold, we do not match that.)
-                this.update_fd_readiness(peer_fd, /* force_edge */ readbuf_now_empty)?;
+                this.update_fd_readiness(
+                    peer_fd,
+                    if readbuf_now_empty {
+                        ReadinessUpdateFlags::FORCE_EDGE
+                    } else {
+                        ReadinessUpdateFlags::DEFAULT
+                    },
+                )?;
             };
             // Notify readiness watchers: we might be no longer readable.
-            this.update_fd_readiness(socket, /* force_edge */ false)?;
+            this.update_fd_readiness(socket, ReadinessUpdateFlags::DEFAULT)?;
 
             return finish.call(this, Ok(read_size));
         }

--- a/src/shims/unix/virtual_socket.rs
+++ b/src/shims/unix/virtual_socket.rs
@@ -60,6 +60,8 @@ struct VirtualSocket {
     /// We need to update the peer_fd readiness when we get dropped, so we keep a reference
     /// to the readiness update queue
     delayed_readiness_updates: Rc<DelayedReadinessUpdates>,
+    /// State for being watched by epoll.
+    watched: ReadinessWatched,
 }
 
 #[derive(Debug)]
@@ -203,7 +205,11 @@ impl FileDescription for VirtualSocket {
         interp_ok(Scalar::from_i32(0))
     }
 
-    fn readiness<'tcx>(&self) -> InterpResult<'tcx, Readiness> {
+    fn readiness_watched(&self) -> Option<&ReadinessWatched> {
+        Some(&self.watched)
+    }
+
+    fn readiness(&self) -> Readiness {
         // We only check the "readable", "writable", "read closed" and "write closed" readiness.
         // If other event flags need to be supported in the future, the check should be added here.
 
@@ -246,7 +252,7 @@ impl FileDescription for VirtualSocket {
                 readiness.error = true;
             }
         }
-        interp_ok(readiness)
+        readiness
     }
 }
 
@@ -609,6 +615,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             is_nonblock: Cell::new(is_sock_nonblock),
             fd_type: VirtualSocketType::Socketpair,
             delayed_readiness_updates: Rc::clone(&this.machine.delayed_readiness_updates),
+            watched: ReadinessWatched::default(),
         });
         let fd1 = fds.new_ref(VirtualSocket {
             readbuf: Some(RefCell::new(Buffer::new())),
@@ -619,6 +626,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             is_nonblock: Cell::new(is_sock_nonblock),
             fd_type: VirtualSocketType::Socketpair,
             delayed_readiness_updates: Rc::clone(&this.machine.delayed_readiness_updates),
+            watched: ReadinessWatched::default(),
         });
 
         // Make the file descriptions point to each other.
@@ -681,6 +689,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             is_nonblock: Cell::new(is_nonblock),
             fd_type: VirtualSocketType::PipeRead,
             delayed_readiness_updates: Rc::clone(&this.machine.delayed_readiness_updates),
+            watched: ReadinessWatched::default(),
         });
         let fd1 = fds.new_ref(VirtualSocket {
             readbuf: None,
@@ -691,6 +700,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             is_nonblock: Cell::new(is_nonblock),
             fd_type: VirtualSocketType::PipeWrite,
             delayed_readiness_updates: Rc::clone(&this.machine.delayed_readiness_updates),
+            watched: ReadinessWatched::default(),
         });
 
         // Make the file descriptions point to each other.

--- a/tests/fail-dep/libc/libc_epoll_unsupported_fd.rs
+++ b/tests/fail-dep/libc/libc_epoll_unsupported_fd.rs
@@ -15,6 +15,6 @@ fn main() {
     let mut ev =
         libc::epoll_event { events: (libc::EPOLLIN | libc::EPOLLET) as _, u64: epfd1 as u64 };
     let res = unsafe { libc::epoll_ctl(epfd0, libc::EPOLL_CTL_ADD, epfd1, &mut ev) };
-    //~^ERROR: epoll: this file description doesn't support I/O readiness
+    //~^ERROR: I/O readiness watching not supported
     assert_eq!(res, 0);
 }

--- a/tests/fail-dep/libc/libc_epoll_unsupported_fd.stderr
+++ b/tests/fail-dep/libc/libc_epoll_unsupported_fd.stderr
@@ -1,4 +1,4 @@
-error: unsupported operation: epoll: this file description doesn't support I/O readiness
+error: unsupported operation: I/O readiness watching not supported for epoll
   --> tests/fail-dep/libc/libc_epoll_unsupported_fd.rs:LL:CC
    |
 LL |     let res = unsafe { libc::epoll_ctl(epfd0, libc::EPOLL_CTL_ADD, epfd1, &mut ev) };

--- a/tests/pass-dep/libc/libc-epoll-blocking.rs
+++ b/tests/pass-dep/libc/libc-epoll-blocking.rs
@@ -141,31 +141,47 @@ fn test_notification_after_timeout() {
     check_epoll_wait(epfd, &[Ev { events: EPOLLIN | EPOLLOUT, data: fds[0] }], 10);
 }
 
-// This test shows that there is no data race when synchronizing through an epoll wakeup.
 fn test_epoll_race() {
-    // Create an epoll instance.
-    let epfd = errno_result(unsafe { libc::epoll_create1(0) }).unwrap();
+    for variant in 0..=1 {
+        // Create an epoll instance.
+        let epfd = errno_result(unsafe { libc::epoll_create1(0) }).unwrap();
 
-    // Create an eventfd instance.
-    let flags = libc::EFD_NONBLOCK | libc::EFD_CLOEXEC;
-    let fd = errno_result(unsafe { libc::eventfd(0, flags) }).unwrap();
+        // Create an eventfd instance.
+        let flags = libc::EFD_NONBLOCK | libc::EFD_CLOEXEC;
+        let fd = errno_result(unsafe { libc::eventfd(0, flags) }).unwrap();
 
-    // Register eventfd with the epoll instance.
-    epoll_ctl_add(epfd, fd, EPOLLIN | EPOLLET_OR_ZERO).unwrap();
+        // Memory we will mutate non-atomically, synchronizing via epoll.
+        static mut VAL: u8 = 0;
+        unsafe { VAL = 0 }; // remember to reset for each variant
 
-    static mut VAL: u8 = 0;
-    let thread1 = thread::spawn(move || {
-        // Write to the static mut variable.
-        unsafe { VAL = 1 };
-        // Write to the eventfd instance.
-        eventfd::write_val(fd, 1).unwrap();
-    });
-    thread::sleep(Duration::from_millis(10));
-    // epoll_wait for EPOLLIN.
-    check_epoll_wait(epfd, &[Ev { events: EPOLLIN, data: fd }], -1);
-    // Read from the static mut variable.
-    assert_eq!(unsafe { VAL }, 1);
-    thread1.join().unwrap();
+        thread::scope(|s| {
+            if variant == 0 {
+                // Register eventfd with the epoll instance.
+                // Variant A: do this before the thread spawns.
+                epoll_ctl_add(epfd, fd, EPOLLIN | EPOLLET_OR_ZERO).unwrap();
+            }
+
+            s.spawn(move || {
+                // Write to the static mut variable.
+                unsafe { VAL = 1 };
+                // Write to the eventfd instance.
+                eventfd::write_val(fd, 1).unwrap();
+            });
+            // Let the thread go first.
+            thread::sleep(Duration::from_millis(10));
+
+            if variant == 1 {
+                // Register eventfd with the epoll instance.
+                // Variant B: do this after the thread spawns.
+                epoll_ctl_add(epfd, fd, EPOLLIN | EPOLLET_OR_ZERO).unwrap();
+            }
+
+            // epoll_wait for EPOLLIN.
+            check_epoll_wait(epfd, &[Ev { events: EPOLLIN, data: fd }], -1);
+            // Read from the static mut variable.
+            assert_eq!(unsafe { VAL }, 1);
+        });
+    }
 }
 
 /// Ensure that a blocked thread gets woken up when new interested are registered with the

--- a/tests/pass-dep/libc/libc-epoll-no-blocking.rs
+++ b/tests/pass-dep/libc/libc-epoll-no-blocking.rs
@@ -339,8 +339,13 @@ fn test_not_fully_closed_fd() {
     // Close the original fd that being used to register with epoll.
     errno_check(unsafe { libc::close(fd) });
 
-    // Notification should still be provided because the file description is not closed.
-    check_epoll_wait_noblock(epfd, &[Ev { events: EPOLLOUT, data: fd }]);
+    // Notification should still be provided because the file description is not closed -- except on
+    // Illumos which tracks file descriptors, not file descriptions.
+    if cfg!(target_os = "illumos") {
+        check_epoll_wait_noblock(epfd, &[]);
+    } else {
+        check_epoll_wait_noblock(epfd, &[Ev { events: EPOLLOUT, data: fd }]);
+    }
 
     // Write to the eventfd instance to produce notification.
     eventfd::write_val(newfd, 1).unwrap();

--- a/tests/pass-dep/libc/libc-fs.rs
+++ b/tests/pass-dep/libc/libc-fs.rs
@@ -269,6 +269,7 @@ fn test_dup_stdout_stderr() {
     }
 }
 
+/// This test assumes that there are no gaps in the FD table and the next free slot is less than 50.
 fn test_dup() {
     let bytes = b"dup and dup2";
     let path = utils::prepare_with_content("miri_test_libc_dup.txt", bytes);
@@ -276,8 +277,16 @@ fn test_dup() {
 
     unsafe {
         let fd = errno_result(libc::open(name.as_ptr(), libc::O_RDONLY)).unwrap();
+        assert!(fd < 50);
         let new_fd = libc::dup(fd);
-        let new_fd2 = libc::dup2(fd, 8);
+        assert_eq!(new_fd, fd + 1);
+        let new_fd = libc::dup2(fd, new_fd); // overwrite the one we just dup'd
+        assert_eq!(new_fd, fd + 1);
+        let new_fd2 = libc::dup2(fd, 99);
+        assert_eq!(new_fd2, 99);
+        let new_fd3 = libc::fcntl(new_fd2, libc::F_DUPFD, 999);
+        assert_eq!(new_fd3, 999);
+        errno_check(libc::close(new_fd2));
 
         let mut first_buf = [0u8; 4];
         let first_len = libc::read(fd, first_buf.as_mut_ptr() as *mut libc::c_void, 4);
@@ -294,7 +303,7 @@ fn test_dup() {
         let remaining_bytes = &remaining_bytes[second_len..];
 
         let mut third_buf = [0u8; 4];
-        let third_len = libc::read(new_fd2, third_buf.as_mut_ptr() as *mut libc::c_void, 4);
+        let third_len = libc::read(new_fd3, third_buf.as_mut_ptr() as *mut libc::c_void, 4);
         assert!(third_len > 0);
         let third_len = third_len as usize;
         assert_eq!(third_buf[..third_len], remaining_bytes[..third_len]);


### PR DESCRIPTION
This allows a bunch of cleanup and fixes:
- Less relying on GC, more immediately cleanup when things get dropped.
- A good place to track the vector clock for the most recent readiness update, so other threads can acquire it when receiving a readiness notification.

While at it I also implemented the Illumos semantics for dealing with closed FD in epoll. I could not test this on a real system though. And I noticed our logic for `fcntl(F_DUPFD)` is wrong; the first commit fixes that.

Fixes https://github.com/rust-lang/miri/issues/5167
Fixes https://github.com/rust-lang/miri/issues/5182