### PR TITLE
Resolve preadv/pwritev as weak symbols on Android

### DIFF
--- a/src/shims/extern_static.rs
+++ b/src/shims/extern_static.rs
@@ -63,7 +63,10 @@ impl<'tcx> MiriMachine<'tcx> {
                 Self::weak_fn_symbols(ecx, &["getrandom", "gettid", "statx", "strlen"])?;
             }
             Os::Android => {
-                Self::weak_fn_symbols(ecx, &["signal", "getrandom", "gettid", "futimens"])?;
+                Self::weak_fn_symbols(
+                    ecx,
+                    &["signal", "getrandom", "gettid", "futimens", "preadv", "pwritev"],
+                )?;
             }
             Os::Windows => {
                 // "_tls_used"

--- a/src/shims/unix/foreign_items.rs
+++ b/src/shims/unix/foreign_items.rs
@@ -30,6 +30,10 @@ pub fn is_dyn_sym(name: &str, target_os: &Os) -> bool {
         // `futimens` is set up as a weak symbol in `init_extern_statics` (on Android), so we
         // allow it here too (it exists on all our Unix targets).
         "futimens" => true,
+        // `preadv`/`pwritev` are set up as weak symbols in `init_extern_statics` (on Android,
+        // where std uses them via `weak!` since bionic only gained them in API level 24), so
+        // we allow them here too. They do not exist on Solaris.
+        "preadv" | "pwritev" if !matches!(*target_os, Os::Solaris) => true,
         // Give specific OSes a chance to allow their symbols.
         _ =>
             match *target_os {

--- a/tests/pass/shims/fs.rs
+++ b/tests/pass/shims/fs.rs
@@ -57,7 +57,7 @@ fn main() {
         test_readv_writev();
         #[cfg(unix)]
         test_pread_pwrite();
-        #[cfg(all(unix, not(any(target_os = "solaris", target_os = "android"))))]
+        #[cfg(all(unix, not(target_os = "solaris")))]
         test_preadv_pwritev();
     }
 }
@@ -513,11 +513,9 @@ fn test_readv_writev() {
 
 /// Test vectored reads and vectored writes with byte offsets.
 ///
-/// **Note**: We skip this test on Solaris and Android targets. This is
-/// because Solaris doesn't have `preadv`/`pwritev`, and on Android the
-/// standard library uses `syscall(...)` for vectored reads/writes with
-/// offsets because older Android versions also didn't have `preadv`/`pwritev`.
-#[cfg(all(unix, not(any(target_os = "solaris", target_os = "android"))))]
+/// **Note**: We skip this test on Solaris targets because Solaris doesn't
+/// have `preadv`/`pwritev`.
+#[cfg(all(unix, not(target_os = "solaris")))]
 fn test_preadv_pwritev() {
     use std::os::unix::fs::FileExt;
 


### PR DESCRIPTION
std on Android does vectored reads and writes at offsets through weak `preadv`/`pwritev` symbols with a raw syscall fallback (bionic gained them in API level 24). The weak symbols did not resolve under Miri, so these calls failed. Register them for Android so they land in the existing shims, and un-skip the Android case in the fs tests.

This is the vectored I/O half of rust-lang/miri#5080. The `fs::hard_link` half is being handled by rust-lang/rust#159346, which switches std to `linkat` on Android; Miri already supports `linkat`.
