### PR TITLE
Add data race test for `poll`

### DIFF
--- a/src/shims/readiness.rs
+++ b/src/shims/readiness.rs
@@ -365,7 +365,7 @@ impl VisitProvenance for ReadinessWatcher {
     fn visit_provenance(&self, _visit: &mut VisitWith<'_>) {}
 }
 
-/// Data about a file descriptiobn that can be watched for readiness
+/// Data about a file description that can be watched for readiness
 /// (meant to be stored inside said file description).
 #[derive(Debug, Default)]
 pub struct ReadinessWatched {

--- a/tests/pass-dep/libc/libc-poll.rs
+++ b/tests/pass-dep/libc/libc-poll.rs
@@ -20,6 +20,7 @@ fn main() {
     test_poll_invalid_non_negative_fd_interest();
     test_poll_zero_timeout();
     test_readiness_event_after_poll_blocked();
+    test_poll_race();
 }
 
 /// Test that the readiness written into the `revents` field on an interest
@@ -191,4 +192,31 @@ fn test_readiness_event_after_poll_blocked() {
     };
 
     t1.join().unwrap();
+}
+
+// This test shows a data race before poll had vector clocks added.
+fn test_poll_race() {
+    let mut fds = [-1, -1];
+    unsafe { errno_check(libc::socketpair(libc::AF_UNIX, libc::SOCK_STREAM, 0, fds.as_mut_ptr())) };
+
+    static mut VAL: u8 = 0;
+    let thread1 = thread::spawn(move || {
+        // Write to the static mut variable.
+        unsafe { VAL = 1 };
+        // Write to `fds[0]` which makes `fds[1]` readable.
+        write_all(fds[0], TEST_BYTES).unwrap();
+    });
+    // Make the other thread go first.
+    thread::sleep(Duration::from_millis(10));
+    // Wait for `fds[1]` to be come readable.
+    let mut interests = [libc::pollfd { fd: fds[1], events: libc::POLLIN, revents: 0 }];
+    let ready = unsafe {
+        errno_result(libc::poll(interests.as_mut_ptr(), interests.len() as libc::nfds_t, -1))
+            .unwrap()
+    };
+    assert_eq!(ready, 1);
+    assert_eq!(interests[0].revents, libc::POLLIN);
+    // Read from the static mut variable.
+    assert_eq!(unsafe { VAL }, 1);
+    thread1.join().unwrap();
 }


### PR DESCRIPTION
This pull request adds a `poll` test to ensure that no false-positive data races are reported. 
The test is essentially the same as the `test_epoll_race` test, just with `socketpair` instead of `eventfd`.