### PR TITLE
test: update cross-namespace diagnostic

### DIFF
--- a/tests/fail/rustc-error.rs
+++ b/tests/fail/rustc-error.rs
@@ -1,4 +1,4 @@
 // Make sure we exit with non-0 status code when the program fails to build.
 fn main() {
-    println("Hello, world!"); //~ ERROR: expected function, found macro
+    println("Hello, world!"); //~ ERROR: cannot find function `println` in this scope
 }

--- a/tests/fail/rustc-error.stderr
+++ b/tests/fail/rustc-error.stderr
@@ -1,8 +1,10 @@
-error[E0423]: expected function, found macro `println`
+error[E0423]: cannot find function `println` in this scope
   --> tests/fail/rustc-error.rs:LL:CC
    |
 LL |     println("Hello, world!");
-   |     ^^^^^^^ not a function
+   |     ^^^^^^^ not found in this scope
+   |
+   = note: a macro named `println` exists in another namespace
    |
 help: use `!` to invoke the macro
    |


### PR DESCRIPTION
## Task

- rust-lang/rust#86290
- Blocked by rust-lang/rust#159307

## How to test

### Before the fix

1. Context: Miri after rust-lang/rust#159307 is included in rust-version
   Action: run tests/fail/rustc-error.rs
   Expected result: the old expectations do not match the rustc diagnostic

### After the fix

1. Context: Miri after rust-lang/rust#159307 is included in rust-version
   Action: run tests/fail/rustc-error.rs
   Expected result: the test accepts the new diagnostic, the note about the macro in another namespace, and the macro invocation suggestion

## Proof

- Only tests/fail/rustc-error.rs and tests/fail/rustc-error.stderr are changed
- The targeted Miri run in the Rust PR passed: https://github.com/rust-lang/rust/commit/61730f748e521b430767e1f871a825f0c53af4e1
- Miri's current rust-version predates the Rust PR, so the local Miri UI run cannot exercise the new expectation yet
