### PR TITLE
[Priroda] Render indirect local values

### DIFF
--- a/priroda/README.md
+++ b/priroda/README.md
@@ -68,6 +68,7 @@ RUSTC_BLESS=1 cargo test
 | `b <path>:<line>`, `break <path>:<line>` | Add a source-location breakpoint. |
 | `l`, `locals` | List source-level locals in the current frame by name. |
 | `p <local>`, `print <local>` | Print one MIR local by numeric id. |
+| `f <alloc> <offset>`, `follow <alloc> <offset>` | Render allocation bytes from an offset, including the full allocation size. |
 | `q`, `quit` | Exit Priroda. |
 
 ## Value Output

--- a/priroda/README.md
+++ b/priroda/README.md
@@ -9,6 +9,8 @@ Current focus:
 - source-location output after stepping
 - source-location breakpoint prototype
 - source-local listing prototype
+- runtime local state and value rendering
+- range-limited byte output for indirect locals
 
 ## Setup
 
@@ -65,7 +67,33 @@ RUSTC_BLESS=1 cargo test
 | `c`, `continue` | Continue until the program finishes or reaches a breakpoint. |
 | `b <path>:<line>`, `break <path>:<line>` | Add a source-location breakpoint. |
 | `l`, `locals` | List source-level locals in the current frame by name. |
+| `p <local>`, `print <local>` | Print one MIR local by numeric id. |
 | `q`, `quit` | Exit Priroda. |
+
+## Value Output
+
+Immediate values use Miri's `Immediate` display representation. Indirect
+locals are rendered as the bytes belonging to the current value range, not as
+the entire backing allocation:
+
+```text
+[01 02 03]
+[?? ?? ??]
+```
+
+`??` means the byte is uninitialized. A value whose runtime size cannot be
+determined is reported as `<unsupported-unsized>`.
+
+Pointer/provenance spans are planned as part of the raw byte output, using a
+compact dump-like marker such as:
+
+```text
+[<ptr alloc5+0> 2a 00 00 00]
+```
+
+Automatic pointer following is future work and should be explicit, not part of
+ordinary value printing. Typed field rendering and dereference/projection-aware
+printing are also future work.
 
 EOF also exits Priroda cleanly.
 

--- a/priroda/src/main.rs
+++ b/priroda/src/main.rs
@@ -18,7 +18,7 @@ use std::collections::{HashMap, HashSet};
 use std::io::{self, Write};
 use std::path::PathBuf;
 
-use miri::Immediate::{Scalar, ScalarPair, Uninit};
+use miri::Immediate::Uninit;
 use miri::{interpret, *};
 use rustc_driver::Compilation;
 use rustc_hir::attrs::CrateType;
@@ -399,6 +399,49 @@ impl<'tcx> PrirodaContext<'tcx> {
         self.build_local_descs(frame)
     }
 
+    fn render_mplace_bytes(&self, mplace: &MPlaceTy<'tcx>) -> InterpResult<'tcx, String> {
+        let size = match self.ecx.size_and_align_of_val(mplace)? {
+            Some((size, _)) => size,
+            None => {
+                // Extern types cannot currently be executed as by-value locals,
+                // so this path cannot yet be covered by a Priroda UI fixture.
+                // FIXME: Add coverage once Priroda supports printing dereferenced places.
+                return interp_ok("<unsupported-unsized>".to_string());
+            }
+        };
+
+        let size = size.bytes_usize();
+        if size == 0 {
+            return interp_ok("[]".to_string());
+        }
+
+        let (alloc_id, offset, _) =
+            self.ecx.ptr_get_alloc_id(mplace.ptr(), size.try_into().unwrap())?;
+        let offset = offset.bytes_usize();
+        let range = offset..offset.strict_add(size);
+        let alloc = self.ecx.get_alloc_raw(alloc_id)?;
+
+        let mut rendered = Vec::with_capacity(size);
+
+        for chunk in alloc.init_mask().range_as_init_chunks(range.into()) {
+            let chunk_range = chunk.range();
+            let chunk_range = chunk_range.start.bytes_usize()..chunk_range.end.bytes_usize();
+
+            if chunk.is_init() {
+                rendered.extend(
+                    alloc
+                        .inspect_with_uninit_and_ptr_outside_interpreter(chunk_range)
+                        .iter()
+                        .map(|byte| format!("{byte:02x}")),
+                );
+            } else {
+                rendered.extend(std::iter::repeat_n("__".to_string(), chunk_range.len()));
+            }
+        }
+
+        interp_ok(format!("[{}]", rendered.join(" ")))
+    }
+
     /// Render the source-side path from composite debug info, such as `.field`.
     fn render_source_projection(
         fragment: Option<&VarDebugInfoFragment<'tcx>>,
@@ -489,25 +532,19 @@ impl<'tcx> PrirodaContext<'tcx> {
             Some(Either::Right(Uninit)) => local_desc.value = "<uninit>".to_string(),
 
             Some(Either::Left(_) | Either::Right(_)) => {
-                match self.ecx.local_to_op(local, None).report_err() {
-                    Ok(op) => {
-                        local_desc.value = match op.as_mplace_or_imm() {
-                            Either::Right(imm) => format!("{imm}"),
+                let op = self
+                    .ecx
+                    .local_to_op(local, None)
+                    .expect("this error can only occur in CTFE on generic code");
+                local_desc.value = match op.as_mplace_or_imm() {
+                    Either::Right(imm) => format!("{imm}"),
 
-                            Either::Left(mplace_ty) => {
-                                match mplace_ty.ptr().provenance.and_then(|p| p.get_alloc_id()) {
-                                    Some(alloc_id) =>
-                                        format!("{:#?}", self.ecx.dump_alloc(alloc_id)),
-                                    None => "<indirect>".to_string(),
-                                }
-                            }
-                        };
-                    }
-                    Err(err) => {
-                        local_desc.value =
-                            format!("<error: {}>", interpret::format_interp_error(err));
-                    }
-                }
+                    Either::Left(mplace) =>
+                        match self.render_mplace_bytes(&mplace).report_err() {
+                            Ok(bytes) => bytes,
+                            Err(err) => format!("<error: {}>", interpret::format_interp_error(err)),
+                        },
+                };
             }
         };
 

--- a/priroda/src/main.rs
+++ b/priroda/src/main.rs
@@ -493,7 +493,14 @@ impl<'tcx> PrirodaContext<'tcx> {
                     Ok(op) => {
                         local_desc.value = match op.as_mplace_or_imm() {
                             Either::Right(imm) => format!("{imm}"),
-                            Either::Left(_) => "<indirect>".to_string(),
+
+                            Either::Left(mplace_ty) => {
+                                match mplace_ty.ptr().provenance.and_then(|p| p.get_alloc_id()) {
+                                    Some(alloc_id) =>
+                                        format!("{:#?}", self.ecx.dump_alloc(alloc_id)),
+                                    None => "<indirect>".to_string(),
+                                }
+                            }
                         };
                     }
                     Err(err) => {

--- a/priroda/src/main.rs
+++ b/priroda/src/main.rs
@@ -1,6 +1,7 @@
 #![feature(rustc_private)]
 
 extern crate miri;
+extern crate rustc_abi;
 extern crate rustc_codegen_ssa;
 extern crate rustc_data_structures;
 extern crate rustc_driver;
@@ -16,10 +17,12 @@ extern crate rustc_type_ir;
 
 use std::collections::{HashMap, HashSet};
 use std::io::{self, Write};
+use std::ops::Range;
 use std::path::PathBuf;
 
 use miri::Immediate::Uninit;
 use miri::{interpret, *};
+use rustc_abi::Size;
 use rustc_driver::Compilation;
 use rustc_hir::attrs::CrateType;
 use rustc_interface::interface;
@@ -399,6 +402,10 @@ impl<'tcx> PrirodaContext<'tcx> {
         self.build_local_descs(frame)
     }
 
+    /// Renders the current byte range of an indirect MIR value.
+    ///
+    /// Initialized bytes are shown in hexadecimal, uninitialized bytes as `??`,
+    /// and complete pointer-sized provenance as pointer markers.
     fn render_mplace_bytes(&self, mplace: &MPlaceTy<'tcx>) -> InterpResult<'tcx, String> {
         let size = match self.ecx.size_and_align_of_val(mplace)? {
             Some((size, _)) => size,
@@ -419,21 +426,60 @@ impl<'tcx> PrirodaContext<'tcx> {
             self.ecx.ptr_get_alloc_id(mplace.ptr(), size.try_into().unwrap())?;
         let offset = offset.bytes_usize();
         let range = offset..offset.strict_add(size);
+
+        self.render_alloc_bytes(alloc_id, range)
+    }
+
+    /// Render a raw allocation range without requiring a typed memory place.
+    ///
+    /// This is also used by the future-facing `follow` command, where we have a
+    /// pointer target but do not yet know the target's type or size.
+    fn render_alloc_bytes(
+        &self,
+        alloc_id: AllocId,
+        range: Range<usize>,
+    ) -> InterpResult<'tcx, String> {
         let alloc = self.ecx.get_alloc_raw(alloc_id)?;
 
-        let mut rendered = Vec::with_capacity(size);
+        let mut rendered = Vec::with_capacity(range.len());
+
+        let ptr_size = self.ecx.tcx.data_layout.pointer_size();
 
         for chunk in alloc.init_mask().range_as_init_chunks(range.into()) {
             let chunk_range = chunk.range();
             let chunk_range = chunk_range.start.bytes_usize()..chunk_range.end.bytes_usize();
 
             if chunk.is_init() {
-                rendered.extend(
-                    alloc
-                        .inspect_with_uninit_and_ptr_outside_interpreter(chunk_range)
-                        .iter()
-                        .map(|byte| format!("{byte:02x}")),
-                );
+                let ptr_size = ptr_size.bytes_usize();
+                let mut cursor = chunk_range.start;
+
+                while cursor < chunk_range.end {
+                    // Full pointer provenance is rendered as a pointer marker. Bytewise
+                    // provenance fragments are intentionally left as raw bytes here: they do
+                    // not represent a complete pointer-sized value.
+                    if let Some(prov) = alloc.provenance().get_ptr(Size::from_bytes(cursor))
+                        && cursor + ptr_size <= chunk_range.end
+                    {
+                        let bytes = alloc.inspect_with_uninit_and_ptr_outside_interpreter(
+                            cursor..cursor + ptr_size,
+                        );
+                        let offset = read_target_uint(self.ecx.tcx.data_layout.endian, bytes)
+                            .map_err(|err| {
+                                miri::err_unsup_format!("invalid pointer representation: {err}")
+                            })?;
+
+                        let offset = Size::from_bytes(offset);
+                        rendered.push(format!("{:?}", Pointer::new(Some(prov), offset)));
+
+                        cursor += ptr_size;
+                    } else {
+                        let byte = alloc
+                            .inspect_with_uninit_and_ptr_outside_interpreter(cursor..cursor + 1)[0];
+
+                        rendered.push(format!("{byte:02x}"));
+                        cursor += 1;
+                    }
+                }
             } else {
                 rendered.extend(std::iter::repeat_n("__".to_string(), chunk_range.len()));
             }

--- a/priroda/src/main.rs
+++ b/priroda/src/main.rs
@@ -19,7 +19,7 @@ use std::io::{self, Write};
 use std::path::PathBuf;
 
 use miri::Immediate::{Scalar, ScalarPair, Uninit};
-use miri::*;
+use miri::{interpret, *};
 use rustc_driver::Compilation;
 use rustc_hir::attrs::CrateType;
 use rustc_interface::interface;
@@ -486,22 +486,21 @@ impl<'tcx> PrirodaContext<'tcx> {
             None => {
                 local_desc.value = "<dead>".to_string();
             }
-            Some(Either::Left(_)) => {
-                local_desc.value = "<indirect>".to_string();
-            }
-            Some(Either::Right(imm)) => {
-                match imm {
-                    Scalar(_) => {
-                        local_desc.value = "<immediate>".to_string();
-                    }
-                    ScalarPair(_, _) => {
-                        local_desc.value = "<immediate-pair>".to_string();
-                    }
+            Some(Either::Right(Uninit)) => local_desc.value = "<uninit>".to_string(),
 
-                    Uninit => {
-                        local_desc.value = "<uninit>".to_string();
+            Some(Either::Left(_) | Either::Right(_)) => {
+                match self.ecx.local_to_op(local, None).report_err() {
+                    Ok(op) => {
+                        local_desc.value = match op.as_mplace_or_imm() {
+                            Either::Right(imm) => format!("{imm}"),
+                            Either::Left(_) => "<indirect>".to_string(),
+                        };
                     }
-                };
+                    Err(err) => {
+                        local_desc.value =
+                            format!("<error: {}>", interpret::format_interp_error(err));
+                    }
+                }
             }
         };
 

--- a/priroda/src/main.rs
+++ b/priroda/src/main.rs
@@ -17,6 +17,7 @@ extern crate rustc_type_ir;
 
 use std::collections::{HashMap, HashSet};
 use std::io::{self, Write};
+use std::num::NonZeroU64;
 use std::ops::Range;
 use std::path::PathBuf;
 
@@ -26,6 +27,7 @@ use rustc_abi::Size;
 use rustc_driver::Compilation;
 use rustc_hir::attrs::CrateType;
 use rustc_interface::interface;
+use rustc_middle::mir::interpret::AllocId;
 use rustc_middle::mir::{self, Local, ProjectionElem, VarDebugInfoContents, VarDebugInfoFragment};
 use rustc_middle::ty::{TyCtxt, TyKind};
 use rustc_session::EarlyDiagCtxt;
@@ -380,8 +382,23 @@ impl<'tcx> PrirodaContext<'tcx> {
             DebuggerCommand::ListLocals => interp_ok(CommandResult::Locals(self.list_locals())),
             DebuggerCommand::Print(local) =>
                 interp_ok(CommandResult::SingleLocal(self.get_local(local))),
+            DebuggerCommand::Follow(alloc_id, offset) =>
+                self.follow_alloc(alloc_id, offset).map(CommandResult::Memory),
             DebuggerCommand::TerminateSession => interp_ok(CommandResult::TerminateSession),
         }
+    }
+
+    fn follow_alloc(&self, alloc_id: AllocId, offset: usize) -> InterpResult<'tcx, String> {
+        let alloc = self.ecx.get_alloc_raw(alloc_id)?;
+        if offset > alloc.len() {
+            return Err(miri::err_unsup_format!(
+                "allocation offset {offset} is outside {alloc_id}"
+            ))
+            .into();
+        }
+
+        let memory = self.render_alloc_bytes(alloc_id, offset..alloc.len())?;
+        interp_ok(format!("Allocation {alloc_id}+{offset}: {memory}"))
     }
 
     fn get_local(&self, local: usize) -> Option<LocalDesc> {
@@ -681,6 +698,7 @@ enum DebuggerCommand {
     Breakpoint(PathBuf, usize),
     ListLocals,
     Print(usize),
+    Follow(AllocId, usize),
 }
 
 enum BreakpointSetResult {
@@ -694,6 +712,7 @@ enum CommandResult {
     BreakpointResult(BreakpointSetResult),
     Locals(Vec<LocalDesc>),
     SingleLocal(Option<LocalDesc>),
+    Memory(String),
     // FIXME: distinguish terminating the debugger session from disconnecting a
     // frontend and terminating the interpreted program once multiple frontends exist.
     TerminateSession,
@@ -782,6 +801,7 @@ impl Cli {
                             }
                             None => println!("no local for this id"),
                         },
+                    CommandResult::Memory(memory) => println!("{memory}"),
                     CommandResult::TerminateSession => {
                         println!("quitting");
                         return interp_ok(());
@@ -814,6 +834,7 @@ impl Cli {
             "b" | "break" => self.parse_breakpoint(args),
             "l" | "locals" => Some(DebuggerCommand::ListLocals),
             "p" | "print" => self.parse_print_local(args),
+            "f" | "follow" => self.parse_follow(args),
             _ => None,
         }
     }
@@ -845,5 +866,19 @@ impl Cli {
     fn parse_print_local(&self, input: &str) -> Option<DebuggerCommand> {
         let local = input.parse().ok()?;
         Some(DebuggerCommand::Print(local))
+    }
+
+    fn parse_follow(&self, input: &str) -> Option<DebuggerCommand> {
+        let mut parts = input.split_whitespace();
+        let alloc_id = parts.next()?;
+        let offset = parts.next()?;
+        if parts.next().is_some() {
+            return None;
+        }
+
+        let alloc_id = alloc_id.strip_prefix("alloc").unwrap_or(alloc_id).parse().ok()?;
+        let alloc_id = AllocId(NonZeroU64::new(alloc_id)?);
+        let offset = offset.parse().ok()?;
+        Some(DebuggerCommand::Follow(alloc_id, offset))
     }
 }

--- a/priroda/tests/cli.rs
+++ b/priroda/tests/cli.rs
@@ -32,11 +32,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Regex::new(&regex::escape(&manifest_dir.display().to_string())).unwrap();
     let miri_dir_regex = Regex::new(&regex::escape(&miri_dir.display().to_string())).unwrap();
     let rustc_sysroot_regex = Regex::new(&regex::escape(&rustc_sysroot)).unwrap();
-
+    let pointer_regex = Regex::new(r"0x[0-9a-f]+\[alloc[0-9]+\]<[0-9]+>").unwrap();
     config.comment_defaults.base().normalize_stdout.extend([
         (manifest_dir_regex.into(), b"{MANIFEST_DIR}".to_vec()),
         (miri_dir_regex.into(), b"{MIRI_DIR}".to_vec()),
         (rustc_sysroot_regex.into(), b"{RUSTC_SYSROOT}".to_vec()),
+        (pointer_regex.into(), b"{ALLOC_PTR}".to_vec()),
     ]);
 
     // Priroda CLI tests do not currently require annotation comments in the test files

--- a/priroda/tests/ui/locals_access_field.stdout
+++ b/priroda/tests/ui/locals_access_field.stdout
@@ -2,21 +2,11 @@
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_access_field.rs:14
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: extraslice, Id: _1, Ty: ExtraSlice<'_>, Value: alloc153 (stack variable, size: 24, align: 8) {
-    0x00 │ ╾0x20af8[alloc2]<327>─╼ 00 00 00 00 00 00 00 00 │ ╾──────╼........
-    0x10 │ 00 00 00 00 __ __ __ __                         │ ....░░░░
-}
-alloc2 (global (static or const), size: 0, align: 1) {}
-
+Name: extraslice, Id: _1, Ty: ExtraSlice<'_>, Value: [f8 0a 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 __ __ __ __]
 Name: _slice, Id: _2, Ty: &[u8], Value: (pointer to 0x20af8[alloc2]<328>, 0x0000000000000000): &[u8]
 Name: _extra, Id: _3, Ty: u32, Value: 0_u32
 (priroda) Id: _0, Ty: (), Value: <uninit>
-(priroda) Id: _1, Ty: ExtraSlice<'_>, Value: alloc153 (stack variable, size: 24, align: 8) {
-    0x00 │ ╾0x20af8[alloc2]<327>─╼ 00 00 00 00 00 00 00 00 │ ╾──────╼........
-    0x10 │ 00 00 00 00 __ __ __ __                         │ ....░░░░
-}
-alloc2 (global (static or const), size: 0, align: 1) {}
-
+(priroda) Id: _1, Ty: ExtraSlice<'_>, Value: [f8 0a 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 __ __ __ __]
 (priroda) Id: _2, Ty: &[u8], Value: (pointer to 0x20af8[alloc2]<328>, 0x0000000000000000): &[u8]
 (priroda) Id: _3, Ty: u32, Value: 0_u32
 (priroda) no local for this id

--- a/priroda/tests/ui/locals_access_field.stdout
+++ b/priroda/tests/ui/locals_access_field.stdout
@@ -2,12 +2,12 @@
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_access_field.rs:14
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: extraslice, Id: _1, Ty: ExtraSlice<'_>, Value: [f8 0a 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 __ __ __ __]
-Name: _slice, Id: _2, Ty: &[u8], Value: (pointer to 0x20af8[alloc2]<328>, 0x0000000000000000): &[u8]
+Name: extraslice, Id: _1, Ty: ExtraSlice<'_>, Value: [{ALLOC_PTR} 00 00 00 00 00 00 00 00 00 00 00 00 __ __ __ __]
+Name: _slice, Id: _2, Ty: &[u8], Value: (pointer to {ALLOC_PTR}, 0x0000000000000000): &[u8]
 Name: _extra, Id: _3, Ty: u32, Value: 0_u32
 (priroda) Id: _0, Ty: (), Value: <uninit>
-(priroda) Id: _1, Ty: ExtraSlice<'_>, Value: [f8 0a 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 __ __ __ __]
-(priroda) Id: _2, Ty: &[u8], Value: (pointer to 0x20af8[alloc2]<328>, 0x0000000000000000): &[u8]
+(priroda) Id: _1, Ty: ExtraSlice<'_>, Value: [{ALLOC_PTR} 00 00 00 00 00 00 00 00 00 00 00 00 __ __ __ __]
+(priroda) Id: _2, Ty: &[u8], Value: (pointer to {ALLOC_PTR}, 0x0000000000000000): &[u8]
 (priroda) Id: _3, Ty: u32, Value: 0_u32
 (priroda) no local for this id
 (priroda) no local for this id

--- a/priroda/tests/ui/locals_access_field.stdout
+++ b/priroda/tests/ui/locals_access_field.stdout
@@ -2,11 +2,21 @@
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_access_field.rs:14
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: extraslice, Id: _1, Ty: ExtraSlice<'_>, Value: <indirect>
+Name: extraslice, Id: _1, Ty: ExtraSlice<'_>, Value: alloc153 (stack variable, size: 24, align: 8) {
+    0x00 │ ╾0x20af8[alloc2]<327>─╼ 00 00 00 00 00 00 00 00 │ ╾──────╼........
+    0x10 │ 00 00 00 00 __ __ __ __                         │ ....░░░░
+}
+alloc2 (global (static or const), size: 0, align: 1) {}
+
 Name: _slice, Id: _2, Ty: &[u8], Value: (pointer to 0x20af8[alloc2]<328>, 0x0000000000000000): &[u8]
 Name: _extra, Id: _3, Ty: u32, Value: 0_u32
 (priroda) Id: _0, Ty: (), Value: <uninit>
-(priroda) Id: _1, Ty: ExtraSlice<'_>, Value: <indirect>
+(priroda) Id: _1, Ty: ExtraSlice<'_>, Value: alloc153 (stack variable, size: 24, align: 8) {
+    0x00 │ ╾0x20af8[alloc2]<327>─╼ 00 00 00 00 00 00 00 00 │ ╾──────╼........
+    0x10 │ 00 00 00 00 __ __ __ __                         │ ....░░░░
+}
+alloc2 (global (static or const), size: 0, align: 1) {}
+
 (priroda) Id: _2, Ty: &[u8], Value: (pointer to 0x20af8[alloc2]<328>, 0x0000000000000000): &[u8]
 (priroda) Id: _3, Ty: u32, Value: 0_u32
 (priroda) no local for this id

--- a/priroda/tests/ui/locals_access_field.stdout
+++ b/priroda/tests/ui/locals_access_field.stdout
@@ -3,12 +3,12 @@
 {MANIFEST_DIR}/tests/ui/locals_access_field.rs:14
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
 Name: extraslice, Id: _1, Ty: ExtraSlice<'_>, Value: <indirect>
-Name: _slice, Id: _2, Ty: &[u8], Value: <immediate-pair>
-Name: _extra, Id: _3, Ty: u32, Value: <immediate>
+Name: _slice, Id: _2, Ty: &[u8], Value: (pointer to 0x20af8[alloc2]<328>, 0x0000000000000000): &[u8]
+Name: _extra, Id: _3, Ty: u32, Value: 0_u32
 (priroda) Id: _0, Ty: (), Value: <uninit>
 (priroda) Id: _1, Ty: ExtraSlice<'_>, Value: <indirect>
-(priroda) Id: _2, Ty: &[u8], Value: <immediate-pair>
-(priroda) Id: _3, Ty: u32, Value: <immediate>
+(priroda) Id: _2, Ty: &[u8], Value: (pointer to 0x20af8[alloc2]<328>, 0x0000000000000000): &[u8]
+(priroda) Id: _3, Ty: u32, Value: 0_u32
 (priroda) no local for this id
 (priroda) no local for this id
 (priroda) quitting

--- a/priroda/tests/ui/locals_corpus_async.stdin
+++ b/priroda/tests/ui/locals_corpus_async.stdin
@@ -12,6 +12,7 @@ continue
 locals
 continue
 locals
+follow 2 0
 continue
 locals
 continue

--- a/priroda/tests/ui/locals_corpus_async.stdout
+++ b/priroda/tests/ui/locals_corpus_async.stdout
@@ -18,12 +18,21 @@ Name: x, Id: _1.0, Ty: f32, Value: <unsupported-projection>
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:55
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: <none>, Id: _1, Ty: std::option::Option<i32>, Value: <indirect>
+Name: <none>, Id: _1, Ty: std::option::Option<i32>, Value: alloc155 (stack variable, size: 8, align: 4) {
+    01 00 00 00 05 00 00 00                         │ ........
+}
+
 Name: inner, Id: _1 as variant#1.0, Ty: i32, Value: <unsupported-projection>
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:66
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: <none>, Id: _1, Ty: std::option::Option<&i32>, Value: <indirect>
+Name: <none>, Id: _1, Ty: std::option::Option<&i32>, Value: alloc157 (stack variable, size: 8, align: 8) {
+    ╾0x20b3c[alloc2]<332>─╼                         │ ╾──────╼
+}
+alloc2 (global (static or const), size: 4, align: 4) {
+    05 00 00 00                                     │ ....
+}
+
 Name: pointer, Id: _1 as variant#1.0, Ty: &i32, Value: <unsupported-projection>
 Name: deref, Id: _1 as variant#1.0.*, Ty: i32, Value: <unsupported-projection>
 (priroda) Hit breakpoint

--- a/priroda/tests/ui/locals_corpus_async.stdout
+++ b/priroda/tests/ui/locals_corpus_async.stdout
@@ -7,13 +7,13 @@
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:31
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: <none>, Id: _1, Ty: (u32, i32), Value: <immediate-pair>
+Name: <none>, Id: _1, Ty: (u32, i32), Value: (0x00000005, 0x00000006): (u32, i32)
 Name: first, Id: _1.0, Ty: u32, Value: <unsupported-projection>
 Name: second, Id: _1.1, Ty: i32, Value: <unsupported-projection>
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:45
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: <none>, Id: _1, Ty: S, Value: <immediate>
+Name: <none>, Id: _1, Ty: S, Value: {transmute(0x40a00000): S}
 Name: x, Id: _1.0, Ty: f32, Value: <unsupported-projection>
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:55
@@ -29,7 +29,7 @@ Name: deref, Id: _1 as variant#1.0.*, Ty: i32, Value: <unsupported-projection>
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:20
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: <none>, Id: _1, Ty: &mut std::option::Option<i32>, Value: <immediate>
+Name: <none>, Id: _1, Ty: &mut std::option::Option<i32>, Value: {&_: &mut std::option::Option<i32>}
 Name: foo, Id: _1.* as variant#1.0, Ty: i32, Value: <unsupported-projection>
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:76

--- a/priroda/tests/ui/locals_corpus_async.stdout
+++ b/priroda/tests/ui/locals_corpus_async.stdout
@@ -26,6 +26,7 @@ Name: inner, Id: _1 as variant#1.0, Ty: i32, Value: <unsupported-projection>
 Name: <none>, Id: _1, Ty: std::option::Option<&i32>, Value: [{ALLOC_PTR}]
 Name: pointer, Id: _1 as variant#1.0, Ty: &i32, Value: <unsupported-projection>
 Name: deref, Id: _1 as variant#1.0.*, Ty: i32, Value: <unsupported-projection>
+(priroda) Allocation alloc2+0: [05 00 00 00]
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:20
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>

--- a/priroda/tests/ui/locals_corpus_async.stdout
+++ b/priroda/tests/ui/locals_corpus_async.stdout
@@ -23,7 +23,7 @@ Name: inner, Id: _1 as variant#1.0, Ty: i32, Value: <unsupported-projection>
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:66
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: <none>, Id: _1, Ty: std::option::Option<&i32>, Value: [3c 0b 02 00 00 00 00 00]
+Name: <none>, Id: _1, Ty: std::option::Option<&i32>, Value: [{ALLOC_PTR}]
 Name: pointer, Id: _1 as variant#1.0, Ty: &i32, Value: <unsupported-projection>
 Name: deref, Id: _1 as variant#1.0.*, Ty: i32, Value: <unsupported-projection>
 (priroda) Hit breakpoint

--- a/priroda/tests/ui/locals_corpus_async.stdout
+++ b/priroda/tests/ui/locals_corpus_async.stdout
@@ -18,21 +18,12 @@ Name: x, Id: _1.0, Ty: f32, Value: <unsupported-projection>
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:55
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: <none>, Id: _1, Ty: std::option::Option<i32>, Value: alloc155 (stack variable, size: 8, align: 4) {
-    01 00 00 00 05 00 00 00                         │ ........
-}
-
+Name: <none>, Id: _1, Ty: std::option::Option<i32>, Value: [01 00 00 00 05 00 00 00]
 Name: inner, Id: _1 as variant#1.0, Ty: i32, Value: <unsupported-projection>
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:66
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: <none>, Id: _1, Ty: std::option::Option<&i32>, Value: alloc157 (stack variable, size: 8, align: 8) {
-    ╾0x20b3c[alloc2]<332>─╼                         │ ╾──────╼
-}
-alloc2 (global (static or const), size: 4, align: 4) {
-    05 00 00 00                                     │ ....
-}
-
+Name: <none>, Id: _1, Ty: std::option::Option<&i32>, Value: [3c 0b 02 00 00 00 00 00]
 Name: pointer, Id: _1 as variant#1.0, Ty: &i32, Value: <unsupported-projection>
 Name: deref, Id: _1 as variant#1.0.*, Ty: i32, Value: <unsupported-projection>
 (priroda) Hit breakpoint

--- a/priroda/tests/ui/locals_in_function.stdout
+++ b/priroda/tests/ui/locals_in_function.stdout
@@ -2,7 +2,7 @@
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_in_function.rs:5
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: x, Id: _1, Ty: i32, Value: <immediate>
+Name: x, Id: _1, Ty: i32, Value: 1_i32
 Name: y, Id: _2, Ty: bool, Value: <dead>
 Name: <none>, Id: _3, Ty: (i32, bool), Value: <dead>
 Name: <none>, Id: _4, Ty: i32, Value: <dead>

--- a/priroda/tests/ui/locals_mplace_metadata.rs
+++ b/priroda/tests/ui/locals_mplace_metadata.rs
@@ -1,0 +1,26 @@
+#![feature(unsized_fn_params)]
+#![allow(incomplete_features, internal_features, unused_variables)]
+
+trait Marker {}
+
+impl Marker for (i32, i32) {}
+
+fn slice_param(slice: [u8]) {
+    std::hint::black_box(&slice);
+}
+
+fn str_param(text: str) {
+    std::hint::black_box(&text);
+}
+
+fn dyn_param(value: dyn Marker) {
+    std::hint::black_box(&value);
+}
+
+fn main() {
+    let slice: Box<[u8]> = Box::new([1_u8, 2, 3]);
+    slice_param(*slice);
+    str_param(*String::from("abc").into_boxed_str());
+    let value: Box<dyn Marker> = Box::new((1_i32, 2_i32));
+    dyn_param(*value);
+}

--- a/priroda/tests/ui/locals_mplace_metadata.stdin
+++ b/priroda/tests/ui/locals_mplace_metadata.stdin
@@ -1,0 +1,13 @@
+break tests/ui/locals_mplace_metadata.rs:8
+break tests/ui/locals_mplace_metadata.rs:12
+break tests/ui/locals_mplace_metadata.rs:16
+continue
+locals
+print 1
+continue
+locals
+print 1
+continue
+locals
+print 1
+quit

--- a/priroda/tests/ui/locals_mplace_metadata.stdout
+++ b/priroda/tests/ui/locals_mplace_metadata.stdout
@@ -4,22 +4,40 @@
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_mplace_metadata.rs:8
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: slice, Id: _1, Ty: [u8], Value: <indirect>
+Name: slice, Id: _1, Ty: [u8], Value: alloc273 (stack variable, size: 3, align: 1) {
+    01 02 03                                        │ ...
+}
+
 Name: <none>, Id: _2, Ty: &[u8], Value: <dead>
 Name: <none>, Id: _3, Ty: &[u8], Value: <dead>
-(priroda) Id: _1, Ty: [u8], Value: <indirect>
+(priroda) Id: _1, Ty: [u8], Value: alloc273 (stack variable, size: 3, align: 1) {
+    01 02 03                                        │ ...
+}
+
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_mplace_metadata.rs:12
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: text, Id: _1, Ty: str, Value: <indirect>
+Name: text, Id: _1, Ty: str, Value: alloc478 (stack variable, size: 3, align: 1) {
+    __ __ __                                        │ ░░░
+}
+
 Name: <none>, Id: _2, Ty: &str, Value: <dead>
 Name: <none>, Id: _3, Ty: &str, Value: <dead>
-(priroda) Id: _1, Ty: str, Value: <indirect>
+(priroda) Id: _1, Ty: str, Value: alloc478 (stack variable, size: 3, align: 1) {
+    __ __ __                                        │ ░░░
+}
+
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_mplace_metadata.rs:16
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: value, Id: _1, Ty: dyn Marker, Value: <indirect>
+Name: value, Id: _1, Ty: dyn Marker, Value: alloc555 (stack variable, size: 8, align: 4) {
+    01 00 00 00 02 00 00 00                         │ ........
+}
+
 Name: <none>, Id: _2, Ty: &dyn Marker, Value: <dead>
 Name: <none>, Id: _3, Ty: &dyn Marker, Value: <dead>
-(priroda) Id: _1, Ty: dyn Marker, Value: <indirect>
+(priroda) Id: _1, Ty: dyn Marker, Value: alloc555 (stack variable, size: 8, align: 4) {
+    01 00 00 00 02 00 00 00                         │ ........
+}
+
 (priroda) quitting

--- a/priroda/tests/ui/locals_mplace_metadata.stdout
+++ b/priroda/tests/ui/locals_mplace_metadata.stdout
@@ -4,40 +4,22 @@
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_mplace_metadata.rs:8
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: slice, Id: _1, Ty: [u8], Value: alloc273 (stack variable, size: 3, align: 1) {
-    01 02 03                                        │ ...
-}
-
+Name: slice, Id: _1, Ty: [u8], Value: [01 02 03]
 Name: <none>, Id: _2, Ty: &[u8], Value: <dead>
 Name: <none>, Id: _3, Ty: &[u8], Value: <dead>
-(priroda) Id: _1, Ty: [u8], Value: alloc273 (stack variable, size: 3, align: 1) {
-    01 02 03                                        │ ...
-}
-
+(priroda) Id: _1, Ty: [u8], Value: [01 02 03]
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_mplace_metadata.rs:12
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: text, Id: _1, Ty: str, Value: alloc478 (stack variable, size: 3, align: 1) {
-    __ __ __                                        │ ░░░
-}
-
+Name: text, Id: _1, Ty: str, Value: [__ __ __]
 Name: <none>, Id: _2, Ty: &str, Value: <dead>
 Name: <none>, Id: _3, Ty: &str, Value: <dead>
-(priroda) Id: _1, Ty: str, Value: alloc478 (stack variable, size: 3, align: 1) {
-    __ __ __                                        │ ░░░
-}
-
+(priroda) Id: _1, Ty: str, Value: [__ __ __]
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_mplace_metadata.rs:16
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: value, Id: _1, Ty: dyn Marker, Value: alloc555 (stack variable, size: 8, align: 4) {
-    01 00 00 00 02 00 00 00                         │ ........
-}
-
+Name: value, Id: _1, Ty: dyn Marker, Value: [01 00 00 00 02 00 00 00]
 Name: <none>, Id: _2, Ty: &dyn Marker, Value: <dead>
 Name: <none>, Id: _3, Ty: &dyn Marker, Value: <dead>
-(priroda) Id: _1, Ty: dyn Marker, Value: alloc555 (stack variable, size: 8, align: 4) {
-    01 00 00 00 02 00 00 00                         │ ........
-}
-
+(priroda) Id: _1, Ty: dyn Marker, Value: [01 00 00 00 02 00 00 00]
 (priroda) quitting

--- a/priroda/tests/ui/locals_mplace_metadata.stdout
+++ b/priroda/tests/ui/locals_mplace_metadata.stdout
@@ -1,0 +1,25 @@
+(priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_mplace_metadata.rs:8
+(priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_mplace_metadata.rs:12
+(priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_mplace_metadata.rs:16
+(priroda) Hit breakpoint
+{MANIFEST_DIR}/tests/ui/locals_mplace_metadata.rs:8
+(priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
+Name: slice, Id: _1, Ty: [u8], Value: <indirect>
+Name: <none>, Id: _2, Ty: &[u8], Value: <dead>
+Name: <none>, Id: _3, Ty: &[u8], Value: <dead>
+(priroda) Id: _1, Ty: [u8], Value: <indirect>
+(priroda) Hit breakpoint
+{MANIFEST_DIR}/tests/ui/locals_mplace_metadata.rs:12
+(priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
+Name: text, Id: _1, Ty: str, Value: <indirect>
+Name: <none>, Id: _2, Ty: &str, Value: <dead>
+Name: <none>, Id: _3, Ty: &str, Value: <dead>
+(priroda) Id: _1, Ty: str, Value: <indirect>
+(priroda) Hit breakpoint
+{MANIFEST_DIR}/tests/ui/locals_mplace_metadata.rs:16
+(priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
+Name: value, Id: _1, Ty: dyn Marker, Value: <indirect>
+Name: <none>, Id: _2, Ty: &dyn Marker, Value: <dead>
+Name: <none>, Id: _3, Ty: &dyn Marker, Value: <dead>
+(priroda) Id: _1, Ty: dyn Marker, Value: <indirect>
+(priroda) quitting

--- a/priroda/tests/ui/locals_pointer_rendering.rs
+++ b/priroda/tests/ui/locals_pointer_rendering.rs
@@ -1,0 +1,68 @@
+//@ normalize-stderr-test: "(?s)^warning: integer-to-pointer cast.*warning: 1 warning emitted\n\n$" -> ""
+use std::mem::{self, MaybeUninit};
+
+#[repr(C)]
+struct PointerAtOffset0<'a> {
+    ptr: &'a u8,
+}
+
+#[repr(C)]
+struct PointerAfterBytes<'a> {
+    bytes: [u8; 3],
+    ptr: &'a u8,
+}
+
+#[repr(C)]
+struct PointerAtEnd<'a> {
+    byte: u8,
+    ptr: &'a u8,
+}
+
+#[repr(C)]
+struct UninitAroundPointer<'a> {
+    before: MaybeUninit<[u8; 2]>,
+    ptr: &'a u8,
+    after: MaybeUninit<[u8; 2]>,
+}
+
+#[repr(C)]
+struct IntegerAndPointer<'a> {
+    integer: u32,
+    ptr: &'a u8,
+}
+
+fn main() {
+    let target = [10u8, 20];
+    let pointer_at_offset0 = PointerAtOffset0 { ptr: &target[0] };
+    let pointer_after_bytes = PointerAfterBytes { bytes: [1, 2, 3], ptr: &target[0] };
+    let pointer_at_end = PointerAtEnd { byte: 4, ptr: &target[0] };
+    let uninit_around_pointer = UninitAroundPointer {
+        before: MaybeUninit::uninit(),
+        ptr: &target[0],
+        after: MaybeUninit::uninit(),
+    };
+    let integer_and_pointer = IntegerAndPointer { integer: 0x44332211, ptr: &target[1] };
+
+    // Keep only fewer than pointer-sized bytes from a pointer representation.
+    let fixed_addr_ptr = std::ptr::with_exposed_provenance::<u8>(0x1234);
+    let short_pointer_bytes = unsafe {
+        let mut bytes = MaybeUninit::<[u8; 1]>::uninit();
+        std::ptr::copy_nonoverlapping(
+            (&fixed_addr_ptr as *const *const u8).cast::<u8>(),
+            bytes.as_mut_ptr().cast::<u8>(),
+            mem::size_of::<[u8; 1]>(),
+        );
+        bytes.assume_init()
+    };
+
+    // Break here so all locals are still available to the debugger.
+    std::hint::black_box((
+        &pointer_at_offset0,
+        &pointer_after_bytes,
+        &pointer_at_end,
+        &uninit_around_pointer,
+        &integer_and_pointer,
+        &fixed_addr_ptr,
+        &short_pointer_bytes,
+    ));
+}

--- a/priroda/tests/ui/locals_pointer_rendering.stdin
+++ b/priroda/tests/ui/locals_pointer_rendering.stdin
@@ -1,0 +1,5 @@
+break tests/ui/locals_pointer_rendering.rs:59
+continue
+locals
+print 2
+quit

--- a/priroda/tests/ui/locals_pointer_rendering.stdout
+++ b/priroda/tests/ui/locals_pointer_rendering.stdout
@@ -1,0 +1,56 @@
+(priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_pointer_rendering.rs:59
+(priroda) Hit breakpoint
+{MANIFEST_DIR}/tests/ui/locals_pointer_rendering.rs:59
+(priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
+Name: target, Id: _1, Ty: [u8; 2], Value: [0a 14]
+Name: pointer_at_offset0, Id: _2, Ty: PointerAtOffset0<'_>, Value: [{ALLOC_PTR}]
+Name: <none>, Id: _3, Ty: &u8, Value: <dead>
+Name: <none>, Id: _4, Ty: &u8, Value: <dead>
+Name: <none>, Id: _5, Ty: usize, Value: <dead>
+Name: <none>, Id: _6, Ty: bool, Value: true
+Name: pointer_after_bytes, Id: _7, Ty: PointerAfterBytes<'_>, Value: [01 02 03 __ __ __ __ __ {ALLOC_PTR}]
+Name: <none>, Id: _8, Ty: [u8; 3], Value: <dead>
+Name: <none>, Id: _9, Ty: &u8, Value: <dead>
+Name: <none>, Id: _10, Ty: &u8, Value: <dead>
+Name: <none>, Id: _11, Ty: usize, Value: <dead>
+Name: <none>, Id: _12, Ty: bool, Value: true
+Name: pointer_at_end, Id: _13, Ty: PointerAtEnd<'_>, Value: [04 __ __ __ __ __ __ __ {ALLOC_PTR}]
+Name: <none>, Id: _14, Ty: &u8, Value: <dead>
+Name: <none>, Id: _15, Ty: &u8, Value: <dead>
+Name: <none>, Id: _16, Ty: usize, Value: <dead>
+Name: <none>, Id: _17, Ty: bool, Value: true
+Name: uninit_around_pointer, Id: _18, Ty: UninitAroundPointer<'_>, Value: [__ __ __ __ __ __ __ __ {ALLOC_PTR} __ __ __ __ __ __ __ __]
+Name: <none>, Id: _19, Ty: std::mem::MaybeUninit<[u8; 2]>, Value: <dead>
+Name: <none>, Id: _20, Ty: &u8, Value: <dead>
+Name: <none>, Id: _21, Ty: &u8, Value: <dead>
+Name: <none>, Id: _22, Ty: usize, Value: <dead>
+Name: <none>, Id: _23, Ty: bool, Value: true
+Name: <none>, Id: _24, Ty: std::mem::MaybeUninit<[u8; 2]>, Value: <dead>
+Name: integer_and_pointer, Id: _25, Ty: IntegerAndPointer<'_>, Value: [11 22 33 44 __ __ __ __ {ALLOC_PTR}]
+Name: <none>, Id: _26, Ty: &u8, Value: <dead>
+Name: <none>, Id: _27, Ty: &u8, Value: <dead>
+Name: <none>, Id: _28, Ty: usize, Value: <dead>
+Name: <none>, Id: _29, Ty: bool, Value: true
+Name: fixed_addr_ptr, Id: _30, Ty: *const u8, Value: [0x1234[wildcard]]
+Name: short_pointer_bytes, Id: _31, Ty: [u8; 1], Value: [34]
+Name: bytes, Id: _32, Ty: std::mem::MaybeUninit<[u8; 1]>, Value: <dead>
+Name: <none>, Id: _33, Ty: (), Value: <dead>
+Name: <none>, Id: _34, Ty: *const u8, Value: <dead>
+Name: <none>, Id: _35, Ty: *const *const u8, Value: <dead>
+Name: <none>, Id: _36, Ty: &*const u8, Value: <dead>
+Name: <none>, Id: _37, Ty: *mut u8, Value: <dead>
+Name: <none>, Id: _38, Ty: *mut [u8; 1], Value: <dead>
+Name: <none>, Id: _39, Ty: &mut std::mem::MaybeUninit<[u8; 1]>, Value: <dead>
+Name: <none>, Id: _40, Ty: usize, Value: <dead>
+Name: <none>, Id: _41, Ty: std::mem::MaybeUninit<[u8; 1]>, Value: <dead>
+Name: <none>, Id: _42, Ty: (&PointerAtOffset0<'_>, &PointerAfterBytes<'_>, &PointerAtEnd<'_>, &UninitAroundPointer<'_>, &IntegerAndPointer<'_>, &*const u8, &[u8; 1]), Value: <dead>
+Name: <none>, Id: _43, Ty: (&PointerAtOffset0<'_>, &PointerAfterBytes<'_>, &PointerAtEnd<'_>, &UninitAroundPointer<'_>, &IntegerAndPointer<'_>, &*const u8, &[u8; 1]), Value: <dead>
+Name: <none>, Id: _44, Ty: &PointerAtOffset0<'_>, Value: <dead>
+Name: <none>, Id: _45, Ty: &PointerAfterBytes<'_>, Value: <dead>
+Name: <none>, Id: _46, Ty: &PointerAtEnd<'_>, Value: <dead>
+Name: <none>, Id: _47, Ty: &UninitAroundPointer<'_>, Value: <dead>
+Name: <none>, Id: _48, Ty: &IntegerAndPointer<'_>, Value: <dead>
+Name: <none>, Id: _49, Ty: &*const u8, Value: <dead>
+Name: <none>, Id: _50, Ty: &[u8; 1], Value: <dead>
+(priroda) Id: _2, Ty: PointerAtOffset0<'_>, Value: [{ALLOC_PTR}]
+(priroda) quitting

--- a/priroda/tests/ui/locals_sroa.stdout
+++ b/priroda/tests/ui/locals_sroa.stdout
@@ -2,7 +2,7 @@
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_sroa.rs:13
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: s, Id: _1, Ty: &[u8], Value: <immediate-pair>
+Name: s, Id: _1, Ty: &[u8], Value: (pointer to 0x20af8[alloc2]<324>, 0x0000000000000002): &[u8]
 Name: <none>, Id: _2, Ty: ExtraSlice<'_>, Value: <uninit>
 Name: <none>, Id: _3, Ty: &[u8], Value: <dead>
 Name: <none>, Id: _4, Ty: u32, Value: <dead>

--- a/priroda/tests/ui/locals_sroa.stdout
+++ b/priroda/tests/ui/locals_sroa.stdout
@@ -2,7 +2,7 @@
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_sroa.rs:13
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: s, Id: _1, Ty: &[u8], Value: (pointer to 0x20af8[alloc2]<324>, 0x0000000000000002): &[u8]
+Name: s, Id: _1, Ty: &[u8], Value: (pointer to {ALLOC_PTR}, 0x0000000000000002): &[u8]
 Name: <none>, Id: _2, Ty: ExtraSlice<'_>, Value: <uninit>
 Name: <none>, Id: _3, Ty: &[u8], Value: <dead>
 Name: <none>, Id: _4, Ty: u32, Value: <dead>

--- a/priroda/tests/ui/locals_struct_field_fragment.stdout
+++ b/priroda/tests/ui/locals_struct_field_fragment.stdout
@@ -5,6 +5,6 @@
 Name: <none>, Id: _1, Ty: Outer, Value: <uninit>
 Name: <none>, Id: _2, Ty: Inner, Value: <uninit>
 Name: <none>, Id: _3, Ty: Inner, Value: <uninit>
-Name: x.inner.value, Id: _4, Ty: u8, Value: <immediate>
+Name: x.inner.value, Id: _4, Ty: u8, Value: 7_u8
 Name: <none>, Id: _5, Ty: u8, Value: <dead>
 (priroda) quitting

--- a/priroda/tests/ui/locals_value_shapes.rs
+++ b/priroda/tests/ui/locals_value_shapes.rs
@@ -1,0 +1,30 @@
+#![allow(dead_code, unused_variables)]
+
+struct Aggregate {
+    byte: u8,
+    word: u16,
+}
+
+fn main() {
+    // Edge case for `None` from `as_mplace_or_imm`: moved/drop temporaries become dead.
+    let dead_box = Box::new(0x11_u8);
+    let consumed = dead_box;
+    drop(consumed);
+
+    let pointed_box = Box::new(0x11_u8);
+    let pointer_box = &pointed_box;
+
+    // Immediate::Scalar.
+    let scalar = 0x2a_u8;
+    let pointed = 0x33_u8;
+    // Immediate::Scalar with pointer provenance.
+    let scalar_pointer = &pointed;
+    // Immediate::ScalarPair.
+    let scalar_pair = &[10_u8, 20_u8][..];
+    // Either::Left mplace/indirect storage.
+    let mplace = Aggregate { byte: scalar, word: 0x1234 };
+    // Immediate::Uninit.
+    let uninit_scalar: u32;
+
+    std::hint::black_box((scalar, scalar_pointer, scalar_pair.len(), &mplace));
+}

--- a/priroda/tests/ui/locals_value_shapes.stdin
+++ b/priroda/tests/ui/locals_value_shapes.stdin
@@ -1,0 +1,12 @@
+break tests/ui/locals_value_shapes.rs:29
+continue
+locals
+print 0
+print 4
+print 5
+print 7
+print 8
+print 13
+print 15
+print 999
+quit

--- a/priroda/tests/ui/locals_value_shapes.stdout
+++ b/priroda/tests/ui/locals_value_shapes.stdout
@@ -2,21 +2,41 @@
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_value_shapes.rs:29
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: dead_box, Id: _1, Ty: std::boxed::Box<u8>, Value: <indirect>
-Name: consumed, Id: _2, Ty: std::boxed::Box<u8>, Value: <indirect>
+Name: dead_box, Id: _1, Ty: std::boxed::Box<u8>, Value: alloc266 (stack variable, size: 8, align: 8) {
+    ╾─0x20b95[a236]<374>──╼                         │ ╾──────╼
+}
+alloc236 (deallocated)
+
+Name: consumed, Id: _2, Ty: std::boxed::Box<u8>, Value: alloc267 (stack variable, size: 8, align: 8) {
+    ╾─0x20b95[a236]<376>──╼                         │ ╾──────╼
+}
+alloc236 (deallocated)
+
 Name: <none>, Id: _3, Ty: (), Value: <dead>
 Name: <none>, Id: _4, Ty: std::boxed::Box<u8>, Value: <dead>
-Name: pointed_box, Id: _5, Ty: std::boxed::Box<u8>, Value: <indirect>
+Name: pointed_box, Id: _5, Ty: std::boxed::Box<u8>, Value: alloc319 (stack variable, size: 8, align: 8) {
+    ╾─0x21030[a289]<468>──╼                         │ ╾──────╼
+}
+alloc289 (Rust heap, size: 1, align: 1) {
+    11                                              │ .
+}
+
 Name: pointer_box, Id: _6, Ty: &std::boxed::Box<u8>, Value: {&_: &std::boxed::Box<u8>}
 Name: scalar, Id: _7, Ty: u8, Value: 42_u8
-Name: pointed, Id: _8, Ty: u8, Value: <indirect>
+Name: pointed, Id: _8, Ty: u8, Value: alloc320 (stack variable, size: 1, align: 1) {
+    33                                              │ 3
+}
+
 Name: scalar_pointer, Id: _9, Ty: &u8, Value: {&_: &u8}
 Name: scalar_pair, Id: _10, Ty: &[u8], Value: (pointer to 0x212fa[alloc2]<489>, 0x0000000000000002): &[u8]
 Name: <none>, Id: _11, Ty: &[u8], Value: (pointer to 0x212fa[alloc2]<488>, 0x0000000000000002): &[u8]
 Name: <none>, Id: _12, Ty: &[u8; 2], Value: <dead>
 Name: <none>, Id: _13, Ty: [u8; 2], Value: <uninit>
 Name: <none>, Id: _14, Ty: std::ops::RangeFull, Value: <dead>
-Name: mplace, Id: _15, Ty: Aggregate, Value: <indirect>
+Name: mplace, Id: _15, Ty: Aggregate, Value: alloc321 (stack variable, size: 4, align: 2) {
+    34 12 2a __                                     │ 4.*░
+}
+
 Name: <none>, Id: _16, Ty: u8, Value: <dead>
 Name: uninit_scalar, Id: _17, Ty: u32, Value: <uninit>
 Name: <none>, Id: _18, Ty: (u8, &u8, usize, &Aggregate), Value: <dead>
@@ -29,10 +49,22 @@ Name: <none>, Id: _24, Ty: &Aggregate, Value: <dead>
 Name: <none>, Id: _25, Ty: &[u8; 2], Value: {&_: &[u8; 2]}
 (priroda) Id: _0, Ty: (), Value: <uninit>
 (priroda) Id: _4, Ty: std::boxed::Box<u8>, Value: <dead>
-(priroda) Id: _5, Ty: std::boxed::Box<u8>, Value: <indirect>
+(priroda) Id: _5, Ty: std::boxed::Box<u8>, Value: alloc319 (stack variable, size: 8, align: 8) {
+    ╾─0x21030[a289]<468>──╼                         │ ╾──────╼
+}
+alloc289 (Rust heap, size: 1, align: 1) {
+    11                                              │ .
+}
+
 (priroda) Id: _7, Ty: u8, Value: 42_u8
-(priroda) Id: _8, Ty: u8, Value: <indirect>
+(priroda) Id: _8, Ty: u8, Value: alloc320 (stack variable, size: 1, align: 1) {
+    33                                              │ 3
+}
+
 (priroda) Id: _13, Ty: [u8; 2], Value: <uninit>
-(priroda) Id: _15, Ty: Aggregate, Value: <indirect>
+(priroda) Id: _15, Ty: Aggregate, Value: alloc321 (stack variable, size: 4, align: 2) {
+    34 12 2a __                                     │ 4.*░
+}
+
 (priroda) no local for this id
 (priroda) quitting

--- a/priroda/tests/ui/locals_value_shapes.stdout
+++ b/priroda/tests/ui/locals_value_shapes.stdout
@@ -2,17 +2,17 @@
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_value_shapes.rs:29
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: dead_box, Id: _1, Ty: std::boxed::Box<u8>, Value: [95 0b 02 00 00 00 00 00]
-Name: consumed, Id: _2, Ty: std::boxed::Box<u8>, Value: [95 0b 02 00 00 00 00 00]
+Name: dead_box, Id: _1, Ty: std::boxed::Box<u8>, Value: [{ALLOC_PTR}]
+Name: consumed, Id: _2, Ty: std::boxed::Box<u8>, Value: [{ALLOC_PTR}]
 Name: <none>, Id: _3, Ty: (), Value: <dead>
 Name: <none>, Id: _4, Ty: std::boxed::Box<u8>, Value: <dead>
-Name: pointed_box, Id: _5, Ty: std::boxed::Box<u8>, Value: [30 10 02 00 00 00 00 00]
+Name: pointed_box, Id: _5, Ty: std::boxed::Box<u8>, Value: [{ALLOC_PTR}]
 Name: pointer_box, Id: _6, Ty: &std::boxed::Box<u8>, Value: {&_: &std::boxed::Box<u8>}
 Name: scalar, Id: _7, Ty: u8, Value: 42_u8
 Name: pointed, Id: _8, Ty: u8, Value: [33]
 Name: scalar_pointer, Id: _9, Ty: &u8, Value: {&_: &u8}
-Name: scalar_pair, Id: _10, Ty: &[u8], Value: (pointer to 0x212fa[alloc2]<489>, 0x0000000000000002): &[u8]
-Name: <none>, Id: _11, Ty: &[u8], Value: (pointer to 0x212fa[alloc2]<488>, 0x0000000000000002): &[u8]
+Name: scalar_pair, Id: _10, Ty: &[u8], Value: (pointer to {ALLOC_PTR}, 0x0000000000000002): &[u8]
+Name: <none>, Id: _11, Ty: &[u8], Value: (pointer to {ALLOC_PTR}, 0x0000000000000002): &[u8]
 Name: <none>, Id: _12, Ty: &[u8; 2], Value: <dead>
 Name: <none>, Id: _13, Ty: [u8; 2], Value: <uninit>
 Name: <none>, Id: _14, Ty: std::ops::RangeFull, Value: <dead>
@@ -29,7 +29,7 @@ Name: <none>, Id: _24, Ty: &Aggregate, Value: <dead>
 Name: <none>, Id: _25, Ty: &[u8; 2], Value: {&_: &[u8; 2]}
 (priroda) Id: _0, Ty: (), Value: <uninit>
 (priroda) Id: _4, Ty: std::boxed::Box<u8>, Value: <dead>
-(priroda) Id: _5, Ty: std::boxed::Box<u8>, Value: [30 10 02 00 00 00 00 00]
+(priroda) Id: _5, Ty: std::boxed::Box<u8>, Value: [{ALLOC_PTR}]
 (priroda) Id: _7, Ty: u8, Value: 42_u8
 (priroda) Id: _8, Ty: u8, Value: [33]
 (priroda) Id: _13, Ty: [u8; 2], Value: <uninit>

--- a/priroda/tests/ui/locals_value_shapes.stdout
+++ b/priroda/tests/ui/locals_value_shapes.stdout
@@ -1,0 +1,38 @@
+(priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_value_shapes.rs:29
+(priroda) Hit breakpoint
+{MANIFEST_DIR}/tests/ui/locals_value_shapes.rs:29
+(priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
+Name: dead_box, Id: _1, Ty: std::boxed::Box<u8>, Value: <indirect>
+Name: consumed, Id: _2, Ty: std::boxed::Box<u8>, Value: <indirect>
+Name: <none>, Id: _3, Ty: (), Value: <dead>
+Name: <none>, Id: _4, Ty: std::boxed::Box<u8>, Value: <dead>
+Name: pointed_box, Id: _5, Ty: std::boxed::Box<u8>, Value: <indirect>
+Name: pointer_box, Id: _6, Ty: &std::boxed::Box<u8>, Value: {&_: &std::boxed::Box<u8>}
+Name: scalar, Id: _7, Ty: u8, Value: 42_u8
+Name: pointed, Id: _8, Ty: u8, Value: <indirect>
+Name: scalar_pointer, Id: _9, Ty: &u8, Value: {&_: &u8}
+Name: scalar_pair, Id: _10, Ty: &[u8], Value: (pointer to 0x212fa[alloc2]<489>, 0x0000000000000002): &[u8]
+Name: <none>, Id: _11, Ty: &[u8], Value: (pointer to 0x212fa[alloc2]<488>, 0x0000000000000002): &[u8]
+Name: <none>, Id: _12, Ty: &[u8; 2], Value: <dead>
+Name: <none>, Id: _13, Ty: [u8; 2], Value: <uninit>
+Name: <none>, Id: _14, Ty: std::ops::RangeFull, Value: <dead>
+Name: mplace, Id: _15, Ty: Aggregate, Value: <indirect>
+Name: <none>, Id: _16, Ty: u8, Value: <dead>
+Name: uninit_scalar, Id: _17, Ty: u32, Value: <uninit>
+Name: <none>, Id: _18, Ty: (u8, &u8, usize, &Aggregate), Value: <dead>
+Name: <none>, Id: _19, Ty: (u8, &u8, usize, &Aggregate), Value: <dead>
+Name: <none>, Id: _20, Ty: u8, Value: <dead>
+Name: <none>, Id: _21, Ty: &u8, Value: <dead>
+Name: <none>, Id: _22, Ty: usize, Value: <dead>
+Name: <none>, Id: _23, Ty: &[u8], Value: <dead>
+Name: <none>, Id: _24, Ty: &Aggregate, Value: <dead>
+Name: <none>, Id: _25, Ty: &[u8; 2], Value: {&_: &[u8; 2]}
+(priroda) Id: _0, Ty: (), Value: <uninit>
+(priroda) Id: _4, Ty: std::boxed::Box<u8>, Value: <dead>
+(priroda) Id: _5, Ty: std::boxed::Box<u8>, Value: <indirect>
+(priroda) Id: _7, Ty: u8, Value: 42_u8
+(priroda) Id: _8, Ty: u8, Value: <indirect>
+(priroda) Id: _13, Ty: [u8; 2], Value: <uninit>
+(priroda) Id: _15, Ty: Aggregate, Value: <indirect>
+(priroda) no local for this id
+(priroda) quitting

--- a/priroda/tests/ui/locals_value_shapes.stdout
+++ b/priroda/tests/ui/locals_value_shapes.stdout
@@ -2,41 +2,21 @@
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_value_shapes.rs:29
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: dead_box, Id: _1, Ty: std::boxed::Box<u8>, Value: alloc266 (stack variable, size: 8, align: 8) {
-    ╾─0x20b95[a236]<374>──╼                         │ ╾──────╼
-}
-alloc236 (deallocated)
-
-Name: consumed, Id: _2, Ty: std::boxed::Box<u8>, Value: alloc267 (stack variable, size: 8, align: 8) {
-    ╾─0x20b95[a236]<376>──╼                         │ ╾──────╼
-}
-alloc236 (deallocated)
-
+Name: dead_box, Id: _1, Ty: std::boxed::Box<u8>, Value: [95 0b 02 00 00 00 00 00]
+Name: consumed, Id: _2, Ty: std::boxed::Box<u8>, Value: [95 0b 02 00 00 00 00 00]
 Name: <none>, Id: _3, Ty: (), Value: <dead>
 Name: <none>, Id: _4, Ty: std::boxed::Box<u8>, Value: <dead>
-Name: pointed_box, Id: _5, Ty: std::boxed::Box<u8>, Value: alloc319 (stack variable, size: 8, align: 8) {
-    ╾─0x21030[a289]<468>──╼                         │ ╾──────╼
-}
-alloc289 (Rust heap, size: 1, align: 1) {
-    11                                              │ .
-}
-
+Name: pointed_box, Id: _5, Ty: std::boxed::Box<u8>, Value: [30 10 02 00 00 00 00 00]
 Name: pointer_box, Id: _6, Ty: &std::boxed::Box<u8>, Value: {&_: &std::boxed::Box<u8>}
 Name: scalar, Id: _7, Ty: u8, Value: 42_u8
-Name: pointed, Id: _8, Ty: u8, Value: alloc320 (stack variable, size: 1, align: 1) {
-    33                                              │ 3
-}
-
+Name: pointed, Id: _8, Ty: u8, Value: [33]
 Name: scalar_pointer, Id: _9, Ty: &u8, Value: {&_: &u8}
 Name: scalar_pair, Id: _10, Ty: &[u8], Value: (pointer to 0x212fa[alloc2]<489>, 0x0000000000000002): &[u8]
 Name: <none>, Id: _11, Ty: &[u8], Value: (pointer to 0x212fa[alloc2]<488>, 0x0000000000000002): &[u8]
 Name: <none>, Id: _12, Ty: &[u8; 2], Value: <dead>
 Name: <none>, Id: _13, Ty: [u8; 2], Value: <uninit>
 Name: <none>, Id: _14, Ty: std::ops::RangeFull, Value: <dead>
-Name: mplace, Id: _15, Ty: Aggregate, Value: alloc321 (stack variable, size: 4, align: 2) {
-    34 12 2a __                                     │ 4.*░
-}
-
+Name: mplace, Id: _15, Ty: Aggregate, Value: [34 12 2a __]
 Name: <none>, Id: _16, Ty: u8, Value: <dead>
 Name: uninit_scalar, Id: _17, Ty: u32, Value: <uninit>
 Name: <none>, Id: _18, Ty: (u8, &u8, usize, &Aggregate), Value: <dead>
@@ -49,22 +29,10 @@ Name: <none>, Id: _24, Ty: &Aggregate, Value: <dead>
 Name: <none>, Id: _25, Ty: &[u8; 2], Value: {&_: &[u8; 2]}
 (priroda) Id: _0, Ty: (), Value: <uninit>
 (priroda) Id: _4, Ty: std::boxed::Box<u8>, Value: <dead>
-(priroda) Id: _5, Ty: std::boxed::Box<u8>, Value: alloc319 (stack variable, size: 8, align: 8) {
-    ╾─0x21030[a289]<468>──╼                         │ ╾──────╼
-}
-alloc289 (Rust heap, size: 1, align: 1) {
-    11                                              │ .
-}
-
+(priroda) Id: _5, Ty: std::boxed::Box<u8>, Value: [30 10 02 00 00 00 00 00]
 (priroda) Id: _7, Ty: u8, Value: 42_u8
-(priroda) Id: _8, Ty: u8, Value: alloc320 (stack variable, size: 1, align: 1) {
-    33                                              │ 3
-}
-
+(priroda) Id: _8, Ty: u8, Value: [33]
 (priroda) Id: _13, Ty: [u8; 2], Value: <uninit>
-(priroda) Id: _15, Ty: Aggregate, Value: alloc321 (stack variable, size: 4, align: 2) {
-    34 12 2a __                                     │ 4.*░
-}
-
+(priroda) Id: _15, Ty: Aggregate, Value: [34 12 2a __]
 (priroda) no local for this id
 (priroda) quitting

--- a/priroda/tests/ui/locals_wildcard_pointer.rs
+++ b/priroda/tests/ui/locals_wildcard_pointer.rs
@@ -1,0 +1,16 @@
+//@ normalize-stderr-test: "(?s)^warning: integer-to-pointer cast.*warning: 1 warning emitted\n\n$" -> ""
+
+#[repr(C)]
+struct WildcardPointer {
+    ptr: *const u8,
+}
+
+fn main() {
+    // The pointer is never dereferenced: this keeps the wildcard provenance
+    // available for the debugger renderer without requiring it to resolve.
+    let ptr = 0x1234usize as *const u8;
+    let wildcard = WildcardPointer { ptr };
+
+    // Keep the local alive for inspection.
+    std::hint::black_box(&wildcard);
+}

--- a/priroda/tests/ui/locals_wildcard_pointer.stdin
+++ b/priroda/tests/ui/locals_wildcard_pointer.stdin
@@ -1,0 +1,5 @@
+break tests/ui/locals_wildcard_pointer.rs:15
+continue
+locals
+print 2
+quit

--- a/priroda/tests/ui/locals_wildcard_pointer.stdout
+++ b/priroda/tests/ui/locals_wildcard_pointer.stdout
@@ -1,0 +1,11 @@
+(priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_wildcard_pointer.rs:15
+(priroda) Hit breakpoint
+{MANIFEST_DIR}/tests/ui/locals_wildcard_pointer.rs:15
+(priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
+Name: ptr, Id: _1, Ty: *const u8, Value: {&_: *const u8}
+Name: wildcard, Id: _2, Ty: WildcardPointer, Value: [0x1234[wildcard]]
+Name: <none>, Id: _3, Ty: *const u8, Value: <dead>
+Name: <none>, Id: _4, Ty: &WildcardPointer, Value: <dead>
+Name: <none>, Id: _5, Ty: &WildcardPointer, Value: <dead>
+(priroda) Id: _2, Ty: WildcardPointer, Value: [0x1234[wildcard]]
+(priroda) quitting


### PR DESCRIPTION
Add raw value rendering for indirect MIR locals.

Priroda now renders immediate locals, indirect mplace byte ranges, uninitialized
bytes, and pointer provenance. It also adds a `follow` command for inspecting
allocation bytes from a rendered pointer.

Includes UI tests covering value shapes, mplace metadata, pointer rendering,
wildcard provenance, and allocation following.