### PR TITLE
[Priroda] Render projected debug-info values

### DIFF
--- a/priroda/src/main.rs
+++ b/priroda/src/main.rs
@@ -505,6 +505,20 @@ impl<'tcx> PrirodaContext<'tcx> {
         interp_ok(format!("[{}]", rendered.join(" ")))
     }
 
+    /// Render an evaluated operand using the same raw representation for
+    /// whole locals and projected MIR places.
+    fn render_op(&self, op: OpTy<'tcx>) -> String {
+        match op.as_mplace_or_imm() {
+            Either::Right(imm) => format!("{imm}"),
+
+            Either::Left(mplace) =>
+                match self.render_mplace_bytes(&mplace).report_err() {
+                    Ok(bytes) => bytes,
+                    Err(err) => format!("<error: {}>", interpret::format_interp_error(err)),
+                },
+        }
+    }
+
     /// Render the source-side path from composite debug info, such as `.field`.
     fn render_source_projection(
         fragment: Option<&VarDebugInfoFragment<'tcx>>,
@@ -599,15 +613,7 @@ impl<'tcx> PrirodaContext<'tcx> {
                     .ecx
                     .local_to_op(local, None)
                     .expect("this error can only occur in CTFE on generic code");
-                local_desc.value = match op.as_mplace_or_imm() {
-                    Either::Right(imm) => format!("{imm}"),
-
-                    Either::Left(mplace) =>
-                        match self.render_mplace_bytes(&mplace).report_err() {
-                            Ok(bytes) => bytes,
-                            Err(err) => format!("<error: {}>", interpret::format_interp_error(err)),
-                        },
-                };
+                local_desc.value = self.render_op(op);
             }
         };
 
@@ -658,7 +664,8 @@ impl<'tcx> PrirodaContext<'tcx> {
         // and `_slice._extra`, not as two separate locals both named `_slice`.
 
         // Whole-place debug entries enrich the direct storage-local description.
-        // Projected places and constants are handled separately/deferred.
+        // Projected places are evaluated from their original MIR Place and use
+        // the same raw renderer as ordinary locals.
         for var_debug_info in &frame.body().var_debug_info {
             if let VarDebugInfoContents::Place(place) = &var_debug_info.value {
                 if let Some(local_idx) = place.as_local()
@@ -672,6 +679,13 @@ impl<'tcx> PrirodaContext<'tcx> {
                     let storage_projection = Self::render_storage_projection(place.projection);
                     let source_projection =
                         Self::render_source_projection(var_debug_info.composite.as_deref());
+                    let value = self
+                        .ecx
+                        .eval_place_to_op(*place, None)
+                        .map(|op| self.render_op(op))
+                        .unwrap_or_else(|err| {
+                            format!("<error: {}>", interpret::format_interp_error(err))
+                        });
 
                     local_descs.push(LocalDesc {
                         source_name: Some(var_debug_info.name),
@@ -679,8 +693,7 @@ impl<'tcx> PrirodaContext<'tcx> {
                         local: Some(place.local),
                         storage_projection,
                         ty: place.ty(local_decls, self.ecx.tcx.tcx).ty.to_string(),
-                        // FIXME: projection not handled yet.
-                        value: "<unsupported-projection>".to_string(),
+                        value,
                     });
                 }
             }

--- a/priroda/tests/ui/locals_corpus_async.stdout
+++ b/priroda/tests/ui/locals_corpus_async.stdout
@@ -8,30 +8,30 @@
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:31
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
 Name: <none>, Id: _1, Ty: (u32, i32), Value: (0x00000005, 0x00000006): (u32, i32)
-Name: first, Id: _1.0, Ty: u32, Value: <unsupported-projection>
-Name: second, Id: _1.1, Ty: i32, Value: <unsupported-projection>
+Name: first, Id: _1.0, Ty: u32, Value: 5_u32
+Name: second, Id: _1.1, Ty: i32, Value: 6_i32
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:45
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
 Name: <none>, Id: _1, Ty: S, Value: {transmute(0x40a00000): S}
-Name: x, Id: _1.0, Ty: f32, Value: <unsupported-projection>
+Name: x, Id: _1.0, Ty: f32, Value: 5f32
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:55
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
 Name: <none>, Id: _1, Ty: std::option::Option<i32>, Value: [01 00 00 00 05 00 00 00]
-Name: inner, Id: _1 as variant#1.0, Ty: i32, Value: <unsupported-projection>
+Name: inner, Id: _1 as variant#1.0, Ty: i32, Value: [05 00 00 00]
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:66
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
 Name: <none>, Id: _1, Ty: std::option::Option<&i32>, Value: [{ALLOC_PTR}]
-Name: pointer, Id: _1 as variant#1.0, Ty: &i32, Value: <unsupported-projection>
-Name: deref, Id: _1 as variant#1.0.*, Ty: i32, Value: <unsupported-projection>
+Name: pointer, Id: _1 as variant#1.0, Ty: &i32, Value: [{ALLOC_PTR}]
+Name: deref, Id: _1 as variant#1.0.*, Ty: i32, Value: [05 00 00 00]
 (priroda) Allocation alloc2+0: [05 00 00 00]
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:20
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
 Name: <none>, Id: _1, Ty: &mut std::option::Option<i32>, Value: {&_: &mut std::option::Option<i32>}
-Name: foo, Id: _1.* as variant#1.0, Ty: i32, Value: <unsupported-projection>
+Name: foo, Id: _1.* as variant#1.0, Ty: i32, Value: [05 00 00 00]
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:76
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>

--- a/priroda/tests/ui/locals_projected_mplace_size.rs
+++ b/priroda/tests/ui/locals_projected_mplace_size.rs
@@ -1,0 +1,48 @@
+//@ compile-flags: -Zmir-opt-level=0
+
+#![allow(internal_features)]
+#![feature(custom_mir, core_intrinsics)]
+
+extern crate core;
+use core::intrinsics::mir::*;
+
+// Regression test for projected values: each `item.<field>` row must render
+// only that field's own value/layout, and the memory-backed `item.target` row
+// must not continue through the rest of the allocation backing `Envelope`.
+#[repr(C)]
+struct Payload {
+    a: u16,
+    b: u8,
+    c: u32,
+    d: u8,
+}
+
+#[repr(C)]
+struct Envelope {
+    prefix: u8,
+    target: Payload,
+    trailer: u64,
+    checksum: u16,
+}
+
+#[custom_mir(dialect = "analysis", phase = "post-cleanup")]
+fn projected_struct(item: Envelope) {
+    mir! {
+        debug prefix => item.prefix;
+        debug target => item.target;
+        debug trailer => item.trailer;
+        debug checksum => item.checksum;
+        {
+            Return()
+        }
+    }
+}
+
+fn main() {
+    projected_struct(Envelope {
+        prefix: 0xaa,
+        target: Payload { a: 0x1122, b: 0x33, c: 0x44556677, d: 0x88 },
+        trailer: 0x99aabbccddeeff00,
+        checksum: 0x1234,
+    });
+}

--- a/priroda/tests/ui/locals_projected_mplace_size.stdin
+++ b/priroda/tests/ui/locals_projected_mplace_size.stdin
@@ -1,0 +1,4 @@
+break tests/ui/locals_projected_mplace_size.rs:36
+continue
+locals
+quit

--- a/priroda/tests/ui/locals_projected_mplace_size.stdout
+++ b/priroda/tests/ui/locals_projected_mplace_size.stdout
@@ -3,8 +3,8 @@
 {MANIFEST_DIR}/tests/ui/locals_projected_mplace_size.rs:36
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
 Name: <none>, Id: _1, Ty: Envelope, Value: [aa __ __ __ 22 11 33 __ 77 66 55 44 88 __ __ __ 00 ff ee dd cc bb aa 99 34 12 __ __ __ __ __ __]
-Name: prefix, Id: _1.0, Ty: u8, Value: <unsupported-projection>
-Name: target, Id: _1.1, Ty: Payload, Value: <unsupported-projection>
-Name: trailer, Id: _1.2, Ty: u64, Value: <unsupported-projection>
-Name: checksum, Id: _1.3, Ty: u16, Value: <unsupported-projection>
+Name: prefix, Id: _1.0, Ty: u8, Value: [aa]
+Name: target, Id: _1.1, Ty: Payload, Value: [22 11 33 __ 77 66 55 44 88 __ __ __]
+Name: trailer, Id: _1.2, Ty: u64, Value: [00 ff ee dd cc bb aa 99]
+Name: checksum, Id: _1.3, Ty: u16, Value: [34 12]
 (priroda) quitting

--- a/priroda/tests/ui/locals_projected_mplace_size.stdout
+++ b/priroda/tests/ui/locals_projected_mplace_size.stdout
@@ -1,0 +1,10 @@
+(priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_projected_mplace_size.rs:36
+(priroda) Hit breakpoint
+{MANIFEST_DIR}/tests/ui/locals_projected_mplace_size.rs:36
+(priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
+Name: <none>, Id: _1, Ty: Envelope, Value: [aa __ __ __ 22 11 33 __ 77 66 55 44 88 __ __ __ 00 ff ee dd cc bb aa 99 34 12 __ __ __ __ __ __]
+Name: prefix, Id: _1.0, Ty: u8, Value: <unsupported-projection>
+Name: target, Id: _1.1, Ty: Payload, Value: <unsupported-projection>
+Name: trailer, Id: _1.2, Ty: u64, Value: <unsupported-projection>
+Name: checksum, Id: _1.3, Ty: u16, Value: <unsupported-projection>
+(priroda) quitting


### PR DESCRIPTION
Keep projected MIR Places long enough to evaluate them with `eval_place_to_op`, then reuse the existing raw operand renderer for immediate and memory-backed values.

This removes `<unsupported-projection>` from projected locals, including fields, enum projections, references, and dereferences. Update the projected debug-info UI expectations and verify the full Priroda suite.