### PR TITLE
readme: fix misspelling of `-Ctarget-feature`

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ endian-sensitive code.
 ### Controlling target features
 
 Controlling target features works similar to regular rustc invocations:
-`RUSTFLAGS="-Ctarget-features=+avx512f" cargo miri test` runs the tests with AVX512 enabled. (Miri
+`RUSTFLAGS="-Ctarget-feature=+avx512f" cargo miri test` runs the tests with AVX512 enabled. (Miri
 only supports very few AVX512 intrinsics at the moment.) `-Ctarget-cpu` also works. If target
 features are also relevant for doctests, you have to also set `RUSTDOCFLAGS`.
 


### PR DESCRIPTION
When using `RUSTFLAGS="-Ctarget-features=+avx512f"`, the Rust compiler complains:

    error: unknown codegen option: `target-features`

The actual option uses the singular form.