### PR TITLE
[Priroda] Render projected locals with source-shaped values

### DIFF
--- a/priroda/src/main.rs
+++ b/priroda/src/main.rs
@@ -551,17 +551,46 @@ impl<'tcx> PrirodaContext<'tcx> {
             // bytes would make debugger output look more certain than it is.
             ty::Adt(def, _) if def.variants().is_empty() || def.is_union() => self.render_op(op),
 
-            ty::Adt(def, _) if def.is_struct() => {
-                let variant_idx = FIRST_VARIANT;
+            ty::Adt(def, _) => {
+                // Enums need their runtime discriminant and a downcasted layout
+                // view before fields can be projected. Structs use their sole
+                // variant directly. Keep the display name tied to the same choice.
+                let (variant_idx, down, name) = if def.is_enum() {
+                    let variant_idx = match self.ecx.read_discriminant(&op).discard_err() {
+                        Some(variant_idx) => variant_idx,
+                        // FIXME: expose this as an explicit render error when
+                        // Priroda grows structured value states. Falling back to
+                        // bytes keeps today's UI usable but hides why the enum
+                        // could not be source-shaped.
+                        None => return self.render_op(op),
+                    };
+                    let down = match self.ecx.project_downcast(&op, variant_idx).discard_err() {
+                        Some(down) => down,
+                        // FIXME: distinguish invalid/uninitialized discriminants
+                        // from projection bugs in the rendered output once locals
+                        // can carry structured diagnostics.
+                        None => return self.render_op(op),
+                    };
+                    let variant_def = &def.variants()[variant_idx];
+                    (
+                        variant_idx,
+                        down,
+                        format!("{}::{}", self.ecx.tcx.item_name(def.did()), variant_def.name),
+                    )
+                } else {
+                    let variant_idx = FIRST_VARIANT;
+                    let variant_def = &def.variants()[variant_idx];
+                    (variant_idx, op.clone(), variant_def.name.to_string())
+                };
+
                 let variant_def = &def.variants()[variant_idx];
-                let name = variant_def.name.to_string();
 
                 let mut fields = Vec::with_capacity(variant_def.fields.len());
                 for i in 0..variant_def.fields.len() {
                     let field_idx = FieldIdx::from_usize(i);
                     // `project_field` avoids manual offset math and works for both
                     // immediate and memory-backed operands through `Projectable`.
-                    let field_op = match self.ecx.project_field(&op, field_idx).discard_err() {
+                    let field_op = match self.ecx.project_field(&down, field_idx).discard_err() {
                         Some(field_op) => field_op,
                         // FIXME: preserve the successfully rendered fields and
                         // mark only this field as unavailable once the value model
@@ -572,9 +601,9 @@ impl<'tcx> PrirodaContext<'tcx> {
                 }
 
                 // Match Rust constructor spelling:
-                // - `Const`: unit structs, e.g. `UnitStruct`
-                // - `Fn`: tuple structs, e.g. `Pair(a, b)` or `EmptyTuple()`
-                // - `None`: braced structs, including the empty `{}` case
+                // - `Const`: unit structs/variants, e.g. `UnitStruct`, `Enum::Unit`
+                // - `Fn`: tuple structs/variants, e.g. `Pair(a, b)` or `EmptyTuple()`
+                // - `None`: braced structs/variants, including the empty `{}` case
                 match variant_def.ctor_kind() {
                     Some(CtorKind::Const) => name,
                     Some(CtorKind::Fn) => format!("{name}({})", fields.join(", ")),

--- a/priroda/src/main.rs
+++ b/priroda/src/main.rs
@@ -23,13 +23,14 @@ use std::path::PathBuf;
 
 use miri::Immediate::Uninit;
 use miri::{interpret, *};
-use rustc_abi::Size;
+use rustc_abi::{FIRST_VARIANT, FieldIdx, Size};
 use rustc_driver::Compilation;
 use rustc_hir::attrs::CrateType;
+use rustc_hir::def::CtorKind;
 use rustc_interface::interface;
 use rustc_middle::mir::interpret::AllocId;
 use rustc_middle::mir::{self, Local, ProjectionElem, VarDebugInfoContents, VarDebugInfoFragment};
-use rustc_middle::ty::{TyCtxt, TyKind};
+use rustc_middle::ty::{self, TyCtxt, TyKind};
 use rustc_session::EarlyDiagCtxt;
 use rustc_session::config::ErrorOutputType;
 use rustc_span::source_map::SourceMap;
@@ -541,7 +542,61 @@ impl<'tcx> PrirodaContext<'tcx> {
             return self.render_op(op);
         }
 
-        self.render_op(op)
+        match op.layout.ty.kind() {
+            // Empty enums have no active variant to format. Unions do not record
+            // which field is currently active, so choosing one would be misleading.
+            //
+            // FIXME: support unions only with an explicit user-selected field or
+            // another source of active-field information. Guessing from layout
+            // bytes would make debugger output look more certain than it is.
+            ty::Adt(def, _) if def.variants().is_empty() || def.is_union() => self.render_op(op),
+
+            ty::Adt(def, _) if def.is_struct() => {
+                let variant_idx = FIRST_VARIANT;
+                let variant_def = &def.variants()[variant_idx];
+                let name = variant_def.name.to_string();
+
+                let mut fields = Vec::with_capacity(variant_def.fields.len());
+                for i in 0..variant_def.fields.len() {
+                    let field_idx = FieldIdx::from_usize(i);
+                    // `project_field` avoids manual offset math and works for both
+                    // immediate and memory-backed operands through `Projectable`.
+                    let field_op = match self.ecx.project_field(&op, field_idx).discard_err() {
+                        Some(field_op) => field_op,
+                        // FIXME: preserve the successfully rendered fields and
+                        // mark only this field as unavailable once the value model
+                        // can represent partial render failures.
+                        None => return self.render_op(op),
+                    };
+                    fields.push(self.render_source_shaped_op_inner(field_op, depth + 1));
+                }
+
+                // Match Rust constructor spelling:
+                // - `Const`: unit structs, e.g. `UnitStruct`
+                // - `Fn`: tuple structs, e.g. `Pair(a, b)` or `EmptyTuple()`
+                // - `None`: braced structs, including the empty `{}` case
+                match variant_def.ctor_kind() {
+                    Some(CtorKind::Const) => name,
+                    Some(CtorKind::Fn) => format!("{name}({})", fields.join(", ")),
+                    None if fields.is_empty() => format!("{name} {{}}"),
+                    None => {
+                        let fields = variant_def
+                            .fields
+                            .iter()
+                            .zip(fields)
+                            .map(|(field_def, value)| format!("{}: {value}", field_def.name))
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        format!("{name} {{ {fields} }}")
+                    }
+                }
+            }
+
+            // FIXME: consider source-shaped special cases for strings, closures,
+            // generators/coroutines, trait objects, and SIMD/vector-like types.
+            // Until then these stay on the raw renderer path.
+            _ => self.render_op(op),
+        }
     }
 
     /// Render an evaluated operand using the same raw representation for

--- a/priroda/src/main.rs
+++ b/priroda/src/main.rs
@@ -644,6 +644,34 @@ impl<'tcx> PrirodaContext<'tcx> {
                 }
             }
 
+            ty::Array(_, _) | ty::Slice(_) => {
+                // `project_array_fields` uses the dynamic length for slices. That
+                // avoids the classic mistake of treating slice layout as a fixed
+                // zero-length array.
+                let mut iter = match self.ecx.project_array_fields(&op).discard_err() {
+                    Some(iter) => iter,
+                    // FIXME: when slice metadata is invalid, show that as a slice
+                    // length problem instead of silently falling back to raw bytes.
+                    None => return self.render_op(op),
+                };
+
+                let mut fields = Vec::new();
+                // FIXME: add an output budget/truncation policy before rendering
+                // very large arrays or slices in full.
+                loop {
+                    match iter.next(&self.ecx).discard_err() {
+                        Some(Some((_idx, field_op))) =>
+                            fields.push(self.render_source_shaped_op_inner(field_op, depth + 1)),
+                        Some(None) => break,
+                        // FIXME: keep already-rendered elements and mark the
+                        // failed index once partial render errors are supported.
+                        None => return self.render_op(op),
+                    }
+                }
+
+                format!("[{}]", fields.join(", "))
+            }
+
             // FIXME: consider source-shaped special cases for strings, closures,
             // generators/coroutines, trait objects, and SIMD/vector-like types.
             // Until then these stay on the raw renderer path.

--- a/priroda/src/main.rs
+++ b/priroda/src/main.rs
@@ -505,6 +505,45 @@ impl<'tcx> PrirodaContext<'tcx> {
         interp_ok(format!("[{}]", rendered.join(" ")))
     }
 
+    /// Render an evaluated operand using Rust-source-shaped containers with raw leaves.
+    ///
+    /// The operand is produced from live interpreter state, usually via `local_to_op`
+    /// for a whole MIR local or `eval_place_to_op` for a projected debug-info place.
+    ///
+    /// This intentionally does not call user `Debug` / `Display`, and it does not
+    /// try to make every scalar leaf pretty yet. Unsupported cases and leaf values
+    /// fall back to `render_op`, preserving the old raw byte/provenance renderer.
+    ///
+    /// FIXME: teach the leaf renderer about simple Rust scalars (`bool`, integers,
+    /// chars, raw pointers/references) once the source-shaped container output is
+    /// stable enough to stop depending on byte dumps for every field.
+    ///
+    /// FIXME: decide how much dereferencing belongs in this renderer. References
+    /// currently stay as raw pointer leaves; following them may belong in the
+    /// existing `follow` command instead of automatic local rendering.
+    fn render_source_shaped_op(&self, op: OpTy<'tcx>) -> String {
+        self.render_source_shaped_op_inner(op, 0)
+    }
+
+    /// Recursive worker for `render_source_shaped_op`.
+    ///
+    /// The depth limit keeps cyclic/reference-heavy values from making debugger
+    /// output explode once more container kinds are added. At the limit, the raw
+    /// renderer remains the ground truth.
+    ///
+    /// FIXME: replace this fixed recursion limit with a value-size/output-budget
+    /// policy so large acyclic values and deeply nested values degrade more
+    /// predictably.
+    fn render_source_shaped_op_inner(&self, op: OpTy<'tcx>, depth: usize) -> String {
+        const MAX_SOURCE_SHAPE_DEPTH: usize = 8;
+
+        if depth >= MAX_SOURCE_SHAPE_DEPTH {
+            return self.render_op(op);
+        }
+
+        self.render_op(op)
+    }
+
     /// Render an evaluated operand using the same raw representation for
     /// whole locals and projected MIR places.
     fn render_op(&self, op: OpTy<'tcx>) -> String {
@@ -613,7 +652,7 @@ impl<'tcx> PrirodaContext<'tcx> {
                     .ecx
                     .local_to_op(local, None)
                     .expect("this error can only occur in CTFE on generic code");
-                local_desc.value = self.render_op(op);
+                local_desc.value = self.render_source_shaped_op(op);
             }
         };
 
@@ -682,7 +721,7 @@ impl<'tcx> PrirodaContext<'tcx> {
                     let value = self
                         .ecx
                         .eval_place_to_op(*place, None)
-                        .map(|op| self.render_op(op))
+                        .map(|op| self.render_source_shaped_op(op))
                         .unwrap_or_else(|err| {
                             format!("<error: {}>", interpret::format_interp_error(err))
                         });

--- a/priroda/src/main.rs
+++ b/priroda/src/main.rs
@@ -621,6 +621,29 @@ impl<'tcx> PrirodaContext<'tcx> {
                 }
             }
 
+            ty::Tuple(args) => {
+                let mut fields = Vec::with_capacity(args.len());
+                for i in 0..args.len() {
+                    // Tuples have no field names in source, so preserve their
+                    // source field order and render children positionally.
+                    let field_op =
+                        match self.ecx.project_field(&op, FieldIdx::from_usize(i)).discard_err() {
+                            Some(field_op) => field_op,
+                            // FIXME: render tuple fields independently so one
+                            // projection failure does not throw away the whole
+                            // source-shaped tuple.
+                            None => return self.render_op(op),
+                        };
+                    fields.push(self.render_source_shaped_op_inner(field_op, depth + 1));
+                }
+
+                if fields.len() == 1 {
+                    format!("({},)", fields[0])
+                } else {
+                    format!("({})", fields.join(", "))
+                }
+            }
+
             // FIXME: consider source-shaped special cases for strings, closures,
             // generators/coroutines, trait objects, and SIMD/vector-like types.
             // Until then these stay on the raw renderer path.

--- a/priroda/tests/ui/locals_access_field.stdout
+++ b/priroda/tests/ui/locals_access_field.stdout
@@ -2,11 +2,11 @@
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_access_field.rs:14
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: extraslice, Id: _1, Ty: ExtraSlice<'_>, Value: [{ALLOC_PTR} 00 00 00 00 00 00 00 00 00 00 00 00 __ __ __ __]
+Name: extraslice, Id: _1, Ty: ExtraSlice<'_>, Value: ExtraSlice { _slice: [{ALLOC_PTR} 00 00 00 00 00 00 00 00], _extra: [00 00 00 00] }
 Name: _slice, Id: _2, Ty: &[u8], Value: (pointer to {ALLOC_PTR}, 0x0000000000000000): &[u8]
 Name: _extra, Id: _3, Ty: u32, Value: 0_u32
 (priroda) Id: _0, Ty: (), Value: <uninit>
-(priroda) Id: _1, Ty: ExtraSlice<'_>, Value: [{ALLOC_PTR} 00 00 00 00 00 00 00 00 00 00 00 00 __ __ __ __]
+(priroda) Id: _1, Ty: ExtraSlice<'_>, Value: ExtraSlice { _slice: [{ALLOC_PTR} 00 00 00 00 00 00 00 00], _extra: [00 00 00 00] }
 (priroda) Id: _2, Ty: &[u8], Value: (pointer to {ALLOC_PTR}, 0x0000000000000000): &[u8]
 (priroda) Id: _3, Ty: u32, Value: 0_u32
 (priroda) no local for this id

--- a/priroda/tests/ui/locals_corpus_async.stdout
+++ b/priroda/tests/ui/locals_corpus_async.stdout
@@ -13,7 +13,7 @@ Name: second, Id: _1.1, Ty: i32, Value: 6_i32
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:45
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: <none>, Id: _1, Ty: S, Value: {transmute(0x40a00000): S}
+Name: <none>, Id: _1, Ty: S, Value: S { x: 5f32 }
 Name: x, Id: _1.0, Ty: f32, Value: 5f32
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:55

--- a/priroda/tests/ui/locals_corpus_async.stdout
+++ b/priroda/tests/ui/locals_corpus_async.stdout
@@ -7,7 +7,7 @@
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:31
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: <none>, Id: _1, Ty: (u32, i32), Value: (0x00000005, 0x00000006): (u32, i32)
+Name: <none>, Id: _1, Ty: (u32, i32), Value: (5_u32, 6_i32)
 Name: first, Id: _1.0, Ty: u32, Value: 5_u32
 Name: second, Id: _1.1, Ty: i32, Value: 6_i32
 (priroda) Hit breakpoint

--- a/priroda/tests/ui/locals_corpus_async.stdout
+++ b/priroda/tests/ui/locals_corpus_async.stdout
@@ -18,12 +18,12 @@ Name: x, Id: _1.0, Ty: f32, Value: 5f32
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:55
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: <none>, Id: _1, Ty: std::option::Option<i32>, Value: [01 00 00 00 05 00 00 00]
+Name: <none>, Id: _1, Ty: std::option::Option<i32>, Value: Option::Some([05 00 00 00])
 Name: inner, Id: _1 as variant#1.0, Ty: i32, Value: [05 00 00 00]
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_corpus_async.rs:66
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: <none>, Id: _1, Ty: std::option::Option<&i32>, Value: [{ALLOC_PTR}]
+Name: <none>, Id: _1, Ty: std::option::Option<&i32>, Value: Option::Some([{ALLOC_PTR}])
 Name: pointer, Id: _1 as variant#1.0, Ty: &i32, Value: [{ALLOC_PTR}]
 Name: deref, Id: _1 as variant#1.0.*, Ty: i32, Value: [05 00 00 00]
 (priroda) Allocation alloc2+0: [05 00 00 00]

--- a/priroda/tests/ui/locals_mplace_metadata.stdout
+++ b/priroda/tests/ui/locals_mplace_metadata.stdout
@@ -4,10 +4,10 @@
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_mplace_metadata.rs:8
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: slice, Id: _1, Ty: [u8], Value: [01 02 03]
+Name: slice, Id: _1, Ty: [u8], Value: [[01], [02], [03]]
 Name: <none>, Id: _2, Ty: &[u8], Value: <dead>
 Name: <none>, Id: _3, Ty: &[u8], Value: <dead>
-(priroda) Id: _1, Ty: [u8], Value: [01 02 03]
+(priroda) Id: _1, Ty: [u8], Value: [[01], [02], [03]]
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_mplace_metadata.rs:12
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>

--- a/priroda/tests/ui/locals_pointer_rendering.stdout
+++ b/priroda/tests/ui/locals_pointer_rendering.stdout
@@ -2,13 +2,13 @@
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_pointer_rendering.rs:59
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: target, Id: _1, Ty: [u8; 2], Value: [0a 14]
+Name: target, Id: _1, Ty: [u8; 2], Value: [[0a], [14]]
 Name: pointer_at_offset0, Id: _2, Ty: PointerAtOffset0<'_>, Value: PointerAtOffset0 { ptr: [{ALLOC_PTR}] }
 Name: <none>, Id: _3, Ty: &u8, Value: <dead>
 Name: <none>, Id: _4, Ty: &u8, Value: <dead>
 Name: <none>, Id: _5, Ty: usize, Value: <dead>
 Name: <none>, Id: _6, Ty: bool, Value: true
-Name: pointer_after_bytes, Id: _7, Ty: PointerAfterBytes<'_>, Value: PointerAfterBytes { bytes: [01 02 03], ptr: [{ALLOC_PTR}] }
+Name: pointer_after_bytes, Id: _7, Ty: PointerAfterBytes<'_>, Value: PointerAfterBytes { bytes: [[01], [02], [03]], ptr: [{ALLOC_PTR}] }
 Name: <none>, Id: _8, Ty: [u8; 3], Value: <dead>
 Name: <none>, Id: _9, Ty: &u8, Value: <dead>
 Name: <none>, Id: _10, Ty: &u8, Value: <dead>
@@ -32,7 +32,7 @@ Name: <none>, Id: _27, Ty: &u8, Value: <dead>
 Name: <none>, Id: _28, Ty: usize, Value: <dead>
 Name: <none>, Id: _29, Ty: bool, Value: true
 Name: fixed_addr_ptr, Id: _30, Ty: *const u8, Value: [0x1234[wildcard]]
-Name: short_pointer_bytes, Id: _31, Ty: [u8; 1], Value: [34]
+Name: short_pointer_bytes, Id: _31, Ty: [u8; 1], Value: [[34]]
 Name: bytes, Id: _32, Ty: std::mem::MaybeUninit<[u8; 1]>, Value: <dead>
 Name: <none>, Id: _33, Ty: (), Value: <dead>
 Name: <none>, Id: _34, Ty: *const u8, Value: <dead>

--- a/priroda/tests/ui/locals_pointer_rendering.stdout
+++ b/priroda/tests/ui/locals_pointer_rendering.stdout
@@ -3,30 +3,30 @@
 {MANIFEST_DIR}/tests/ui/locals_pointer_rendering.rs:59
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
 Name: target, Id: _1, Ty: [u8; 2], Value: [0a 14]
-Name: pointer_at_offset0, Id: _2, Ty: PointerAtOffset0<'_>, Value: [{ALLOC_PTR}]
+Name: pointer_at_offset0, Id: _2, Ty: PointerAtOffset0<'_>, Value: PointerAtOffset0 { ptr: [{ALLOC_PTR}] }
 Name: <none>, Id: _3, Ty: &u8, Value: <dead>
 Name: <none>, Id: _4, Ty: &u8, Value: <dead>
 Name: <none>, Id: _5, Ty: usize, Value: <dead>
 Name: <none>, Id: _6, Ty: bool, Value: true
-Name: pointer_after_bytes, Id: _7, Ty: PointerAfterBytes<'_>, Value: [01 02 03 __ __ __ __ __ {ALLOC_PTR}]
+Name: pointer_after_bytes, Id: _7, Ty: PointerAfterBytes<'_>, Value: PointerAfterBytes { bytes: [01 02 03], ptr: [{ALLOC_PTR}] }
 Name: <none>, Id: _8, Ty: [u8; 3], Value: <dead>
 Name: <none>, Id: _9, Ty: &u8, Value: <dead>
 Name: <none>, Id: _10, Ty: &u8, Value: <dead>
 Name: <none>, Id: _11, Ty: usize, Value: <dead>
 Name: <none>, Id: _12, Ty: bool, Value: true
-Name: pointer_at_end, Id: _13, Ty: PointerAtEnd<'_>, Value: [04 __ __ __ __ __ __ __ {ALLOC_PTR}]
+Name: pointer_at_end, Id: _13, Ty: PointerAtEnd<'_>, Value: PointerAtEnd { byte: [04], ptr: [{ALLOC_PTR}] }
 Name: <none>, Id: _14, Ty: &u8, Value: <dead>
 Name: <none>, Id: _15, Ty: &u8, Value: <dead>
 Name: <none>, Id: _16, Ty: usize, Value: <dead>
 Name: <none>, Id: _17, Ty: bool, Value: true
-Name: uninit_around_pointer, Id: _18, Ty: UninitAroundPointer<'_>, Value: [__ __ __ __ __ __ __ __ {ALLOC_PTR} __ __ __ __ __ __ __ __]
+Name: uninit_around_pointer, Id: _18, Ty: UninitAroundPointer<'_>, Value: UninitAroundPointer { before: [__ __], ptr: [{ALLOC_PTR}], after: [__ __] }
 Name: <none>, Id: _19, Ty: std::mem::MaybeUninit<[u8; 2]>, Value: <dead>
 Name: <none>, Id: _20, Ty: &u8, Value: <dead>
 Name: <none>, Id: _21, Ty: &u8, Value: <dead>
 Name: <none>, Id: _22, Ty: usize, Value: <dead>
 Name: <none>, Id: _23, Ty: bool, Value: true
 Name: <none>, Id: _24, Ty: std::mem::MaybeUninit<[u8; 2]>, Value: <dead>
-Name: integer_and_pointer, Id: _25, Ty: IntegerAndPointer<'_>, Value: [11 22 33 44 __ __ __ __ {ALLOC_PTR}]
+Name: integer_and_pointer, Id: _25, Ty: IntegerAndPointer<'_>, Value: IntegerAndPointer { integer: [11 22 33 44], ptr: [{ALLOC_PTR}] }
 Name: <none>, Id: _26, Ty: &u8, Value: <dead>
 Name: <none>, Id: _27, Ty: &u8, Value: <dead>
 Name: <none>, Id: _28, Ty: usize, Value: <dead>
@@ -52,5 +52,5 @@ Name: <none>, Id: _47, Ty: &UninitAroundPointer<'_>, Value: <dead>
 Name: <none>, Id: _48, Ty: &IntegerAndPointer<'_>, Value: <dead>
 Name: <none>, Id: _49, Ty: &*const u8, Value: <dead>
 Name: <none>, Id: _50, Ty: &[u8; 1], Value: <dead>
-(priroda) Id: _2, Ty: PointerAtOffset0<'_>, Value: [{ALLOC_PTR}]
+(priroda) Id: _2, Ty: PointerAtOffset0<'_>, Value: PointerAtOffset0 { ptr: [{ALLOC_PTR}] }
 (priroda) quitting

--- a/priroda/tests/ui/locals_projected_mplace_size.stdout
+++ b/priroda/tests/ui/locals_projected_mplace_size.stdout
@@ -2,9 +2,9 @@
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_projected_mplace_size.rs:36
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: <none>, Id: _1, Ty: Envelope, Value: [aa __ __ __ 22 11 33 __ 77 66 55 44 88 __ __ __ 00 ff ee dd cc bb aa 99 34 12 __ __ __ __ __ __]
+Name: <none>, Id: _1, Ty: Envelope, Value: Envelope { prefix: [aa], target: Payload { a: [22 11], b: [33], c: [77 66 55 44], d: [88] }, trailer: [00 ff ee dd cc bb aa 99], checksum: [34 12] }
 Name: prefix, Id: _1.0, Ty: u8, Value: [aa]
-Name: target, Id: _1.1, Ty: Payload, Value: [22 11 33 __ 77 66 55 44 88 __ __ __]
+Name: target, Id: _1.1, Ty: Payload, Value: Payload { a: [22 11], b: [33], c: [77 66 55 44], d: [88] }
 Name: trailer, Id: _1.2, Ty: u64, Value: [00 ff ee dd cc bb aa 99]
 Name: checksum, Id: _1.3, Ty: u16, Value: [34 12]
 (priroda) quitting

--- a/priroda/tests/ui/locals_source_shapes.rs
+++ b/priroda/tests/ui/locals_source_shapes.rs
@@ -1,0 +1,72 @@
+#![allow(dead_code, unused_variables)]
+
+struct Named {
+    a: u8,
+    b: u16,
+}
+
+struct EmptyBraced {}
+
+struct UnitStruct;
+
+struct TupleStruct(u8, u16);
+
+struct SingleTupleStruct(u8);
+
+struct ZeroTupleStruct();
+
+enum Variants {
+    Unit,
+    Tuple(u8, u16),
+    SingleTuple(u8),
+    Struct { n: u32, ok: bool },
+    EmptyStruct {},
+}
+
+union RawUnion {
+    byte: u8,
+    word: u16,
+}
+
+fn main() {
+    let named = Named { a: 0x01, b: 0x0302 };
+    let empty_braced = EmptyBraced {};
+    let unit_struct = UnitStruct;
+    let tuple_struct = TupleStruct(0x04, 0x0605);
+    let single_tuple_struct = SingleTupleStruct(0x07);
+    let zero_tuple_struct = ZeroTupleStruct();
+    let tuple_zero = ();
+    let tuple_one = (0x08_u8,);
+    let tuple_many = (0x09_u8, 0x0b0a_u16);
+    let array_zero: [u8; 0] = [];
+    let array_one = [0x0c_u8];
+    let array_many = [0x0d_u8, 0x0e, 0x0f];
+    let variant_unit = Variants::Unit;
+    let variant_tuple = Variants::Tuple(0x10, 0x1211);
+    let variant_single_tuple = Variants::SingleTuple(0x13);
+    let variant_struct = Variants::Struct { n: 0x17161514, ok: false };
+    let variant_empty_struct = Variants::EmptyStruct {};
+    let raw_union = RawUnion { word: 0x1918 };
+
+    std::hint::black_box((
+        &named,
+        &empty_braced,
+        &unit_struct,
+        &tuple_struct,
+        &single_tuple_struct,
+        &zero_tuple_struct,
+        &tuple_zero,
+        &tuple_one,
+        &tuple_many,
+        &array_zero,
+        &array_one,
+        &array_many,
+        &variant_unit,
+        &variant_tuple,
+        &variant_single_tuple,
+        &variant_struct,
+        &variant_empty_struct,
+        &raw_union,
+    ));
+    std::hint::black_box(0_u8);
+}

--- a/priroda/tests/ui/locals_source_shapes.stdin
+++ b/priroda/tests/ui/locals_source_shapes.stdin
@@ -1,0 +1,22 @@
+break tests/ui/locals_source_shapes.rs:71
+continue
+locals
+print 1
+print 2
+print 3
+print 4
+print 5
+print 6
+print 7
+print 8
+print 9
+print 10
+print 11
+print 12
+print 13
+print 14
+print 15
+print 16
+print 17
+print 18
+quit

--- a/priroda/tests/ui/locals_source_shapes.stdout
+++ b/priroda/tests/ui/locals_source_shapes.stdout
@@ -12,8 +12,8 @@ Name: tuple_zero, Id: _7, Ty: (), Value: ()
 Name: tuple_one, Id: _8, Ty: (u8,), Value: ([08],)
 Name: tuple_many, Id: _9, Ty: (u8, u16), Value: ([09], [0a 0b])
 Name: array_zero, Id: _10, Ty: [u8; 0], Value: []
-Name: array_one, Id: _11, Ty: [u8; 1], Value: [0c]
-Name: array_many, Id: _12, Ty: [u8; 3], Value: [0d 0e 0f]
+Name: array_one, Id: _11, Ty: [u8; 1], Value: [[0c]]
+Name: array_many, Id: _12, Ty: [u8; 3], Value: [[0d], [0e], [0f]]
 Name: variant_unit, Id: _13, Ty: Variants, Value: Variants::Unit
 Name: variant_tuple, Id: _14, Ty: Variants, Value: Variants::Tuple([10], [11 12])
 Name: variant_single_tuple, Id: _15, Ty: Variants, Value: Variants::SingleTuple([13])
@@ -51,8 +51,8 @@ Name: <none>, Id: _39, Ty: u8, Value: <dead>
 (priroda) Id: _8, Ty: (u8,), Value: ([08],)
 (priroda) Id: _9, Ty: (u8, u16), Value: ([09], [0a 0b])
 (priroda) Id: _10, Ty: [u8; 0], Value: []
-(priroda) Id: _11, Ty: [u8; 1], Value: [0c]
-(priroda) Id: _12, Ty: [u8; 3], Value: [0d 0e 0f]
+(priroda) Id: _11, Ty: [u8; 1], Value: [[0c]]
+(priroda) Id: _12, Ty: [u8; 3], Value: [[0d], [0e], [0f]]
 (priroda) Id: _13, Ty: Variants, Value: Variants::Unit
 (priroda) Id: _14, Ty: Variants, Value: Variants::Tuple([10], [11 12])
 (priroda) Id: _15, Ty: Variants, Value: Variants::SingleTuple([13])

--- a/priroda/tests/ui/locals_source_shapes.stdout
+++ b/priroda/tests/ui/locals_source_shapes.stdout
@@ -8,9 +8,9 @@ Name: unit_struct, Id: _3, Ty: UnitStruct, Value: UnitStruct
 Name: tuple_struct, Id: _4, Ty: TupleStruct, Value: TupleStruct([04], [05 06])
 Name: single_tuple_struct, Id: _5, Ty: SingleTupleStruct, Value: SingleTupleStruct([07])
 Name: zero_tuple_struct, Id: _6, Ty: ZeroTupleStruct, Value: ZeroTupleStruct()
-Name: tuple_zero, Id: _7, Ty: (), Value: []
-Name: tuple_one, Id: _8, Ty: (u8,), Value: [08]
-Name: tuple_many, Id: _9, Ty: (u8, u16), Value: [09 __ 0a 0b]
+Name: tuple_zero, Id: _7, Ty: (), Value: ()
+Name: tuple_one, Id: _8, Ty: (u8,), Value: ([08],)
+Name: tuple_many, Id: _9, Ty: (u8, u16), Value: ([09], [0a 0b])
 Name: array_zero, Id: _10, Ty: [u8; 0], Value: []
 Name: array_one, Id: _11, Ty: [u8; 1], Value: [0c]
 Name: array_many, Id: _12, Ty: [u8; 3], Value: [0d 0e 0f]
@@ -47,9 +47,9 @@ Name: <none>, Id: _39, Ty: u8, Value: <dead>
 (priroda) Id: _4, Ty: TupleStruct, Value: TupleStruct([04], [05 06])
 (priroda) Id: _5, Ty: SingleTupleStruct, Value: SingleTupleStruct([07])
 (priroda) Id: _6, Ty: ZeroTupleStruct, Value: ZeroTupleStruct()
-(priroda) Id: _7, Ty: (), Value: []
-(priroda) Id: _8, Ty: (u8,), Value: [08]
-(priroda) Id: _9, Ty: (u8, u16), Value: [09 __ 0a 0b]
+(priroda) Id: _7, Ty: (), Value: ()
+(priroda) Id: _8, Ty: (u8,), Value: ([08],)
+(priroda) Id: _9, Ty: (u8, u16), Value: ([09], [0a 0b])
 (priroda) Id: _10, Ty: [u8; 0], Value: []
 (priroda) Id: _11, Ty: [u8; 1], Value: [0c]
 (priroda) Id: _12, Ty: [u8; 3], Value: [0d 0e 0f]

--- a/priroda/tests/ui/locals_source_shapes.stdout
+++ b/priroda/tests/ui/locals_source_shapes.stdout
@@ -14,11 +14,11 @@ Name: tuple_many, Id: _9, Ty: (u8, u16), Value: [09 __ 0a 0b]
 Name: array_zero, Id: _10, Ty: [u8; 0], Value: []
 Name: array_one, Id: _11, Ty: [u8; 1], Value: [0c]
 Name: array_many, Id: _12, Ty: [u8; 3], Value: [0d 0e 0f]
-Name: variant_unit, Id: _13, Ty: Variants, Value: [00 __ __ __ __ __ __ __]
-Name: variant_tuple, Id: _14, Ty: Variants, Value: [01 10 11 12 __ __ __ __]
-Name: variant_single_tuple, Id: _15, Ty: Variants, Value: [02 13 __ __ __ __ __ __]
-Name: variant_struct, Id: _16, Ty: Variants, Value: [03 00 __ __ 14 15 16 17]
-Name: variant_empty_struct, Id: _17, Ty: Variants, Value: [04 __ __ __ __ __ __ __]
+Name: variant_unit, Id: _13, Ty: Variants, Value: Variants::Unit
+Name: variant_tuple, Id: _14, Ty: Variants, Value: Variants::Tuple([10], [11 12])
+Name: variant_single_tuple, Id: _15, Ty: Variants, Value: Variants::SingleTuple([13])
+Name: variant_struct, Id: _16, Ty: Variants, Value: Variants::Struct { n: [14 15 16 17], ok: [00] }
+Name: variant_empty_struct, Id: _17, Ty: Variants, Value: Variants::EmptyStruct {}
 Name: raw_union, Id: _18, Ty: RawUnion, Value: [18 19]
 Name: <none>, Id: _19, Ty: (&Named, &EmptyBraced, &UnitStruct, &TupleStruct, &SingleTupleStruct, &ZeroTupleStruct, &(), &(u8,), &(u8, u16), &[u8; 0], &[u8; 1], &[u8; 3], &Variants, &Variants, &Variants, &Variants, &Variants, &RawUnion), Value: <dead>
 Name: <none>, Id: _20, Ty: (&Named, &EmptyBraced, &UnitStruct, &TupleStruct, &SingleTupleStruct, &ZeroTupleStruct, &(), &(u8,), &(u8, u16), &[u8; 0], &[u8; 1], &[u8; 3], &Variants, &Variants, &Variants, &Variants, &Variants, &RawUnion), Value: <dead>
@@ -53,10 +53,10 @@ Name: <none>, Id: _39, Ty: u8, Value: <dead>
 (priroda) Id: _10, Ty: [u8; 0], Value: []
 (priroda) Id: _11, Ty: [u8; 1], Value: [0c]
 (priroda) Id: _12, Ty: [u8; 3], Value: [0d 0e 0f]
-(priroda) Id: _13, Ty: Variants, Value: [00 __ __ __ __ __ __ __]
-(priroda) Id: _14, Ty: Variants, Value: [01 10 11 12 __ __ __ __]
-(priroda) Id: _15, Ty: Variants, Value: [02 13 __ __ __ __ __ __]
-(priroda) Id: _16, Ty: Variants, Value: [03 00 __ __ 14 15 16 17]
-(priroda) Id: _17, Ty: Variants, Value: [04 __ __ __ __ __ __ __]
+(priroda) Id: _13, Ty: Variants, Value: Variants::Unit
+(priroda) Id: _14, Ty: Variants, Value: Variants::Tuple([10], [11 12])
+(priroda) Id: _15, Ty: Variants, Value: Variants::SingleTuple([13])
+(priroda) Id: _16, Ty: Variants, Value: Variants::Struct { n: [14 15 16 17], ok: [00] }
+(priroda) Id: _17, Ty: Variants, Value: Variants::EmptyStruct {}
 (priroda) Id: _18, Ty: RawUnion, Value: [18 19]
 (priroda) quitting

--- a/priroda/tests/ui/locals_source_shapes.stdout
+++ b/priroda/tests/ui/locals_source_shapes.stdout
@@ -2,12 +2,12 @@
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_source_shapes.rs:71
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: named, Id: _1, Ty: Named, Value: [02 03 01 __]
-Name: empty_braced, Id: _2, Ty: EmptyBraced, Value: []
-Name: unit_struct, Id: _3, Ty: UnitStruct, Value: []
-Name: tuple_struct, Id: _4, Ty: TupleStruct, Value: [05 06 04 __]
-Name: single_tuple_struct, Id: _5, Ty: SingleTupleStruct, Value: [07]
-Name: zero_tuple_struct, Id: _6, Ty: ZeroTupleStruct, Value: []
+Name: named, Id: _1, Ty: Named, Value: Named { a: [01], b: [02 03] }
+Name: empty_braced, Id: _2, Ty: EmptyBraced, Value: EmptyBraced {}
+Name: unit_struct, Id: _3, Ty: UnitStruct, Value: UnitStruct
+Name: tuple_struct, Id: _4, Ty: TupleStruct, Value: TupleStruct([04], [05 06])
+Name: single_tuple_struct, Id: _5, Ty: SingleTupleStruct, Value: SingleTupleStruct([07])
+Name: zero_tuple_struct, Id: _6, Ty: ZeroTupleStruct, Value: ZeroTupleStruct()
 Name: tuple_zero, Id: _7, Ty: (), Value: []
 Name: tuple_one, Id: _8, Ty: (u8,), Value: [08]
 Name: tuple_many, Id: _9, Ty: (u8, u16), Value: [09 __ 0a 0b]
@@ -41,12 +41,12 @@ Name: <none>, Id: _36, Ty: &Variants, Value: <dead>
 Name: <none>, Id: _37, Ty: &Variants, Value: <dead>
 Name: <none>, Id: _38, Ty: &RawUnion, Value: <dead>
 Name: <none>, Id: _39, Ty: u8, Value: <dead>
-(priroda) Id: _1, Ty: Named, Value: [02 03 01 __]
-(priroda) Id: _2, Ty: EmptyBraced, Value: []
-(priroda) Id: _3, Ty: UnitStruct, Value: []
-(priroda) Id: _4, Ty: TupleStruct, Value: [05 06 04 __]
-(priroda) Id: _5, Ty: SingleTupleStruct, Value: [07]
-(priroda) Id: _6, Ty: ZeroTupleStruct, Value: []
+(priroda) Id: _1, Ty: Named, Value: Named { a: [01], b: [02 03] }
+(priroda) Id: _2, Ty: EmptyBraced, Value: EmptyBraced {}
+(priroda) Id: _3, Ty: UnitStruct, Value: UnitStruct
+(priroda) Id: _4, Ty: TupleStruct, Value: TupleStruct([04], [05 06])
+(priroda) Id: _5, Ty: SingleTupleStruct, Value: SingleTupleStruct([07])
+(priroda) Id: _6, Ty: ZeroTupleStruct, Value: ZeroTupleStruct()
 (priroda) Id: _7, Ty: (), Value: []
 (priroda) Id: _8, Ty: (u8,), Value: [08]
 (priroda) Id: _9, Ty: (u8, u16), Value: [09 __ 0a 0b]

--- a/priroda/tests/ui/locals_source_shapes.stdout
+++ b/priroda/tests/ui/locals_source_shapes.stdout
@@ -1,0 +1,62 @@
+(priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_source_shapes.rs:71
+(priroda) Hit breakpoint
+{MANIFEST_DIR}/tests/ui/locals_source_shapes.rs:71
+(priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
+Name: named, Id: _1, Ty: Named, Value: [02 03 01 __]
+Name: empty_braced, Id: _2, Ty: EmptyBraced, Value: []
+Name: unit_struct, Id: _3, Ty: UnitStruct, Value: []
+Name: tuple_struct, Id: _4, Ty: TupleStruct, Value: [05 06 04 __]
+Name: single_tuple_struct, Id: _5, Ty: SingleTupleStruct, Value: [07]
+Name: zero_tuple_struct, Id: _6, Ty: ZeroTupleStruct, Value: []
+Name: tuple_zero, Id: _7, Ty: (), Value: []
+Name: tuple_one, Id: _8, Ty: (u8,), Value: [08]
+Name: tuple_many, Id: _9, Ty: (u8, u16), Value: [09 __ 0a 0b]
+Name: array_zero, Id: _10, Ty: [u8; 0], Value: []
+Name: array_one, Id: _11, Ty: [u8; 1], Value: [0c]
+Name: array_many, Id: _12, Ty: [u8; 3], Value: [0d 0e 0f]
+Name: variant_unit, Id: _13, Ty: Variants, Value: [00 __ __ __ __ __ __ __]
+Name: variant_tuple, Id: _14, Ty: Variants, Value: [01 10 11 12 __ __ __ __]
+Name: variant_single_tuple, Id: _15, Ty: Variants, Value: [02 13 __ __ __ __ __ __]
+Name: variant_struct, Id: _16, Ty: Variants, Value: [03 00 __ __ 14 15 16 17]
+Name: variant_empty_struct, Id: _17, Ty: Variants, Value: [04 __ __ __ __ __ __ __]
+Name: raw_union, Id: _18, Ty: RawUnion, Value: [18 19]
+Name: <none>, Id: _19, Ty: (&Named, &EmptyBraced, &UnitStruct, &TupleStruct, &SingleTupleStruct, &ZeroTupleStruct, &(), &(u8,), &(u8, u16), &[u8; 0], &[u8; 1], &[u8; 3], &Variants, &Variants, &Variants, &Variants, &Variants, &RawUnion), Value: <dead>
+Name: <none>, Id: _20, Ty: (&Named, &EmptyBraced, &UnitStruct, &TupleStruct, &SingleTupleStruct, &ZeroTupleStruct, &(), &(u8,), &(u8, u16), &[u8; 0], &[u8; 1], &[u8; 3], &Variants, &Variants, &Variants, &Variants, &Variants, &RawUnion), Value: <dead>
+Name: <none>, Id: _21, Ty: &Named, Value: <dead>
+Name: <none>, Id: _22, Ty: &EmptyBraced, Value: <dead>
+Name: <none>, Id: _23, Ty: &UnitStruct, Value: <dead>
+Name: <none>, Id: _24, Ty: &TupleStruct, Value: <dead>
+Name: <none>, Id: _25, Ty: &SingleTupleStruct, Value: <dead>
+Name: <none>, Id: _26, Ty: &ZeroTupleStruct, Value: <dead>
+Name: <none>, Id: _27, Ty: &(), Value: <dead>
+Name: <none>, Id: _28, Ty: &(u8,), Value: <dead>
+Name: <none>, Id: _29, Ty: &(u8, u16), Value: <dead>
+Name: <none>, Id: _30, Ty: &[u8; 0], Value: <dead>
+Name: <none>, Id: _31, Ty: &[u8; 1], Value: <dead>
+Name: <none>, Id: _32, Ty: &[u8; 3], Value: <dead>
+Name: <none>, Id: _33, Ty: &Variants, Value: <dead>
+Name: <none>, Id: _34, Ty: &Variants, Value: <dead>
+Name: <none>, Id: _35, Ty: &Variants, Value: <dead>
+Name: <none>, Id: _36, Ty: &Variants, Value: <dead>
+Name: <none>, Id: _37, Ty: &Variants, Value: <dead>
+Name: <none>, Id: _38, Ty: &RawUnion, Value: <dead>
+Name: <none>, Id: _39, Ty: u8, Value: <dead>
+(priroda) Id: _1, Ty: Named, Value: [02 03 01 __]
+(priroda) Id: _2, Ty: EmptyBraced, Value: []
+(priroda) Id: _3, Ty: UnitStruct, Value: []
+(priroda) Id: _4, Ty: TupleStruct, Value: [05 06 04 __]
+(priroda) Id: _5, Ty: SingleTupleStruct, Value: [07]
+(priroda) Id: _6, Ty: ZeroTupleStruct, Value: []
+(priroda) Id: _7, Ty: (), Value: []
+(priroda) Id: _8, Ty: (u8,), Value: [08]
+(priroda) Id: _9, Ty: (u8, u16), Value: [09 __ 0a 0b]
+(priroda) Id: _10, Ty: [u8; 0], Value: []
+(priroda) Id: _11, Ty: [u8; 1], Value: [0c]
+(priroda) Id: _12, Ty: [u8; 3], Value: [0d 0e 0f]
+(priroda) Id: _13, Ty: Variants, Value: [00 __ __ __ __ __ __ __]
+(priroda) Id: _14, Ty: Variants, Value: [01 10 11 12 __ __ __ __]
+(priroda) Id: _15, Ty: Variants, Value: [02 13 __ __ __ __ __ __]
+(priroda) Id: _16, Ty: Variants, Value: [03 00 __ __ 14 15 16 17]
+(priroda) Id: _17, Ty: Variants, Value: [04 __ __ __ __ __ __ __]
+(priroda) Id: _18, Ty: RawUnion, Value: [18 19]
+(priroda) quitting

--- a/priroda/tests/ui/locals_source_slices.rs
+++ b/priroda/tests/ui/locals_source_slices.rs
@@ -1,0 +1,20 @@
+#![feature(unsized_fn_params)]
+#![allow(incomplete_features, internal_features, unused_variables)]
+
+fn slice_zero(slice: [u8]) {
+    std::hint::black_box(&slice);
+}
+
+fn slice_one(slice: [u8]) {
+    std::hint::black_box(&slice);
+}
+
+fn slice_many(slice: [u8]) {
+    std::hint::black_box(&slice);
+}
+
+fn main() {
+    slice_zero(*Box::<[u8]>::from([]));
+    slice_one(*Box::<[u8]>::from([0x1a_u8]));
+    slice_many(*Box::<[u8]>::from([0x1b_u8, 0x1c]));
+}

--- a/priroda/tests/ui/locals_source_slices.stdin
+++ b/priroda/tests/ui/locals_source_slices.stdin
@@ -1,0 +1,13 @@
+break tests/ui/locals_source_slices.rs:4
+break tests/ui/locals_source_slices.rs:8
+break tests/ui/locals_source_slices.rs:12
+continue
+locals
+print 1
+continue
+locals
+print 1
+continue
+locals
+print 1
+quit

--- a/priroda/tests/ui/locals_source_slices.stdout
+++ b/priroda/tests/ui/locals_source_slices.stdout
@@ -11,15 +11,15 @@ Name: <none>, Id: _3, Ty: &[u8], Value: <dead>
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_source_slices.rs:8
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: slice, Id: _1, Ty: [u8], Value: [1a]
+Name: slice, Id: _1, Ty: [u8], Value: [[1a]]
 Name: <none>, Id: _2, Ty: &[u8], Value: <dead>
 Name: <none>, Id: _3, Ty: &[u8], Value: <dead>
-(priroda) Id: _1, Ty: [u8], Value: [1a]
+(priroda) Id: _1, Ty: [u8], Value: [[1a]]
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_source_slices.rs:12
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: slice, Id: _1, Ty: [u8], Value: [1b 1c]
+Name: slice, Id: _1, Ty: [u8], Value: [[1b], [1c]]
 Name: <none>, Id: _2, Ty: &[u8], Value: <dead>
 Name: <none>, Id: _3, Ty: &[u8], Value: <dead>
-(priroda) Id: _1, Ty: [u8], Value: [1b 1c]
+(priroda) Id: _1, Ty: [u8], Value: [[1b], [1c]]
 (priroda) quitting

--- a/priroda/tests/ui/locals_source_slices.stdout
+++ b/priroda/tests/ui/locals_source_slices.stdout
@@ -1,0 +1,25 @@
+(priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_source_slices.rs:4
+(priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_source_slices.rs:8
+(priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_source_slices.rs:12
+(priroda) Hit breakpoint
+{MANIFEST_DIR}/tests/ui/locals_source_slices.rs:4
+(priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
+Name: slice, Id: _1, Ty: [u8], Value: []
+Name: <none>, Id: _2, Ty: &[u8], Value: <dead>
+Name: <none>, Id: _3, Ty: &[u8], Value: <dead>
+(priroda) Id: _1, Ty: [u8], Value: []
+(priroda) Hit breakpoint
+{MANIFEST_DIR}/tests/ui/locals_source_slices.rs:8
+(priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
+Name: slice, Id: _1, Ty: [u8], Value: [1a]
+Name: <none>, Id: _2, Ty: &[u8], Value: <dead>
+Name: <none>, Id: _3, Ty: &[u8], Value: <dead>
+(priroda) Id: _1, Ty: [u8], Value: [1a]
+(priroda) Hit breakpoint
+{MANIFEST_DIR}/tests/ui/locals_source_slices.rs:12
+(priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
+Name: slice, Id: _1, Ty: [u8], Value: [1b 1c]
+Name: <none>, Id: _2, Ty: &[u8], Value: <dead>
+Name: <none>, Id: _3, Ty: &[u8], Value: <dead>
+(priroda) Id: _1, Ty: [u8], Value: [1b 1c]
+(priroda) quitting

--- a/priroda/tests/ui/locals_value_shapes.rs
+++ b/priroda/tests/ui/locals_value_shapes.rs
@@ -5,6 +5,19 @@ struct Aggregate {
     word: u16,
 }
 
+struct TupleAggregate(u8, u16);
+
+struct Nested {
+    aggregate: Aggregate,
+    tuple: (u8, u16),
+}
+
+enum Choice {
+    Unit,
+    Tuple(u8, u16),
+    Struct { n: u32, ok: bool },
+}
+
 fn main() {
     // Edge case for `None` from `as_mplace_or_imm`: moved/drop temporaries become dead.
     let dead_box = Box::new(0x11_u8);
@@ -23,8 +36,27 @@ fn main() {
     let scalar_pair = &[10_u8, 20_u8][..];
     // Either::Left mplace/indirect storage.
     let mplace = Aggregate { byte: scalar, word: 0x1234 };
+    let tuple = (0x01_u8, 0x0203_u16);
+    let tuple_struct = TupleAggregate(0x04_u8, 0x0506_u16);
+    let array = [0x07_u8, 0x08, 0x09];
+    let nested = Nested { aggregate: Aggregate { byte: 0x0a, word: 0x0b0c }, tuple };
+    let unit_variant = Choice::Unit;
+    let tuple_variant = Choice::Tuple(0x0d, 0x0e0f);
+    let struct_variant = Choice::Struct { n: 0x10111213, ok: true };
     // Immediate::Uninit.
     let uninit_scalar: u32;
 
-    std::hint::black_box((scalar, scalar_pointer, scalar_pair.len(), &mplace));
+    std::hint::black_box((
+        scalar,
+        scalar_pointer,
+        scalar_pair.len(),
+        &mplace,
+        &tuple,
+        &tuple_struct,
+        &array,
+        &nested,
+        &unit_variant,
+        &tuple_variant,
+        &struct_variant,
+    ));
 }

--- a/priroda/tests/ui/locals_value_shapes.stdin
+++ b/priroda/tests/ui/locals_value_shapes.stdin
@@ -1,4 +1,4 @@
-break tests/ui/locals_value_shapes.rs:29
+break tests/ui/locals_value_shapes.rs:49
 continue
 locals
 print 0
@@ -8,5 +8,12 @@ print 7
 print 8
 print 13
 print 15
+print 17
+print 18
+print 19
+print 20
+print 23
+print 24
+print 25
 print 999
 quit

--- a/priroda/tests/ui/locals_value_shapes.stdout
+++ b/priroda/tests/ui/locals_value_shapes.stdout
@@ -20,7 +20,7 @@ Name: mplace, Id: _15, Ty: Aggregate, Value: Aggregate { byte: [2a], word: [34 1
 Name: <none>, Id: _16, Ty: u8, Value: <dead>
 Name: tuple, Id: _17, Ty: (u8, u16), Value: ([01], [03 02])
 Name: tuple_struct, Id: _18, Ty: TupleAggregate, Value: TupleAggregate([04], [06 05])
-Name: array, Id: _19, Ty: [u8; 3], Value: [07 08 09]
+Name: array, Id: _19, Ty: [u8; 3], Value: [[07], [08], [09]]
 Name: nested, Id: _20, Ty: Nested, Value: Nested { aggregate: Aggregate { byte: [0a], word: [0c 0b] }, tuple: ([01], [03 02]) }
 Name: <none>, Id: _21, Ty: Aggregate, Value: <dead>
 Name: <none>, Id: _22, Ty: (u8, u16), Value: <dead>
@@ -52,7 +52,7 @@ Name: <none>, Id: _41, Ty: &[u8; 2], Value: {&_: &[u8; 2]}
 (priroda) Id: _15, Ty: Aggregate, Value: Aggregate { byte: [2a], word: [34 12] }
 (priroda) Id: _17, Ty: (u8, u16), Value: ([01], [03 02])
 (priroda) Id: _18, Ty: TupleAggregate, Value: TupleAggregate([04], [06 05])
-(priroda) Id: _19, Ty: [u8; 3], Value: [07 08 09]
+(priroda) Id: _19, Ty: [u8; 3], Value: [[07], [08], [09]]
 (priroda) Id: _20, Ty: Nested, Value: Nested { aggregate: Aggregate { byte: [0a], word: [0c 0b] }, tuple: ([01], [03 02]) }
 (priroda) Id: _23, Ty: Choice, Value: Choice::Unit
 (priroda) Id: _24, Ty: Choice, Value: Choice::Tuple([0d], [0f 0e])

--- a/priroda/tests/ui/locals_value_shapes.stdout
+++ b/priroda/tests/ui/locals_value_shapes.stdout
@@ -1,6 +1,6 @@
-(priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_value_shapes.rs:29
+(priroda) breakpoint added: {MANIFEST_DIR}/tests/ui/locals_value_shapes.rs:49
 (priroda) Hit breakpoint
-{MANIFEST_DIR}/tests/ui/locals_value_shapes.rs:29
+{MANIFEST_DIR}/tests/ui/locals_value_shapes.rs:49
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
 Name: dead_box, Id: _1, Ty: std::boxed::Box<u8>, Value: [{ALLOC_PTR}]
 Name: consumed, Id: _2, Ty: std::boxed::Box<u8>, Value: [{ALLOC_PTR}]
@@ -18,15 +18,31 @@ Name: <none>, Id: _13, Ty: [u8; 2], Value: <uninit>
 Name: <none>, Id: _14, Ty: std::ops::RangeFull, Value: <dead>
 Name: mplace, Id: _15, Ty: Aggregate, Value: [34 12 2a __]
 Name: <none>, Id: _16, Ty: u8, Value: <dead>
-Name: uninit_scalar, Id: _17, Ty: u32, Value: <uninit>
-Name: <none>, Id: _18, Ty: (u8, &u8, usize, &Aggregate), Value: <dead>
-Name: <none>, Id: _19, Ty: (u8, &u8, usize, &Aggregate), Value: <dead>
-Name: <none>, Id: _20, Ty: u8, Value: <dead>
-Name: <none>, Id: _21, Ty: &u8, Value: <dead>
-Name: <none>, Id: _22, Ty: usize, Value: <dead>
-Name: <none>, Id: _23, Ty: &[u8], Value: <dead>
-Name: <none>, Id: _24, Ty: &Aggregate, Value: <dead>
-Name: <none>, Id: _25, Ty: &[u8; 2], Value: {&_: &[u8; 2]}
+Name: tuple, Id: _17, Ty: (u8, u16), Value: [01 __ 03 02]
+Name: tuple_struct, Id: _18, Ty: TupleAggregate, Value: [06 05 04 __]
+Name: array, Id: _19, Ty: [u8; 3], Value: [07 08 09]
+Name: nested, Id: _20, Ty: Nested, Value: [0c 0b 0a __ 01 __ 03 02]
+Name: <none>, Id: _21, Ty: Aggregate, Value: <dead>
+Name: <none>, Id: _22, Ty: (u8, u16), Value: <dead>
+Name: unit_variant, Id: _23, Ty: Choice, Value: [00 __ __ __ __ __ __ __]
+Name: tuple_variant, Id: _24, Ty: Choice, Value: [01 0d 0f 0e __ __ __ __]
+Name: struct_variant, Id: _25, Ty: Choice, Value: [02 01 __ __ 13 12 11 10]
+Name: uninit_scalar, Id: _26, Ty: u32, Value: <uninit>
+Name: <none>, Id: _27, Ty: (u8, &u8, usize, &Aggregate, &(u8, u16), &TupleAggregate, &[u8; 3], &Nested, &Choice, &Choice, &Choice), Value: <dead>
+Name: <none>, Id: _28, Ty: (u8, &u8, usize, &Aggregate, &(u8, u16), &TupleAggregate, &[u8; 3], &Nested, &Choice, &Choice, &Choice), Value: <dead>
+Name: <none>, Id: _29, Ty: u8, Value: <dead>
+Name: <none>, Id: _30, Ty: &u8, Value: <dead>
+Name: <none>, Id: _31, Ty: usize, Value: <dead>
+Name: <none>, Id: _32, Ty: &[u8], Value: <dead>
+Name: <none>, Id: _33, Ty: &Aggregate, Value: <dead>
+Name: <none>, Id: _34, Ty: &(u8, u16), Value: <dead>
+Name: <none>, Id: _35, Ty: &TupleAggregate, Value: <dead>
+Name: <none>, Id: _36, Ty: &[u8; 3], Value: <dead>
+Name: <none>, Id: _37, Ty: &Nested, Value: <dead>
+Name: <none>, Id: _38, Ty: &Choice, Value: <dead>
+Name: <none>, Id: _39, Ty: &Choice, Value: <dead>
+Name: <none>, Id: _40, Ty: &Choice, Value: <dead>
+Name: <none>, Id: _41, Ty: &[u8; 2], Value: {&_: &[u8; 2]}
 (priroda) Id: _0, Ty: (), Value: <uninit>
 (priroda) Id: _4, Ty: std::boxed::Box<u8>, Value: <dead>
 (priroda) Id: _5, Ty: std::boxed::Box<u8>, Value: [{ALLOC_PTR}]
@@ -34,5 +50,12 @@ Name: <none>, Id: _25, Ty: &[u8; 2], Value: {&_: &[u8; 2]}
 (priroda) Id: _8, Ty: u8, Value: [33]
 (priroda) Id: _13, Ty: [u8; 2], Value: <uninit>
 (priroda) Id: _15, Ty: Aggregate, Value: [34 12 2a __]
+(priroda) Id: _17, Ty: (u8, u16), Value: [01 __ 03 02]
+(priroda) Id: _18, Ty: TupleAggregate, Value: [06 05 04 __]
+(priroda) Id: _19, Ty: [u8; 3], Value: [07 08 09]
+(priroda) Id: _20, Ty: Nested, Value: [0c 0b 0a __ 01 __ 03 02]
+(priroda) Id: _23, Ty: Choice, Value: [00 __ __ __ __ __ __ __]
+(priroda) Id: _24, Ty: Choice, Value: [01 0d 0f 0e __ __ __ __]
+(priroda) Id: _25, Ty: Choice, Value: [02 01 __ __ 13 12 11 10]
 (priroda) no local for this id
 (priroda) quitting

--- a/priroda/tests/ui/locals_value_shapes.stdout
+++ b/priroda/tests/ui/locals_value_shapes.stdout
@@ -18,10 +18,10 @@ Name: <none>, Id: _13, Ty: [u8; 2], Value: <uninit>
 Name: <none>, Id: _14, Ty: std::ops::RangeFull, Value: <dead>
 Name: mplace, Id: _15, Ty: Aggregate, Value: Aggregate { byte: [2a], word: [34 12] }
 Name: <none>, Id: _16, Ty: u8, Value: <dead>
-Name: tuple, Id: _17, Ty: (u8, u16), Value: [01 __ 03 02]
+Name: tuple, Id: _17, Ty: (u8, u16), Value: ([01], [03 02])
 Name: tuple_struct, Id: _18, Ty: TupleAggregate, Value: TupleAggregate([04], [06 05])
 Name: array, Id: _19, Ty: [u8; 3], Value: [07 08 09]
-Name: nested, Id: _20, Ty: Nested, Value: Nested { aggregate: Aggregate { byte: [0a], word: [0c 0b] }, tuple: [01 __ 03 02] }
+Name: nested, Id: _20, Ty: Nested, Value: Nested { aggregate: Aggregate { byte: [0a], word: [0c 0b] }, tuple: ([01], [03 02]) }
 Name: <none>, Id: _21, Ty: Aggregate, Value: <dead>
 Name: <none>, Id: _22, Ty: (u8, u16), Value: <dead>
 Name: unit_variant, Id: _23, Ty: Choice, Value: Choice::Unit
@@ -50,10 +50,10 @@ Name: <none>, Id: _41, Ty: &[u8; 2], Value: {&_: &[u8; 2]}
 (priroda) Id: _8, Ty: u8, Value: [33]
 (priroda) Id: _13, Ty: [u8; 2], Value: <uninit>
 (priroda) Id: _15, Ty: Aggregate, Value: Aggregate { byte: [2a], word: [34 12] }
-(priroda) Id: _17, Ty: (u8, u16), Value: [01 __ 03 02]
+(priroda) Id: _17, Ty: (u8, u16), Value: ([01], [03 02])
 (priroda) Id: _18, Ty: TupleAggregate, Value: TupleAggregate([04], [06 05])
 (priroda) Id: _19, Ty: [u8; 3], Value: [07 08 09]
-(priroda) Id: _20, Ty: Nested, Value: Nested { aggregate: Aggregate { byte: [0a], word: [0c 0b] }, tuple: [01 __ 03 02] }
+(priroda) Id: _20, Ty: Nested, Value: Nested { aggregate: Aggregate { byte: [0a], word: [0c 0b] }, tuple: ([01], [03 02]) }
 (priroda) Id: _23, Ty: Choice, Value: Choice::Unit
 (priroda) Id: _24, Ty: Choice, Value: Choice::Tuple([0d], [0f 0e])
 (priroda) Id: _25, Ty: Choice, Value: Choice::Struct { n: [13 12 11 10], ok: [01] }

--- a/priroda/tests/ui/locals_value_shapes.stdout
+++ b/priroda/tests/ui/locals_value_shapes.stdout
@@ -24,9 +24,9 @@ Name: array, Id: _19, Ty: [u8; 3], Value: [07 08 09]
 Name: nested, Id: _20, Ty: Nested, Value: Nested { aggregate: Aggregate { byte: [0a], word: [0c 0b] }, tuple: [01 __ 03 02] }
 Name: <none>, Id: _21, Ty: Aggregate, Value: <dead>
 Name: <none>, Id: _22, Ty: (u8, u16), Value: <dead>
-Name: unit_variant, Id: _23, Ty: Choice, Value: [00 __ __ __ __ __ __ __]
-Name: tuple_variant, Id: _24, Ty: Choice, Value: [01 0d 0f 0e __ __ __ __]
-Name: struct_variant, Id: _25, Ty: Choice, Value: [02 01 __ __ 13 12 11 10]
+Name: unit_variant, Id: _23, Ty: Choice, Value: Choice::Unit
+Name: tuple_variant, Id: _24, Ty: Choice, Value: Choice::Tuple([0d], [0f 0e])
+Name: struct_variant, Id: _25, Ty: Choice, Value: Choice::Struct { n: [13 12 11 10], ok: [01] }
 Name: uninit_scalar, Id: _26, Ty: u32, Value: <uninit>
 Name: <none>, Id: _27, Ty: (u8, &u8, usize, &Aggregate, &(u8, u16), &TupleAggregate, &[u8; 3], &Nested, &Choice, &Choice, &Choice), Value: <dead>
 Name: <none>, Id: _28, Ty: (u8, &u8, usize, &Aggregate, &(u8, u16), &TupleAggregate, &[u8; 3], &Nested, &Choice, &Choice, &Choice), Value: <dead>
@@ -54,8 +54,8 @@ Name: <none>, Id: _41, Ty: &[u8; 2], Value: {&_: &[u8; 2]}
 (priroda) Id: _18, Ty: TupleAggregate, Value: TupleAggregate([04], [06 05])
 (priroda) Id: _19, Ty: [u8; 3], Value: [07 08 09]
 (priroda) Id: _20, Ty: Nested, Value: Nested { aggregate: Aggregate { byte: [0a], word: [0c 0b] }, tuple: [01 __ 03 02] }
-(priroda) Id: _23, Ty: Choice, Value: [00 __ __ __ __ __ __ __]
-(priroda) Id: _24, Ty: Choice, Value: [01 0d 0f 0e __ __ __ __]
-(priroda) Id: _25, Ty: Choice, Value: [02 01 __ __ 13 12 11 10]
+(priroda) Id: _23, Ty: Choice, Value: Choice::Unit
+(priroda) Id: _24, Ty: Choice, Value: Choice::Tuple([0d], [0f 0e])
+(priroda) Id: _25, Ty: Choice, Value: Choice::Struct { n: [13 12 11 10], ok: [01] }
 (priroda) no local for this id
 (priroda) quitting

--- a/priroda/tests/ui/locals_value_shapes.stdout
+++ b/priroda/tests/ui/locals_value_shapes.stdout
@@ -2,11 +2,11 @@
 (priroda) Hit breakpoint
 {MANIFEST_DIR}/tests/ui/locals_value_shapes.rs:49
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
-Name: dead_box, Id: _1, Ty: std::boxed::Box<u8>, Value: [{ALLOC_PTR}]
-Name: consumed, Id: _2, Ty: std::boxed::Box<u8>, Value: [{ALLOC_PTR}]
+Name: dead_box, Id: _1, Ty: std::boxed::Box<u8>, Value: Box(Unique { pointer: NonNull { pointer: [{ALLOC_PTR}] }, _marker: PhantomData }, Global)
+Name: consumed, Id: _2, Ty: std::boxed::Box<u8>, Value: Box(Unique { pointer: NonNull { pointer: [{ALLOC_PTR}] }, _marker: PhantomData }, Global)
 Name: <none>, Id: _3, Ty: (), Value: <dead>
 Name: <none>, Id: _4, Ty: std::boxed::Box<u8>, Value: <dead>
-Name: pointed_box, Id: _5, Ty: std::boxed::Box<u8>, Value: [{ALLOC_PTR}]
+Name: pointed_box, Id: _5, Ty: std::boxed::Box<u8>, Value: Box(Unique { pointer: NonNull { pointer: [{ALLOC_PTR}] }, _marker: PhantomData }, Global)
 Name: pointer_box, Id: _6, Ty: &std::boxed::Box<u8>, Value: {&_: &std::boxed::Box<u8>}
 Name: scalar, Id: _7, Ty: u8, Value: 42_u8
 Name: pointed, Id: _8, Ty: u8, Value: [33]
@@ -16,12 +16,12 @@ Name: <none>, Id: _11, Ty: &[u8], Value: (pointer to {ALLOC_PTR}, 0x000000000000
 Name: <none>, Id: _12, Ty: &[u8; 2], Value: <dead>
 Name: <none>, Id: _13, Ty: [u8; 2], Value: <uninit>
 Name: <none>, Id: _14, Ty: std::ops::RangeFull, Value: <dead>
-Name: mplace, Id: _15, Ty: Aggregate, Value: [34 12 2a __]
+Name: mplace, Id: _15, Ty: Aggregate, Value: Aggregate { byte: [2a], word: [34 12] }
 Name: <none>, Id: _16, Ty: u8, Value: <dead>
 Name: tuple, Id: _17, Ty: (u8, u16), Value: [01 __ 03 02]
-Name: tuple_struct, Id: _18, Ty: TupleAggregate, Value: [06 05 04 __]
+Name: tuple_struct, Id: _18, Ty: TupleAggregate, Value: TupleAggregate([04], [06 05])
 Name: array, Id: _19, Ty: [u8; 3], Value: [07 08 09]
-Name: nested, Id: _20, Ty: Nested, Value: [0c 0b 0a __ 01 __ 03 02]
+Name: nested, Id: _20, Ty: Nested, Value: Nested { aggregate: Aggregate { byte: [0a], word: [0c 0b] }, tuple: [01 __ 03 02] }
 Name: <none>, Id: _21, Ty: Aggregate, Value: <dead>
 Name: <none>, Id: _22, Ty: (u8, u16), Value: <dead>
 Name: unit_variant, Id: _23, Ty: Choice, Value: [00 __ __ __ __ __ __ __]
@@ -45,15 +45,15 @@ Name: <none>, Id: _40, Ty: &Choice, Value: <dead>
 Name: <none>, Id: _41, Ty: &[u8; 2], Value: {&_: &[u8; 2]}
 (priroda) Id: _0, Ty: (), Value: <uninit>
 (priroda) Id: _4, Ty: std::boxed::Box<u8>, Value: <dead>
-(priroda) Id: _5, Ty: std::boxed::Box<u8>, Value: [{ALLOC_PTR}]
+(priroda) Id: _5, Ty: std::boxed::Box<u8>, Value: Box(Unique { pointer: NonNull { pointer: [{ALLOC_PTR}] }, _marker: PhantomData }, Global)
 (priroda) Id: _7, Ty: u8, Value: 42_u8
 (priroda) Id: _8, Ty: u8, Value: [33]
 (priroda) Id: _13, Ty: [u8; 2], Value: <uninit>
-(priroda) Id: _15, Ty: Aggregate, Value: [34 12 2a __]
+(priroda) Id: _15, Ty: Aggregate, Value: Aggregate { byte: [2a], word: [34 12] }
 (priroda) Id: _17, Ty: (u8, u16), Value: [01 __ 03 02]
-(priroda) Id: _18, Ty: TupleAggregate, Value: [06 05 04 __]
+(priroda) Id: _18, Ty: TupleAggregate, Value: TupleAggregate([04], [06 05])
 (priroda) Id: _19, Ty: [u8; 3], Value: [07 08 09]
-(priroda) Id: _20, Ty: Nested, Value: [0c 0b 0a __ 01 __ 03 02]
+(priroda) Id: _20, Ty: Nested, Value: Nested { aggregate: Aggregate { byte: [0a], word: [0c 0b] }, tuple: [01 __ 03 02] }
 (priroda) Id: _23, Ty: Choice, Value: [00 __ __ __ __ __ __ __]
 (priroda) Id: _24, Ty: Choice, Value: [01 0d 0f 0e __ __ __ __]
 (priroda) Id: _25, Ty: Choice, Value: [02 01 __ __ 13 12 11 10]

--- a/priroda/tests/ui/locals_wildcard_pointer.stdout
+++ b/priroda/tests/ui/locals_wildcard_pointer.stdout
@@ -3,9 +3,9 @@
 {MANIFEST_DIR}/tests/ui/locals_wildcard_pointer.rs:15
 (priroda) Name: <none>, Id: _0, Ty: (), Value: <uninit>
 Name: ptr, Id: _1, Ty: *const u8, Value: {&_: *const u8}
-Name: wildcard, Id: _2, Ty: WildcardPointer, Value: [0x1234[wildcard]]
+Name: wildcard, Id: _2, Ty: WildcardPointer, Value: WildcardPointer { ptr: [0x1234[wildcard]] }
 Name: <none>, Id: _3, Ty: *const u8, Value: <dead>
 Name: <none>, Id: _4, Ty: &WildcardPointer, Value: <dead>
 Name: <none>, Id: _5, Ty: &WildcardPointer, Value: <dead>
-(priroda) Id: _2, Ty: WildcardPointer, Value: [0x1234[wildcard]]
+(priroda) Id: _2, Ty: WildcardPointer, Value: WildcardPointer { ptr: [0x1234[wildcard]] }
 (priroda) quitting


### PR DESCRIPTION
Improve Priroda local rendering by adding UI coverage, routing locals through a source-shaped renderer, and formatting structs, enums, tuples, arrays, and slices with Rust-like structure while preserving raw rendering for unsupported leaves and documented follow-ups.