### PR TITLE
[Priroda] CI: add clippy check for priroda

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,9 @@ jobs:
       - name: build Priroda
         working-directory: priroda
         run: cargo build --locked
+      - name: clippy Priroda
+        working-directory: priroda
+        run: cargo clippy --all-targets --locked -- -D warnings
       - name: test Priroda
         working-directory: priroda
         run: |


### PR DESCRIPTION
Add a `cargo clippy --all-targets --locked -- -D warnings` step to the Priroda CI job.