### PR TITLE
Implement AVX-512 IFMA vpmadd52 intrinsics

### DIFF
--- a/src/intrinsics/x86/avx512.rs
+++ b/src/intrinsics/x86/avx512.rs
@@ -178,6 +178,20 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 packusdw(this, a, b, dest)?;
             }
+            // Used to implement the _mm512_madd52lo_epu64 and _mm512_madd52hi_epu64
+            // functions (and their 128/256-bit variants).
+            "vpmadd52l.uq.512" | "vpmadd52h.uq.512" | "vpmadd52l.uq.256" | "vpmadd52h.uq.256"
+            | "vpmadd52l.uq.128" | "vpmadd52h.uq.128" => {
+                this.expect_target_feature_for_intrinsic(link_name, "avx512ifma")?;
+                if !unprefixed_name.ends_with("512") {
+                    this.expect_target_feature_for_intrinsic(link_name, "avx512vl")?;
+                }
+
+                let [z, x, y] = this.check_shim_sig_unadjusted(link_name, args)?;
+
+                let high = unprefixed_name.starts_with("vpmadd52h");
+                vpmadd52uq(this, z, x, y, high, dest)?;
+            }
             _ => return interp_ok(EmulateItemResult::NotSupported),
         }
         interp_ok(EmulateItemResult::NeedsReturn)
@@ -192,6 +206,48 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 /// <https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_dpbusd_epi32>
 /// <https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_dpbusd_epi32>
 /// <https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_dpbusd_epi32>
+/// Multiply the low unsigned 52-bit integers in each 64-bit lane of `x` and
+/// `y`, producing a 104-bit product, then add either its low (`high ==
+/// false`) or high (`high == true`) 52-bit half to the full 64-bit lane of
+/// `z` with wrapping arithmetic.
+///
+/// <https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_madd52lo_epu64>
+/// <https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_madd52hi_epu64>
+fn vpmadd52uq<'tcx>(
+    ecx: &mut crate::MiriInterpCx<'tcx>,
+    z: &OpTy<'tcx>,
+    x: &OpTy<'tcx>,
+    y: &OpTy<'tcx>,
+    high: bool,
+    dest: &MPlaceTy<'tcx>,
+) -> InterpResult<'tcx, ()> {
+    let (z, z_len) = ecx.project_to_simd(z)?;
+    let (x, x_len) = ecx.project_to_simd(x)?;
+    let (y, y_len) = ecx.project_to_simd(y)?;
+    let (dest, dest_len) = ecx.project_to_simd(dest)?;
+
+    // fn vpmadd52luq_512(z: i64x8, x: i64x8, y: i64x8) -> i64x8;
+    assert_eq!(z_len, dest_len);
+    assert_eq!(x_len, dest_len);
+    assert_eq!(y_len, dest_len);
+
+    const MASK52: u64 = (1 << 52) - 1;
+    for i in 0..dest_len {
+        let z = ecx.read_scalar(&ecx.project_index(&z, i)?)?.to_u64()?;
+        let x = ecx.read_scalar(&ecx.project_index(&x, i)?)?.to_u64()?;
+        let y = ecx.read_scalar(&ecx.project_index(&y, i)?)?.to_u64()?;
+        let dest = ecx.project_index(&dest, i)?;
+
+        let product = u128::from(x & MASK52).strict_mul(u128::from(y & MASK52));
+        let shifted = if high { product >> 52 } else { product };
+        let chunk = u64::try_from(shifted & u128::from(MASK52)).unwrap();
+        let res = Scalar::from_u64(z.wrapping_add(chunk));
+        ecx.write_scalar(res, &dest)?;
+    }
+
+    interp_ok(())
+}
+
 fn vpdpbusd<'tcx>(
     ecx: &mut crate::MiriInterpCx<'tcx>,
     src: &OpTy<'tcx>,

--- a/src/intrinsics/x86/avx512.rs
+++ b/src/intrinsics/x86/avx512.rs
@@ -198,14 +198,6 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     }
 }
 
-/// Multiply groups of 4 adjacent pairs of unsigned 8-bit integers in `a` with corresponding signed
-/// 8-bit integers in `b`, producing 4 intermediate signed 16-bit results. Sum these 4 results with
-/// the corresponding 32-bit integer in `src` (using wrapping arighmetic), and store the packed
-/// 32-bit results in `dst`.
-///
-/// <https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_dpbusd_epi32>
-/// <https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_dpbusd_epi32>
-/// <https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_dpbusd_epi32>
 /// Multiply the low unsigned 52-bit integers in each 64-bit lane of `x` and
 /// `y`, producing a 104-bit product, then add either its low (`high ==
 /// false`) or high (`high == true`) 52-bit half to the full 64-bit lane of
@@ -248,6 +240,14 @@ fn vpmadd52uq<'tcx>(
     interp_ok(())
 }
 
+/// Multiply groups of 4 adjacent pairs of unsigned 8-bit integers in `a` with corresponding signed
+/// 8-bit integers in `b`, producing 4 intermediate signed 16-bit results. Sum these 4 results with
+/// the corresponding 32-bit integer in `src` (using wrapping arighmetic), and store the packed
+/// 32-bit results in `dst`.
+///
+/// <https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm_dpbusd_epi32>
+/// <https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm256_dpbusd_epi32>
+/// <https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=_mm512_dpbusd_epi32>
 fn vpdpbusd<'tcx>(
     ecx: &mut crate::MiriInterpCx<'tcx>,
     src: &OpTy<'tcx>,

--- a/tests/pass/shims/x86/intrinsics-x86-avx512.rs
+++ b/tests/pass/shims/x86/intrinsics-x86-avx512.rs
@@ -1,6 +1,6 @@
 // We're testing x86 target specific features
 //@only-target: x86_64 i686
-//@compile-flags: -C target-feature=+avx512f,+avx512vl,+avx512bw,+avx512bitalg,+avx512vpopcntdq,+avx512vnni,+avx512vbmi
+//@compile-flags: -C target-feature=+avx512f,+avx512vl,+avx512bw,+avx512bitalg,+avx512vpopcntdq,+avx512vnni,+avx512vbmi,+avx512ifma
 //@run-native
 
 #[cfg(target_arch = "x86")]
@@ -33,6 +33,12 @@ fn main() {
         test_avx512ternarylogic();
         test_avx512vnni();
         test_avx512vbmi();
+        if is_x86_feature_detected!("avx512ifma") {
+            test_avx512ifma();
+        } else {
+            // Older AVX-512 silicon (e.g. Skylake-SP) lacks IFMA.
+            println!("warning: skipping avx512ifma tests");
+        }
     }
 }
 
@@ -982,4 +988,38 @@ unsafe fn assert_eq_m256i(a: __m256i, b: __m256i) {
 #[track_caller]
 unsafe fn assert_eq_m128i(a: __m128i, b: __m128i) {
     assert_eq!(transmute::<_, [u64; 2]>(a), transmute::<_, [u64; 2]>(b))
+}
+
+#[target_feature(enable = "avx512ifma,avx512vl")]
+unsafe fn test_avx512ifma() {
+    // (2^52 - 1)^2 = 2^104 - 2^53 + 1: low 52-bit chunk 1, high chunk 2^52 - 2.
+    const MASK52: u64 = (1 << 52) - 1;
+    let max52 = _mm512_set1_epi64(MASK52 as i64);
+    let zero = _mm512_setzero_si512();
+    let ones = _mm512_set1_epi64(1);
+    let wrap = _mm512_set1_epi64(u64::MAX as i64);
+
+    let lo = _mm512_madd52lo_epu64(zero, max52, max52);
+    assert_eq_m512i(lo, _mm512_set1_epi64(1));
+    let hi = _mm512_madd52hi_epu64(zero, max52, max52);
+    assert_eq_m512i(hi, _mm512_set1_epi64((MASK52 - 1) as i64));
+    // The accumulator is a full 64-bit lane with wrapping addition.
+    let wrapped = _mm512_madd52lo_epu64(wrap, max52, max52);
+    assert_eq_m512i(wrapped, zero);
+    // Multiplicands only contribute their low 52 bits.
+    let high_garbage = _mm512_set1_epi64(((1u64 << 63) | 3) as i64);
+    let masked = _mm512_madd52lo_epu64(zero, high_garbage, ones);
+    assert_eq_m512i(masked, _mm512_set1_epi64(3));
+
+    let max52_256 = _mm256_set1_epi64x(MASK52 as i64);
+    let lo256 = _mm256_madd52lo_epu64(_mm256_setzero_si256(), max52_256, max52_256);
+    assert_eq_m256i(lo256, _mm256_set1_epi64x(1));
+    let hi256 = _mm256_madd52hi_epu64(_mm256_setzero_si256(), max52_256, max52_256);
+    assert_eq_m256i(hi256, _mm256_set1_epi64x((MASK52 - 1) as i64));
+
+    let max52_128 = _mm_set1_epi64x(MASK52 as i64);
+    let lo128 = _mm_madd52lo_epu64(_mm_setzero_si128(), max52_128, max52_128);
+    assert_eq_m128i(lo128, _mm_set1_epi64x(1));
+    let hi128 = _mm_madd52hi_epu64(_mm_setzero_si128(), max52_128, max52_128);
+    assert_eq_m128i(hi128, _mm_set1_epi64x((MASK52 - 1) as i64));
 }


### PR DESCRIPTION
Adds shims for `llvm.x86.avx512.vpmadd52l.uq.{128,256,512}` and `vpmadd52h.uq.{128,256,512}`, used by `_mm512_madd52lo_epu64` / `_mm512_madd52hi_epu64` and their 128/256-bit variants.

Semantics per the Intel intrinsics guide: multiply the low 52 bits of each 64-bit lane of the two multiplicands into a 104-bit product, then add the selected 52-bit half to the full 64-bit accumulator lane with wrapping arithmetic. Feature gates follow the existing avx512 shims: `avx512ifma`, plus `avx512vl` for the narrower widths.

Tests cover the `(2^52 - 1)^2` saturation pattern for both halves, accumulator wraparound, and the low-52-bit masking of the multiplicands, at all three widths. Motivation: interpreting radix-52 big-integer cryptography (the vpmadd52-based Montgomery multiplication pattern) under Miri.