### PR TITLE
[Priroda] Add TCP DAP mode for VS Code attach

### DIFF
--- a/priroda/README.md
+++ b/priroda/README.md
@@ -63,60 +63,44 @@ does not register a debug type. VS Code still needs a registered `priroda`
 debug type, which must come from a debug extension. A custom Priroda extension
 is deferred to future graphical features.
 
-Copy the example files into the workspace you want to debug:
+The templates assume `${workspaceFolder}` is the `miri/priroda` directory that
+contains them. Copy them into that directory's `.vscode/`, or edit
+`--manifest-path` and the final `args` entry when using them from elsewhere:
 
 ```sh
-mkdir -p /path/to/project/.vscode
-cp vscode_launch.json /path/to/project/.vscode/launch.json
-cp vscode_tasks.json /path/to/project/.vscode/tasks.json
+mkdir -p /path/to/miri/priroda/.vscode
+cp vscode_launch.json /path/to/miri/priroda/.vscode/launch.json
+cp vscode_tasks.json /path/to/miri/priroda/.vscode/tasks.json
 ```
 
 Before running the debugger configuration, make sure:
 
-- Priroda has been built, so the binary path in `command` exists.
 - `MIRI_SYSROOT` points at a Miri sysroot, for example from
   `cargo +miri miri setup --print-sysroot`.
-- If running the `priroda` binary directly, `LD_LIBRARY_PATH` may need to point
-  at the pinned `miri` toolchain's `lib` directory.
+- The `cargo` in `command` resolves to the `miri` toolchain's cargo, so the
+  task builds Priroda with `rustc_private`.
 - The Rust file path at the end of `args` is the file you want Priroda to run.
 - Port `4711` is free, or both `--port` and `debugServer` use the same different
   port.
 - VS Code has a debugger contribution installed that accepts
   `type: "priroda"` debug configurations.
 
-Then edit `.vscode/tasks.json` for your local paths. Set `command` to the
-Priroda binary you want VS Code to run:
-
-```json
-"command": "${workspaceFolder}/target/debug/priroda"
-```
-
-If the binary cannot find rustc libraries, add an `env` block under
-`options`:
-
-```json
-"options": {
-    "cwd": "${workspaceFolder}",
-    "env": {
-        "LD_LIBRARY_PATH": "/path/to/miri-toolchain/lib",
-        "MIRI_SYSROOT": "/path/to/miri-sysroot"
-    }
-}
-```
-
-Also edit the final argument in `args` to point at the Rust file you want
-Priroda to run. This task argument, not `launch.json`, selects the interpreted
-program:
-
-```json
-"${workspaceFolder}/src/main.rs"
-```
-
-The task runs Priroda like this:
+The task runs Priroda through `cargo run` against the Priroda crate:
 
 ```sh
-cargo run -- --dap --port 4711 /path/to/project/src/main.rs
+cargo run --manifest-path /path/to/miri/priroda/Cargo.toml -- \
+    --dap --port 4711 --sysroot "$MIRI_SYSROOT" /path/to/project/src/main.rs
 ```
+
+Edit the final argument in `args` to point at the Rust file you want Priroda to
+run (the checked-in default is `../tests/pass/empty_main.rs`). This task
+argument, not `launch.json`, selects the interpreted program.
+
+Running through `cargo run` sets the dynamic library path automatically. The
+`priroda` binary links rustc's shared libraries, so running it directly, or via
+`cargo install`, still needs `LD_LIBRARY_PATH` to point at the pinned `miri`
+toolchain's `lib` directory; a future packaging step (an rpath, or shipping
+Priroda next to Miri) will remove that requirement.
 
 Once Priroda prints `priroda dap listening on 127.0.0.1:4711`, VS Code treats
 the background task as ready and connects with:

--- a/priroda/README.md
+++ b/priroda/README.md
@@ -58,14 +58,12 @@ when you run the debugger configuration. The launch configuration does not spawn
 Priroda directly; it starts a background task and then connects through
 `debugServer`.
 
-This requires a VS Code debug extension that contributes the `priroda` debugger
-type. The `debugServer` setting only tells VS Code to connect to an
-already-running adapter; it does not register a new debugger type. On a clean VS
-Code install, copying these JSON files is not enough for the launch
-configuration to be accepted.
+`debugServer` only tells VS Code to connect to an already-running adapter; it
+does not register a debug type. VS Code still needs a registered `priroda`
+debug type, which must come from a debug extension. A custom Priroda extension
+is deferred to future graphical features.
 
-After that debugger type is registered, copy the example files into the
-workspace you want to debug:
+Copy the example files into the workspace you want to debug:
 
 ```sh
 mkdir -p /path/to/project/.vscode

--- a/priroda/README.md
+++ b/priroda/README.md
@@ -40,8 +40,9 @@ cargo run -- ../tests/pass/empty_main.rs
 
 ## DAP Prototype
 
-Priroda's `--dap` mode speaks a bounded Debug Adapter Protocol prototype over
-stdio. It currently supports the startup handshake, stops at the first
+Priroda speaks a bounded Debug Adapter Protocol prototype over stdio with
+`--dap`, or over TCP with `--port N`. It currently supports the startup
+handshake, stops at the first
 user-relevant source location after `configurationDone`, reports one current
 stack frame, exposes one flat Locals scope, and maps `list_locals()` into DAP
 variables with no child expansion.

--- a/priroda/README.md
+++ b/priroda/README.md
@@ -51,6 +51,90 @@ The `next` and `stepIn` requests are wired to Priroda's existing source-line
 step so VS Code can drive one visible step. They are not true DAP step-over or
 step-in semantics yet.
 
+### VS Code
+
+VS Code can start Priroda as a TCP DAP server and then attach to that server
+when you run the debugger configuration. The launch configuration does not spawn
+Priroda directly; it starts a background task and then connects through
+`debugServer`.
+
+This requires a VS Code debug extension that contributes the `priroda` debugger
+type. The `debugServer` setting only tells VS Code to connect to an
+already-running adapter; it does not register a new debugger type. On a clean VS
+Code install, copying these JSON files is not enough for the launch
+configuration to be accepted.
+
+After that debugger type is registered, copy the example files into the
+workspace you want to debug:
+
+```sh
+mkdir -p /path/to/project/.vscode
+cp vscode_launch.json /path/to/project/.vscode/launch.json
+cp vscode_tasks.json /path/to/project/.vscode/tasks.json
+```
+
+Before running the debugger configuration, make sure:
+
+- Priroda has been built, so the binary path in `command` exists.
+- `MIRI_SYSROOT` points at a Miri sysroot, for example from
+  `cargo +miri miri setup --print-sysroot`.
+- If running the `priroda` binary directly, `LD_LIBRARY_PATH` may need to point
+  at the pinned `miri` toolchain's `lib` directory.
+- The Rust file path at the end of `args` is the file you want Priroda to run.
+- Port `4711` is free, or both `--port` and `debugServer` use the same different
+  port.
+- VS Code has a debugger contribution installed that accepts
+  `type: "priroda"` debug configurations.
+
+Then edit `.vscode/tasks.json` for your local paths. Set `command` to the
+Priroda binary you want VS Code to run:
+
+```json
+"command": "${workspaceFolder}/target/debug/priroda"
+```
+
+If the binary cannot find rustc libraries, add an `env` block under
+`options`:
+
+```json
+"options": {
+    "cwd": "${workspaceFolder}",
+    "env": {
+        "LD_LIBRARY_PATH": "/path/to/miri-toolchain/lib",
+        "MIRI_SYSROOT": "/path/to/miri-sysroot"
+    }
+}
+```
+
+Also edit the final argument in `args` to point at the Rust file you want
+Priroda to run. This task argument, not `launch.json`, selects the interpreted
+program:
+
+```json
+"${workspaceFolder}/src/main.rs"
+```
+
+The task runs Priroda like this:
+
+```sh
+cargo run -- --dap --port 4711 /path/to/project/src/main.rs
+```
+
+Once Priroda prints `priroda dap listening on 127.0.0.1:4711`, VS Code treats
+the background task as ready and connects with:
+
+```json
+{
+    "type": "priroda",
+    "request": "launch",
+    "preLaunchTask": "Priroda: Start DAP Server",
+    "debugServer": 4711
+}
+```
+
+Priroda accepts one TCP connection and waits for VS Code before running the DAP
+handshake.
+
 ## Test
 
 Priroda's CLI tests also need `MIRI_SYSROOT`. Run them from `miri/priroda/`:

--- a/priroda/src/frontend/dap.rs
+++ b/priroda/src/frontend/dap.rs
@@ -1,4 +1,4 @@
-use std::io::{self, BufReader, BufWriter};
+use std::io::{self, BufReader, BufWriter, Read, Write};
 
 use emmy_dap_types::errors::ServerError;
 use emmy_dap_types::prelude::events::{ExitedEventBody, StoppedEventBody};
@@ -72,15 +72,13 @@ impl Dap {
     }
 }
 
-type DapServer = Server<io::StdinLock<'static>, io::StdoutLock<'static>>;
-
-/// Owns the DAP stdio transport and dispatches requests into Priroda handlers.
-struct DapSession {
-    server: DapServer,
+/// Owns a DAP transport and dispatches requests into Priroda handlers.
+struct DapSession<R: Read, W: Write> {
+    server: Server<R, W>,
     state: DapState,
 }
 
-impl DapSession {
+impl DapSession<io::StdinLock<'static>, io::StdoutLock<'static>> {
     fn stdio() -> Self {
         Self {
             server: Server::new(
@@ -90,7 +88,9 @@ impl DapSession {
             state: DapState::Fresh,
         }
     }
+}
 
+impl<R: Read, W: Write> DapSession<R, W> {
     fn run_requests<'tcx>(
         &mut self,
         session: &mut PrirodaContext<'tcx>,

--- a/priroda/src/frontend/dap.rs
+++ b/priroda/src/frontend/dap.rs
@@ -101,17 +101,30 @@ impl DapSession<io::StdinLock<'static>, io::StdoutLock<'static>> {
 
 impl DapSession<TcpStream, TcpStream> {
     fn tcp(port: u16) -> Self {
-        let listener =
-            TcpListener::bind(("127.0.0.1", port)).expect("failed to listen on DAP TCP socket");
+        let listener = match TcpListener::bind(("127.0.0.1", port)) {
+            Ok(listener) => listener,
+            Err(err) => fatal(&format!("failed to listen on DAP TCP socket: {err}")),
+        };
         eprintln!("priroda dap listening on 127.0.0.1:{port}");
-        let (stream, _) = listener.accept().expect("failed to accept DAP TCP connection");
-        let reader = stream.try_clone().expect("failed to clone DAP TCP stream");
+        let (stream, _) = match listener.accept() {
+            Ok(conn) => conn,
+            Err(err) => fatal(&format!("failed to accept DAP TCP connection: {err}")),
+        };
+        let reader = match stream.try_clone() {
+            Ok(clone) => clone,
+            Err(err) => fatal(&format!("failed to clone DAP TCP stream: {err}")),
+        };
 
         Self {
             server: Server::new(BufReader::new(reader), BufWriter::new(stream)),
             state: DapState::Fresh,
         }
     }
+}
+
+fn fatal(message: &str) -> ! {
+    eprintln!("priroda dap: {message}");
+    std::process::exit(1);
 }
 
 impl<R: Read, W: Write> DapSession<R, W> {

--- a/priroda/src/frontend/dap.rs
+++ b/priroda/src/frontend/dap.rs
@@ -103,6 +103,7 @@ impl DapSession<TcpStream, TcpStream> {
     fn tcp(port: u16) -> Self {
         let listener =
             TcpListener::bind(("127.0.0.1", port)).expect("failed to listen on DAP TCP socket");
+        eprintln!("priroda dap listening on 127.0.0.1:{port}");
         let (stream, _) = listener.accept().expect("failed to accept DAP TCP connection");
         let reader = stream.try_clone().expect("failed to clone DAP TCP stream");
 

--- a/priroda/src/frontend/dap.rs
+++ b/priroda/src/frontend/dap.rs
@@ -1,4 +1,5 @@
 use std::io::{self, BufReader, BufWriter, Read, Write};
+use std::net::{TcpListener, TcpStream};
 
 use emmy_dap_types::errors::ServerError;
 use emmy_dap_types::prelude::events::{ExitedEventBody, StoppedEventBody};
@@ -56,15 +57,23 @@ enum ExecutionOutcome {
 }
 
 /// Debug Adapter Protocol frontend.
-pub(crate) struct Dap;
+pub(crate) struct Dap {
+    pub(crate) port: Option<u16>,
+}
 
 impl Dap {
-    /// Serve DAP requests on stdin/stdout.
+    /// Serve DAP requests on stdin/stdout, or on a TCP socket if `port` is set.
     pub(crate) fn run_dap_loop<'tcx>(
         &self,
         session: &mut PrirodaContext<'tcx>,
     ) -> InterpResult<'tcx> {
-        if let Err(err) = DapSession::stdio().run_requests(session) {
+        let result = if let Some(port) = self.port {
+            DapSession::tcp(port).run_requests(session)
+        } else {
+            DapSession::stdio().run_requests(session)
+        };
+
+        if let Err(err) = result {
             eprintln!("priroda dap error: {err:?}");
         }
 
@@ -85,6 +94,20 @@ impl DapSession<io::StdinLock<'static>, io::StdoutLock<'static>> {
                 BufReader::new(io::stdin().lock()),
                 BufWriter::new(io::stdout().lock()),
             ),
+            state: DapState::Fresh,
+        }
+    }
+}
+
+impl DapSession<TcpStream, TcpStream> {
+    fn tcp(port: u16) -> Self {
+        let listener =
+            TcpListener::bind(("127.0.0.1", port)).expect("failed to listen on DAP TCP socket");
+        let (stream, _) = listener.accept().expect("failed to accept DAP TCP connection");
+        let reader = stream.try_clone().expect("failed to clone DAP TCP stream");
+
+        Self {
+            server: Server::new(BufReader::new(reader), BufWriter::new(stream)),
             state: DapState::Fresh,
         }
     }

--- a/priroda/src/main.rs
+++ b/priroda/src/main.rs
@@ -107,7 +107,7 @@ impl rustc_driver::Callbacks for PrirodaCompilerCalls {
         let mut session = PrirodaContext::new(ecx);
         let result = match self.frontend {
             Frontend::Cli => frontend::Cli {}.run_cli_loop(&mut session),
-            Frontend::Dap => frontend::Dap {}.run_dap_loop(&mut session),
+            Frontend::Dap => frontend::Dap { port: None }.run_dap_loop(&mut session),
         };
 
         match result.report_err() {

--- a/priroda/src/main.rs
+++ b/priroda/src/main.rs
@@ -54,7 +54,7 @@ fn main() {
 #[derive(Clone, Copy)]
 enum Frontend {
     Cli,
-    Dap,
+    Dap { port: Option<u16> },
 }
 
 impl Frontend {
@@ -64,14 +64,36 @@ impl Frontend {
         let mut rustc_args = Vec::with_capacity(args.len());
         let mut parsing_priroda_args = true;
 
-        for (idx, arg) in args.drain(..).enumerate() {
-            if idx != 0 && parsing_priroda_args && arg == "--dap" {
-                frontend = Frontend::Dap;
-                continue;
-            }
+        let mut arg_iter = std::mem::take(args).into_iter();
+        if let Some(program) = arg_iter.next() {
+            rustc_args.push(program);
+        }
 
-            if arg == "--" {
-                parsing_priroda_args = false;
+        while let Some(arg) = arg_iter.next() {
+            if parsing_priroda_args {
+                if arg == "--dap" {
+                    if matches!(frontend, Frontend::Cli) {
+                        frontend = Frontend::Dap { port: None };
+                    }
+                    continue;
+                }
+
+                if arg == "--port" {
+                    let port_str = arg_iter
+                        .next()
+                        .unwrap_or_else(|| Self::fatal_arg_error("--port requires a value"));
+                    frontend = Frontend::Dap { port: Some(Self::parse_port(&port_str)) };
+                    continue;
+                }
+
+                if let Some(port_str) = arg.strip_prefix("--port=") {
+                    frontend = Frontend::Dap { port: Some(Self::parse_port(port_str)) };
+                    continue;
+                }
+
+                if arg == "--" {
+                    parsing_priroda_args = false;
+                }
             }
 
             rustc_args.push(arg);
@@ -79,6 +101,16 @@ impl Frontend {
 
         *args = rustc_args;
         frontend
+    }
+
+    fn parse_port(port: &str) -> u16 {
+        port.parse()
+            .unwrap_or_else(|_| Self::fatal_arg_error("--port requires a valid u16 port number"))
+    }
+
+    fn fatal_arg_error(message: &str) -> ! {
+        eprintln!("priroda: {message}");
+        std::process::exit(1);
     }
 }
 
@@ -107,7 +139,7 @@ impl rustc_driver::Callbacks for PrirodaCompilerCalls {
         let mut session = PrirodaContext::new(ecx);
         let result = match self.frontend {
             Frontend::Cli => frontend::Cli {}.run_cli_loop(&mut session),
-            Frontend::Dap => frontend::Dap { port: None }.run_dap_loop(&mut session),
+            Frontend::Dap { port } => frontend::Dap { port }.run_dap_loop(&mut session),
         };
 
         match result.report_err() {

--- a/priroda/vscode_launch.json
+++ b/priroda/vscode_launch.json
@@ -1,0 +1,15 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Priroda: Run and Attach",
+            // Requires a VS Code debug extension that contributes the "priroda" type.
+            // The debugServer field only tells VS Code to connect to an already-running
+            // adapter; it does not register a new debugger type by itself.
+            "type": "priroda",
+            "request": "launch",
+            "preLaunchTask": "Priroda: Start DAP Server",
+            "debugServer": 4711
+        }
+    ]
+}

--- a/priroda/vscode_launch.json
+++ b/priroda/vscode_launch.json
@@ -3,9 +3,10 @@
     "configurations": [
         {
             "name": "Priroda: Run and Attach",
-            // Requires a VS Code debug extension that contributes the "priroda" type.
-            // The debugServer field only tells VS Code to connect to an already-running
-            // adapter; it does not register a new debugger type by itself.
+            // Attaches to an already-running Priroda DAP server started by the
+            // preLaunchTask below. VS Code still needs a registered "priroda" debug
+            // type from a debug extension; a custom Priroda extension is deferred
+            // to future graphical features.
             "type": "priroda",
             "request": "launch",
             "preLaunchTask": "Priroda: Start DAP Server",

--- a/priroda/vscode_tasks.json
+++ b/priroda/vscode_tasks.json
@@ -4,14 +4,18 @@
         {
             "label": "Priroda: Start DAP Server",
             "type": "process",
-            "command": "${workspaceFolder}/target/debug/priroda",
+            "command": "cargo",
             "args": [
+                "run",
+                "--manifest-path",
+                "${workspaceFolder}/Cargo.toml",
+                "--",
                 "--dap",
                 "--port",
                 "4711",
                 "--sysroot",
                 "${env:MIRI_SYSROOT}",
-                "${workspaceFolder}/src/main.rs"
+                "../tests/pass/empty_main.rs"
             ],
             "isBackground": true,
             "options": {

--- a/priroda/vscode_tasks.json
+++ b/priroda/vscode_tasks.json
@@ -1,0 +1,38 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Priroda: Start DAP Server",
+            "type": "process",
+            "command": "${workspaceFolder}/target/debug/priroda",
+            "args": [
+                "--dap",
+                "--port",
+                "4711",
+                "--sysroot",
+                "${env:MIRI_SYSROOT}",
+                "${workspaceFolder}/src/main.rs"
+            ],
+            "isBackground": true,
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": true,
+                "panel": "dedicated"
+            },
+            "problemMatcher": {
+                "pattern": {
+                    "regexp": "^(.*)$"
+                },
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": ".",
+                    "endsPattern": "priroda dap listening on 127\\.0\\.0\\.1:4711"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Adds a --port option for Priroda’s DAP frontend so it can serve one blocking TCP DAP connection on localhost, while keeping stdio DAP behavior unchanged. Also adds example VS Code launch.json / tasks.json files and README setup notes for using debugServer to attach to the Priroda DAP server.