### PR TITLE
x86 intrinsics: remove no-longer-needed intrinsics

### DIFF
--- a/src/intrinsics/x86/avx2.rs
+++ b/src/intrinsics/x86/avx2.rs
@@ -1,9 +1,8 @@
-use rustc_middle::mir;
 use rustc_span::Symbol;
 
 use super::{
-    ShiftOp, horizontal_bin_op, mpsadbw, packssdw, packsswb, packusdw, packuswb, permute, pmaddbw,
-    pmaddwd, pmulhrsw, psadbw, pshufb, psign, shift_simd_by_scalar,
+    ShiftOp, mpsadbw, packssdw, packsswb, packusdw, packuswb, permute, pmaddbw, pmaddwd, pmulhrsw,
+    psadbw, pshufb, psign, shift_simd_by_scalar,
 };
 use crate::*;
 
@@ -21,20 +20,6 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let unprefixed_name = link_name.as_str().strip_prefix("llvm.x86.avx2.").unwrap();
 
         match unprefixed_name {
-            // Used to implement the _mm256_h{adds,subs}_epi16 functions.
-            // Horizontally add / subtract with saturation adjacent 16-bit
-            // integer values in `left` and `right`.
-            "phadd.sw" | "phsub.sw" => {
-                let [left, right] = this.check_shim_sig_unadjusted(link_name, args)?;
-
-                let which = match unprefixed_name {
-                    "phadd.sw" => mir::BinOp::Add,
-                    "phsub.sw" => mir::BinOp::Sub,
-                    _ => unreachable!(),
-                };
-
-                horizontal_bin_op(this, which, /*saturating*/ true, left, right, dest)?;
-            }
             // Used to implement `_mm{,_mask}_{i32,i64}gather_{epi32,epi64,pd,ps}` functions
             // Gathers elements from `slice` using `offsets * scale` as indices.
             // When the highest bit of the corresponding element of `mask` is 0,

--- a/src/intrinsics/x86/mod.rs
+++ b/src/intrinsics/x86/mod.rs
@@ -667,58 +667,6 @@ fn split_simd_to_128bit_chunks<'tcx, P: Projectable<'tcx, Provenance>>(
     interp_ok((num_chunks, items_per_chunk, chunked_op))
 }
 
-/// Horizontally performs `which` operation on adjacent values of
-/// `left` and `right` SIMD vectors and stores the result in `dest`.
-/// "Horizontal" means that the i-th output element is calculated
-/// from the elements 2*i and 2*i+1 of the concatenation of `left` and
-/// `right`.
-///
-/// Each 128-bit chunk is treated independently (i.e., the value for
-/// the is i-th 128-bit chunk of `dest` is calculated with the i-th
-/// 128-bit chunks of `left` and `right`).
-fn horizontal_bin_op<'tcx>(
-    ecx: &mut crate::MiriInterpCx<'tcx>,
-    which: mir::BinOp,
-    saturating: bool,
-    left: &OpTy<'tcx>,
-    right: &OpTy<'tcx>,
-    dest: &MPlaceTy<'tcx>,
-) -> InterpResult<'tcx, ()> {
-    assert_eq!(left.layout, dest.layout);
-    assert_eq!(right.layout, dest.layout);
-
-    let (num_chunks, items_per_chunk, left) = split_simd_to_128bit_chunks(ecx, left)?;
-    let (_, _, right) = split_simd_to_128bit_chunks(ecx, right)?;
-    let (_, _, dest) = split_simd_to_128bit_chunks(ecx, dest)?;
-
-    let middle = items_per_chunk / 2;
-    for i in 0..num_chunks {
-        let left = ecx.project_index(&left, i)?;
-        let right = ecx.project_index(&right, i)?;
-        let dest = ecx.project_index(&dest, i)?;
-
-        for j in 0..items_per_chunk {
-            // `j` is the index in `dest`
-            // `k` is the index of the 2-item chunk in `src`
-            let (k, src) = if j < middle { (j, &left) } else { (j.strict_sub(middle), &right) };
-            // `base_i` is the index of the first item of the 2-item chunk in `src`
-            let base_i = k.strict_mul(2);
-            let lhs = ecx.read_immediate(&ecx.project_index(src, base_i)?)?;
-            let rhs = ecx.read_immediate(&ecx.project_index(src, base_i.strict_add(1))?)?;
-
-            let res = if saturating {
-                Immediate::from(ecx.saturating_arith(which, &lhs, &rhs)?)
-            } else {
-                *ecx.binary_op(which, &lhs, &rhs)?
-            };
-
-            ecx.write_immediate(res, &ecx.project_index(&dest, j)?)?;
-        }
-    }
-
-    interp_ok(())
-}
-
 /// Conditionally multiplies the packed floating-point elements in
 /// `left` and `right` using the high 4 bits in `imm`, sums the calculated
 /// products (up to 4), and conditionally stores the sum in `dest` using

--- a/src/intrinsics/x86/ssse3.rs
+++ b/src/intrinsics/x86/ssse3.rs
@@ -1,7 +1,6 @@
-use rustc_middle::mir;
 use rustc_span::Symbol;
 
-use super::{horizontal_bin_op, pmaddbw, pmulhrsw, pshufb, psign};
+use super::{pmaddbw, pmulhrsw, pshufb, psign};
 use crate::*;
 
 impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
@@ -25,20 +24,6 @@ pub(super) trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let [left, right] = this.check_shim_sig_unadjusted(link_name, args)?;
 
                 pshufb(this, left, right, dest)?;
-            }
-            // Used to implement the _mm_h{adds,subs}_epi16 functions.
-            // Horizontally add / subtract with saturation adjacent 16-bit
-            // integer values in `left` and `right`.
-            "phadd.sw.128" | "phsub.sw.128" => {
-                let [left, right] = this.check_shim_sig_unadjusted(link_name, args)?;
-
-                let which = match unprefixed_name {
-                    "phadd.sw.128" => mir::BinOp::Add,
-                    "phsub.sw.128" => mir::BinOp::Sub,
-                    _ => unreachable!(),
-                };
-
-                horizontal_bin_op(this, which, /*saturating*/ true, left, right, dest)?;
             }
             // Used to implement the _mm_maddubs_epi16 function.
             "pmadd.ub.sw.128" => {


### PR DESCRIPTION
stdarch doesn't use these "horizontal" operations any more so let's get rid of the code for them.