### PR TITLE
Add shim for `malloc_usable_size`

### DIFF
--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -652,6 +652,39 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     this.write_null(dest)?;
                 }
             }
+            "malloc_usable_size" => {
+                this.check_target_os(&[Os::Linux, Os::FreeBsd, Os::Android], link_name)?;
+
+                let [ptr] = this.check_shim_sig(
+                    shim_sig!(extern "C" fn(*mut _) -> usize),
+                    link_name,
+                    abi,
+                    args,
+                )?;
+                let ptr = this.read_pointer(ptr)?;
+                let size = if this.ptr_is_null(ptr)? {
+                    0
+                } else {
+                    let (alloc_id, offset, _) = this.ptr_get_alloc_id(ptr, 0)?;
+                    if offset.bytes() != 0 {
+                        throw_ub_format!(
+                            "`malloc_usable_size` was called on a pointer that does not point to the beginning of its allocation"
+                        );
+                    }
+                    let Some((alloc_kind, _)) = this.memory.alloc_map().get(alloc_id) else {
+                        throw_ub_format!(
+                            "`malloc_usable_size` was called on a pointer to memory not managed by the C allocator"
+                        );
+                    };
+                    if *alloc_kind != MiriMemoryKind::C.into() {
+                        throw_ub_format!(
+                            "`malloc_usable_size` was called on a pointer to {alloc_kind} memory, which is not managed by the C allocator"
+                        );
+                    }
+                    this.get_alloc_info(alloc_id).size.bytes()
+                };
+                this.write_scalar(Scalar::from_target_usize(size, this), dest)?;
+            }
 
             // C memory handling functions
             "memcmp" => {

--- a/tests/fail-dep/libc/malloc_usable_size.rs
+++ b/tests/fail-dep/libc/malloc_usable_size.rs
@@ -1,0 +1,10 @@
+//@only-target: linux android freebsd
+
+fn main() {
+    unsafe {
+        // A Rust heap allocation is not managed by the C allocator.
+        let b = Box::new(42);
+        let p = Box::into_raw(b).cast::<libc::c_void>();
+        libc::malloc_usable_size(p); //~ERROR: not managed by the C allocator
+    }
+}

--- a/tests/fail-dep/libc/malloc_usable_size.stderr
+++ b/tests/fail-dep/libc/malloc_usable_size.stderr
@@ -1,0 +1,13 @@
+error: Undefined Behavior: `malloc_usable_size` was called on a pointer to Rust heap memory, which is not managed by the C allocator
+  --> tests/fail-dep/libc/malloc_usable_size.rs:LL:CC
+   |
+LL |         libc::malloc_usable_size(p);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/tests/fail-dep/libc/malloc_usable_size_interior.rs
+++ b/tests/fail-dep/libc/malloc_usable_size_interior.rs
@@ -1,0 +1,10 @@
+//@only-target: linux android freebsd
+
+fn main() {
+    unsafe {
+        // The pointer must point to the beginning of the block.
+        let p = libc::malloc(1024);
+        let mid = p.cast::<u8>().add(512).cast::<libc::c_void>();
+        libc::malloc_usable_size(mid); //~ERROR: does not point to the beginning
+    }
+}

--- a/tests/fail-dep/libc/malloc_usable_size_interior.stderr
+++ b/tests/fail-dep/libc/malloc_usable_size_interior.stderr
@@ -1,0 +1,13 @@
+error: Undefined Behavior: `malloc_usable_size` was called on a pointer that does not point to the beginning of its allocation
+  --> tests/fail-dep/libc/malloc_usable_size_interior.rs:LL:CC
+   |
+LL |         libc::malloc_usable_size(mid);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/tests/fail-dep/libc/malloc_usable_size_stack.rs
+++ b/tests/fail-dep/libc/malloc_usable_size_stack.rs
@@ -1,0 +1,10 @@
+//@only-target: linux android freebsd
+
+fn main() {
+    unsafe {
+        // A stack variable is not managed by the C allocator.
+        let mut x = 42;
+        let p = (&raw mut x).cast::<libc::c_void>();
+        libc::malloc_usable_size(p); //~ERROR: not managed by the C allocator
+    }
+}

--- a/tests/fail-dep/libc/malloc_usable_size_stack.stderr
+++ b/tests/fail-dep/libc/malloc_usable_size_stack.stderr
@@ -1,0 +1,13 @@
+error: Undefined Behavior: `malloc_usable_size` was called on a pointer to stack variable memory, which is not managed by the C allocator
+  --> tests/fail-dep/libc/malloc_usable_size_stack.rs:LL:CC
+   |
+LL |         libc::malloc_usable_size(p);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/tests/pass-dep/libc/libc-mem.rs
+++ b/tests/pass-dep/libc/libc-mem.rs
@@ -408,6 +408,24 @@ fn test_strnlen() {
     }
 }
 
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+fn test_malloc_usable_size() {
+    unsafe {
+        // `malloc_usable_size(NULL)` returns 0.
+        assert_eq!(libc::malloc_usable_size(ptr::null_mut()), 0);
+
+        for size in [1, 2, 5, 16, 123, 1024] {
+            let p = libc::malloc(size);
+            if cfg!(miri) {
+                // Miri returns the exact size, but it doesn't need to.
+                assert_eq!(libc::malloc_usable_size(p), size);
+            }
+            assert!(libc::malloc_usable_size(p) >= size);
+            libc::free(p);
+        }
+    }
+}
+
 fn test_wcslen() {
     fn to_c_wchar_t_str(s: &str) -> Vec<libc::wchar_t> {
         let mut r = Vec::<libc::wchar_t>::new();
@@ -444,6 +462,8 @@ fn main() {
     test_reallocarray();
     #[cfg(not(target_os = "windows"))]
     test_aligned_alloc();
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+    test_malloc_usable_size();
 
     test_memcpy();
     test_strcpy();


### PR DESCRIPTION
My relibc trick can't provide this specific function, so I decided to add its shim to miri.