### PR TITLE
have triagebot link to LLM policy

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -17,6 +17,7 @@ allow-unauthenticated = [
 [assign]
 warn_non_default_branch = true
 contributing_url = "https://github.com/rust-lang/miri/blob/master/CONTRIBUTING.md#pr-review-process"
+llm_policy_url = "https://github.com/rust-lang/miri/blob/master/CONTRIBUTING.md#ai-policy"
 
 [no-merges]
 exclude_titles = ["Rustup"]


### PR DESCRIPTION
I saw this in https://github.com/rust-lang/triagebot/pull/2486. @Kobzol is this already live?