### PR TITLE
Relax size and align check of extern statics

### DIFF
--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1472,8 +1472,8 @@ impl<'tcx> Machine<'tcx> for MiriMachine<'tcx> {
                 panic!("extern_statics cannot contain wildcards")
             };
             let info = ecx.get_alloc_info(alloc_id);
-            if extern_decl_layout.size != info.size || extern_decl_layout.align.abi != info.align {
-                throw_unsup_format!(
+            if extern_decl_layout.size > info.size || extern_decl_layout.align.abi > info.align {
+                throw_ub_format!(
                     "extern static `{link_name}` has been declared as `{krate}::{name}` \
                     with a size of {decl_size} bytes and alignment of {decl_align} bytes, \
                     but Miri emulates it via an extern static shim \
@@ -1516,7 +1516,7 @@ impl<'tcx> Machine<'tcx> for MiriMachine<'tcx> {
             // Validate the allocation matches the declared size and alignment.
             let alloc_id = static_ptr.provenance.get_alloc_id().unwrap();
             let info = ecx.get_alloc_info(alloc_id);
-            if extern_decl_layout.size != info.size || extern_decl_layout.align.abi != info.align {
+            if extern_decl_layout.size > info.size || extern_decl_layout.align.abi > info.align {
                 throw_ub_format!(
                     "extern static `{link_name}` has been declared as `{krate}::{name}` \
                     with a size of {decl_size} bytes and alignment of {decl_align} bytes, \

--- a/tests/fail/extern_static/wrong_size_shim.rs
+++ b/tests/fail/extern_static/wrong_size_shim.rs
@@ -2,9 +2,13 @@
 //@normalize-stderr-test: "[48] bytes" -> "N bytes"
 
 extern "C" {
-    static mut environ: i8;
+    #[link_name = "environ"]
+    static mut environ_good: i8;
+    #[link_name = "environ"]
+    static mut environ_bad: [i8; 10];
 }
 
 fn main() {
-    let _val = unsafe { environ }; //~ ERROR: /with a size of 1 bytes and alignment of 1 bytes, but Miri emulates it via an extern static shim with a size of [48] bytes and alignment of [48] bytes/
+    let _val = unsafe { environ_good };
+    let _val = unsafe { environ_bad }; //~ ERROR: /with a size of 10 bytes and alignment of 1 bytes, but Miri emulates it via an extern static shim with a size of [48] bytes and alignment of [48] bytes/
 }

--- a/tests/fail/extern_static/wrong_size_shim.stderr
+++ b/tests/fail/extern_static/wrong_size_shim.stderr
@@ -1,10 +1,11 @@
-error: unsupported operation: extern static `environ` has been declared as `wrong_size_shim::environ` with a size of 1 bytes and alignment of 1 bytes, but Miri emulates it via an extern static shim with a size of N bytes and alignment of N bytes
+error: Undefined Behavior: extern static `environ` has been declared as `wrong_size_shim::environ_bad` with a size of 10 bytes and alignment of 1 bytes, but Miri emulates it via an extern static shim with a size of N bytes and alignment of N bytes
   --> tests/fail/extern_static/wrong_size_shim.rs:LL:CC
    |
-LL |     let _val = unsafe { environ };
-   |                         ^^^^^^^ unsupported operation occurred here
+LL |     let _val = unsafe { environ_bad };
+   |                         ^^^^^^^^^^^ Undefined Behavior occurred here
    |
-   = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/tests/pass/extern_static.rs
+++ b/tests/pass/extern_static.rs
@@ -20,6 +20,9 @@ static FOO_U32: u32 = 42;
 #[no_mangle]
 static INTERIOR_MUT: SyncUnsafeCell<i32> = SyncUnsafeCell::new(42);
 
+#[no_mangle]
+static ARRAY: [u32; 5] = [1, 2, 3, 4, 5];
+
 fn increase_mutable_static_by_original_def(add_val: i32) {
     unsafe {
         let new_val = (&raw mut MUTABLE_STATIC).read() + add_val;
@@ -59,6 +62,30 @@ fn main() {
         unsafe {
             (&raw mut INTERIOR_MUT_AS_MUTABLE_STATIC).write(7);
             MUTABLE_STATIC_AS_INTERIOR_MUT.get().write(3);
+        }
+
+        // It's okay for the actual static to be bigger or more aligned than the extern declaration.
+        extern "C" {
+            // Actual size is bigger (20 bytes).
+            #[link_name = "ARRAY"]
+            static ARRAY_UNKNOWN_SIZE: [u32; 0];
+
+            // Actual size and alignment is that of u32, not u16.
+            #[link_name = "FOO_U32"]
+            static U16_TO_FOO_U32: u16;
+        }
+
+        unsafe {
+            let ptr = (&raw const ARRAY_UNKNOWN_SIZE).cast::<i32>();
+            assert_eq!(ptr.read(), 1);
+            assert_eq!(ptr.offset(2).read(), 3);
+
+            // We see one half of FOO_U32, depending on endianess.
+            if cfg!(target_endian = "little") {
+                assert_eq!(U16_TO_FOO_U32, 42);
+            } else {
+                assert_eq!(U16_TO_FOO_U32, 0);
+            }
         }
     }
 


### PR DESCRIPTION
Fix [#t-opsem > How to define an extern static to an array with unknown size](https://rust-lang.zulipchat.com/#narrow/channel/136281-t-opsem/topic/How.20to.20define.20an.20extern.20static.20to.20an.20array.20with.20unknown.20size/with/618080238)