### PR TITLE
Bail out in more tests if we don't detect the required feature at runtime

### DIFF
--- a/tests/pass/shims/x86/intrinsics-x86-aes-vaes.rs
+++ b/tests/pass/shims/x86/intrinsics-x86-aes-vaes.rs
@@ -11,10 +11,20 @@ use std::arch::x86_64::*;
 
 fn main() {
     assert!(is_x86_feature_detected!("aes"));
-    assert!(is_x86_feature_detected!("vaes"));
 
     unsafe {
         test_aes();
+    }
+
+    // The tests below require vaes, which is recent enough that contributors may be using CPUs that
+    // do not support it. But we still want to run this natively if the machine happens to have vaes.
+    // So we bail out dynamically.
+    if !is_x86_feature_detected!("vaes") {
+        println!("warning: skipping vaes tests");
+        return;
+    }
+
+    unsafe {
         test_vaes();
     }
 }

--- a/tests/pass/shims/x86/intrinsics-x86-vpclmulqdq.rs
+++ b/tests/pass/shims/x86/intrinsics-x86-vpclmulqdq.rs
@@ -19,8 +19,15 @@ use std::mem::transmute;
 fn main() {
     // Mostly copied from library/stdarch/crates/core_arch/src/x86/vpclmulqdq.rs
 
+    // These tests require vpclmuldqd, which is recent enough that contributors may be using CPUs that
+    // do not support it. But we still want to run this natively if the machine happens to have vpclmulqdq.
+    // So we bail out dynamically.
+    if !is_x86_feature_detected!("vpclmulqdq") {
+        println!("warning: skipping vpclmulqdq tests");
+        return;
+    }
+
     assert!(is_x86_feature_detected!("pclmulqdq"));
-    assert!(is_x86_feature_detected!("vpclmulqdq"));
 
     unsafe {
         test_mm256_clmulepi64_epi128();


### PR DESCRIPTION
See [#miri > Which tests should be run natively (by default?)](https://rust-lang.zulipchat.com/#narrow/channel/269128-miri/topic/Which.20tests.20should.20be.20run.20natively.20.28by.20default.3F.29/with/616779386)

This is enough changes to get `./miri test` to pass cleanly on my desktop.