### PR TITLE
run `f16` and `f128` tests natively when reliable

### DIFF
--- a/tests/pass/intrinsics/portable-simd.rs
+++ b/tests/pass/intrinsics/portable-simd.rs
@@ -8,6 +8,7 @@
     intrinsics,
     core_intrinsics,
     repr_simd,
+    cfg_target_has_reliable_f16_f128,
     f16,
     f128
 )]
@@ -77,7 +78,7 @@ impl<T: Copy, const N: usize> PackedSimd<T, N> {
 #[rustc_nounwind]
 pub const unsafe fn simd_shuffle_const_generic<T, U, const IDX: &'static [u32]>(x: T, y: T) -> U;
 
-#[cfg(miri)] // FIXME(f16_f128) doesn't always work natively
+#[cfg(any(miri, target_has_reliable_f16_math))]
 fn simd_ops_f16() {
     use intrinsics::*;
 
@@ -316,7 +317,7 @@ fn simd_ops_f64() {
     }
 }
 
-#[cfg(miri)] // FIXME(f16_f128) doesn't always work natively
+#[cfg(any(miri, target_has_reliable_f128_math))]
 fn simd_ops_f128() {
     use intrinsics::*;
 
@@ -860,7 +861,7 @@ fn simd_gather_scatter() {
 }
 
 fn simd_round() {
-    #[cfg(miri)] // FIXME(f16_f128) doesn't always work natively
+    #[cfg(any(miri, target_has_reliable_f16_math))]
     unsafe {
         use intrinsics::*;
 
@@ -928,7 +929,7 @@ fn simd_round() {
         f64x4::from_array([0.0, 1.0, 2.0, -4.0])
     );
 
-    #[cfg(miri)] // FIXME(f16_f128) doesn't always work natively
+    #[cfg(any(miri, target_has_reliable_f128_math))]
     unsafe {
         use intrinsics::*;
 
@@ -1169,11 +1170,11 @@ fn simd_ops_non_pow2() {
 
 fn main() {
     simd_mask();
-    #[cfg(miri)]
+    #[cfg(any(miri, target_has_reliable_f16_math))]
     simd_ops_f16();
     simd_ops_f32();
     simd_ops_f64();
-    #[cfg(miri)]
+    #[cfg(any(miri, target_has_reliable_f128_math))]
     simd_ops_f128();
     simd_ops_i32();
     simd_ops_non_pow2();

--- a/tests/pass/intrinsics/portable-simd.rs
+++ b/tests/pass/intrinsics/portable-simd.rs
@@ -20,6 +20,16 @@ use std::ptr;
 use std::simd::StdFloat;
 use std::simd::prelude::*;
 
+// small hack to make type inference better
+macro_rules! assert_eq {
+    ($a:expr, $b:expr $(,$t:tt)* $(,)?) => {{
+        let a = $a;
+        let b = $b;
+        if false { let _inference = b == a; }
+        ::std::assert_eq!(a, b, $(,$t)*)
+    }}
+}
+
 // The `portable_simd` crate currently does not support f16 or f128 vectors, so we define our own.
 #[repr(simd, packed)]
 #[derive(Copy)]
@@ -70,16 +80,6 @@ pub const unsafe fn simd_shuffle_const_generic<T, U, const IDX: &'static [u32]>(
 #[cfg(miri)] // FIXME(f16_f128) doesn't always work natively
 fn simd_ops_f16() {
     use intrinsics::*;
-
-    // small hack to make type inference better
-    macro_rules! assert_eq {
-        ($a:expr, $b:expr $(,$t:tt)*) => {{
-            let a = $a;
-            let b = $b;
-            if false { let _inference = b == a; }
-            ::std::assert_eq!(a, b, $(,$t)*)
-        }}
-    }
 
     let a = f16x4::splat(10.0);
     let b = f16x4::from_array([1.0, 2.0, 3.0, -4.0]);
@@ -132,10 +132,6 @@ fn simd_ops_f16() {
         assert_eq!(simd_reduce_add_ordered(b, 0.0), 2.0f16);
         assert_eq!(simd_reduce_mul_ordered(a, 1.0), 10000.0f16);
         assert_eq!(simd_reduce_mul_ordered(b, 1.0), -24.0f16);
-        assert_eq!(simd_reduce_max(a), 10.0f16);
-        assert_eq!(simd_reduce_max(b), 3.0f16);
-        assert_eq!(simd_reduce_min(a), 10.0f16);
-        assert_eq!(simd_reduce_min(b), -4.0f16);
 
         assert_eq!(
             simd_maximum_number_nsz(
@@ -144,8 +140,6 @@ fn simd_ops_f16() {
             ),
             f16x2::from_array([0.0, 0.0])
         );
-        assert_eq!(simd_reduce_max(f16x2::from_array([0.0, f16::NAN])), 0.0f16);
-        assert_eq!(simd_reduce_max(f16x2::from_array([f16::NAN, 0.0])), 0.0f16);
         assert_eq!(
             simd_minimum_number_nsz(
                 f16x2::from_array([0.0, f16::NAN]),
@@ -153,8 +147,22 @@ fn simd_ops_f16() {
             ),
             f16x2::from_array([0.0, 0.0])
         );
-        assert_eq!(simd_reduce_min(f16x2::from_array([0.0, f16::NAN])), 0.0f16);
-        assert_eq!(simd_reduce_min(f16x2::from_array([f16::NAN, 0.0])), 0.0f16);
+
+        // FIXME(llvm): The LLVM backend rejects float `simd_reduce_{min,max}`,
+        // see https://github.com/llvm/llvm-project/issues/185827.
+        #[cfg(miri)]
+        {
+            assert_eq!(simd_reduce_max(a), 10.0f16);
+            assert_eq!(simd_reduce_max(b), 3.0f16);
+            assert_eq!(simd_reduce_min(a), 10.0f16);
+            assert_eq!(simd_reduce_min(b), -4.0f16);
+
+            assert_eq!(simd_reduce_max(f16x2::from_array([0.0, f16::NAN])), 0.0f16);
+            assert_eq!(simd_reduce_max(f16x2::from_array([f16::NAN, 0.0])), 0.0f16);
+
+            assert_eq!(simd_reduce_min(f16x2::from_array([0.0, f16::NAN])), 0.0f16);
+            assert_eq!(simd_reduce_min(f16x2::from_array([f16::NAN, 0.0])), 0.0f16);
+        }
     }
 }
 
@@ -204,23 +212,33 @@ fn simd_ops_f32() {
     assert_eq!(b.reduce_sum(), 2.0);
     assert_eq!(a.reduce_product(), 100.0 * 100.0);
     assert_eq!(b.reduce_product(), -24.0);
-    assert_eq!(a.reduce_max(), 10.0);
-    assert_eq!(b.reduce_max(), 3.0);
-    assert_eq!(a.reduce_min(), 10.0);
-    assert_eq!(b.reduce_min(), -4.0);
 
     assert_eq!(
         f32x2::from_array([0.0, f32::NAN]).simd_max(f32x2::from_array([f32::NAN, 0.0])),
         f32x2::from_array([0.0, 0.0])
     );
-    assert_eq!(f32x2::from_array([0.0, f32::NAN]).reduce_max(), 0.0);
-    assert_eq!(f32x2::from_array([f32::NAN, 0.0]).reduce_max(), 0.0);
     assert_eq!(
         f32x2::from_array([0.0, f32::NAN]).simd_min(f32x2::from_array([f32::NAN, 0.0])),
         f32x2::from_array([0.0, 0.0])
     );
-    assert_eq!(f32x2::from_array([0.0, f32::NAN]).reduce_min(), 0.0);
-    assert_eq!(f32x2::from_array([f32::NAN, 0.0]).reduce_min(), 0.0);
+
+    // FIXME(llvm): The LLVM backend rejects float `simd_reduce_{min,max}`,
+    // see https://github.com/llvm/llvm-project/issues/185827.
+    #[cfg(miri)]
+    unsafe {
+        use intrinsics::{simd_reduce_max, simd_reduce_min};
+
+        assert_eq!(simd_reduce_max(a), 10.0f32);
+        assert_eq!(simd_reduce_max(b), 3.0f32);
+        assert_eq!(simd_reduce_min(a), 10.0f32);
+        assert_eq!(simd_reduce_min(b), -4.0f32);
+
+        assert_eq!(simd_reduce_max(f32x2::from_array([0.0, f32::NAN])), 0.0f32);
+        assert_eq!(simd_reduce_max(f32x2::from_array([f32::NAN, 0.0])), 0.0f32);
+
+        assert_eq!(simd_reduce_min(f32x2::from_array([0.0, f32::NAN])), 0.0f32);
+        assert_eq!(simd_reduce_min(f32x2::from_array([f32::NAN, 0.0])), 0.0f32);
+    }
 }
 
 fn simd_ops_f64() {
@@ -269,38 +287,38 @@ fn simd_ops_f64() {
     assert_eq!(b.reduce_sum(), 2.0);
     assert_eq!(a.reduce_product(), 100.0 * 100.0);
     assert_eq!(b.reduce_product(), -24.0);
-    assert_eq!(a.reduce_max(), 10.0);
-    assert_eq!(b.reduce_max(), 3.0);
-    assert_eq!(a.reduce_min(), 10.0);
-    assert_eq!(b.reduce_min(), -4.0);
 
     assert_eq!(
         f64x2::from_array([0.0, f64::NAN]).simd_max(f64x2::from_array([f64::NAN, 0.0])),
         f64x2::from_array([0.0, 0.0])
     );
-    assert_eq!(f64x2::from_array([0.0, f64::NAN]).reduce_max(), 0.0);
-    assert_eq!(f64x2::from_array([f64::NAN, 0.0]).reduce_max(), 0.0);
     assert_eq!(
         f64x2::from_array([0.0, f64::NAN]).simd_min(f64x2::from_array([f64::NAN, 0.0])),
         f64x2::from_array([0.0, 0.0])
     );
-    assert_eq!(f64x2::from_array([0.0, f64::NAN]).reduce_min(), 0.0);
-    assert_eq!(f64x2::from_array([f64::NAN, 0.0]).reduce_min(), 0.0);
+
+    // FIXME(llvm): The LLVM backend rejects float `simd_reduce_{min,max}`,
+    // see https://github.com/llvm/llvm-project/issues/185827.
+    #[cfg(miri)]
+    unsafe {
+        use intrinsics::{simd_reduce_max, simd_reduce_min};
+
+        assert_eq!(simd_reduce_max(a), 10.0f64);
+        assert_eq!(simd_reduce_max(b), 3.0f64);
+        assert_eq!(simd_reduce_min(a), 10.0f64);
+        assert_eq!(simd_reduce_min(b), -4.0f64);
+
+        assert_eq!(simd_reduce_max(f64x2::from_array([0.0, f64::NAN])), 0.0f64);
+        assert_eq!(simd_reduce_max(f64x2::from_array([f64::NAN, 0.0])), 0.0f64);
+
+        assert_eq!(simd_reduce_min(f64x2::from_array([0.0, f64::NAN])), 0.0f64);
+        assert_eq!(simd_reduce_min(f64x2::from_array([f64::NAN, 0.0])), 0.0f64);
+    }
 }
 
 #[cfg(miri)] // FIXME(f16_f128) doesn't always work natively
 fn simd_ops_f128() {
     use intrinsics::*;
-
-    // small hack to make type inference better
-    macro_rules! assert_eq {
-        ($a:expr, $b:expr $(,$t:tt)*) => {{
-            let a = $a;
-            let b = $b;
-            if false { let _inference = b == a; }
-            ::std::assert_eq!(a, b, $(,$t)*)
-        }}
-    }
 
     let a = f128x4::splat(10.0);
     let b = f128x4::from_array([1.0, 2.0, 3.0, -4.0]);
@@ -353,10 +371,6 @@ fn simd_ops_f128() {
         assert_eq!(simd_reduce_add_ordered(b, 0.0), 2.0f128);
         assert_eq!(simd_reduce_mul_ordered(a, 1.0), 10000.0f128);
         assert_eq!(simd_reduce_mul_ordered(b, 1.0), -24.0f128);
-        assert_eq!(simd_reduce_max(a), 10.0f128);
-        assert_eq!(simd_reduce_max(b), 3.0f128);
-        assert_eq!(simd_reduce_min(a), 10.0f128);
-        assert_eq!(simd_reduce_min(b), -4.0f128);
 
         assert_eq!(
             simd_maximum_number_nsz(
@@ -365,8 +379,6 @@ fn simd_ops_f128() {
             ),
             f128x2::from_array([0.0, 0.0])
         );
-        assert_eq!(simd_reduce_max(f128x2::from_array([0.0, f128::NAN])), 0.0f128);
-        assert_eq!(simd_reduce_max(f128x2::from_array([f128::NAN, 0.0])), 0.0f128);
         assert_eq!(
             simd_minimum_number_nsz(
                 f128x2::from_array([0.0, f128::NAN]),
@@ -374,8 +386,22 @@ fn simd_ops_f128() {
             ),
             f128x2::from_array([0.0, 0.0])
         );
-        assert_eq!(simd_reduce_min(f128x2::from_array([0.0, f128::NAN])), 0.0f128);
-        assert_eq!(simd_reduce_min(f128x2::from_array([f128::NAN, 0.0])), 0.0f128);
+
+        // FIXME(llvm): The LLVM backend rejects float `simd_reduce_{min,max}`,
+        // see https://github.com/llvm/llvm-project/issues/185827.
+        #[cfg(miri)]
+        {
+            assert_eq!(simd_reduce_max(a), 10.0f128);
+            assert_eq!(simd_reduce_max(b), 3.0f128);
+            assert_eq!(simd_reduce_min(a), 10.0f128);
+            assert_eq!(simd_reduce_min(b), -4.0f128);
+
+            assert_eq!(simd_reduce_max(f128x2::from_array([0.0, f128::NAN])), 0.0f128);
+            assert_eq!(simd_reduce_max(f128x2::from_array([f128::NAN, 0.0])), 0.0f128);
+
+            assert_eq!(simd_reduce_min(f128x2::from_array([0.0, f128::NAN])), 0.0f128);
+            assert_eq!(simd_reduce_min(f128x2::from_array([f128::NAN, 0.0])), 0.0f128);
+        }
     }
 }
 


### PR DESCRIPTION
I think this should just work? It seems to work locally anyway.