### PR TITLE
port all variadic functions to strict signature checking

### DIFF
--- a/src/shims/alloc.rs
+++ b/src/shims/alloc.rs
@@ -125,9 +125,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             SpecialAllocatorMethod::Alloc | SpecialAllocatorMethod::AllocZeroed => {
                 let [size, align] = this.check_shim_sig(
                     shim_sig_nounwind!(extern "Rust" fn(usize, core::mem::Alignment) -> *_),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let size = this.read_target_usize(size)?;
                 let align = this.read_target_usize(align)?;
@@ -150,9 +148,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             SpecialAllocatorMethod::Dealloc => {
                 let [ptr, old_size, align] = this.check_shim_sig(
                     shim_sig_nounwind!(extern "Rust" fn(*_, usize, core::mem::Alignment) -> ()),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let ptr = this.read_pointer(ptr)?;
                 let old_size = this.read_target_usize(old_size)?;
@@ -168,9 +164,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             SpecialAllocatorMethod::Realloc => {
                 let [ptr, old_size, align, new_size] = this.check_shim_sig(
                     shim_sig_nounwind!(extern "Rust" fn(*_, usize, core::mem::Alignment, usize) -> *_),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let ptr = this.read_pointer(ptr)?;
                 let old_size = this.read_target_usize(old_size)?;

--- a/src/shims/alloc.rs
+++ b/src/shims/alloc.rs
@@ -1,4 +1,4 @@
-use rustc_abi::{Align, AlignFromBytesError, CanonAbi, Size};
+use rustc_abi::{Align, AlignFromBytesError, Size};
 use rustc_ast::expand::allocator::SpecialAllocatorMethod;
 use rustc_middle::ty::Ty;
 use rustc_span::Symbol;
@@ -123,8 +123,12 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
         match method {
             SpecialAllocatorMethod::Alloc | SpecialAllocatorMethod::AllocZeroed => {
-                let [size, align] =
-                    this.check_shim_sig_deprecated(abi, CanonAbi::Rust, link_name, args)?;
+                let [size, align] = this.check_shim_sig(
+                    shim_sig_nounwind!(extern "Rust" fn(usize, core::mem::Alignment) -> *_),
+                    link_name,
+                    abi,
+                    args,
+                )?;
                 let size = this.read_target_usize(size)?;
                 let align = this.read_target_usize(align)?;
 
@@ -144,8 +148,12 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 this.write_pointer(ptr, dest)
             }
             SpecialAllocatorMethod::Dealloc => {
-                let [ptr, old_size, align] =
-                    this.check_shim_sig_deprecated(abi, CanonAbi::Rust, link_name, args)?;
+                let [ptr, old_size, align] = this.check_shim_sig(
+                    shim_sig_nounwind!(extern "Rust" fn(*_, usize, core::mem::Alignment) -> ()),
+                    link_name,
+                    abi,
+                    args,
+                )?;
                 let ptr = this.read_pointer(ptr)?;
                 let old_size = this.read_target_usize(old_size)?;
                 let align = this.read_target_usize(align)?;
@@ -158,8 +166,12 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 )
             }
             SpecialAllocatorMethod::Realloc => {
-                let [ptr, old_size, align, new_size] =
-                    this.check_shim_sig_deprecated(abi, CanonAbi::Rust, link_name, args)?;
+                let [ptr, old_size, align, new_size] = this.check_shim_sig(
+                    shim_sig_nounwind!(extern "Rust" fn(*_, usize, core::mem::Alignment, usize) -> *_),
+                    link_name,
+                    abi,
+                    args,
+                )?;
                 let ptr = this.read_pointer(ptr)?;
                 let old_size = this.read_target_usize(old_size)?;
                 let align = this.read_target_usize(align)?;

--- a/src/shims/backtrace.rs
+++ b/src/shims/backtrace.rs
@@ -16,7 +16,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     ) -> InterpResult<'tcx> {
         let this = self.eval_context_mut();
         let [flags] =
-            this.check_shim_sig(shim_sig!(extern "Rust" fn(u64) -> usize), link_name, abi, args)?;
+            this.check_shim_sig(shim_sig!(extern "Rust" fn(u64) -> usize), (link_name, abi, args))?;
 
         let flags = this.read_scalar(flags)?.to_u64()?;
         if flags != 0 {
@@ -38,8 +38,8 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         let ptr_ty = this.machine.layouts.mut_raw_ptr.ty;
         let ptr_layout = this.layout_of(ptr_ty)?;
 
-        let [flags, buf] =
-            this.check_shim_sig(shim_sig!(extern "Rust" fn(u64, *_) -> ()), link_name, abi, args)?;
+        let [flags, buf] = this
+            .check_shim_sig(shim_sig!(extern "Rust" fn(u64, *_) -> ()), (link_name, abi, args))?;
 
         let flags = this.read_scalar(flags)?.to_u64()?;
         let buf_place = this.deref_pointer_as(buf, ptr_layout)?;
@@ -195,9 +195,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
         let [ptr, flags, name_ptr, filename_ptr] = this.check_shim_sig(
             shim_sig!(extern "Rust" fn(*_, u64, *_, *_) -> ()),
-            link_name,
-            abi,
-            args,
+            (link_name, abi, args),
         )?;
 
         let flags = this.read_scalar(flags)?.to_u64()?;

--- a/src/shims/foreign_items.rs
+++ b/src/shims/foreign_items.rs
@@ -319,9 +319,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // instantly stable.
                 let [] = this.check_shim_sig(
                     shim_sig_nounwind!(extern "Rust" fn() -> ()),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
             }
 
@@ -329,9 +327,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "miri_alloc" => {
                 let [size, align] = this.check_shim_sig(
                     shim_sig!(extern "Rust" fn(usize, usize) -> *_),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let size = this.read_target_usize(size)?;
                 let align = this.read_target_usize(align)?;
@@ -350,9 +346,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "miri_dealloc" => {
                 let [ptr, old_size, align] = this.check_shim_sig(
                     shim_sig!(extern "Rust" fn(*_, usize, usize) -> ()),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let ptr = this.read_pointer(ptr)?;
                 let old_size = this.read_target_usize(old_size)?;
@@ -368,9 +362,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "miri_track_alloc" => {
                 let [ptr] = this.check_shim_sig(
                     shim_sig!(extern "Rust" fn(*_) -> ()),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let ptr = this.read_pointer(ptr)?;
                 let (alloc_id, _, _) = this.ptr_get_alloc_id(ptr, 0).map_err_kind(|_e| {
@@ -386,26 +378,20 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 }
             }
             "miri_start_unwind" => {
-                let [payload] = this.check_shim_sig(
-                    shim_sig!(extern "Rust" fn(*_) -> !),
-                    link_name,
-                    abi,
-                    args,
-                )?;
+                let [payload] = this
+                    .check_shim_sig(shim_sig!(extern "Rust" fn(*_) -> !), (link_name, abi, args))?;
                 this.handle_miri_start_unwind(payload)?;
                 return interp_ok(EmulateItemResult::NeedsUnwind);
             }
             "miri_run_provenance_gc" => {
-                let [] =
-                    this.check_shim_sig(shim_sig!(extern "Rust" fn() -> ()), link_name, abi, args)?;
+                let [] = this
+                    .check_shim_sig(shim_sig!(extern "Rust" fn() -> ()), (link_name, abi, args))?;
                 this.run_provenance_gc();
             }
             "miri_get_alloc_id" => {
                 let [ptr] = this.check_shim_sig(
                     shim_sig!(extern "Rust" fn(*_) -> u64),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let ptr = this.read_pointer(ptr)?;
                 let (alloc_id, _, _) = this.ptr_get_alloc_id(ptr, 0).map_err_kind(|_e| {
@@ -418,9 +404,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "miri_print_borrow_state" => {
                 let [id, show_unnamed] = this.check_shim_sig(
                     shim_sig!(extern "Rust" fn(u64, bool) -> ()),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let id = this.read_scalar(id)?.to_u64()?;
                 let show_unnamed = this.read_scalar(show_unnamed)?.to_bool()?;
@@ -437,9 +421,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // tests more strict.
                 let [ptr, nth_parent, name] = this.check_shim_sig(
                     shim_sig!(extern "Rust" fn(*_, u8, &[u8]) -> ()),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let ptr = this.read_pointer(ptr)?;
                 let nth_parent = this.read_scalar(nth_parent)?.to_u8()?;
@@ -455,9 +437,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "miri_static_root" => {
                 let [ptr] = this.check_shim_sig(
                     shim_sig!(extern "Rust" fn(*_) -> ()),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let ptr = this.read_pointer(ptr)?;
                 let (alloc_id, offset, _) = this.ptr_get_alloc_id(ptr, 0)?;
@@ -471,9 +451,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "miri_host_to_target_path" => {
                 let [ptr, out, out_size] = this.check_shim_sig(
                     shim_sig!(extern "Rust" fn(*_, *_, usize) -> usize),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let ptr = this.read_pointer(ptr)?;
                 let out = this.read_pointer(out)?;
@@ -493,9 +471,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let [start_routine, func_arg] = this.check_shim_sig(
                     // FIXME: The first argument is actually a function pointer.
                     shim_sig!(extern "Rust" fn(fn(..) -> _, *_) -> usize),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let start_routine = this.read_pointer(start_routine)?;
                 let func_arg = this.read_immediate(func_arg)?;
@@ -511,9 +487,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "miri_thread_join" => {
                 let [thread_id] = this.check_shim_sig(
                     shim_sig!(extern "Rust" fn(usize) -> bool),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
 
                 let thread = this.read_target_usize(thread_id)?;
@@ -535,8 +509,8 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
             }
             // Hint that a loop is spinning indefinitely.
             "miri_spin_loop" => {
-                let [] =
-                    this.check_shim_sig(shim_sig!(extern "Rust" fn() -> ()), link_name, abi, args)?;
+                let [] = this
+                    .check_shim_sig(shim_sig!(extern "Rust" fn() -> ()), (link_name, abi, args))?;
 
                 // Try to run another thread to maximize the chance of finding actual bugs.
                 this.yield_active_thread();
@@ -563,9 +537,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "miri_write_to_stdout" | "miri_write_to_stderr" => {
                 let [msg] = this.check_shim_sig(
                     shim_sig!(extern "Rust" fn(&[u8]) -> ()),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let msg = this.read_immediate(msg)?;
                 let msg = this.read_byte_slice(&msg)?;
@@ -582,9 +554,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 let [ptr, align] = this.check_shim_sig(
                     shim_sig!(extern "Rust" fn(*_, usize) -> ()),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
 
                 let ptr = this.read_pointer(ptr)?;
@@ -628,9 +598,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "miri_genmc_assume" => {
                 let [condition] = this.check_shim_sig(
                     shim_sig!(extern "Rust" fn(bool) -> ()),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
 
                 if this.machine.data_race.as_genmc_ref().is_some() {
@@ -643,8 +611,8 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
             // Aborting the process.
             "exit" => {
                 // FIXME: This does not have a direct test (#3179).
-                let [code] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(i32) -> ()), link_name, abi, args)?;
+                let [code] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(i32) -> ()), (link_name, abi, args))?;
                 let code = this.read_scalar(code)?.to_i32()?;
                 if let Some(genmc_ctx) = this.machine.data_race.as_genmc_ref() {
                     // If there is no error, execution should continue (on a different thread).
@@ -660,7 +628,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "abort" => {
                 // FIXME: This does not have a direct test (#3179).
                 let [] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn() -> ()), link_name, abi, args)?;
+                    this.check_shim_sig(shim_sig!(extern "C" fn() -> ()), (link_name, abi, args))?;
                 throw_machine_stop!(TerminationInfo::Abort(
                     "the program aborted execution".to_owned()
                 ));
@@ -670,9 +638,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "malloc" => {
                 let [size] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(usize) -> *_),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let size = this.read_target_usize(size)?;
                 if size <= this.max_size_of_val().bytes() {
@@ -689,9 +655,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "calloc" => {
                 let [items, elem_size] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(usize, usize) -> *_),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let items = this.read_target_usize(items)?;
                 let elem_size = this.read_target_usize(elem_size)?;
@@ -707,17 +671,15 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 }
             }
             "free" => {
-                let [ptr] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> ()), link_name, abi, args)?;
+                let [ptr] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> ()), (link_name, abi, args))?;
                 let ptr = this.read_pointer(ptr)?;
                 this.free(ptr)?;
             }
             "realloc" => {
                 let [old_ptr, new_size] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, usize) -> *_),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let old_ptr = this.read_pointer(old_ptr)?;
                 let new_size = this.read_target_usize(new_size)?;
@@ -737,9 +699,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 let [ptr] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_) -> usize),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let ptr = this.read_pointer(ptr)?;
                 let size = if this.ptr_is_null(ptr)? {
@@ -770,9 +730,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "memcmp" => {
                 let [left, right, n] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, *_, usize) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let left = this.read_pointer(left)?;
                 let right = this.read_pointer(right)?;
@@ -803,9 +761,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "memchr" => {
                 let [ptr, val, num] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, i32, usize) -> *_),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let ptr = this.read_pointer(ptr)?;
                 let val = this.read_scalar(val)?.to_i32()?;
@@ -832,9 +788,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 let [ptr, val, num] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, i32, usize) -> *_),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let ptr = this.read_pointer(ptr)?;
                 let val = this.read_scalar(val)?.to_i32()?;
@@ -858,9 +812,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "strlen" => {
                 let [ptr] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_) -> usize),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let ptr = this.read_pointer(ptr)?;
                 // This reads at least 1 byte, so we are already enforcing that this is a valid pointer.
@@ -873,9 +825,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "strnlen" => {
                 let [ptr, num] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, usize) -> usize),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let ptr = this.read_pointer(ptr)?;
                 let num = this.read_target_usize(num)?;
@@ -891,9 +841,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "wcslen" => {
                 let [ptr] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_) -> usize),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let ptr = this.read_pointer(ptr)?;
                 // This reads at least 1 byte, so we are already enforcing that this is a valid pointer.
@@ -906,9 +854,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "memcpy" => {
                 let [ptr_dest, ptr_src, n] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, *_, usize) -> *_),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let ptr_dest = this.read_pointer(ptr_dest)?;
                 let ptr_src = this.read_pointer(ptr_src)?;
@@ -925,9 +871,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "strcpy" => {
                 let [ptr_dest, ptr_src] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, *_) -> *_),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let ptr_dest = this.read_pointer(ptr_dest)?;
                 let ptr_src = this.read_pointer(ptr_src)?;
@@ -945,9 +889,7 @@ trait EvalContextExtPriv<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "memset" => {
                 let [ptr_dest, val, n] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, i32, usize) -> *_),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let ptr_dest = this.read_pointer(ptr_dest)?;
                 let val = this.read_scalar(val)?.to_i32()?;

--- a/src/shims/sig.rs
+++ b/src/shims/sig.rs
@@ -340,9 +340,8 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     fn check_shim_sig<'a, const N: usize>(
         &self,
         shim_sig: fn(&MiriInterpCx<'tcx>) -> ShimSig<'tcx, N>,
-        link_name: Symbol,
-        caller_fn_abi: &FnAbi<'tcx, Ty<'tcx>>,
-        caller_args: &'a [OpTy<'tcx>],
+        // We take these as a tuple so that this takes less space on the caller side.
+        (link_name, caller_fn_abi, caller_args): (Symbol, &FnAbi<'tcx, Ty<'tcx>>, &'a [OpTy<'tcx>]),
     ) -> InterpResult<'tcx, &'a [OpTy<'tcx>; N]> {
         let this = self.eval_context_ref();
 
@@ -367,9 +366,8 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     fn check_shim_sig_variadic<'a, const N: usize>(
         &self,
         shim_sig: fn(&MiriInterpCx<'tcx>) -> ShimSig<'tcx, N>,
-        link_name: Symbol,
-        caller_fn_abi: &FnAbi<'tcx, Ty<'tcx>>,
-        caller_args: &'a [OpTy<'tcx>],
+        // We take these as a tuple so that this takes less space on the caller side.
+        (link_name, caller_fn_abi, caller_args): (Symbol, &FnAbi<'tcx, Ty<'tcx>>, &'a [OpTy<'tcx>]),
     ) -> InterpResult<'tcx, (&'a [OpTy<'tcx>; N], Varargs<'tcx, 'a>)> {
         let this = self.eval_context_ref();
 

--- a/src/shims/sig.rs
+++ b/src/shims/sig.rs
@@ -13,6 +13,7 @@ pub struct ShimSig<'tcx, const ARGS: usize> {
     pub args: [Ty<'tcx>; ARGS],
     pub ret: Ty<'tcx>,
     pub nounwind: bool,
+    pub c_variadic: bool,
 }
 
 /// Construct a `ShimSig` with convenient syntax:
@@ -34,6 +35,21 @@ macro_rules! shim_sig {
             args: shim_sig_args_sep!(this, [$($args)*]),
             ret: shim_sig_arg!(this, $($ret)*),
             nounwind: false,
+            c_variadic: false,
+        }
+    };
+}
+
+/// Same as `shim_sig!` but declares a variadic function. The signature is for the fixed part.
+#[macro_export]
+macro_rules! shim_sig_variadic {
+    (extern $abi:literal fn($($args:tt)*) -> $($ret:tt)*) => {
+        |this| $crate::shims::sig::ShimSig {
+            abi: std::str::FromStr::from_str($abi).expect("incorrect abi specified"),
+            args: shim_sig_args_sep!(this, [$($args)*]),
+            ret: shim_sig_arg!(this, $($ret)*),
+            nounwind: true,
+            c_variadic: true,
         }
     };
 }
@@ -47,7 +63,16 @@ macro_rules! shim_sig_nounwind {
             args: shim_sig_args_sep!(this, [$($args)*]),
             ret: shim_sig_arg!(this, $($ret)*),
             nounwind: true,
+            c_variadic: false,
         }
+    };
+}
+
+/// Computes a list of types for varargs, using the same syntax as `shim_sig!`.
+#[macro_export]
+macro_rules! shim_varargs {
+    ($($args:tt)*) => {
+        |this| shim_sig_args_sep!(this, [$($args)*])
     };
 }
 
@@ -86,7 +111,7 @@ macro_rules! shim_sig_args_sep {
     (@ $this:ident [$($final:tt)*] [$($collected:tt)+] ) => {
         [$($final)* shim_sig_arg!($this, $($collected)*)]
     };
-    // No more tokens - emit final output.
+    // No more tokens, empty collector - emit final output.
     (@ $this:ident [$($final:tt)*] [] ) => {
         [$($final)*]
     };
@@ -169,6 +194,19 @@ macro_rules! shim_sig_arg {
     }
 }
 
+impl<'tcx, const ARGS: usize> ShimSig<'tcx, ARGS> {
+    fn as_abi(&self, ecx: &MiriInterpCx<'tcx>) -> &FnAbi<'tcx, Ty<'tcx>> {
+        let mut inputs_and_output = Vec::with_capacity(ARGS.strict_add(1));
+        inputs_and_output.extend(&self.args);
+        inputs_and_output.push(self.ret);
+        let fn_sig_binder = Binder::dummy(FnSig {
+            inputs_and_output: ecx.machine.tcx.mk_type_list(&inputs_and_output),
+            fn_sig_kind: FnSigKind::default().set_c_variadic(self.c_variadic).set_abi(self.abi),
+        });
+        ecx.fn_abi_of_fn_ptr(fn_sig_binder, Default::default()).unwrap()
+    }
+}
+
 /// Helper function to compare two ABIs.
 fn check_shim_abi<'tcx>(
     this: &MiriInterpCx<'tcx>,
@@ -203,8 +241,9 @@ fn check_shim_abi<'tcx>(
 
     if callee_abi.fixed_count != caller_abi.fixed_count {
         throw_ub_format!(
-            "ABI mismatch: calling `{link_name}` which takes {} argument{}, but {} argument{} given",
+            "ABI mismatch: calling `{link_name}` which takes {} {}argument{}, but {} argument{} given",
             callee_abi.fixed_count,
+            if callee_abi.c_variadic { "fixed (non-variadic) " } else { "" },
             if callee_abi.fixed_count == 1 { "" } else { "s" },
             caller_abi.fixed_count,
             if caller_abi.fixed_count == 1 { " was" } else { "s were" },
@@ -231,6 +270,14 @@ fn check_shim_abi<'tcx>(
     }
 
     interp_ok(())
+}
+
+/// Represents a tail of variadic arguments that have not yet been checked.
+// Deliberately not `Copy` so that we don't consume the same vararg multiple times accidentally.
+pub struct Varargs<'tcx, 'a> {
+    args: &'a [OpTy<'tcx>],
+    /// Number of variadic arguments that have already been taken, for error messages.
+    already_gone: usize,
 }
 
 impl<'tcx> EvalContextExt<'tcx> for crate::MiriInterpCx<'tcx> {}
@@ -291,27 +338,18 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     /// Check that the given `caller_fn_abi` matches the expected ABI described by `shim_sig`, and
     /// then returns the list of arguments.
     fn check_shim_sig<'a, const N: usize>(
-        &mut self,
+        &self,
         shim_sig: fn(&MiriInterpCx<'tcx>) -> ShimSig<'tcx, N>,
         link_name: Symbol,
         caller_fn_abi: &FnAbi<'tcx, Ty<'tcx>>,
         caller_args: &'a [OpTy<'tcx>],
     ) -> InterpResult<'tcx, &'a [OpTy<'tcx>; N]> {
-        let this = self.eval_context_mut();
-        let shim_sig = shim_sig(this);
+        let this = self.eval_context_ref();
 
-        // Compute full callee ABI.
-        let mut inputs_and_output = Vec::with_capacity(N.strict_add(1));
-        inputs_and_output.extend(&shim_sig.args);
-        inputs_and_output.push(shim_sig.ret);
-        let fn_sig_binder = Binder::dummy(FnSig {
-            inputs_and_output: this.machine.tcx.mk_type_list(&inputs_and_output),
-            // Safety and splatted do not matter for the ABI.
-            fn_sig_kind: FnSigKind::default()
-                .set_abi(shim_sig.abi)
-                .set_safety(rustc_hir::Safety::Safe),
-        });
-        let callee_fn_abi = this.fn_abi_of_fn_ptr(fn_sig_binder, Default::default())?;
+        // Compute callee ABI.
+        let shim_sig = shim_sig(this);
+        assert!(!shim_sig.c_variadic);
+        let callee_fn_abi = shim_sig.as_abi(this);
 
         // Check everything.
         check_shim_abi(this, link_name, callee_fn_abi, shim_sig.nounwind, caller_fn_abi)?;
@@ -324,42 +362,63 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         unreachable!()
     }
 
-    /// Check shim for variadic function.
-    /// Returns a tuple that consisting of an array of fixed args, and a slice of varargs.
-    fn check_shim_sig_variadic_lenient<'a, const N: usize>(
-        &mut self,
-        abi: &FnAbi<'tcx, Ty<'tcx>>,
-        exp_abi: CanonAbi,
+    /// Check that the given `caller_fn_abi` matches the expected ABI described by `shim_sig`, and
+    /// then returns the list of fixed and variadic arguments in separate lists.
+    fn check_shim_sig_variadic<'a, const N: usize>(
+        &self,
+        shim_sig: fn(&MiriInterpCx<'tcx>) -> ShimSig<'tcx, N>,
         link_name: Symbol,
-        args: &'a [OpTy<'tcx>],
-    ) -> InterpResult<'tcx, (&'a [OpTy<'tcx>; N], &'a [OpTy<'tcx>])>
-    where
-        &'a [OpTy<'tcx>; N]: TryFrom<&'a [OpTy<'tcx>]>,
-    {
-        self.check_shim_symbol_clash(link_name)?;
+        caller_fn_abi: &FnAbi<'tcx, Ty<'tcx>>,
+        caller_args: &'a [OpTy<'tcx>],
+    ) -> InterpResult<'tcx, (&'a [OpTy<'tcx>; N], Varargs<'tcx, 'a>)> {
+        let this = self.eval_context_ref();
 
-        if abi.conv != exp_abi {
-            throw_ub_format!(
-                r#"calling a function with calling convention "{exp_abi}" using caller calling convention "{}""#,
-                abi.conv
-            );
+        // Compute callee ABI.
+        let shim_sig = shim_sig(this);
+        assert!(shim_sig.c_variadic);
+        let callee_fn_abi = shim_sig.as_abi(this);
+
+        // Check everything.
+        check_shim_abi(this, link_name, callee_fn_abi, shim_sig.nounwind, caller_fn_abi)?;
+        this.check_shim_symbol_clash(link_name)?;
+
+        // Return arguments.
+        if let Some((fixed, var)) = caller_args.split_first_chunk() {
+            return interp_ok((fixed, Varargs { args: var, already_gone: 0 }));
         }
-        if !abi.c_variadic {
+        unreachable!()
+    }
+
+    /// Fetches `N` arguments from `varargs`, checking their types.
+    /// Also returns the remaining varargs.
+    fn check_varargs<'a, const N: usize>(
+        &self,
+        tys: fn(&MiriInterpCx<'tcx>) -> [Ty<'tcx>; N],
+        varargs: Varargs<'tcx, 'a>,
+        fn_name: &str,
+    ) -> InterpResult<'tcx, (&'a [OpTy<'tcx>; N], Varargs<'tcx, 'a>)> {
+        let this = self.eval_context_ref();
+        let tys = tys(this);
+
+        let Some((now, tail)) = varargs.args.split_first_chunk::<N>() else {
             throw_ub_format!(
-                "calling a variadic function with a non-variadic caller-side signature"
-            );
-        }
-        if abi.fixed_count != u32::try_from(N).unwrap() {
-            throw_ub_format!(
-                "incorrect number of fixed arguments for variadic function `{}`: got {}, expected {N}",
-                link_name.as_str(),
-                abi.fixed_count
+                "not enough variadic arguments for `{fn_name}`: got {}, expected at least {}",
+                varargs.already_gone.strict_add(varargs.args.len()),
+                varargs.already_gone.strict_add(N),
             )
+        };
+
+        for (n, (caller_gave, callee_expected)) in now.iter().zip(tys).enumerate() {
+            // Check ABI compatibility. This is less strict than `next_arg` but we're also
+            // not limited to just a few simple types.
+            let callee_expected = this.layout_of(callee_expected)?;
+
+            // FIXME: check compatibility once <https://github.com/rust-lang/rust/pull/161615>
+            // landed.
+            let _unused = (n, caller_gave, callee_expected);
         }
-        if let Some(args) = args.split_first_chunk() {
-            return interp_ok(args);
-        }
-        panic!("mismatch between signature and `args` slice");
+
+        interp_ok((now, Varargs { args: tail, already_gone: varargs.already_gone.strict_add(N) }))
     }
 
     /// Check that the given function has the expected amount of arguments, and then
@@ -384,20 +443,4 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             N
         )
     }
-}
-
-/// Check that the number of varargs is at least the minimum what we expect.
-/// Fixed args should not be included.
-pub fn check_min_vararg_count<'a, 'tcx, const N: usize>(
-    name: &'a str,
-    args: &'a [OpTy<'tcx>],
-) -> InterpResult<'tcx, &'a [OpTy<'tcx>; N]> {
-    if let Some((ops, _)) = args.split_first_chunk() {
-        return interp_ok(ops);
-    }
-    throw_ub_format!(
-        "not enough variadic arguments for `{name}`: got {}, expected at least {}",
-        args.len(),
-        N
-    )
 }

--- a/src/shims/unix/android/foreign_items.rs
+++ b/src/shims/unix/android/foreign_items.rs
@@ -31,9 +31,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [fd, buf, count, offset] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, *_, usize, libc::off64_t) -> isize),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let fd = this.read_scalar(fd)?.to_i32()?;
                 let buf = this.read_pointer(buf)?;
@@ -45,9 +43,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [fd, buf, n, offset] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, *_, usize, libc::off64_t) -> isize),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let fd = this.read_scalar(fd)?.to_i32()?;
                 let buf = this.read_pointer(buf)?;
@@ -60,9 +56,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [fd, offset, whence] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, libc::off64_t, i32) -> libc::off64_t),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let fd = this.read_scalar(fd)?.to_i32()?;
                 let offset = this.read_scalar(offset)?.to_int(offset.layout.size)?;
@@ -72,9 +66,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "ftruncate64" => {
                 let [fd, length] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, libc::off64_t) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let fd = this.read_scalar(fd)?.to_i32()?;
                 let length = this.read_scalar(length)?.to_int(length.layout.size)?;

--- a/src/shims/unix/fd.rs
+++ b/src/shims/unix/fd.rs
@@ -10,7 +10,7 @@ use rustc_target::spec::Os;
 
 use crate::shims::FileDescriptionRef;
 use crate::shims::files::{DynFileDescriptionRef, FdNum, FileDescription};
-use crate::shims::sig::check_min_vararg_count;
+use crate::shims::sig::Varargs;
 use crate::shims::unix::socket::UnixSocketFileDescription;
 use crate::shims::unix::*;
 use crate::*;
@@ -71,7 +71,7 @@ pub trait UnixFileDescription: FileDescription {
     fn ioctl<'tcx>(
         &self,
         _op: Scalar,
-        _arg: Option<&OpTy<'tcx>>,
+        _args: Varargs<'tcx, '_>,
         _ecx: &mut MiriInterpCx<'tcx>,
     ) -> InterpResult<'tcx, i32> {
         throw_unsup_format!("cannot use ioctl on {}", self.name());
@@ -181,16 +181,12 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         &mut self,
         fd: &OpTy<'tcx>,
         op: &OpTy<'tcx>,
-        varargs: &[OpTy<'tcx>],
+        varargs: Varargs<'tcx, '_>,
     ) -> InterpResult<'tcx, Scalar> {
         let this = self.eval_context_mut();
 
         let fd = this.read_scalar(fd)?.to_i32()?;
         let op = this.read_scalar(op)?;
-        // There is at most one relevant variadic argument.
-        // It exists depending on the device and the opcode and thus we can't
-        // use `check_min_vararg_count` here.
-        let arg = varargs.first();
 
         let Some(fd) = this.machine.fds.get(fd) else {
             return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
@@ -206,7 +202,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
         // Since some ioctl operations use the return value as an output parameter, we cannot strictly use the convention of
         // zero indicating success and -1 indicating an error.
-        let return_value = fd.as_unix(this).ioctl(op, arg, this)?;
+        let return_value = fd.as_unix(this).ioctl(op, varargs, this)?;
         interp_ok(Scalar::from_i32(return_value))
     }
 
@@ -214,7 +210,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         &mut self,
         fd_num: &OpTy<'tcx>,
         cmd: &OpTy<'tcx>,
-        varargs: &[OpTy<'tcx>],
+        varargs: Varargs<'tcx, '_>,
     ) -> InterpResult<'tcx, Scalar> {
         let this = self.eval_context_mut();
 
@@ -251,7 +247,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     "fcntl(fd, F_DUPFD_CLOEXEC, ...)"
                 };
 
-                let [start] = check_min_vararg_count(cmd_name, varargs)?;
+                let ([start], _) = this.check_varargs(shim_varargs![i32], varargs, cmd_name)?;
                 let start = this.read_scalar(start)?.to_i32()?;
 
                 if let Some(fd) = this.machine.fds.get(fd_num) {
@@ -274,7 +270,8 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     return this.set_errno_and_return_neg1_i32(LibcError("EBADF"));
                 };
 
-                let [flag] = check_min_vararg_count("fcntl(fd, F_SETFL, ...)", varargs)?;
+                let ([flag], _) =
+                    this.check_varargs(shim_varargs![i32], varargs, "fcntl(fd, F_SETFL, ...)")?;
                 let flag = this.read_scalar(flag)?.to_i32()?;
 
                 // Ignore flags that never get stored by SETFL.

--- a/src/shims/unix/foreign_items.rs
+++ b/src/shims/unix/foreign_items.rs
@@ -131,23 +131,21 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         match link_name.as_str() {
             // Environment related shims
             "getenv" => {
-                let [name] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> *_), link_name, abi, args)?;
+                let [name] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> *_), (link_name, abi, args))?;
                 let result = this.getenv(name)?;
                 this.write_pointer(result, dest)?;
             }
             "unsetenv" => {
-                let [name] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), link_name, abi, args)?;
+                let [name] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), (link_name, abi, args))?;
                 let result = this.unsetenv(name)?;
                 this.write_scalar(result, dest)?;
             }
             "setenv" => {
                 let [name, value, overwrite] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, *_, i32) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.read_scalar(overwrite)?.to_i32()?;
                 let result = this.setenv(name, value)?;
@@ -157,9 +155,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [buf, size] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, usize) -> *_),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.getcwd(buf, size)?;
                 this.write_pointer(result, dest)?;
@@ -167,26 +163,22 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "gethostname" => {
                 let [name, len] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, usize) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.gethostname(name, len)?;
                 this.write_scalar(result, dest)?;
             }
             "chdir" => {
                 // FIXME: This does not have a direct test (#3179).
-                let [path] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), link_name, abi, args)?;
+                let [path] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), (link_name, abi, args))?;
                 let result = this.chdir(path)?;
                 this.write_scalar(result, dest)?;
             }
             "getpid" => {
                 let [] = this.check_shim_sig(
                     shim_sig!(extern "C" fn() -> libc::pid_t),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.getpid()?;
                 this.write_scalar(result, dest)?;
@@ -198,17 +190,15 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     link_name,
                 )?;
 
-                let [uname] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), link_name, abi, args)?;
+                let [uname] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), (link_name, abi, args))?;
                 let result = this.uname(uname, None)?;
                 this.write_scalar(result, dest)?;
             }
             "sysconf" => {
                 let [val] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32) -> isize),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.sysconf(val)?;
                 this.write_scalar(result, dest)?;
@@ -217,9 +207,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "read" => {
                 let [fd, buf, count] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, *_, usize) -> isize),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let fd = this.read_scalar(fd)?.to_i32()?;
                 let buf = this.read_pointer(buf)?;
@@ -229,9 +217,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "write" => {
                 let [fd, buf, n] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, *_, usize) -> isize),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let fd = this.read_scalar(fd)?.to_i32()?;
                 let buf = this.read_pointer(buf)?;
@@ -242,27 +228,21 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "readv" => {
                 let [fd, iov, iovcnt] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, *_, i32) -> isize),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.readv(fd, iov, iovcnt, None, dest)?;
             }
             "writev" => {
                 let [fd, iov, iovcnt] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, *_, i32) -> isize),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.writev(fd, iov, iovcnt, None, dest)?;
             }
             "pread" => {
                 let [fd, buf, count, offset] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, *_, usize, libc::off_t) -> isize),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let fd = this.read_scalar(fd)?.to_i32()?;
                 let buf = this.read_pointer(buf)?;
@@ -273,9 +253,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "pwrite" => {
                 let [fd, buf, n, offset] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, *_, usize, libc::off_t) -> isize),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let fd = this.read_scalar(fd)?.to_i32()?;
                 let buf = this.read_pointer(buf)?;
@@ -287,29 +265,21 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "preadv" => {
                 let [fd, iov, iovcnt, offset] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, *_, i32, libc::off_t) -> isize),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.readv(fd, iov, iovcnt, Some(offset), dest)?;
             }
             "pwritev" => {
                 let [fd, iov, iovcnt, offset] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, *_, i32, libc::off_t) -> isize),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.writev(fd, iov, iovcnt, Some(offset), dest)?;
             }
 
             "close" => {
-                let [fd] = this.check_shim_sig(
-                    shim_sig!(extern "C" fn(i32) -> i32),
-                    link_name,
-                    abi,
-                    args,
-                )?;
+                let [fd] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(i32) -> i32), (link_name, abi, args))?;
                 let fd = this.read_scalar(fd)?.to_i32()?;
                 let result = this.close(fd)?;
                 this.write_scalar(result, dest)?;
@@ -317,20 +287,14 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "fcntl" => {
                 let ([fd_num, cmd], varargs) = this.check_shim_sig_variadic(
                     shim_sig_variadic!(extern "C" fn(i32, i32) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.fcntl(fd_num, cmd, varargs)?;
                 this.write_scalar(result, dest)?;
             }
             "dup" => {
-                let [old_fd] = this.check_shim_sig(
-                    shim_sig!(extern "C" fn(i32) -> i32),
-                    link_name,
-                    abi,
-                    args,
-                )?;
+                let [old_fd] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(i32) -> i32), (link_name, abi, args))?;
                 let old_fd = this.read_scalar(old_fd)?.to_i32()?;
                 let new_fd = this.dup(old_fd)?;
                 this.write_scalar(new_fd, dest)?;
@@ -338,9 +302,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "dup2" => {
                 let [old_fd, new_fd] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, i32) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let old_fd = this.read_scalar(old_fd)?.to_i32()?;
                 let new_fd = this.read_scalar(new_fd)?.to_i32()?;
@@ -356,9 +318,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 let [fd, op] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, i32) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let fd = this.read_scalar(fd)?.to_i32()?;
                 let op = this.read_scalar(op)?.to_i32()?;
@@ -379,9 +339,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     } else {
                         shim_sig_variadic!(extern "C" fn(i32, i32) -> i32)
                     },
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.ioctl(fd, op, varargs)?;
                 this.write_scalar(result, dest)?;
@@ -393,17 +351,15 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // has O_CREAT (or on linux O_TMPFILE, but miri doesn't support that) set
                 let ([path_raw, flag], varargs) = this.check_shim_sig_variadic(
                     shim_sig_variadic!(extern "C" fn(*_, i32) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.open(path_raw, flag, varargs)?;
                 this.write_scalar(result, dest)?;
             }
             "unlink" => {
                 // FIXME: This does not have a direct test (#3179).
-                let [path] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), link_name, abi, args)?;
+                let [path] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), (link_name, abi, args))?;
                 let result = this.unlink(path)?;
                 this.write_scalar(result, dest)?;
             }
@@ -411,9 +367,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [target, linkpath] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.symlink(target, linkpath)?;
                 this.write_scalar(result, dest)?;
@@ -421,9 +375,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "linkat" => {
                 let [oldfd, oldpath, newfd, newpath, flags] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, *_, i32, *_, i32) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.linkat(oldfd, oldpath, newfd, newpath, flags)?;
                 this.write_scalar(result, dest)?;
@@ -431,9 +383,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "fstat" => {
                 let [fd, buf] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.fstat(fd, buf)?;
                 this.write_scalar(result, dest)?;
@@ -441,9 +391,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "lstat" => {
                 let [path, buf] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.lstat(path, buf)?;
                 this.write_scalar(result, dest)?;
@@ -451,9 +399,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "stat" => {
                 let [path, buf] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.stat(path, buf)?;
                 this.write_scalar(result, dest)?;
@@ -461,9 +407,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "chmod" => {
                 let [path, mode] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, libc::mode_t) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.chmod(path, mode)?;
                 this.write_scalar(result, dest)?;
@@ -471,9 +415,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "fchmod" => {
                 let [fd, mode] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, libc::mode_t) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.fchmod(fd, mode)?;
                 this.write_scalar(result, dest)?;
@@ -482,9 +424,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [oldpath, newpath] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.rename(oldpath, newpath)?;
                 this.write_scalar(result, dest)?;
@@ -493,44 +433,40 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [path, mode] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, libc::mode_t) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.mkdir(path, mode)?;
                 this.write_scalar(result, dest)?;
             }
             "rmdir" => {
                 // FIXME: This does not have a direct test (#3179).
-                let [path] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), link_name, abi, args)?;
+                let [path] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), (link_name, abi, args))?;
                 let result = this.rmdir(path)?;
                 this.write_scalar(result, dest)?;
             }
             "opendir" => {
-                let [name] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> *_), link_name, abi, args)?;
+                let [name] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> *_), (link_name, abi, args))?;
                 let result = this.opendir(name)?;
                 this.write_scalar(result, dest)?;
             }
             "closedir" => {
-                let [dirp] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), link_name, abi, args)?;
+                let [dirp] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), (link_name, abi, args))?;
                 let result = this.closedir(dirp)?;
                 this.write_scalar(result, dest)?;
             }
             "readdir" => {
-                let [dirp] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> *_), link_name, abi, args)?;
+                let [dirp] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> *_), (link_name, abi, args))?;
                 this.readdir(dirp, dest)?;
             }
             "lseek" => {
                 // FIXME: This does not have a direct test (#3179).
                 let [fd, offset, whence] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, libc::off_t, i32) -> libc::off_t),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let fd = this.read_scalar(fd)?.to_i32()?;
                 let offset = this.read_scalar(offset)?.to_int(offset.layout.size)?;
@@ -540,9 +476,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "ftruncate" => {
                 let [fd, length] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, libc::off_t) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let fd = this.read_scalar(fd)?.to_i32()?;
                 let length = this.read_scalar(length)?.to_int(length.layout.size)?;
@@ -551,32 +485,22 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             }
             "fsync" => {
                 // FIXME: This does not have a direct test (#3179).
-                let [fd] = this.check_shim_sig(
-                    shim_sig!(extern "C" fn(i32) -> i32),
-                    link_name,
-                    abi,
-                    args,
-                )?;
+                let [fd] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(i32) -> i32), (link_name, abi, args))?;
                 let result = this.fsync(fd)?;
                 this.write_scalar(result, dest)?;
             }
             "fdatasync" => {
                 // FIXME: This does not have a direct test (#3179).
-                let [fd] = this.check_shim_sig(
-                    shim_sig!(extern "C" fn(i32) -> i32),
-                    link_name,
-                    abi,
-                    args,
-                )?;
+                let [fd] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(i32) -> i32), (link_name, abi, args))?;
                 let result = this.fdatasync(fd)?;
                 this.write_scalar(result, dest)?;
             }
             "futimens" => {
                 let [fd, times] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.futimens(fd, times)?;
                 this.write_scalar(result, dest)?;
@@ -584,9 +508,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "readlink" => {
                 let [pathname, buf, bufsize] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, *_, usize) -> isize),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.readlink(pathname, buf, bufsize)?;
                 this.write_scalar(Scalar::from_target_isize(result, this), dest)?;
@@ -594,9 +516,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "posix_fadvise" => {
                 let [fd, offset, len, advice] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, libc::off_t, libc::off_t, i32) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.read_scalar(fd)?.to_i32()?;
                 this.read_scalar(offset)?.to_int(offset.layout.size)?;
@@ -615,9 +535,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 let [fd, offset, len] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, libc::off_t, libc::off_t) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
 
                 let fd = this.read_scalar(fd)?.to_i32()?;
@@ -633,16 +551,14 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "realpath" => {
                 let [path, resolved_path] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, *_) -> *_),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.realpath(path, resolved_path)?;
                 this.write_scalar(result, dest)?;
             }
             "mkstemp" => {
-                let [template] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), link_name, abi, args)?;
+                let [template] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), (link_name, abi, args))?;
                 let result = this.mkstemp(template)?;
                 this.write_scalar(result, dest)?;
             }
@@ -651,9 +567,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "poll" => {
                 let [fds, nfds, timeout] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, libc::nfds_t, i32) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.poll(fds, nfds, timeout, dest)?;
             }
@@ -662,16 +576,14 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "socketpair" => {
                 let [domain, type_, protocol, sv] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, i32, i32, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.socketpair(domain, type_, protocol, sv)?;
                 this.write_scalar(result, dest)?;
             }
             "pipe" => {
-                let [pipefd] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), link_name, abi, args)?;
+                let [pipefd] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), (link_name, abi, args))?;
                 let result = this.pipe2(pipefd, /*flags*/ None)?;
                 this.write_scalar(result, dest)?;
             }
@@ -684,9 +596,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 let [pipefd, flags] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, i32) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.pipe2(pipefd, Some(flags))?;
                 this.write_scalar(result, dest)?;
@@ -696,9 +606,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "socket" => {
                 let [domain, type_, protocol] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, i32, i32) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.socket(domain, type_, protocol)?;
                 this.write_scalar(result, dest)?;
@@ -706,9 +614,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "bind" => {
                 let [socket, address, address_len] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, *_, libc::socklen_t) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.bind(socket, address, address_len)?;
                 this.write_scalar(result, dest)?;
@@ -716,9 +622,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "listen" => {
                 let [socket, backlog] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, i32) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.listen(socket, backlog)?;
                 this.write_scalar(result, dest)?;
@@ -726,54 +630,42 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "accept" => {
                 let [socket, address, address_len] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, *_, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.accept4(socket, address, address_len, /* flags */ None, dest)?;
             }
             "accept4" => {
                 let [socket, address, address_len, flags] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, *_, *_, i32) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.accept4(socket, address, address_len, Some(flags), dest)?;
             }
             "connect" => {
                 let [socket, address, address_len] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, *_, libc::socklen_t) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.connect(socket, address, address_len, dest)?;
             }
             "send" => {
                 let [socket, buffer, length, flags] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, *_, libc::size_t, i32) -> libc::ssize_t),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.send(socket, buffer, length, flags, dest)?;
             }
             "recv" => {
                 let [socket, buffer, length, flags] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, *_, libc::size_t, i32) -> libc::ssize_t),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.recv(socket, buffer, length, flags, dest)?;
             }
             "setsockopt" => {
                 let [socket, level, option_name, option_value, option_len] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, i32, i32, *_, libc::socklen_t) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result =
                     this.setsockopt(socket, level, option_name, option_value, option_len)?;
@@ -782,9 +674,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "getsockopt" => {
                 let [socket, level, option_name, option_value, option_len] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, i32, i32, *_, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result =
                     this.getsockopt(socket, level, option_name, option_value, option_len)?;
@@ -793,9 +683,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "getsockname" => {
                 let [socket, address, address_len] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, *_, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.getsockname(socket, address, address_len)?;
                 this.write_scalar(result, dest)?;
@@ -803,18 +691,14 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "getpeername" => {
                 let [socket, address, address_len] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, *_, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.getpeername(socket, address, address_len, dest)?;
             }
             "shutdown" => {
                 let [sockfd, how] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, i32) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.shutdown(sockfd, how)?;
                 this.write_scalar(result, dest)?;
@@ -822,16 +706,14 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "getaddrinfo" => {
                 let [node, service, hints, res] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, *_, *_, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.getaddrinfo(node, service, hints, res)?;
                 this.write_scalar(result, dest)?;
             }
             "freeaddrinfo" => {
-                let [res] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> ()), link_name, abi, args)?;
+                let [res] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> ()), (link_name, abi, args))?;
                 this.freeaddrinfo(res)?;
             }
 
@@ -839,9 +721,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "gettimeofday" => {
                 let [tv, tz] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.gettimeofday(tv, tz)?;
                 this.write_scalar(result, dest)?;
@@ -849,9 +729,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "localtime_r" => {
                 let [timep, result_op] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, *_) -> *_),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.localtime_r(timep, result_op)?;
                 this.write_pointer(result, dest)?;
@@ -859,9 +737,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "clock_gettime" => {
                 let [clk_id, tp] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(libc::clockid_t, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.clock_gettime(clk_id, tp, dest)?;
             }
@@ -870,9 +746,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "posix_memalign" => {
                 let [memptr, align, size] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, usize, usize) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.posix_memalign(memptr, align, size)?;
                 this.write_scalar(result, dest)?;
@@ -881,9 +755,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "mmap" => {
                 let [addr, length, prot, flags, fd, offset] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, usize, i32, i32, i32, libc::off_t) -> *_),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let offset = this.read_scalar(offset)?.to_int(this.libc_ty_layout("off_t").size)?;
                 let ptr = this.mmap(addr, length, prot, flags, fd, offset)?;
@@ -892,9 +764,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "munmap" => {
                 let [addr, length] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, usize) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.munmap(addr, length)?;
                 this.write_scalar(result, dest)?;
@@ -902,9 +772,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "mprotect" => {
                 let [addr, length, prot] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, usize, i32) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.mprotect(addr, length, prot)?;
                 this.write_scalar(result, dest)?;
@@ -912,9 +780,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "madvise" => {
                 let [addr, length, advice] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, usize, i32) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.madvise(addr, length, advice)?;
                 this.write_scalar(result, dest)?;
@@ -926,9 +792,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 let [ptr, nmemb, size] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, usize, usize) -> *_),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let ptr = this.read_pointer(ptr)?;
                 let nmemb = this.read_target_usize(nmemb)?;
@@ -954,9 +818,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // (MSVC explicitly does not support this.)
                 let [align, size] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(usize, usize) -> *_),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let res = this.aligned_alloc(align, size)?;
                 this.write_pointer(res, dest)?;
@@ -966,9 +828,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "dlsym" => {
                 let [handle, symbol] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, *_) -> *_),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.read_target_usize(handle)?;
                 let symbol = this.read_pointer(symbol)?;
@@ -990,9 +850,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "pthread_key_create" => {
                 let [key, dtor] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, fn(..) -> _) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let key_place = this.deref_pointer_as(key, this.libc_ty_layout("pthread_key_t"))?;
                 let dtor = this.read_pointer(dtor)?;
@@ -1027,9 +885,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [key] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(libc::pthread_key_t) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let key = this.read_scalar(key)?.to_bits(key.layout.size)?;
                 this.machine.tls.delete_tls_key(key)?;
@@ -1040,9 +896,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [key] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(libc::pthread_key_t) -> *_),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let key = this.read_scalar(key)?.to_bits(key.layout.size)?;
                 let active_thread = this.active_thread();
@@ -1052,9 +906,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "pthread_setspecific" => {
                 let [key, new_ptr] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(libc::pthread_key_t, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let key = this.read_scalar(key)?.to_bits(key.layout.size)?;
                 let active_thread = this.active_thread();
@@ -1067,106 +919,100 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
             // Synchronization primitives
             "pthread_mutexattr_init" => {
-                let [attr] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), link_name, abi, args)?;
+                let [attr] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), (link_name, abi, args))?;
                 this.pthread_mutexattr_init(attr)?;
                 this.write_null(dest)?;
             }
             "pthread_mutexattr_settype" => {
                 let [attr, kind] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, i32) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.pthread_mutexattr_settype(attr, kind)?;
                 this.write_scalar(result, dest)?;
             }
             "pthread_mutexattr_destroy" => {
-                let [attr] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), link_name, abi, args)?;
+                let [attr] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), (link_name, abi, args))?;
                 this.pthread_mutexattr_destroy(attr)?;
                 this.write_null(dest)?;
             }
             "pthread_mutex_init" => {
                 let [mutex, attr] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.pthread_mutex_init(mutex, attr)?;
                 this.write_null(dest)?;
             }
             "pthread_mutex_lock" => {
-                let [mutex] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), link_name, abi, args)?;
+                let [mutex] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), (link_name, abi, args))?;
                 this.pthread_mutex_lock(mutex, dest)?;
             }
             "pthread_mutex_trylock" => {
-                let [mutex] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), link_name, abi, args)?;
+                let [mutex] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), (link_name, abi, args))?;
                 let result = this.pthread_mutex_trylock(mutex)?;
                 this.write_scalar(result, dest)?;
             }
             "pthread_mutex_unlock" => {
-                let [mutex] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), link_name, abi, args)?;
+                let [mutex] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), (link_name, abi, args))?;
                 let result = this.pthread_mutex_unlock(mutex)?;
                 this.write_scalar(result, dest)?;
             }
             "pthread_mutex_destroy" => {
-                let [mutex] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), link_name, abi, args)?;
+                let [mutex] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), (link_name, abi, args))?;
                 this.pthread_mutex_destroy(mutex)?;
                 this.write_int(0, dest)?;
             }
             "pthread_rwlock_rdlock" => {
-                let [rwlock] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), link_name, abi, args)?;
+                let [rwlock] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), (link_name, abi, args))?;
                 this.pthread_rwlock_rdlock(rwlock, dest)?;
             }
             "pthread_rwlock_tryrdlock" => {
-                let [rwlock] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), link_name, abi, args)?;
+                let [rwlock] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), (link_name, abi, args))?;
                 let result = this.pthread_rwlock_tryrdlock(rwlock)?;
                 this.write_scalar(result, dest)?;
             }
             "pthread_rwlock_wrlock" => {
-                let [rwlock] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), link_name, abi, args)?;
+                let [rwlock] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), (link_name, abi, args))?;
                 this.pthread_rwlock_wrlock(rwlock, dest)?;
             }
             "pthread_rwlock_trywrlock" => {
-                let [rwlock] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), link_name, abi, args)?;
+                let [rwlock] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), (link_name, abi, args))?;
                 let result = this.pthread_rwlock_trywrlock(rwlock)?;
                 this.write_scalar(result, dest)?;
             }
             "pthread_rwlock_unlock" => {
-                let [rwlock] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), link_name, abi, args)?;
+                let [rwlock] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), (link_name, abi, args))?;
                 this.pthread_rwlock_unlock(rwlock)?;
                 this.write_null(dest)?;
             }
             "pthread_rwlock_destroy" => {
-                let [rwlock] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), link_name, abi, args)?;
+                let [rwlock] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), (link_name, abi, args))?;
                 this.pthread_rwlock_destroy(rwlock)?;
                 this.write_null(dest)?;
             }
             "pthread_condattr_init" => {
-                let [attr] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), link_name, abi, args)?;
+                let [attr] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), (link_name, abi, args))?;
                 this.pthread_condattr_init(attr)?;
                 this.write_null(dest)?;
             }
             "pthread_condattr_setclock" => {
                 let [attr, clock_id] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, i32) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.pthread_condattr_setclock(attr, clock_id)?;
                 this.write_scalar(result, dest)?;
@@ -1174,64 +1020,56 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "pthread_condattr_getclock" => {
                 let [attr, clock_id] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.pthread_condattr_getclock(attr, clock_id)?;
                 this.write_null(dest)?;
             }
             "pthread_condattr_destroy" => {
-                let [attr] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), link_name, abi, args)?;
+                let [attr] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), (link_name, abi, args))?;
                 this.pthread_condattr_destroy(attr)?;
                 this.write_null(dest)?;
             }
             "pthread_cond_init" => {
                 let [cond, attr] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.pthread_cond_init(cond, attr)?;
                 this.write_null(dest)?;
             }
             "pthread_cond_signal" => {
-                let [cond] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), link_name, abi, args)?;
+                let [cond] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), (link_name, abi, args))?;
                 this.pthread_cond_signal(cond)?;
                 this.write_null(dest)?;
             }
             "pthread_cond_broadcast" => {
-                let [cond] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), link_name, abi, args)?;
+                let [cond] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), (link_name, abi, args))?;
                 this.pthread_cond_broadcast(cond)?;
                 this.write_null(dest)?;
             }
             "pthread_cond_wait" => {
                 let [cond, mutex] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.pthread_cond_wait(cond, mutex, dest)?;
             }
             "pthread_cond_timedwait" => {
                 let [cond, mutex, abstime] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, *_, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.pthread_cond_timedwait(
                     cond, mutex, abstime, dest, /* macos_relative_np */ false,
                 )?;
             }
             "pthread_cond_destroy" => {
-                let [cond] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), link_name, abi, args)?;
+                let [cond] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), (link_name, abi, args))?;
                 this.pthread_cond_destroy(cond)?;
                 this.write_null(dest)?;
             }
@@ -1240,9 +1078,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "pthread_create" => {
                 let [thread, attr, start, arg] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, *_, fn(..) -> _, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.pthread_create(thread, attr, start, arg)?;
                 this.write_null(dest)?;
@@ -1250,18 +1086,14 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "pthread_join" => {
                 let [thread, retval] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(libc::pthread_t, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.pthread_join(thread, retval, dest)?;
             }
             "pthread_detach" => {
                 let [thread] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(libc::pthread_t) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let res = this.pthread_detach(thread)?;
                 this.write_scalar(res, dest)?;
@@ -1269,9 +1101,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "pthread_self" => {
                 let [] = this.check_shim_sig(
                     shim_sig!(extern "C" fn() -> libc::pthread_t),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let res = this.pthread_self()?;
                 this.write_scalar(res, dest)?;
@@ -1279,16 +1109,14 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "sched_yield" => {
                 // FIXME: This does not have a direct test (#3179).
                 let [] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn() -> i32), link_name, abi, args)?;
+                    this.check_shim_sig(shim_sig!(extern "C" fn() -> i32), (link_name, abi, args))?;
                 this.sched_yield()?;
                 this.write_null(dest)?;
             }
             "nanosleep" => {
                 let [duration, rem] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.nanosleep(duration, rem)?;
                 this.write_scalar(result, dest)?;
@@ -1302,9 +1130,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 let [clock_id, flags, req, rem] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(libc::clockid_t, i32, *_, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.clock_nanosleep(clock_id, flags, req, rem)?;
                 this.write_scalar(result, dest)?;
@@ -1315,9 +1141,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 let [pid, cpusetsize, mask] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(libc::pid_t, usize, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let pid = this.read_scalar(pid)?.to_u32()?;
                 let cpusetsize = this.read_target_usize(cpusetsize)?;
@@ -1372,9 +1196,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 let [pid, cpusetsize, mask] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(libc::pid_t, usize, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let pid = this.read_scalar(pid)?.to_u32()?;
                 let cpusetsize = this.read_target_usize(cpusetsize)?;
@@ -1431,12 +1253,8 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
             // Miscellaneous
             "isatty" => {
-                let [fd] = this.check_shim_sig(
-                    shim_sig!(extern "C" fn(i32) -> i32),
-                    link_name,
-                    abi,
-                    args,
-                )?;
+                let [fd] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(i32) -> i32), (link_name, abi, args))?;
                 let result = this.isatty(fd)?;
                 this.write_scalar(result, dest)?;
             }
@@ -1444,9 +1262,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [prepare, parent, child] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(fn(..) -> _, fn(..) -> _, fn(..) -> _) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.read_pointer(prepare)?;
                 this.read_pointer(parent)?;
@@ -1457,9 +1273,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "strerror_r" => {
                 let [errnum, buf, buflen] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, *_, usize) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.strerror_r(errnum, buf, buflen)?;
                 this.write_scalar(result, dest)?;
@@ -1474,9 +1288,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 let [buf, bufsize] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, usize) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let buf = this.read_pointer(buf)?;
                 let bufsize = this.read_target_usize(bufsize)?;
@@ -1503,9 +1315,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 let [ptr, len, flags] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, usize, u32) -> isize),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let ptr = this.read_pointer(ptr)?;
                 let len = this.read_target_usize(len)?;
@@ -1521,9 +1331,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
 
                 let [ptr, len] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, usize) -> ()),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let ptr = this.read_pointer(ptr)?;
                 let len = this.read_target_usize(len)?;
@@ -1551,9 +1359,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // This function looks and behaves exactly like miri_start_unwind.
                 let [payload] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_) -> unwind::_Unwind_Reason_Code),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.handle_miri_start_unwind(payload)?;
                 return interp_ok(EmulateItemResult::NeedsUnwind);
@@ -1561,9 +1367,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "getuid" | "geteuid" => {
                 let [] = this.check_shim_sig(
                     shim_sig!(extern "C" fn() -> libc::uid_t),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 // For now, just pretend we always have this fixed UID.
                 this.write_int(UID, dest)?;

--- a/src/shims/unix/foreign_items.rs
+++ b/src/shims/unix/foreign_items.rs
@@ -6,7 +6,7 @@ use rustc_abi::{CanonAbi, Size};
 use rustc_middle::ty::Ty;
 use rustc_span::Symbol;
 use rustc_target::callconv::FnAbi;
-use rustc_target::spec::Os;
+use rustc_target::spec::{Env, Os};
 
 use self::shims::unix::android::foreign_items as android;
 use self::shims::unix::freebsd::foreign_items as freebsd;
@@ -315,8 +315,12 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 this.write_scalar(result, dest)?;
             }
             "fcntl" => {
-                let ([fd_num, cmd], varargs) =
-                    this.check_shim_sig_variadic_lenient(abi, CanonAbi::C, link_name, args)?;
+                let ([fd_num, cmd], varargs) = this.check_shim_sig_variadic(
+                    shim_sig_variadic!(extern "C" fn(i32, i32) -> i32),
+                    link_name,
+                    abi,
+                    args,
+                )?;
                 let result = this.fcntl(fd_num, cmd, varargs)?;
                 this.write_scalar(result, dest)?;
             }
@@ -362,8 +366,23 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 this.write_scalar(result, dest)?;
             }
             "ioctl" => {
-                let ([fd, op], varargs) =
-                    this.check_shim_sig_variadic_lenient(abi, CanonAbi::C, link_name, args)?;
+                // The type of `op` depends on the libc. :(
+                // glibc, BSD use `unsigned long`, the rest uses `int`.
+                let op_is_ulong = match this.tcx.sess.target.os {
+                    Os::FreeBsd | Os::NetBsd | Os::MacOs => true,
+                    Os::Linux if this.tcx.sess.target.env == Env::Gnu => true,
+                    _ => false,
+                };
+                let ([fd, op], varargs) = this.check_shim_sig_variadic(
+                    if op_is_ulong {
+                        shim_sig_variadic!(extern "C" fn(i32, usize) -> i32)
+                    } else {
+                        shim_sig_variadic!(extern "C" fn(i32, i32) -> i32)
+                    },
+                    link_name,
+                    abi,
+                    args,
+                )?;
                 let result = this.ioctl(fd, op, varargs)?;
                 this.write_scalar(result, dest)?;
             }
@@ -372,8 +391,12 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "open" => {
                 // `open` is variadic, the third argument is only present when the second argument
                 // has O_CREAT (or on linux O_TMPFILE, but miri doesn't support that) set
-                let ([path_raw, flag], varargs) =
-                    this.check_shim_sig_variadic_lenient(abi, CanonAbi::C, link_name, args)?;
+                let ([path_raw, flag], varargs) = this.check_shim_sig_variadic(
+                    shim_sig_variadic!(extern "C" fn(*_, i32) -> i32),
+                    link_name,
+                    abi,
+                    args,
+                )?;
                 let result = this.open(path_raw, flag, varargs)?;
                 this.write_scalar(result, dest)?;
             }

--- a/src/shims/unix/freebsd/foreign_items.rs
+++ b/src/shims/unix/freebsd/foreign_items.rs
@@ -178,9 +178,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // https://github.com/freebsd/freebsd-src/blob/3542d60fb8042474f66fbf2d779ed8c5a80d0f78/lib/libc/gen/uname.c#L44
                 let [size, uname] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.uname(uname, Some(size))?;
                 this.write_scalar(result, dest)?;

--- a/src/shims/unix/fs.rs
+++ b/src/shims/unix/fs.rs
@@ -15,7 +15,7 @@ use rustc_target::spec::Os;
 use self::shims::time::system_time_to_duration;
 use crate::shims::files::FileHandle;
 use crate::shims::os_str::bytes_to_os_str;
-use crate::shims::sig::check_min_vararg_count;
+use crate::shims::sig::Varargs;
 use crate::shims::unix::fd::{FlockOp, UnixFileDescription};
 use crate::*;
 
@@ -399,7 +399,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         &mut self,
         path_raw: &OpTy<'tcx>,
         flag: &OpTy<'tcx>,
-        varargs: &[OpTy<'tcx>],
+        varargs: Varargs<'tcx, '_>,
     ) -> InterpResult<'tcx, Scalar> {
         let this = self.eval_context_mut();
 
@@ -463,7 +463,11 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             // Get the mode.  On macOS, the argument type `mode_t` is actually `u16`, but
             // C integer promotion rules mean that on the ABI level, it gets passed as `u32`
             // (see https://github.com/rust-lang/rust/issues/71915).
-            let [mode] = check_min_vararg_count("open(pathname, O_CREAT, ...)", varargs)?;
+            let ([mode], _) = this.check_varargs(
+                shim_varargs![libc::mode_t],
+                varargs,
+                "open(pathname, O_CREAT, ...)",
+            )?;
             let mode = this.read_scalar(mode)?.to_u32()?;
 
             #[cfg(unix)]

--- a/src/shims/unix/linux/foreign_items.rs
+++ b/src/shims/unix/linux/foreign_items.rs
@@ -40,8 +40,12 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "open64" => {
                 // `open64` is variadic, the third argument is only present when the second argument
                 // has O_CREAT (or on linux O_TMPFILE, but miri doesn't support that) set
-                let ([path_raw, flag], varargs) =
-                    this.check_shim_sig_variadic_lenient(abi, CanonAbi::C, link_name, args)?;
+                let ([path_raw, flag], varargs) = this.check_shim_sig_variadic(
+                    shim_sig_variadic!(extern "C" fn(*_, i32) -> i32),
+                    link_name,
+                    abi,
+                    args,
+                )?;
                 let result = this.open(path_raw, flag, varargs)?;
                 this.write_scalar(result, dest)?;
             }
@@ -253,8 +257,12 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 this.write_scalar(ptr, dest)?;
             }
             "mremap" => {
-                let ([old_address, old_size, new_size, flags], _) =
-                    this.check_shim_sig_variadic_lenient(abi, CanonAbi::C, link_name, args)?;
+                let ([old_address, old_size, new_size, flags], _) = this.check_shim_sig_variadic(
+                    shim_sig_variadic!(extern "C" fn(*_, usize, usize, i32) -> *_),
+                    link_name,
+                    abi,
+                    args,
+                )?;
                 let ptr = this.mremap(old_address, old_size, new_size, flags)?;
                 this.write_scalar(ptr, dest)?;
             }

--- a/src/shims/unix/linux/foreign_items.rs
+++ b/src/shims/unix/linux/foreign_items.rs
@@ -42,9 +42,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // has O_CREAT (or on linux O_TMPFILE, but miri doesn't support that) set
                 let ([path_raw, flag], varargs) = this.check_shim_sig_variadic(
                     shim_sig_variadic!(extern "C" fn(*_, i32) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.open(path_raw, flag, varargs)?;
                 this.write_scalar(result, dest)?;
@@ -53,9 +51,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [fd, buf, count, offset] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, *_, usize, libc::off64_t) -> isize),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let fd = this.read_scalar(fd)?.to_i32()?;
                 let buf = this.read_pointer(buf)?;
@@ -67,9 +63,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [fd, buf, n, offset] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, *_, usize, libc::off64_t) -> isize),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let fd = this.read_scalar(fd)?.to_i32()?;
                 let buf = this.read_pointer(buf)?;
@@ -82,9 +76,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [fd, offset, whence] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, libc::off64_t, i32) -> libc::off64_t),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let fd = this.read_scalar(fd)?.to_i32()?;
                 let offset = this.read_scalar(offset)?.to_int(offset.layout.size)?;
@@ -94,9 +86,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "ftruncate64" => {
                 let [fd, length] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, libc::off64_t) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let fd = this.read_scalar(fd)?.to_i32()?;
                 let length = this.read_scalar(length)?.to_int(length.layout.size)?;
@@ -106,9 +96,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "posix_fallocate64" => {
                 let [fd, offset, len] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, libc::off64_t, libc::off64_t) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
 
                 let fd = this.read_scalar(fd)?.to_i32()?;
@@ -122,9 +110,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "fallocate" => {
                 let [fd, mode, offset, len] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, i32, libc::off_t, libc::off_t) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
 
                 let fd = this.read_scalar(fd)?.to_i32()?;
@@ -141,9 +127,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "fallocate64" => {
                 let [fd, mode, offset, len] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, i32, libc::off64_t, libc::off64_t) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
 
                 let fd = this.read_scalar(fd)?.to_i32()?;
@@ -259,9 +243,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "mremap" => {
                 let ([old_address, old_size, new_size, flags], _) = this.check_shim_sig_variadic(
                     shim_sig_variadic!(extern "C" fn(*_, usize, usize, i32) -> *_),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let ptr = this.mremap(old_address, old_size, new_size, flags)?;
                 this.write_scalar(ptr, dest)?;

--- a/src/shims/unix/linux_like/sync.rs
+++ b/src/shims/unix/linux_like/sync.rs
@@ -1,5 +1,5 @@
 use crate::concurrency::sync::{FutexRef, SyncObj};
-use crate::shims::sig::check_min_vararg_count;
+use crate::shims::sig::Varargs;
 use crate::*;
 
 struct LinuxFutex {
@@ -12,10 +12,11 @@ impl SyncObj for LinuxFutex {}
 /// `args` is the arguments *including* the syscall number.
 pub fn futex<'tcx>(
     ecx: &mut MiriInterpCx<'tcx>,
-    varargs: &[OpTy<'tcx>],
+    varargs: Varargs<'tcx, '_>,
     dest: &MPlaceTy<'tcx>,
 ) -> InterpResult<'tcx> {
-    let [addr, op, val] = check_min_vararg_count("`syscall(SYS_futex, ...)`", varargs)?;
+    let ([addr, op, val], varargs) =
+        ecx.check_varargs(shim_varargs![*_, i32, u32], varargs, "syscall(SYS_futex, ...)")?;
 
     // See <https://man7.org/linux/man-pages/man2/futex.2.html> for docs.
     // The first three arguments (after the syscall number itself) are the same to all futex operations:
@@ -50,16 +51,19 @@ pub fn futex<'tcx>(
             let wait_bitset = op & !futex_realtime == futex_wait_bitset;
 
             let (timeout, bitset) = if wait_bitset {
-                let [_, _, _, timeout, uaddr2, bitset] = check_min_vararg_count(
-                    "`syscall(SYS_futex, FUTEX_WAIT_BITSET, ...)`",
+                let ([timeout, uaddr2, bitset], _) = ecx.check_varargs(
+                    shim_varargs![*_, *_, u32],
                     varargs,
+                    "syscall(SYS_futex, ...)",
                 )?;
-                let _timeout = ecx.read_pointer(timeout)?;
-                let _uaddr2 = ecx.read_pointer(uaddr2)?;
+                let uaddr2 = ecx.read_pointer(uaddr2)?;
+                if !ecx.ptr_is_null(uaddr2)? {
+                    throw_ub_format!("`uaddr2` pointer must be null for `FUTEX_WAIT_BITSET`");
+                }
                 (timeout, ecx.read_scalar(bitset)?.to_u32()?)
             } else {
-                let [_, _, _, timeout] =
-                    check_min_vararg_count("`syscall(SYS_futex, FUTEX_WAIT, ...)`", varargs)?;
+                let ([timeout], _) =
+                    ecx.check_varargs(shim_varargs![*_], varargs, "syscall(SYS_futex, ...)")?;
                 (timeout, u32::MAX)
             };
 
@@ -194,12 +198,19 @@ pub fn futex<'tcx>(
             let futex_ref = futex_ref.futex.clone();
 
             let bitset = if op == futex_wake_bitset {
-                let [_, _, _, timeout, uaddr2, bitset] = check_min_vararg_count(
-                    "`syscall(SYS_futex, FUTEX_WAKE_BITSET, ...)`",
+                let ([timeout, uaddr2, bitset], _) = ecx.check_varargs(
+                    shim_varargs![*_, *_, u32],
                     varargs,
+                    "syscall(SYS_futex, ...)",
                 )?;
-                let _timeout = ecx.read_pointer(timeout)?;
-                let _uaddr2 = ecx.read_pointer(uaddr2)?;
+                let timeout = ecx.read_pointer(timeout)?;
+                if !ecx.ptr_is_null(timeout)? {
+                    throw_ub_format!("`timeout` pointer must be null for `FUTEX_WAKE_BITSET`");
+                }
+                let uaddr2 = ecx.read_pointer(uaddr2)?;
+                if !ecx.ptr_is_null(uaddr2)? {
+                    throw_ub_format!("`uaddr2` pointer must be null for `FUTEX_WAKE_BITSET`");
+                }
                 ecx.read_scalar(bitset)?.to_u32()?
             } else {
                 u32::MAX

--- a/src/shims/unix/linux_like/syscall.rs
+++ b/src/shims/unix/linux_like/syscall.rs
@@ -1,9 +1,7 @@
-use rustc_abi::CanonAbi;
 use rustc_middle::ty::Ty;
 use rustc_span::Symbol;
 use rustc_target::callconv::FnAbi;
 
-use crate::shims::sig::check_min_vararg_count;
 use crate::shims::unix::env::EvalContextExt;
 use crate::shims::unix::linux_like::eventfd::EvalContextExt as _;
 use crate::shims::unix::linux_like::sync::futex;
@@ -17,7 +15,12 @@ pub fn syscall<'tcx>(
     args: &[OpTy<'tcx>],
     dest: &MPlaceTy<'tcx>,
 ) -> InterpResult<'tcx> {
-    let ([op], varargs) = ecx.check_shim_sig_variadic_lenient(abi, CanonAbi::C, link_name, args)?;
+    let ([op], varargs) = ecx.check_shim_sig_variadic(
+        shim_sig_variadic!(extern "C" fn(isize) -> isize),
+        link_name,
+        abi,
+        args,
+    )?;
     // The syscall variadic function is legal to call with more arguments than needed,
     // extra arguments are simply ignored. The important check is that when we use an
     // argument, we have to also check all arguments *before* it to ensure that they
@@ -35,7 +38,11 @@ pub fn syscall<'tcx>(
         num if num == sys_getrandom => {
             // Used by getrandom 0.1
             // The first argument is the syscall id, so skip over it.
-            let [ptr, len, flags] = check_min_vararg_count("syscall(SYS_getrandom, ...)", varargs)?;
+            let ([ptr, len, flags], _) = ecx.check_varargs(
+                shim_varargs![*_, usize, i32],
+                varargs,
+                "syscall(SYS_getrandom, ...)",
+            )?;
 
             let ptr = ecx.read_pointer(ptr)?;
             let len = ecx.read_target_usize(len)?;
@@ -52,7 +59,8 @@ pub fn syscall<'tcx>(
             futex(ecx, varargs, dest)?;
         }
         num if num == sys_eventfd2 => {
-            let [initval, flags] = check_min_vararg_count("syscall(SYS_evetfd2, ...)", varargs)?;
+            let ([initval, flags], _) =
+                ecx.check_varargs(shim_varargs![u32, i32], varargs, "syscall(SYS_evetfd2, ...)")?;
 
             let result = ecx.eventfd(initval, flags)?;
             ecx.write_int(result.to_i32()?, dest)?;
@@ -63,8 +71,11 @@ pub fn syscall<'tcx>(
         }
         num if num == sys_accept4 => {
             // Used on Android.
-            let [socket, address, address_len, flags] =
-                check_min_vararg_count("syscall(SYS_accept4, ...)", varargs)?;
+            let ([socket, address, address_len, flags], _) = ecx.check_varargs(
+                shim_varargs![i32, *_, *_, i32],
+                varargs,
+                "syscall(SYS_accept4, ...)",
+            )?;
             ecx.accept4(socket, address, address_len, Some(flags), dest)?;
         }
         num => {

--- a/src/shims/unix/linux_like/syscall.rs
+++ b/src/shims/unix/linux_like/syscall.rs
@@ -17,9 +17,7 @@ pub fn syscall<'tcx>(
 ) -> InterpResult<'tcx> {
     let ([op], varargs) = ecx.check_shim_sig_variadic(
         shim_sig_variadic!(extern "C" fn(isize) -> isize),
-        link_name,
-        abi,
-        args,
+        (link_name, abi, args),
     )?;
     // The syscall variadic function is legal to call with more arguments than needed,
     // extra arguments are simply ignored. The important check is that when we use an

--- a/src/shims/unix/linux_like/thread.rs
+++ b/src/shims/unix/linux_like/thread.rs
@@ -1,9 +1,8 @@
-use rustc_abi::{CanonAbi, Size};
+use rustc_abi::Size;
 use rustc_middle::ty::Ty;
 use rustc_span::Symbol;
 use rustc_target::callconv::FnAbi;
 
-use crate::shims::sig::check_min_vararg_count;
 use crate::shims::unix::thread::{EvalContextExt as _, ThreadNameResult};
 use crate::*;
 
@@ -16,14 +15,21 @@ pub fn prctl<'tcx>(
     args: &[OpTy<'tcx>],
     dest: &MPlaceTy<'tcx>,
 ) -> InterpResult<'tcx> {
-    let ([op], varargs) = ecx.check_shim_sig_variadic_lenient(abi, CanonAbi::C, link_name, args)?;
+    let ([op], varargs) = ecx.check_shim_sig_variadic(
+        shim_sig_variadic!(extern "C" fn(i32) -> i32),
+        link_name,
+        abi,
+        args,
+    )?;
 
     let pr_set_name = ecx.eval_libc_i32("PR_SET_NAME");
     let pr_get_name = ecx.eval_libc_i32("PR_GET_NAME");
 
     let res = match ecx.read_scalar(op)?.to_i32()? {
         op if op == pr_set_name => {
-            let [name] = check_min_vararg_count("prctl(PR_SET_NAME, ...)", varargs)?;
+            let ([name], _) =
+                ecx.check_varargs(shim_varargs![*_], varargs, "prctl(PR_SET_NAME, ...)")?;
+
             let name = ecx.read_scalar(name)?;
             let thread = ecx.pthread_self()?;
             // The Linux kernel silently truncates long names.
@@ -34,7 +40,9 @@ pub fn prctl<'tcx>(
             Scalar::from_u32(0)
         }
         op if op == pr_get_name => {
-            let [name] = check_min_vararg_count("prctl(PR_GET_NAME, ...)", varargs)?;
+            let ([name], _) =
+                ecx.check_varargs(shim_varargs![*_], varargs, "prctl(PR_GET_NAME, ...)")?;
+
             let name = ecx.read_scalar(name)?;
             let thread = ecx.pthread_self()?;
             let len = Scalar::from_target_usize(TASK_COMM_LEN, ecx);

--- a/src/shims/unix/linux_like/thread.rs
+++ b/src/shims/unix/linux_like/thread.rs
@@ -17,9 +17,7 @@ pub fn prctl<'tcx>(
 ) -> InterpResult<'tcx> {
     let ([op], varargs) = ecx.check_shim_sig_variadic(
         shim_sig_variadic!(extern "C" fn(i32) -> i32),
-        link_name,
-        abi,
-        args,
+        (link_name, abi, args),
     )?;
 
     let pr_set_name = ecx.eval_libc_i32("PR_SET_NAME");

--- a/src/shims/unix/netbsd/foreign_items.rs
+++ b/src/shims/unix/netbsd/foreign_items.rs
@@ -22,8 +22,8 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         match link_name.as_str() {
             // Environment
             "__unsetenv13" => {
-                let [name] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), link_name, abi, args)?;
+                let [name] = this
+                    .check_shim_sig(shim_sig!(extern "C" fn(*_) -> i32), (link_name, abi, args))?;
                 let result = this.unsetenv(name)?;
                 this.write_scalar(result, dest)?;
             }
@@ -31,7 +31,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             // Miscellaneous
             "__errno" => {
                 let [] =
-                    this.check_shim_sig(shim_sig!(extern "C" fn() -> *_), link_name, abi, args)?;
+                    this.check_shim_sig(shim_sig!(extern "C" fn() -> *_), (link_name, abi, args))?;
                 let errno_place = this.last_error_place()?;
                 this.write_scalar(errno_place.to_ref(this).to_scalar(), dest)?;
             }

--- a/src/shims/unix/solarish/foreign_items.rs
+++ b/src/shims/unix/solarish/foreign_items.rs
@@ -118,9 +118,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "__xnet_socket" | "__xnet7_socket" => {
                 let [domain, type_, protocol] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, i32, i32) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.socket(domain, type_, protocol)?;
                 this.write_scalar(result, dest)?;
@@ -128,9 +126,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "__xnet_bind" => {
                 let [socket, address, address_len] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, *_, libc::socklen_t) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.bind(socket, address, address_len)?;
                 this.write_scalar(result, dest)?;
@@ -138,18 +134,14 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "__xnet_connect" => {
                 let [socket, address, address_len] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, *_, libc::socklen_t) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.connect(socket, address, address_len, dest)?;
             }
             "__xnet_getaddrinfo" => {
                 let [node, service, hints, res] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_, *_, *_, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.getaddrinfo(node, service, hints, res)?;
                 this.write_scalar(result, dest)?;
@@ -157,9 +149,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "__xnet_getsockopt" => {
                 let [socket, level, option_name, option_value, option_len] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(i32, i32, i32, *_, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result =
                     this.getsockopt(socket, level, option_name, option_value, option_len)?;

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -12,6 +12,7 @@ use rustc_middle::throw_unsup_format;
 use rustc_target::spec::Os;
 
 use crate::shims::files::{EvalContextExt as _, FdNum, FileDescription, FileDescriptionRef};
+use crate::shims::sig::Varargs;
 use crate::shims::unix::UnixFileDescription;
 use crate::shims::unix::socket::{SocketFamily, UnixSocketFileDescription};
 use crate::*;
@@ -185,7 +186,7 @@ impl UnixFileDescription for TcpSocket {
     fn ioctl<'tcx>(
         &self,
         op: Scalar,
-        arg: Option<&OpTy<'tcx>>,
+        args: Varargs<'tcx, '_>,
         ecx: &mut MiriInterpCx<'tcx>,
     ) -> InterpResult<'tcx, i32> {
         assert!(ecx.machine.communicate(), "cannot have `TcpSocket` with isolation enabled!");
@@ -207,9 +208,7 @@ impl UnixFileDescription for TcpSocket {
                 );
             }
 
-            let Some(value_ptr) = arg else {
-                throw_ub_format!("ioctl: setting FIONBIO on sockets requires a third argument");
-            };
+            let ([value_ptr], _) = ecx.check_varargs(shim_varargs![*_], args, "ioctl")?;
             let value = ecx.deref_pointer_as(value_ptr, ecx.machine.layouts.i32)?;
             let non_block = ecx.read_scalar(&value)?.to_i32()? != 0;
             self.is_non_block.set(non_block);

--- a/src/shims/unix/virtual_socket.rs
+++ b/src/shims/unix/virtual_socket.rs
@@ -14,6 +14,7 @@ use crate::shims::files::{
     EvalContextExt as _, FileDescription, FileDescriptionRef, WeakFileDescriptionRef,
 };
 use crate::shims::readiness::DelayedReadinessUpdates;
+use crate::shims::sig::Varargs;
 use crate::shims::unix::UnixFileDescription;
 use crate::shims::unix::socket::UnixSocketFileDescription;
 use crate::*;
@@ -260,7 +261,7 @@ impl UnixFileDescription for VirtualSocket {
     fn ioctl<'tcx>(
         &self,
         op: Scalar,
-        arg: Option<&OpTy<'tcx>>,
+        args: Varargs<'tcx, '_>,
         ecx: &mut MiriInterpCx<'tcx>,
     ) -> InterpResult<'tcx, i32> {
         match self.fd_type {
@@ -290,9 +291,7 @@ impl UnixFileDescription for VirtualSocket {
                 );
             }
 
-            let Some(value_ptr) = arg else {
-                throw_ub_format!("ioctl: setting FIONBIO on sockets requires a third argument");
-            };
+            let ([value_ptr], _) = ecx.check_varargs(shim_varargs![*_], args, "ioctl")?;
             let value = ecx.deref_pointer_as(value_ptr, ecx.machine.layouts.i32)?;
             let non_block = ecx.read_scalar(&value)?.to_i32()? != 0;
             self.is_nonblock.set(non_block);

--- a/src/shims/windows/foreign_items.rs
+++ b/src/shims/windows/foreign_items.rs
@@ -151,9 +151,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [name, buf, size] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(*_, *_, u32) -> u32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.GetEnvironmentVariableW(name, buf, size)?;
                 this.write_scalar(result, dest)?;
@@ -162,9 +160,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [name, value] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(*_, *_) -> winapi::BOOL),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.SetEnvironmentVariableW(name, value)?;
                 this.write_scalar(result, dest)?;
@@ -173,9 +169,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [] = this.check_shim_sig(
                     shim_sig!(extern "system" fn() -> *_),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.GetEnvironmentStringsW()?;
                 this.write_pointer(result, dest)?;
@@ -184,9 +178,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [env_block] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(*_) -> winapi::BOOL),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.FreeEnvironmentStringsW(env_block)?;
                 this.write_scalar(result, dest)?;
@@ -195,9 +187,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [size, buf] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(u32, *_) -> u32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.GetCurrentDirectoryW(size, buf)?;
                 this.write_scalar(result, dest)?;
@@ -206,9 +196,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [path] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(*_) -> winapi::BOOL),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.SetCurrentDirectoryW(path)?;
                 this.write_scalar(result, dest)?;
@@ -217,9 +205,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [token, buf, size] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(winapi::HANDLE, *_, *_) -> winapi::BOOL),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.GetUserProfileDirectoryW(token, buf, size)?;
                 this.write_scalar(result, dest)?;
@@ -228,9 +214,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [] = this.check_shim_sig(
                     shim_sig!(extern "system" fn() -> u32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.GetCurrentProcessId()?;
                 this.write_scalar(result, dest)?;
@@ -239,9 +223,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [bufferlength, buffer] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(u32, *_) -> u32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.GetTempPathW(bufferlength, buffer)?;
                 this.write_scalar(result, dest)?;
@@ -273,9 +255,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                             *_,
                         ) -> i32
                     ),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.NtWriteFile(
                     handle,
@@ -315,9 +295,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                             *_,
                         ) -> i32
                     ),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.NtReadFile(
                     handle,
@@ -336,9 +314,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [filename, size, buffer, filepart] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(*_, u32, *_, *_) -> u32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.check_no_isolation("`GetFullPathNameW`")?;
 
@@ -388,9 +364,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                             winapi::HANDLE,
                         ) -> winapi::HANDLE
                     ),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let handle = this.CreateFileW(
                     file_name,
@@ -406,9 +380,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "GetFileInformationByHandle" => {
                 let [handle, info] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(winapi::HANDLE, *_) -> winapi::BOOL),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let res = this.GetFileInformationByHandle(handle, info)?;
                 this.write_scalar(res, dest)?;
@@ -423,9 +395,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                             u32,
                         ) -> winapi::BOOL
                     ),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let res = this.SetFileInformationByHandle(handle, class, info, size)?;
                 this.write_scalar(res, dest)?;
@@ -433,9 +403,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "FlushFileBuffers" => {
                 let [handle] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(winapi::HANDLE) -> winapi::BOOL),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let res = this.FlushFileBuffers(handle)?;
                 this.write_scalar(res, dest)?;
@@ -443,9 +411,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "DeleteFileW" => {
                 let [file_name] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(*_) -> winapi::BOOL),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let res = this.DeleteFileW(file_name)?;
                 this.write_scalar(res, dest)?;
@@ -454,9 +420,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let [file, distance_to_move, new_file_pointer, move_method] = this.check_shim_sig(
                     // i64 is actually a LARGE_INTEGER union of {u32, i32} and {i64}
                     shim_sig!(extern "system" fn(winapi::HANDLE, i64, *_, u32) -> winapi::BOOL),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let res =
                     this.SetFilePointerEx(file, distance_to_move, new_file_pointer, move_method)?;
@@ -465,9 +429,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "MoveFileExW" => {
                 let [existing_name, new_name, flags] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(*_, *_, u32) -> winapi::BOOL),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let res = this.MoveFileExW(existing_name, new_name, flags)?;
                 this.write_scalar(res, dest)?;
@@ -478,9 +440,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [handle, flags, size] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(winapi::HANDLE, u32, usize) -> *_),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.read_target_isize(handle)?;
                 let flags = this.read_scalar(flags)?.to_u32()?;
@@ -506,9 +466,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [handle, flags, ptr] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(winapi::HANDLE, u32, *_) -> winapi::BOOL),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.read_target_isize(handle)?;
                 this.read_scalar(flags)?.to_u32()?;
@@ -524,9 +482,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [handle, flags, old_ptr, size] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(winapi::HANDLE, u32, *_, usize) -> *_),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.read_target_isize(handle)?;
                 this.read_scalar(flags)?.to_u32()?;
@@ -550,9 +506,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [ptr] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(winapi::HLOCAL) -> winapi::HLOCAL),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let ptr = this.read_pointer(ptr)?;
                 // "If the hMem parameter is NULL, LocalFree ignores the parameter and returns NULL."
@@ -567,9 +521,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "SetLastError" => {
                 let [error] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(u32) -> ()),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let error = this.read_scalar(error)?;
                 this.set_last_error(error)?;
@@ -577,9 +529,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "GetLastError" => {
                 let [] = this.check_shim_sig(
                     shim_sig!(extern "system" fn() -> u32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let last_error = this.get_last_error()?;
                 this.write_scalar(last_error, dest)?;
@@ -587,9 +537,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "RtlNtStatusToDosError" => {
                 let [status] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(i32) -> u32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let status = this.read_scalar(status)?.to_u32()?;
                 let err = match status {
@@ -615,9 +563,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // Also called from `page_size` crate.
                 let [system_info] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(*_) -> ()),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let system_info =
                     this.deref_pointer_as(system_info, this.windows_ty_layout("SYSTEM_INFO"))?;
@@ -644,9 +590,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // Create key and return it.
                 let [] = this.check_shim_sig(
                     shim_sig!(extern "system" fn() -> u32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let key = this.machine.tls.create_tls_key(None, dest.layout.size)?;
                 this.write_scalar(Scalar::from_uint(key, dest.layout.size), dest)?;
@@ -655,9 +599,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [key] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(u32) -> *_),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let key = u128::from(this.read_scalar(key)?.to_u32()?);
                 let active_thread = this.active_thread();
@@ -668,9 +610,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [key, new_ptr] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(u32, *_) -> winapi::BOOL),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let key = u128::from(this.read_scalar(key)?.to_u32()?);
                 let active_thread = this.active_thread();
@@ -684,9 +624,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [key] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(u32) -> winapi::BOOL),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let key = u128::from(this.read_scalar(key)?.to_u32()?);
                 this.machine.tls.delete_tls_key(key)?;
@@ -701,9 +639,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // Create key and return it.
                 let [dtor] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(winapi::PFLS_CALLBACK_FUNCTION) -> u32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let dtor = this.read_pointer(dtor)?;
 
@@ -724,9 +660,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [key] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(u32) -> *_),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let key = u128::from(this.read_scalar(key)?.to_u32()?);
                 let active_thread = this.active_thread();
@@ -737,9 +671,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [key, new_ptr] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(u32, *_) -> winapi::BOOL),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let key = u128::from(this.read_scalar(key)?.to_u32()?);
                 let active_thread = this.active_thread();
@@ -753,9 +685,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [key] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(u32) -> winapi::BOOL),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let key = u128::from(this.read_scalar(key)?.to_u32()?);
                 let tls_entry = this.machine.tls.delete_tls_key(key)?;
@@ -774,9 +704,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [] = this.check_shim_sig(
                     shim_sig!(extern "system" fn() -> winapi::BOOL),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
 
                 // Return FALSE, as Miri does not support fibers.
@@ -788,9 +716,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [] = this.check_shim_sig(
                     shim_sig!(extern "system" fn() -> *_),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.write_pointer(
                     this.machine.cmd_line.expect("machine must be initialized"),
@@ -803,9 +729,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [filetime] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(*_) -> ()),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.GetSystemTimeAsFileTime(link_name.as_str(), filetime)?;
             }
@@ -813,9 +737,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [performance_count] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(*_) -> winapi::BOOL),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.QueryPerformanceCounter(performance_count)?;
                 this.write_scalar(result, dest)?;
@@ -824,9 +746,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [frequency] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(*_) -> winapi::BOOL),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.QueryPerformanceFrequency(frequency)?;
                 this.write_scalar(result, dest)?;
@@ -835,9 +755,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [timeout] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(u32) -> ()),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
 
                 this.Sleep(timeout)?;
@@ -846,9 +764,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [attributes, name, flags, access] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(*_, *_, u32, u32) -> winapi::HANDLE),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.read_pointer(attributes)?;
                 this.read_pointer(name)?;
@@ -864,18 +780,14 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "InitOnceBeginInitialize" => {
                 let [ptr, flags, pending, context] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(*_, u32, *_, *_) -> winapi::BOOL),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.InitOnceBeginInitialize(ptr, flags, pending, context, dest)?;
             }
             "InitOnceComplete" => {
                 let [ptr, flags, context] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(*_, u32, *_) -> winapi::BOOL),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let result = this.InitOnceComplete(ptr, flags, context)?;
                 this.write_scalar(result, dest)?;
@@ -885,9 +797,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let [ptr_op, compare_op, size_op, timeout_op] = this.check_shim_sig(
                     // First pointer is volatile
                     shim_sig!(extern "system" fn(*_, *_, usize, u32) -> winapi::BOOL),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
 
                 this.WaitOnAddress(ptr_op, compare_op, size_op, timeout_op, dest)?;
@@ -896,9 +806,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [ptr_op] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(*_) -> ()),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
 
                 this.WakeByAddressSingle(ptr_op)?;
@@ -907,9 +815,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [ptr_op] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(*_) -> ()),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
 
                 this.WakeByAddressAll(ptr_op)?;
@@ -920,9 +826,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [module, proc_name] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(winapi::HMODULE, *_) -> winapi::FARPROC),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.read_target_isize(module)?;
                 let name = this.read_c_str(this.read_pointer(proc_name)?)?;
@@ -949,9 +853,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                             *_,
                         ) -> winapi::HANDLE
                     ),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
 
                 let thread_id =
@@ -962,9 +864,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "WaitForSingleObject" => {
                 let [handle, timeout] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(winapi::HANDLE, u32) -> u32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
 
                 this.WaitForSingleObject(handle, timeout, dest)?;
@@ -972,9 +872,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "GetCurrentProcess" => {
                 let [] = this.check_shim_sig(
                     shim_sig!(extern "system" fn() -> winapi::HANDLE),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
 
                 this.write_scalar(
@@ -985,9 +883,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "GetCurrentThread" => {
                 let [] = this.check_shim_sig(
                     shim_sig!(extern "system" fn() -> winapi::HANDLE),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
 
                 this.write_scalar(
@@ -998,9 +894,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "SetThreadDescription" => {
                 let [handle, name] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(winapi::HANDLE, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
 
                 let handle = this.read_handle(handle, "SetThreadDescription")?;
@@ -1018,9 +912,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "GetThreadDescription" => {
                 let [handle, name_ptr] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(winapi::HANDLE, *_) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
 
                 let handle = this.read_handle(handle, "GetThreadDescription")?;
@@ -1046,9 +938,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "GetThreadId" => {
                 let [handle] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(winapi::HANDLE) -> u32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let handle = this.read_handle(handle, "GetThreadId")?;
                 let thread = match handle {
@@ -1061,9 +951,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "GetCurrentThreadId" => {
                 let [] = this.check_shim_sig(
                     shim_sig!(extern "system" fn() -> u32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.write_scalar(Scalar::from_u32(this.active_thread().to_u32()), dest)?;
             }
@@ -1073,9 +961,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [code] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(u32) -> ()),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 // Windows technically uses u32, but we unify everything to a Unix-style i32.
                 let code = this.read_scalar(code)?.to_i32()?;
@@ -1087,9 +973,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let [ptr, len] = this.check_shim_sig(
                     // Returns winapi::BOOLEAN, which is a byte
                     shim_sig!(extern "system" fn(*_, u32) -> u8),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let ptr = this.read_pointer(ptr)?;
                 let len = this.read_scalar(len)?.to_u32()?;
@@ -1101,9 +985,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // used by `std`
                 let [ptr, len] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(*_, usize) -> winapi::BOOL),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let ptr = this.read_pointer(ptr)?;
                 let len = this.read_target_usize(len)?;
@@ -1114,9 +996,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // used by getrandom 0.2
                 let [algorithm, ptr, len, flags] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(*_, *_, u32, u32) -> i32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let algorithm = this.read_scalar(algorithm)?;
                 let algorithm = algorithm.to_target_usize(this)?;
@@ -1154,9 +1034,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // `term` needs this, so we fake it.
                 let [console, buffer_info] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(winapi::HANDLE, *_) -> winapi::BOOL),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.read_target_isize(console)?;
                 // FIXME: this should use deref_pointer_as, but CONSOLE_SCREEN_BUFFER_INFO is not in std
@@ -1169,9 +1047,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [which] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(u32) -> winapi::HANDLE),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 let res = this.GetStdHandle(which)?;
                 this.write_scalar(res, dest)?;
@@ -1190,9 +1066,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                                 u32,
                             ) -> winapi::BOOL
                         ),
-                        link_name,
-                        abi,
-                        args,
+                        (link_name, abi, args),
                     )?;
                 let res = this.DuplicateHandle(
                     src_proc,
@@ -1208,9 +1082,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "CloseHandle" => {
                 let [handle] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(winapi::HANDLE) -> winapi::BOOL),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
 
                 let ret = this.CloseHandle(handle)?;
@@ -1221,9 +1093,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // FIXME: This does not have a direct test (#3179).
                 let [handle, filename, size] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(winapi::HMODULE, *_, u32) -> u32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.check_no_isolation("`GetModuleFileNameW`")?;
 
@@ -1263,9 +1133,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                         shim_sig!(
                             extern "system" fn(u32, *_, u32, u32, *_, u32, *_) -> u32
                         ),
-                        link_name,
-                        abi,
-                        args,
+                        (link_name, abi, args),
                     )?;
 
                 let flags = this.read_scalar(flags)?.to_u32()?;
@@ -1312,9 +1180,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // This function looks and behaves exactly like miri_start_unwind.
                 let [payload] = this.check_shim_sig(
                     shim_sig!(extern "C" fn(*_) -> unwind::_Unwind_Reason_Code),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.handle_miri_start_unwind(payload)?;
                 return interp_ok(EmulateItemResult::NeedsUnwind);
@@ -1325,9 +1191,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "GetProcessHeap" if this.frame_in_std() => {
                 let [] = this.check_shim_sig(
                     shim_sig!(extern "system" fn() -> winapi::HANDLE),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 // Just fake a HANDLE
                 // It's fine to not use the Handle type here because its a stub
@@ -1336,9 +1200,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "GetModuleHandleA" if this.frame_in_std() => {
                 let [_module_name] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(*_) -> winapi::HMODULE),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 // We need to return something non-null here to make `compat_fn!` work.
                 this.write_int(1, dest)?;
@@ -1346,9 +1208,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "SetConsoleTextAttribute" if this.frame_in_std() => {
                 let [_console_output, _attribute] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(winapi::HANDLE, u16) -> winapi::BOOL),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 // Pretend these does not exist / nothing happened, by returning zero.
                 this.write_null(dest)?;
@@ -1356,9 +1216,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "GetConsoleMode" if this.frame_in_std() => {
                 let [console, mode] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(winapi::HANDLE, *_) -> winapi::BOOL),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 this.read_target_isize(console)?;
                 this.deref_pointer_as(mode, this.machine.layouts.u32)?;
@@ -1368,9 +1226,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "GetFileType" if this.frame_in_std() => {
                 let [_file] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(winapi::HANDLE) -> u32),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 // Return unknown file type.
                 this.write_null(dest)?;
@@ -1378,9 +1234,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "AddVectoredExceptionHandler" if this.frame_in_std() => {
                 let [_first, _handler] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(u32, *_) -> *_),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 // Any non zero value works for the stdlib. This is just used for stack overflows anyway.
                 this.write_int(1, dest)?;
@@ -1388,9 +1242,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "SetThreadStackGuarantee" if this.frame_in_std() => {
                 let [_stack_size_in_bytes] = this.check_shim_sig(
                     shim_sig!(extern "system" fn(*_) -> winapi::BOOL),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
                 // Any non zero value works for the stdlib. This is just used for stack overflows anyway.
                 this.write_int(1, dest)?;
@@ -1399,9 +1251,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             "SwitchToThread" if this.frame_in_std() => {
                 let [] = this.check_shim_sig(
                     shim_sig!(extern "system" fn() -> winapi::BOOL),
-                    link_name,
-                    abi,
-                    args,
+                    (link_name, abi, args),
                 )?;
 
                 this.yield_active_thread();

--- a/tests/fail/alloc/too_large.rs
+++ b/tests/fail/alloc/too_large.rs
@@ -1,13 +1,14 @@
 #![feature(rustc_attrs)]
+#![feature(ptr_alignment_type)]
 
 extern "Rust" {
     #[rustc_std_internal_symbol]
-    fn __rust_alloc(size: usize, align: usize) -> *mut u8;
+    fn __rust_alloc(size: usize, align: core::mem::Alignment) -> *mut u8;
 }
 
 fn main() {
     let bytes = isize::MAX as usize + 1;
     unsafe {
-        __rust_alloc(bytes, 1); //~ERROR: larger than half the address space
+        __rust_alloc(bytes, 1usize.try_into().unwrap()); //~ERROR: larger than half the address space
     }
 }

--- a/tests/fail/alloc/too_large.stderr
+++ b/tests/fail/alloc/too_large.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: creating an allocation larger than half the address space
   --> tests/fail/alloc/too_large.rs:LL:CC
    |
-LL |         __rust_alloc(bytes, 1);
-   |         ^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+LL |         __rust_alloc(bytes, 1usize.try_into().unwrap());
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/alloc/unsupported_big_alignment.rs
+++ b/tests/fail/alloc/unsupported_big_alignment.rs
@@ -3,15 +3,16 @@
 // https://github.com/rust-lang/miri/issues/3687
 
 #![feature(rustc_attrs)]
+#![feature(ptr_alignment_type)]
 
 extern "Rust" {
     #[rustc_std_internal_symbol]
-    fn __rust_alloc(size: usize, align: usize) -> *mut u8;
+    fn __rust_alloc(size: usize, align: core::mem::Alignment) -> *mut u8;
 }
 
 fn main() {
     unsafe {
-        __rust_alloc(1, 1 << 30);
+        __rust_alloc(1, (1 << 30).try_into().unwrap());
         //~^ERROR: exceeding rustc's maximum supported value
     }
 }

--- a/tests/fail/alloc/unsupported_big_alignment.stderr
+++ b/tests/fail/alloc/unsupported_big_alignment.stderr
@@ -1,8 +1,8 @@
 error: unsupported operation: creating allocation with alignment ALIGN exceeding rustc's maximum supported value
   --> tests/fail/alloc/unsupported_big_alignment.rs:LL:CC
    |
-LL |         __rust_alloc(1, 1 << 30);
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^ unsupported operation occurred here
+LL |         __rust_alloc(1, (1 << 30).try_into().unwrap());
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsupported operation occurred here
    |
    = help: this is likely not a bug in the program; it indicates that the program performed an operation that Miri does not support
 

--- a/tests/fail/alloc/unsupported_non_power_two_alignment.rs
+++ b/tests/fail/alloc/unsupported_non_power_two_alignment.rs
@@ -2,14 +2,12 @@
 
 #![feature(rustc_attrs)]
 
-extern "Rust" {
-    #[rustc_std_internal_symbol]
-    fn __rust_alloc(size: usize, align: usize) -> *mut u8;
-}
+#[path = "../../utils/mod.no_std.rs"]
+mod utils;
 
 fn main() {
     unsafe {
-        __rust_alloc(1, 3);
+        utils::miri_alloc(1, 3);
         //~^ERROR: creating allocation with non-power-of-two alignment
     }
 }

--- a/tests/fail/alloc/unsupported_non_power_two_alignment.stderr
+++ b/tests/fail/alloc/unsupported_non_power_two_alignment.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: creating allocation with non-power-of-two alignment ALIGN
   --> tests/fail/alloc/unsupported_non_power_two_alignment.rs:LL:CC
    |
-LL |         __rust_alloc(1, 3);
-   |         ^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+LL |         utils::miri_alloc(1, 3);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information

--- a/tests/fail/data_race/dealloc_read_race1.rs
+++ b/tests/fail/data_race/dealloc_read_race1.rs
@@ -2,6 +2,7 @@
 //@compile-flags: -Zmiri-deterministic-concurrency -Zmiri-disable-stacked-borrows
 
 #![feature(rustc_attrs)]
+#![feature(ptr_alignment_type)]
 
 use std::thread::spawn;
 
@@ -13,7 +14,7 @@ unsafe impl<T> Sync for EvilSend<T> {}
 
 extern "Rust" {
     #[rustc_std_internal_symbol]
-    fn __rust_dealloc(ptr: *mut u8, size: usize, align: usize);
+    fn __rust_dealloc(ptr: *mut u8, size: usize, align: core::mem::Alignment);
 }
 
 fn main() {
@@ -33,7 +34,7 @@ fn main() {
                 //~^ ERROR: Data race detected between (1) non-atomic read on thread `unnamed-1` and (2) deallocation on thread `unnamed-2`
                 ptr.0 as *mut _,
                 std::mem::size_of::<usize>(),
-                std::mem::align_of::<usize>(),
+                std::mem::align_of::<usize>().try_into().unwrap(),
             );
         });
 

--- a/tests/fail/data_race/dealloc_read_race1.stderr
+++ b/tests/fail/data_race/dealloc_read_race1.stderr
@@ -5,7 +5,7 @@ LL | / ...   __rust_dealloc(
 LL | | ...
 LL | | ...       ptr.0 as *mut _,
 LL | | ...       std::mem::size_of::<usize>(),
-LL | | ...       std::mem::align_of::<usize>(),
+LL | | ...       std::mem::align_of::<usize>().try_into().unwrap(),
 LL | | ...   );
    | |_______^ (2) just happened here
    |

--- a/tests/fail/data_race/dealloc_read_race2.rs
+++ b/tests/fail/data_race/dealloc_read_race2.rs
@@ -2,6 +2,7 @@
 //@compile-flags: -Zmiri-deterministic-concurrency -Zmiri-disable-stacked-borrows
 
 #![feature(rustc_attrs)]
+#![feature(ptr_alignment_type)]
 
 use std::thread::spawn;
 
@@ -13,7 +14,7 @@ unsafe impl<T> Sync for EvilSend<T> {}
 
 extern "Rust" {
     #[rustc_std_internal_symbol]
-    fn __rust_dealloc(ptr: *mut u8, size: usize, align: usize);
+    fn __rust_dealloc(ptr: *mut u8, size: usize, align: core::mem::Alignment);
 }
 
 fn main() {
@@ -27,7 +28,7 @@ fn main() {
             __rust_dealloc(
                 ptr.0 as *mut _,
                 std::mem::size_of::<usize>(),
-                std::mem::align_of::<usize>(),
+                std::mem::align_of::<usize>().try_into().unwrap(),
             )
         });
 

--- a/tests/fail/data_race/dealloc_read_race2.stderr
+++ b/tests/fail/data_race/dealloc_read_race2.stderr
@@ -17,7 +17,7 @@ help: ALLOC was deallocated here:
 LL | /             __rust_dealloc(
 LL | |                 ptr.0 as *mut _,
 LL | |                 std::mem::size_of::<usize>(),
-LL | |                 std::mem::align_of::<usize>(),
+LL | |                 std::mem::align_of::<usize>().try_into().unwrap(),
 LL | |             )
    | |_____________^
    = note: this is on thread `unnamed-ID`

--- a/tests/fail/data_race/dealloc_write_race1.rs
+++ b/tests/fail/data_race/dealloc_write_race1.rs
@@ -2,6 +2,7 @@
 //@compile-flags: -Zmiri-deterministic-concurrency -Zmiri-disable-stacked-borrows
 
 #![feature(rustc_attrs)]
+#![feature(ptr_alignment_type)]
 
 use std::thread::spawn;
 
@@ -13,7 +14,7 @@ unsafe impl<T> Sync for EvilSend<T> {}
 
 extern "Rust" {
     #[rustc_std_internal_symbol]
-    fn __rust_dealloc(ptr: *mut u8, size: usize, align: usize);
+    fn __rust_dealloc(ptr: *mut u8, size: usize, align: core::mem::Alignment);
 }
 fn main() {
     // Shared atomic pointer
@@ -32,7 +33,7 @@ fn main() {
                 //~^ ERROR: Data race detected between (1) non-atomic write on thread `unnamed-1` and (2) deallocation on thread `unnamed-2`
                 ptr.0 as *mut _,
                 std::mem::size_of::<usize>(),
-                std::mem::align_of::<usize>(),
+                std::mem::align_of::<usize>().try_into().unwrap(),
             );
         });
 

--- a/tests/fail/data_race/dealloc_write_race1.stderr
+++ b/tests/fail/data_race/dealloc_write_race1.stderr
@@ -5,7 +5,7 @@ LL | / ...   __rust_dealloc(
 LL | | ...
 LL | | ...       ptr.0 as *mut _,
 LL | | ...       std::mem::size_of::<usize>(),
-LL | | ...       std::mem::align_of::<usize>(),
+LL | | ...       std::mem::align_of::<usize>().try_into().unwrap(),
 LL | | ...   );
    | |_______^ (2) just happened here
    |

--- a/tests/fail/data_race/dealloc_write_race2.rs
+++ b/tests/fail/data_race/dealloc_write_race2.rs
@@ -2,6 +2,7 @@
 //@compile-flags: -Zmiri-deterministic-concurrency -Zmiri-disable-stacked-borrows
 
 #![feature(rustc_attrs)]
+#![feature(ptr_alignment_type)]
 
 use std::thread::spawn;
 
@@ -13,7 +14,7 @@ unsafe impl<T> Sync for EvilSend<T> {}
 
 extern "Rust" {
     #[rustc_std_internal_symbol]
-    fn __rust_dealloc(ptr: *mut u8, size: usize, align: usize);
+    fn __rust_dealloc(ptr: *mut u8, size: usize, align: core::mem::Alignment);
 }
 fn main() {
     // Shared atomic pointer
@@ -26,7 +27,7 @@ fn main() {
             __rust_dealloc(
                 ptr.0 as *mut _,
                 std::mem::size_of::<usize>(),
-                std::mem::align_of::<usize>(),
+                std::mem::align_of::<usize>().try_into().unwrap(),
             );
         });
 

--- a/tests/fail/data_race/dealloc_write_race2.stderr
+++ b/tests/fail/data_race/dealloc_write_race2.stderr
@@ -17,7 +17,7 @@ help: ALLOC was deallocated here:
 LL | /             __rust_dealloc(
 LL | |                 ptr.0 as *mut _,
 LL | |                 std::mem::size_of::<usize>(),
-LL | |                 std::mem::align_of::<usize>(),
+LL | |                 std::mem::align_of::<usize>().try_into().unwrap(),
 LL | |             );
    | |_____________^
    = note: this is on thread `unnamed-ID`

--- a/tests/fail/shims/non_vararg_signature_mismatch.rs
+++ b/tests/fail/shims/non_vararg_signature_mismatch.rs
@@ -15,6 +15,6 @@ fn main() {
     let c_path = CString::new(OsStr::new("./text").as_bytes()).expect("CString::new failed");
     let _fd = unsafe {
         open(c_path.as_ptr(), /* value does not matter */ 0)
-        //~^ ERROR: calling a variadic function with a non-variadic caller-side signature
+        //~^ ERROR: is a variadic function, but the caller is using a non-variadic signature
     };
 }

--- a/tests/fail/shims/non_vararg_signature_mismatch.stderr
+++ b/tests/fail/shims/non_vararg_signature_mismatch.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: calling a variadic function with a non-variadic caller-side signature
+error: Undefined Behavior: ABI mismatch: `open` is a variadic function, but the caller is using a non-variadic signature
   --> tests/fail/shims/non_vararg_signature_mismatch.rs:LL:CC
    |
 LL |         open(c_path.as_ptr(), /* value does not matter */ 0)

--- a/tests/fail/shims/wrong_fixed_arg_count.rs
+++ b/tests/fail/shims/wrong_fixed_arg_count.rs
@@ -14,6 +14,6 @@ fn main() {
     let c_path = CString::new(OsStr::new("./text").as_bytes()).expect("CString::new failed");
     let _fd = unsafe {
         open(c_path.as_ptr(), /* value does not matter */ 0)
-        //~^ ERROR: incorrect number of fixed arguments for variadic function
+        //~^ ERROR: takes 2 fixed (non-variadic) arguments, but 1 argument was given
     };
 }

--- a/tests/fail/shims/wrong_fixed_arg_count.stderr
+++ b/tests/fail/shims/wrong_fixed_arg_count.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: incorrect number of fixed arguments for variadic function `open`: got 1, expected 2
+error: Undefined Behavior: ABI mismatch: calling `open` which takes 2 fixed (non-variadic) arguments, but 1 argument was given
   --> tests/fail/shims/wrong_fixed_arg_count.rs:LL:CC
    |
 LL |         open(c_path.as_ptr(), /* value does not matter */ 0)


### PR DESCRIPTION
Also port the allocators, which requires test adjustments as we relied on `mem::Alignmetn` having the same ABI as `usize` which is not the case.

And the last commit is a formatting trick, to make these signature checks take less space.