### PR TITLE
unify shim_sig and shim_sig_variadic macros

### DIFF
--- a/src/shims/sig.rs
+++ b/src/shims/sig.rs
@@ -30,26 +30,15 @@ pub struct ShimSig<'tcx, const ARGS: usize> {
 #[macro_export]
 macro_rules! shim_sig {
     (extern $abi:literal fn($($args:tt)*) -> $($ret:tt)*) => {
-        |this| $crate::shims::sig::ShimSig {
-            abi: std::str::FromStr::from_str($abi).expect("incorrect abi specified"),
-            args: shim_sig_args_sep!(this, [$($args)*]),
-            ret: shim_sig_arg!(this, $($ret)*),
-            nounwind: false,
-            c_variadic: false,
-        }
-    };
-}
-
-/// Same as `shim_sig!` but declares a variadic function. The signature is for the fixed part.
-#[macro_export]
-macro_rules! shim_sig_variadic {
-    (extern $abi:literal fn($($args:tt)*) -> $($ret:tt)*) => {
-        |this| $crate::shims::sig::ShimSig {
-            abi: std::str::FromStr::from_str($abi).expect("incorrect abi specified"),
-            args: shim_sig_args_sep!(this, [$($args)*]),
-            ret: shim_sig_arg!(this, $($ret)*),
-            nounwind: true,
-            c_variadic: true,
+        |this| {
+            let (args, c_variadic) = shim_sig_args_sep!(this, [$($args)*]);
+            $crate::shims::sig::ShimSig {
+                abi: std::str::FromStr::from_str($abi).expect("incorrect abi specified"),
+                args,
+                ret: shim_sig_arg!(this, $($ret)*),
+                nounwind: false,
+                c_variadic,
+            }
         }
     };
 }
@@ -58,12 +47,15 @@ macro_rules! shim_sig_variadic {
 #[macro_export]
 macro_rules! shim_sig_nounwind {
     (extern $abi:literal fn($($args:tt)*) -> $($ret:tt)*) => {
-        |this| $crate::shims::sig::ShimSig {
-            abi: std::str::FromStr::from_str($abi).expect("incorrect abi specified"),
-            args: shim_sig_args_sep!(this, [$($args)*]),
-            ret: shim_sig_arg!(this, $($ret)*),
-            nounwind: true,
-            c_variadic: false,
+        |this| {
+            let (args, c_variadic) = shim_sig_args_sep!(this, [$($args)*]);
+            $crate::shims::sig::ShimSig {
+                abi: std::str::FromStr::from_str($abi).expect("incorrect abi specified"),
+                args,
+                ret: shim_sig_arg!(this, $($ret)*),
+                nounwind: true,
+                c_variadic,
+            }
         }
     };
 }
@@ -72,13 +64,18 @@ macro_rules! shim_sig_nounwind {
 #[macro_export]
 macro_rules! shim_varargs {
     ($($args:tt)*) => {
-        |this| shim_sig_args_sep!(this, [$($args)*])
+        |this| {
+            let (args, c_variadic) = shim_sig_args_sep!(this, [$($args)*]);
+            assert!(!c_variadic); // don't accept `...` here
+            args
+        }
     };
 }
 
 /// Helper for `shim_sig!`.
 ///
 /// Groups tokens into comma-separated chunks and calls the provided macro on them.
+/// Returns a list of types and a boolean indicating whether there was a trailing `...`.
 ///
 /// # Examples
 ///
@@ -107,13 +104,17 @@ macro_rules! shim_sig_args_sep {
     (@ $this:ident [$($final:tt)*] [$($collected:tt)*] $first:tt $($tt:tt)*) => {
         shim_sig_args_sep!(@ $this [$($final)*] [$($collected)* $first] $($tt)*)
     };
+    // No more tokens, trailing `...` - emit final output, indicate this is variadic.
+    (@ $this:ident [$($final:tt)*] [...] ) => {
+        ([$($final)*], true)
+    };
     // No more tokens - emit final output, including final non-comma type.
     (@ $this:ident [$($final:tt)*] [$($collected:tt)+] ) => {
-        [$($final)* shim_sig_arg!($this, $($collected)*)]
+        ([$($final)* shim_sig_arg!($this, $($collected)*)], false)
     };
     // No more tokens, empty collector - emit final output.
     (@ $this:ident [$($final:tt)*] [] ) => {
-        [$($final)*]
+        ([$($final)*], false)
     };
 }
 

--- a/src/shims/unix/foreign_items.rs
+++ b/src/shims/unix/foreign_items.rs
@@ -286,7 +286,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             }
             "fcntl" => {
                 let ([fd_num, cmd], varargs) = this.check_shim_sig_variadic(
-                    shim_sig_variadic!(extern "C" fn(i32, i32) -> i32),
+                    shim_sig!(extern "C" fn(i32, i32, ...) -> i32),
                     (link_name, abi, args),
                 )?;
                 let result = this.fcntl(fd_num, cmd, varargs)?;
@@ -335,9 +335,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 };
                 let ([fd, op], varargs) = this.check_shim_sig_variadic(
                     if op_is_ulong {
-                        shim_sig_variadic!(extern "C" fn(i32, usize) -> i32)
+                        shim_sig!(extern "C" fn(i32, usize, ...) -> i32)
                     } else {
-                        shim_sig_variadic!(extern "C" fn(i32, i32) -> i32)
+                        shim_sig!(extern "C" fn(i32, i32, ...) -> i32)
                     },
                     (link_name, abi, args),
                 )?;
@@ -350,7 +350,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // `open` is variadic, the third argument is only present when the second argument
                 // has O_CREAT (or on linux O_TMPFILE, but miri doesn't support that) set
                 let ([path_raw, flag], varargs) = this.check_shim_sig_variadic(
-                    shim_sig_variadic!(extern "C" fn(*_, i32) -> i32),
+                    shim_sig!(extern "C" fn(*_, i32, ...) -> i32),
                     (link_name, abi, args),
                 )?;
                 let result = this.open(path_raw, flag, varargs)?;

--- a/src/shims/unix/linux/foreign_items.rs
+++ b/src/shims/unix/linux/foreign_items.rs
@@ -41,7 +41,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // `open64` is variadic, the third argument is only present when the second argument
                 // has O_CREAT (or on linux O_TMPFILE, but miri doesn't support that) set
                 let ([path_raw, flag], varargs) = this.check_shim_sig_variadic(
-                    shim_sig_variadic!(extern "C" fn(*_, i32) -> i32),
+                    shim_sig!(extern "C" fn(*_, i32, ...) -> i32),
                     (link_name, abi, args),
                 )?;
                 let result = this.open(path_raw, flag, varargs)?;
@@ -242,7 +242,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             }
             "mremap" => {
                 let ([old_address, old_size, new_size, flags], _) = this.check_shim_sig_variadic(
-                    shim_sig_variadic!(extern "C" fn(*_, usize, usize, i32) -> *_),
+                    shim_sig!(extern "C" fn(*_, usize, usize, i32, ...) -> *_),
                     (link_name, abi, args),
                 )?;
                 let ptr = this.mremap(old_address, old_size, new_size, flags)?;

--- a/src/shims/unix/linux_like/syscall.rs
+++ b/src/shims/unix/linux_like/syscall.rs
@@ -16,7 +16,7 @@ pub fn syscall<'tcx>(
     dest: &MPlaceTy<'tcx>,
 ) -> InterpResult<'tcx> {
     let ([op], varargs) = ecx.check_shim_sig_variadic(
-        shim_sig_variadic!(extern "C" fn(isize) -> isize),
+        shim_sig!(extern "C" fn(isize, ...) -> isize),
         (link_name, abi, args),
     )?;
     // The syscall variadic function is legal to call with more arguments than needed,

--- a/src/shims/unix/linux_like/thread.rs
+++ b/src/shims/unix/linux_like/thread.rs
@@ -16,7 +16,7 @@ pub fn prctl<'tcx>(
     dest: &MPlaceTy<'tcx>,
 ) -> InterpResult<'tcx> {
     let ([op], varargs) = ecx.check_shim_sig_variadic(
-        shim_sig_variadic!(extern "C" fn(i32) -> i32),
+        shim_sig!(extern "C" fn(i32, ...) -> i32),
         (link_name, abi, args),
     )?;
 


### PR DESCRIPTION
I found a way to make a trailing `...` indicate that this is a variadic signature.