### PR TITLE
[WIP][DRAFT] opt-in recursion detection

### DIFF
--- a/src/bin/miri.rs
+++ b/src/bin/miri.rs
@@ -683,6 +683,8 @@ fn main() -> ExitCode {
             miri_config.page_size = Some(page_size);
         } else if let Some(param) = arg.strip_prefix("-Zmiri-user-relevant-crates=") {
             miri_config.user_relevant_crates.extend(param.split(',').map(|s| s.to_owned()));
+        } else if arg == "-Zno-recursion" {
+            miri_config.diagnose_recursion = true;
         } else {
             // Forward to rustc.
             rustc_args.push(arg);

--- a/src/concurrency/thread.rs
+++ b/src/concurrency/thread.rs
@@ -167,6 +167,8 @@ pub struct Thread<'tcx> {
     /// The virtual call stack.
     stack: Vec<Frame<'tcx, Provenance, FrameExtra<'tcx>>>,
 
+    zz: Option<rustc_data_structures::fx::FxHashSet<rustc_middle::ty::Instance<'tcx>>>,
+
     /// A span that explains where the thread (or more specifically, its current root
     /// frame) "comes from".
     pub(crate) origin_span: Span,
@@ -308,6 +310,7 @@ impl<'tcx> Thread<'tcx> {
             state: ThreadState::Enabled,
             thread_name: name.map(|name| Vec::from(name.as_bytes())),
             stack: Vec::new(),
+            zz: None,
             origin_span: DUMMY_SP,
             top_user_relevant_frame: None,
             join_status: ThreadJoinStatus::Joinable,
@@ -324,6 +327,7 @@ impl VisitProvenance for Thread<'_> {
             unwind_payloads: panic_payload,
             last_error,
             stack,
+            zz: _,
             origin_span: _,
             top_user_relevant_frame: _,
             state: _,
@@ -487,6 +491,12 @@ impl<'tcx> ThreadManager<'tcx> {
         &mut self,
     ) -> &mut Vec<Frame<'tcx, Provenance, FrameExtra<'tcx>>> {
         &mut self.threads[self.active_thread].stack
+    }
+
+    pub fn active_thread_zz_mut(
+        &mut self,
+    ) -> &mut Option<rustc_data_structures::fx::FxHashSet<rustc_middle::ty::Instance<'tcx>>> {
+        &mut self.threads[self.active_thread].zz
     }
 
     pub(super) fn all_threads(&self) -> impl Iterator<Item = (ThreadId, &Thread<'tcx>)> {
@@ -1073,6 +1083,13 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     ) -> &'a mut Vec<Frame<'tcx, Provenance, FrameExtra<'tcx>>> {
         let this = self.eval_context_mut();
         this.machine.threads.active_thread_stack_mut()
+    }
+
+    fn active_thread_zz_mut(
+        &mut self,
+    ) -> &mut Option<rustc_data_structures::fx::FxHashSet<rustc_middle::ty::Instance<'tcx>>> {
+        let this = self.eval_context_mut();
+        this.machine.threads.active_thread_zz_mut()
     }
 
     /// Set the name of the current thread. The buffer must not include the null terminator.

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -58,6 +58,7 @@ pub enum TerminationInfo {
         extra: Option<&'static str>,
         retag_explain: bool,
     },
+    Recursion,
     UnsupportedForeignItem(String),
 }
 
@@ -100,6 +101,7 @@ impl fmt::Display for TerminationInfo {
                     op2.thread_info
                 ),
             UnsupportedForeignItem(msg) => write!(f, "{msg}"),
+            Recursion => Ok(()),
         }
     }
 }
@@ -292,6 +294,7 @@ pub fn report_result<'tcx>(
                 }
                 return None;
             }
+            Recursion => Some("recursive call"),
             MultipleSymbolDefinitions { .. } | SymbolShimClashing { .. } => None,
         };
         #[rustfmt::skip]
@@ -360,8 +363,34 @@ pub fn report_result<'tcx>(
                 helps.push(note!("this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior"));
                 helps.push(note!("see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information"));
                 helps
-            }
-                ,
+            },
+            Recursion => {
+                let mut helps = vec![];
+                let stacktrace = ecx.generate_stacktrace();
+                let mut frames = stacktrace.iter();
+                if let Some(frame) = frames.next() {
+                    labels.push(format!("recursive call of function `{}`", frame.instance));
+                }
+                if let Some(frame) = frames.next() {
+                    helps.push(note_span!(frame.span.data(), "(1) called from function `{}`", frame.instance));
+                }
+                if let Some(frame) = frames.next() {
+                    helps.push(note_span!(frame.span.data(), "... which itself was called from function `{}`", frame.instance));
+                }
+                let mut frames = stacktrace.iter().skip(1);
+                for stackframe in frames.by_ref() {
+                    if stacktrace.first().unwrap().instance == stackframe.instance {
+                        break;
+                    }
+                }
+                if let Some(frame) = frames.next() {
+                    helps.push(note_span!(frame.span.data(), "(2) originally called from function `{}`", frame.instance));
+                }
+                if let Some(frame) = frames.next() && ecx.machine.is_local(frame.instance) {
+                    helps.push(note_span!(frame.span.data(), "... which itself was called from function `{}`", frame.instance));
+                }
+                helps
+            },
             _ => vec![],
         };
         (title, helps)

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -170,6 +170,8 @@ pub struct MiriConfig {
     pub short_fd_operations: bool,
     /// A list of crates that are considered user-relevant.
     pub user_relevant_crates: Vec<String>,
+    /// Should recursion be disallowed, and diagnosed.
+    pub diagnose_recursion: bool,
 }
 
 impl Default for MiriConfig {
@@ -212,6 +214,7 @@ impl Default for MiriConfig {
             float_rounding_error: FloatRoundingErrorMode::Random,
             short_fd_operations: true,
             user_relevant_crates: vec![],
+            diagnose_recursion: false,
         }
     }
 }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -670,6 +670,9 @@ pub struct MiriMachine<'tcx> {
 
     /// Whether Miri artificially introduces short reads/writes on file descriptors.
     pub short_fd_operations: bool,
+
+    /// Whether Miri disallows recursion, and diagnoses when it happens.
+    pub diagnose_recursion: bool,
 }
 
 impl<'tcx> MiriMachine<'tcx> {
@@ -841,6 +844,7 @@ impl<'tcx> MiriMachine<'tcx> {
             float_nondet: config.float_nondet,
             float_rounding_error: config.float_rounding_error,
             short_fd_operations: config.short_fd_operations,
+            diagnose_recursion: config.diagnose_recursion,
         }
     }
 
@@ -1071,6 +1075,7 @@ impl VisitProvenance for MiriMachine<'_> {
             float_nondet: _,
             float_rounding_error: _,
             short_fd_operations: _,
+            diagnose_recursion: _,
         } = self;
 
         threads.visit_provenance(visit);
@@ -1940,6 +1945,14 @@ impl<'tcx> Machine<'tcx> for MiriMachine<'tcx> {
 
     #[inline(always)]
     fn after_stack_push(ecx: &mut InterpCx<'tcx, Self>) -> InterpResult<'tcx> {
+        if ecx.machine.diagnose_recursion
+            && ecx.machine.is_local(ecx.frame().instance())
+            && let frame_instance = ecx.frame().instance()
+            && !ecx.active_thread_zz_mut().get_or_insert_default().insert(frame_instance)
+        {
+            throw_machine_stop!(TerminationInfo::Recursion);
+        }
+
         if ecx.frame().extra.user_relevance >= ecx.active_thread_ref().current_user_relevance() {
             // We just pushed a frame that's at least as relevant as the so-far most relevant frame.
             // That means we are now the most relevant frame.
@@ -1986,12 +1999,19 @@ impl<'tcx> Machine<'tcx> for MiriMachine<'tcx> {
             // Move `frame` into a sub-scope so we control when it will be dropped.
             let mut frame = frame;
             let timing = frame.extra.timing.take();
+            if ecx.machine.diagnose_recursion
+                && ecx.machine.is_local(frame.instance())
+                && let zz = ecx.active_thread_zz_mut().as_mut().expect("ZZ should exist")
+            {
+                assert!(zz.remove(&frame.instance()), "??");
+            }
             let res = ecx.handle_stack_pop_unwind(frame.extra, unwinding);
             if let Some(profiler) = ecx.machine.profiler.as_ref() {
                 profiler.finish_recording_interval_event(timing.unwrap());
             }
             res
         };
+
         // Needs to be done after dropping frame to show up on the right nesting level.
         // (Cc https://github.com/rust-lang/miri/issues/2266)
         if !ecx.active_thread_stack().is_empty() {

--- a/tests/fail/recursion/associated-fn-on-new-object.rs
+++ b/tests/fail/recursion/associated-fn-on-new-object.rs
@@ -1,0 +1,21 @@
+//@compile-flags: -Zno-recursion
+
+struct Foo {
+    depth: u64,
+}
+
+impl Foo {
+    fn recurse(&mut self) {
+        //~^ ERROR: recursive call
+        eprintln!("recurse @ {}", self.depth);
+        if self.depth > 0 {
+            eprintln!("recursion not caught!");
+            return;
+        }
+        Foo { depth: self.depth + 1 }.recurse();
+    }
+}
+
+fn main() {
+    Foo { depth: 0 }.recurse();
+}

--- a/tests/fail/recursion/associated-fn-on-new-object.stderr
+++ b/tests/fail/recursion/associated-fn-on-new-object.stderr
@@ -1,0 +1,34 @@
+recurse @ 0
+error: recursive call: 
+  --> tests/fail/recursion/associated-fn-on-new-object.rs:LL:CC
+   |
+LL |     fn recurse(&mut self) {
+   |     ^^^^^^^^^^^^^^^^^^^^^ recursive call of function `Foo::recurse`
+   |
+help: (1) called from function `Foo::recurse`
+  --> tests/fail/recursion/associated-fn-on-new-object.rs:LL:CC
+   |
+LL |         Foo { depth: self.depth + 1 }.recurse();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: ... which itself was called from function `main`
+  --> tests/fail/recursion/associated-fn-on-new-object.rs:LL:CC
+   |
+LL |     Foo { depth: 0 }.recurse();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: (2) originally called from function `main`
+  --> tests/fail/recursion/associated-fn-on-new-object.rs:LL:CC
+   |
+LL |     Foo { depth: 0 }.recurse();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: stack backtrace:
+           0: Foo::recurse
+               at tests/fail/recursion/associated-fn-on-new-object.rs:LL:CC
+           1: Foo::recurse
+               at tests/fail/recursion/associated-fn-on-new-object.rs:LL:CC
+           2: main
+               at tests/fail/recursion/associated-fn-on-new-object.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/tests/fail/recursion/associated-fn.rs
+++ b/tests/fail/recursion/associated-fn.rs
@@ -1,0 +1,22 @@
+//@compile-flags: -Zno-recursion
+
+struct Foo {
+    depth: u64,
+}
+
+impl Foo {
+    fn recurse(&mut self) {
+        //~^ ERROR: recursive call
+        eprintln!("recurse @ {}", self.depth);
+        if self.depth > 0 {
+            eprintln!("recursion not caught!");
+            return;
+        }
+        self.depth += 1;
+        self.recurse();
+    }
+}
+
+fn main() {
+    Foo { depth: 0 }.recurse();
+}

--- a/tests/fail/recursion/associated-fn.stderr
+++ b/tests/fail/recursion/associated-fn.stderr
@@ -1,0 +1,34 @@
+recurse @ 0
+error: recursive call: 
+  --> tests/fail/recursion/associated-fn.rs:LL:CC
+   |
+LL |     fn recurse(&mut self) {
+   |     ^^^^^^^^^^^^^^^^^^^^^ recursive call of function `Foo::recurse`
+   |
+help: (1) called from function `Foo::recurse`
+  --> tests/fail/recursion/associated-fn.rs:LL:CC
+   |
+LL |         self.recurse();
+   |         ^^^^^^^^^^^^^^
+help: ... which itself was called from function `main`
+  --> tests/fail/recursion/associated-fn.rs:LL:CC
+   |
+LL |     Foo { depth: 0 }.recurse();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: (2) originally called from function `main`
+  --> tests/fail/recursion/associated-fn.rs:LL:CC
+   |
+LL |     Foo { depth: 0 }.recurse();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: stack backtrace:
+           0: Foo::recurse
+               at tests/fail/recursion/associated-fn.rs:LL:CC
+           1: Foo::recurse
+               at tests/fail/recursion/associated-fn.rs:LL:CC
+           2: main
+               at tests/fail/recursion/associated-fn.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/tests/fail/recursion/direct-cond.rs
+++ b/tests/fail/recursion/direct-cond.rs
@@ -1,0 +1,16 @@
+//@compile-flags: -Zno-recursion
+
+fn recurse(depth: u64) {
+    //~^ ERROR: recursive call
+    eprintln!("recurse @ {depth}");
+    if depth > 0 {
+        panic!("recursion not caught!");
+    }
+    if std::env::args().len() == 1 {
+        recurse(depth + 1);
+    }
+}
+
+fn main() {
+    recurse(0);
+}

--- a/tests/fail/recursion/direct-cond.stderr
+++ b/tests/fail/recursion/direct-cond.stderr
@@ -1,0 +1,34 @@
+recurse @ 0
+error: recursive call: 
+  --> tests/fail/recursion/direct-cond.rs:LL:CC
+   |
+LL | fn recurse(depth: u64) {
+   | ^^^^^^^^^^^^^^^^^^^^^^ recursive call of function `recurse`
+   |
+help: (1) called from function `recurse`
+  --> tests/fail/recursion/direct-cond.rs:LL:CC
+   |
+LL |         recurse(depth + 1);
+   |         ^^^^^^^^^^^^^^^^^^
+help: ... which itself was called from function `main`
+  --> tests/fail/recursion/direct-cond.rs:LL:CC
+   |
+LL |     recurse(0);
+   |     ^^^^^^^^^^
+help: (2) originally called from function `main`
+  --> tests/fail/recursion/direct-cond.rs:LL:CC
+   |
+LL |     recurse(0);
+   |     ^^^^^^^^^^
+   = note: stack backtrace:
+           0: recurse
+               at tests/fail/recursion/direct-cond.rs:LL:CC
+           1: recurse
+               at tests/fail/recursion/direct-cond.rs:LL:CC
+           2: main
+               at tests/fail/recursion/direct-cond.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/tests/fail/recursion/direct-uncond.rs
+++ b/tests/fail/recursion/direct-uncond.rs
@@ -1,0 +1,14 @@
+//@compile-flags: -Zno-recursion
+
+fn recurse(depth: u64) {
+    //~^ ERROR: recursive call
+    eprintln!("recurse @ {depth}");
+    if depth > 0 {
+        panic!("recursion not caught!");
+    }
+    recurse(depth + 1);
+}
+
+fn main() {
+    recurse(0);
+}

--- a/tests/fail/recursion/direct-uncond.stderr
+++ b/tests/fail/recursion/direct-uncond.stderr
@@ -1,0 +1,34 @@
+recurse @ 0
+error: recursive call: 
+  --> tests/fail/recursion/direct-uncond.rs:LL:CC
+   |
+LL | fn recurse(depth: u64) {
+   | ^^^^^^^^^^^^^^^^^^^^^^ recursive call of function `recurse`
+   |
+help: (1) called from function `recurse`
+  --> tests/fail/recursion/direct-uncond.rs:LL:CC
+   |
+LL |     recurse(depth + 1);
+   |     ^^^^^^^^^^^^^^^^^^
+help: ... which itself was called from function `main`
+  --> tests/fail/recursion/direct-uncond.rs:LL:CC
+   |
+LL |     recurse(0);
+   |     ^^^^^^^^^^
+help: (2) originally called from function `main`
+  --> tests/fail/recursion/direct-uncond.rs:LL:CC
+   |
+LL |     recurse(0);
+   |     ^^^^^^^^^^
+   = note: stack backtrace:
+           0: recurse
+               at tests/fail/recursion/direct-uncond.rs:LL:CC
+           1: recurse
+               at tests/fail/recursion/direct-uncond.rs:LL:CC
+           2: main
+               at tests/fail/recursion/direct-uncond.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/tests/fail/recursion/generic-fn-with-different-generic-arg.rs
+++ b/tests/fail/recursion/generic-fn-with-different-generic-arg.rs
@@ -1,0 +1,18 @@
+//@check-pass
+//@compile-flags: -Zno-recursion
+
+struct Foo;
+struct Bar;
+
+fn recurse<T>(depth: u64) {
+    eprintln!("recurse @ {depth}");
+    if depth > 0 {
+        eprintln!("recursion not caught!");
+        return;
+    }
+    recurse::<Bar>(depth + 1);
+}
+
+fn main() {
+    recurse::<Foo>(0);
+}

--- a/tests/fail/recursion/generic-fn-with-different-generic-arg.stderr
+++ b/tests/fail/recursion/generic-fn-with-different-generic-arg.stderr
@@ -1,0 +1,3 @@
+recurse @ 0
+recurse @ 1
+recursion not caught!

--- a/tests/fail/recursion/generic-fn-with-same-generic-arg.rs
+++ b/tests/fail/recursion/generic-fn-with-same-generic-arg.rs
@@ -1,0 +1,17 @@
+//@compile-flags: -Zno-recursion
+
+struct Foo;
+
+fn recurse<T>(depth: u64) {
+    //~^ ERROR: recursive call
+    eprintln!("recurse @ {depth}");
+    if depth > 0 {
+        eprintln!("recursion not caught!");
+        return;
+    }
+    recurse::<Foo>(depth + 1);
+}
+
+fn main() {
+    recurse::<Foo>(0);
+}

--- a/tests/fail/recursion/generic-fn-with-same-generic-arg.stderr
+++ b/tests/fail/recursion/generic-fn-with-same-generic-arg.stderr
@@ -1,0 +1,34 @@
+recurse @ 0
+error: recursive call: 
+  --> tests/fail/recursion/generic-fn-with-same-generic-arg.rs:LL:CC
+   |
+LL | fn recurse<T>(depth: u64) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ recursive call of function `recurse::<Foo>`
+   |
+help: (1) called from function `recurse::<Foo>`
+  --> tests/fail/recursion/generic-fn-with-same-generic-arg.rs:LL:CC
+   |
+LL |     recurse::<Foo>(depth + 1);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+help: ... which itself was called from function `main`
+  --> tests/fail/recursion/generic-fn-with-same-generic-arg.rs:LL:CC
+   |
+LL |     recurse::<Foo>(0);
+   |     ^^^^^^^^^^^^^^^^^
+help: (2) originally called from function `main`
+  --> tests/fail/recursion/generic-fn-with-same-generic-arg.rs:LL:CC
+   |
+LL |     recurse::<Foo>(0);
+   |     ^^^^^^^^^^^^^^^^^
+   = note: stack backtrace:
+           0: recurse::<Foo>
+               at tests/fail/recursion/generic-fn-with-same-generic-arg.rs:LL:CC
+           1: recurse::<Foo>
+               at tests/fail/recursion/generic-fn-with-same-generic-arg.rs:LL:CC
+           2: main
+               at tests/fail/recursion/generic-fn-with-same-generic-arg.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/tests/fail/recursion/indirect.rs
+++ b/tests/fail/recursion/indirect.rs
@@ -1,0 +1,18 @@
+//@compile-flags: -Zno-recursion
+
+fn indirection(depth: u64) {
+    indirectly_recurse(depth + 1);
+}
+
+fn indirectly_recurse(depth: u64) {
+    //~^ ERROR: recursive call
+    eprintln!("recurse @ {depth}");
+    if depth > 0 {
+        panic!("recursion not caught!");
+    }
+    indirection(depth);
+}
+
+fn main() {
+    indirectly_recurse(0);
+}

--- a/tests/fail/recursion/indirect.stderr
+++ b/tests/fail/recursion/indirect.stderr
@@ -1,0 +1,36 @@
+recurse @ 0
+error: recursive call: 
+  --> tests/fail/recursion/indirect.rs:LL:CC
+   |
+LL | fn indirectly_recurse(depth: u64) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ recursive call of function `indirectly_recurse`
+   |
+help: (1) called from function `indirection`
+  --> tests/fail/recursion/indirect.rs:LL:CC
+   |
+LL |     indirectly_recurse(depth + 1);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: ... which itself was called from function `indirectly_recurse`
+  --> tests/fail/recursion/indirect.rs:LL:CC
+   |
+LL |     indirection(depth);
+   |     ^^^^^^^^^^^^^^^^^^
+help: (2) originally called from function `main`
+  --> tests/fail/recursion/indirect.rs:LL:CC
+   |
+LL |     indirectly_recurse(0);
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   = note: stack backtrace:
+           0: indirectly_recurse
+               at tests/fail/recursion/indirect.rs:LL:CC
+           1: indirection
+               at tests/fail/recursion/indirect.rs:LL:CC
+           2: indirectly_recurse
+               at tests/fail/recursion/indirect.rs:LL:CC
+           3: main
+               at tests/fail/recursion/indirect.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/tests/fail/recursion/nested-direct.rs
+++ b/tests/fail/recursion/nested-direct.rs
@@ -1,0 +1,18 @@
+//@compile-flags: -Zno-recursion
+
+fn recurse(depth: u64) {
+    //~^ ERROR: recursive call
+    eprintln!("recurse @ {depth}");
+    if depth > 0 {
+        panic!("recursion not caught!");
+    }
+    recurse(depth + 1);
+}
+
+fn wrapper() {
+    recurse(0);
+}
+
+fn main() {
+    wrapper();
+}

--- a/tests/fail/recursion/nested-direct.stderr
+++ b/tests/fail/recursion/nested-direct.stderr
@@ -1,0 +1,41 @@
+recurse @ 0
+error: recursive call: 
+  --> tests/fail/recursion/nested-direct.rs:LL:CC
+   |
+LL | fn recurse(depth: u64) {
+   | ^^^^^^^^^^^^^^^^^^^^^^ recursive call of function `recurse`
+   |
+help: (1) called from function `recurse`
+  --> tests/fail/recursion/nested-direct.rs:LL:CC
+   |
+LL |     recurse(depth + 1);
+   |     ^^^^^^^^^^^^^^^^^^
+help: ... which itself was called from function `wrapper`
+  --> tests/fail/recursion/nested-direct.rs:LL:CC
+   |
+LL |     recurse(0);
+   |     ^^^^^^^^^^
+help: (2) originally called from function `wrapper`
+  --> tests/fail/recursion/nested-direct.rs:LL:CC
+   |
+LL |     recurse(0);
+   |     ^^^^^^^^^^
+help: ... which itself was called from function `main`
+  --> tests/fail/recursion/nested-direct.rs:LL:CC
+   |
+LL |     wrapper();
+   |     ^^^^^^^^^
+   = note: stack backtrace:
+           0: recurse
+               at tests/fail/recursion/nested-direct.rs:LL:CC
+           1: recurse
+               at tests/fail/recursion/nested-direct.rs:LL:CC
+           2: wrapper
+               at tests/fail/recursion/nested-direct.rs:LL:CC
+           3: main
+               at tests/fail/recursion/nested-direct.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/tests/fail/recursion/nested-indirect.rs
+++ b/tests/fail/recursion/nested-indirect.rs
@@ -1,0 +1,22 @@
+//@compile-flags: -Zno-recursion
+
+fn indirection(depth: u64) {
+    indirectly_recurse(depth + 1);
+}
+
+fn indirectly_recurse(depth: u64) {
+    //~^ ERROR: recursive call
+    eprintln!("recurse @ {depth}");
+    if depth > 0 {
+        panic!("recursion not caught!");
+    }
+    indirection(depth);
+}
+
+fn wrapper() {
+    indirectly_recurse(0);
+}
+
+fn main() {
+    wrapper();
+}

--- a/tests/fail/recursion/nested-indirect.stderr
+++ b/tests/fail/recursion/nested-indirect.stderr
@@ -1,0 +1,43 @@
+recurse @ 0
+error: recursive call: 
+  --> tests/fail/recursion/nested-indirect.rs:LL:CC
+   |
+LL | fn indirectly_recurse(depth: u64) {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ recursive call of function `indirectly_recurse`
+   |
+help: (1) called from function `indirection`
+  --> tests/fail/recursion/nested-indirect.rs:LL:CC
+   |
+LL |     indirectly_recurse(depth + 1);
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: ... which itself was called from function `indirectly_recurse`
+  --> tests/fail/recursion/nested-indirect.rs:LL:CC
+   |
+LL |     indirection(depth);
+   |     ^^^^^^^^^^^^^^^^^^
+help: (2) originally called from function `wrapper`
+  --> tests/fail/recursion/nested-indirect.rs:LL:CC
+   |
+LL |     indirectly_recurse(0);
+   |     ^^^^^^^^^^^^^^^^^^^^^
+help: ... which itself was called from function `main`
+  --> tests/fail/recursion/nested-indirect.rs:LL:CC
+   |
+LL |     wrapper();
+   |     ^^^^^^^^^
+   = note: stack backtrace:
+           0: indirectly_recurse
+               at tests/fail/recursion/nested-indirect.rs:LL:CC
+           1: indirection
+               at tests/fail/recursion/nested-indirect.rs:LL:CC
+           2: indirectly_recurse
+               at tests/fail/recursion/nested-indirect.rs:LL:CC
+           3: wrapper
+               at tests/fail/recursion/nested-indirect.rs:LL:CC
+           4: main
+               at tests/fail/recursion/nested-indirect.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/tests/fail/recursion/opt-in.rs
+++ b/tests/fail/recursion/opt-in.rs
@@ -1,0 +1,15 @@
+//@check-pass
+// Note: -Zno-recursion is *NOT* passed.
+
+fn recurse(depth: u64) {
+    eprintln!("recurse @ {depth}");
+    if depth > 0 {
+        eprintln!("recursion not caught!");
+        return;
+    }
+    recurse(depth + 1);
+}
+
+fn main() {
+    recurse(0);
+}

--- a/tests/fail/recursion/opt-in.stderr
+++ b/tests/fail/recursion/opt-in.stderr
@@ -1,0 +1,3 @@
+recurse @ 0
+recurse @ 1
+recursion not caught!


### PR DESCRIPTION
Recursion is a valid programming technique, and is not UB in Rust.

However, code that uses recursion, can "trivially" end up with a stack overflow due to the depth of recursion, and thus artificial safeguards must be placed
to avoid such pathological edge-cases.

The alternative is to write explicit workqueues.

So anyways, it would be very convenient to have tooling that would notify when there is a recursion aloof.

And here comes the problem. It would of course be ideal to be able to detect it statically (i.e. a clippy lint/etc), but there is a design decision choice:
should there be no false-positives, or no false-negatives?

Because while it would be trivial to build function call graph, the moment there is an indirect call, we can no longer prove that there is/isn't a recursive call...

We'd need to track all possible callees for each indirect call, and then intersect with all possible callees of each function that does an indirect call. This might well be doable in Rust.

On the other hand, in Miri, detecting recursive call is trivial, since we already maintain the call stack.
(Yes, i'm just completely ignoring external calls.)

So, would there be any interest for this in Miri?
If not, that's fine, writing this satisfied my curiosity.

Not implemented/not tested:
* all the `async` stuff
* tracking recursion through thread creation
* ???