### PR TITLE
Add `miri.toml` config file for `./miri` script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ flamegraph*.svg
 rustc-ice*.txt
 tests/native-lib/libtestlib.so
 .auto-*
+miri.toml
 
 /genmc/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,12 +111,22 @@ install that exact version of rustc as a toolchain:
 This will set up a rustup toolchain called `miri` and set it as an override for
 the current directory.
 
-You can also create a `.auto-everything` file (contents don't matter, can be empty), which
-will cause any `./miri` command to automatically call `./miri toolchain`, `clippy` and `rustfmt`
-for you. If you don't want all of these to happen, you can add individual `.auto-toolchain`,
-`.auto-clippy` and `.auto-fmt` files respectively.
-
 [`rustup-toolchain-install-master`]: https://github.com/kennytm/rustup-toolchain-install-master
+
+### Configuring `./miri`
+
+The `./miri` script supports optional configuration via a `miri.toml` file.
+The following configuration keys are currently supported, with the given default values:
+
+```toml
+[auto]
+# Automatically run `./miri toolchain` before most commands.
+toolchain = false
+# Automatically run `./miri clippy` before most commands.
+clippy = false
+# Automatically run `./miri fmt` before most commands.
+fmt = false
+```
 
 ## Building and testing Miri
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,11 @@ The following configuration keys are currently supported, with the given default
 # (Though note that if you have `auto.toolchain` enabled, most commands will run `./miri toolchain`
 # first, which will activate the toolchain given here.)
 name = "miri"
+# Additional components to install with the toolchain. Note that if you remove `clippy` or `rustfmt`
+# from this list then obviously `./miri clippy`/`./miri fmt` will not work.
+# Only takes effect when a new toolchain is installed. Run `rustup toolchain remove <name>` followed
+# by `./miri toolchain` to force this to have effect.
+components = ["clippy", "rustfmt"]
 
 [auto]
 # Automatically run `./miri toolchain` before most commands.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,8 +119,16 @@ The `./miri` script supports optional configuration via a `miri.toml` file.
 The following configuration keys are currently supported, with the given default values:
 
 ```toml
+[toolchain]
+# Overwrite the default toolchain name used by `./miri toolchain`.
+# Note that all other commands will just use the currently active rustup toolchain!
+# (Though note that if you have `auto.toolchain` enabled, most commands will run `./miri toolchain`
+# first, which will activate the toolchain given here.)
+name = "miri"
+
 [auto]
 # Automatically run `./miri toolchain` before most commands.
+# Uses the toolchain name configured above, if any.
 toolchain = false
 # Automatically run `./miri clippy` before most commands.
 clippy = false

--- a/miri-script/Cargo.lock
+++ b/miri-script/Cargo.lock
@@ -274,6 +274,7 @@ dependencies = [
  "serde_json",
  "shell-words",
  "tempfile",
+ "toml",
  "walkdir",
  "xshell",
 ]
@@ -410,6 +411,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +453,37 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+dependencies = [
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -548,6 +589,12 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen"

--- a/miri-script/Cargo.toml
+++ b/miri-script/Cargo.toml
@@ -22,7 +22,8 @@ xshell = "0.2.6"
 rustc_version = "0.4"
 dunce = "1.0.4"
 serde = "1"
+serde_derive = "1" # direct dependency better parallelizes builds
 serde_json = "1"
-serde_derive = "1"
 tempfile = "3.13.0"
 clap = { version = "4.5.21", features = ["derive"] }
+toml = {version = "1", default-features = false, features = ["serde", "parse"] }

--- a/miri-script/src/commands.rs
+++ b/miri-script/src/commands.rs
@@ -14,7 +14,7 @@ use walkdir::WalkDir;
 use xshell::{Shell, cmd};
 
 use crate::Command;
-use crate::config::Config;
+use crate::config::{Config, Toolchain};
 use crate::util::*;
 
 impl MiriEnv {
@@ -128,7 +128,8 @@ impl Command {
         flags: Vec<String>,
         config: &Config,
     ) -> Result<()> {
-        let name = name.as_deref().or(config.toolchain.name.as_deref()).unwrap_or("miri");
+        let name =
+            name.as_deref().or(config.toolchain.name.as_deref()).unwrap_or(Toolchain::DEFAULT_NAME);
 
         let sh = Shell::new()?;
         sh.change_dir(miri_dir()?);
@@ -158,10 +159,15 @@ impl Command {
             }
             return Ok(());
         }
+
+        // Compute rustup-toolchain-install-master flags for additional components.
+        let components =
+            config.toolchain.components.as_deref().unwrap_or(Toolchain::DEFAULT_COMPONENTS);
+        let component_flags = components.iter().flat_map(|component| ["-c", component]);
+
         // Install and setup new toolchain.
         cmd!(sh, "rustup toolchain uninstall {name}").run()?;
-
-        cmd!(sh, "rustup-toolchain-install-master -n {name} -c cargo -c rust-src -c rustc-dev -c llvm-tools -c rustfmt -c clippy {flags...} -- {new_commit}")
+        cmd!(sh, "rustup-toolchain-install-master -n {name} -c cargo -c rust-src -c rustc-dev -c llvm-tools {component_flags...} {flags...} -- {new_commit}")
             .run()
             .context("Failed to run rustup-toolchain-install-master. If it is not installed, run 'cargo install --locked rustup-toolchain-install-master'.")?;
         cmd!(sh, "rustup override set {name}").run()?;

--- a/miri-script/src/commands.rs
+++ b/miri-script/src/commands.rs
@@ -75,7 +75,7 @@ impl Command {
 
         // `toolchain` goes first as it could affect the others
         if config.auto.toolchain {
-            Self::toolchain(None, vec![])?;
+            Self::toolchain(None, None, vec![])?;
         }
         if config.auto.fmt {
             Self::fmt(vec![])?;
@@ -116,12 +116,18 @@ impl Command {
             Command::Clippy { features, flags } => Self::clippy(features, flags),
             Command::Bench { target, no_install, save_baseline, load_baseline, benches } =>
                 Self::bench(target, no_install, save_baseline, load_baseline, benches),
-            Command::Toolchain { commit, flags } => Self::toolchain(commit, flags),
+            Command::Toolchain { name, commit, flags } => Self::toolchain(name, commit, flags),
             Command::Squash => Self::squash(),
         }
     }
 
-    fn toolchain(new_commit: Option<String>, flags: Vec<String>) -> Result<()> {
+    fn toolchain(
+        name: Option<String>,
+        new_commit: Option<String>,
+        flags: Vec<String>,
+    ) -> Result<()> {
+        let name = name.as_deref().unwrap_or("miri");
+
         let sh = Shell::new()?;
         sh.change_dir(miri_dir()?);
         let new_commit = match new_commit {
@@ -129,7 +135,7 @@ impl Command {
             None => sh.read_file("rust-version")?.trim().to_owned(),
         };
         let current_commit = {
-            let rustc_info = cmd!(sh, "rustc +miri --version -v").read();
+            let rustc_info = cmd!(sh, "rustc +{name} --version -v").read();
             if let Ok(rustc_info) = rustc_info {
                 let metadata = rustc_version::version_meta_for(&rustc_info)?;
                 Some(
@@ -143,18 +149,20 @@ impl Command {
         };
         // Check if we already are at that commit.
         if current_commit.as_ref() == Some(&new_commit) {
-            if active_toolchain()? != "miri" {
-                cmd!(sh, "rustup override set miri").run()?;
+            // The toolchain is already at the right version. Make sure it is active in `miri_dir`.
+            // Ignore errors from `active_toolchain`, the active toolchain might be uninstalled.
+            if active_toolchain().ok().is_none_or(|toolchain| toolchain != name) {
+                cmd!(sh, "rustup override set {name}").run()?;
             }
             return Ok(());
         }
         // Install and setup new toolchain.
-        cmd!(sh, "rustup toolchain uninstall miri").run()?;
+        cmd!(sh, "rustup toolchain uninstall {name}").run()?;
 
-        cmd!(sh, "rustup-toolchain-install-master -n miri -c cargo -c rust-src -c rustc-dev -c llvm-tools -c rustfmt -c clippy {flags...} -- {new_commit}")
+        cmd!(sh, "rustup-toolchain-install-master -n {name} -c cargo -c rust-src -c rustc-dev -c llvm-tools -c rustfmt -c clippy {flags...} -- {new_commit}")
             .run()
             .context("Failed to run rustup-toolchain-install-master. If it is not installed, run 'cargo install --locked rustup-toolchain-install-master'.")?;
-        cmd!(sh, "rustup override set miri").run()?;
+        cmd!(sh, "rustup override set {name}").run()?;
         // Cleanup.
         cmd!(sh, "cargo clean").run()?;
         Ok(())

--- a/miri-script/src/commands.rs
+++ b/miri-script/src/commands.rs
@@ -75,7 +75,7 @@ impl Command {
 
         // `toolchain` goes first as it could affect the others
         if config.auto.toolchain {
-            Self::toolchain(None, None, vec![])?;
+            Self::toolchain(None, None, vec![], config)?;
         }
         if config.auto.fmt {
             Self::fmt(vec![])?;
@@ -116,7 +116,8 @@ impl Command {
             Command::Clippy { features, flags } => Self::clippy(features, flags),
             Command::Bench { target, no_install, save_baseline, load_baseline, benches } =>
                 Self::bench(target, no_install, save_baseline, load_baseline, benches),
-            Command::Toolchain { name, commit, flags } => Self::toolchain(name, commit, flags),
+            Command::Toolchain { name, commit, flags } =>
+                Self::toolchain(name, commit, flags, config),
             Command::Squash => Self::squash(),
         }
     }
@@ -125,8 +126,9 @@ impl Command {
         name: Option<String>,
         new_commit: Option<String>,
         flags: Vec<String>,
+        config: &Config,
     ) -> Result<()> {
-        let name = name.as_deref().unwrap_or("miri");
+        let name = name.as_deref().or(config.toolchain.name.as_deref()).unwrap_or("miri");
 
         let sh = Shell::new()?;
         sh.change_dir(miri_dir()?);

--- a/miri-script/src/commands.rs
+++ b/miri-script/src/commands.rs
@@ -14,6 +14,7 @@ use walkdir::WalkDir;
 use xshell::{Shell, cmd};
 
 use crate::Command;
+use crate::config::Config;
 use crate::util::*;
 
 impl MiriEnv {
@@ -67,25 +68,19 @@ impl MiriEnv {
 }
 
 impl Command {
-    fn auto_actions() -> Result<()> {
+    fn auto_actions(config: &Config) -> Result<()> {
         if env::var_os("MIRI_AUTO_OPS").is_some_and(|x| x == "no") {
             return Ok(());
         }
 
-        let miri_dir = miri_dir()?;
-        let auto_everything = path!(miri_dir / ".auto-everything").exists();
-        let auto_toolchain = auto_everything || path!(miri_dir / ".auto-toolchain").exists();
-        let auto_fmt = auto_everything || path!(miri_dir / ".auto-fmt").exists();
-        let auto_clippy = auto_everything || path!(miri_dir / ".auto-clippy").exists();
-
         // `toolchain` goes first as it could affect the others
-        if auto_toolchain {
+        if config.auto.toolchain {
             Self::toolchain(None, vec![])?;
         }
-        if auto_fmt {
+        if config.auto.fmt {
             Self::fmt(vec![])?;
         }
-        if auto_clippy {
+        if config.auto.clippy {
             // no features for auto actions, see
             // https://github.com/rust-lang/miri/pull/4396#discussion_r2149654845
             Self::clippy(vec![], vec![])?;
@@ -94,7 +89,7 @@ impl Command {
         Ok(())
     }
 
-    pub fn exec(self) -> Result<()> {
+    pub fn exec(self, config: &Config) -> Result<()> {
         // First, and crucially only once, run the auto-actions -- but not for all commands.
         match &self {
             Command::Install { .. }
@@ -104,7 +99,7 @@ impl Command {
             | Command::Run { .. }
             | Command::Fmt { .. }
             | Command::Doc { .. }
-            | Command::Clippy { .. } => Self::auto_actions()?,
+            | Command::Clippy { .. } => Self::auto_actions(config)?,
             | Command::Toolchain { .. } | Command::Bench { .. } | Command::Squash => {}
         }
         // Then run the actual command.

--- a/miri-script/src/config.rs
+++ b/miri-script/src/config.rs
@@ -9,7 +9,14 @@ use crate::util::miri_dir;
 #[derive(Deserialize, Default)]
 pub struct Config {
     #[serde(default)]
+    pub toolchain: Toolchain,
+    #[serde(default)]
     pub auto: Auto,
+}
+
+#[derive(Deserialize, Default)]
+pub struct Toolchain {
+    pub name: Option<String>,
 }
 
 #[derive(Deserialize, Default)]

--- a/miri-script/src/config.rs
+++ b/miri-script/src/config.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::{fs, io};
 
 use anyhow::{Context, Result, bail};
@@ -17,6 +18,13 @@ pub struct Config {
 #[derive(Deserialize, Default)]
 pub struct Toolchain {
     pub name: Option<String>,
+    pub components: Option<Vec<Cow<'static, str>>>,
+}
+
+impl Toolchain {
+    pub const DEFAULT_NAME: &str = "miri";
+    pub const DEFAULT_COMPONENTS: &[Cow<'static, str>] =
+        &[Cow::Borrowed("clippy"), Cow::Borrowed("rustfmt")];
 }
 
 #[derive(Deserialize, Default)]

--- a/miri-script/src/config.rs
+++ b/miri-script/src/config.rs
@@ -1,0 +1,44 @@
+use std::{fs, io};
+
+use anyhow::{Context, Result, bail};
+use path_macro::path;
+use serde_derive::Deserialize;
+
+use crate::util::miri_dir;
+
+#[derive(Deserialize, Default)]
+pub struct Config {
+    #[serde(default)]
+    pub auto: Auto,
+}
+
+#[derive(Deserialize, Default)]
+pub struct Auto {
+    #[serde(default)]
+    pub toolchain: bool,
+    #[serde(default)]
+    pub fmt: bool,
+    #[serde(default)]
+    pub clippy: bool,
+}
+
+impl Config {
+    pub fn load() -> Result<Self> {
+        let miri_dir = miri_dir()?;
+
+        Ok(match fs::read(path!(miri_dir / "miri.toml")) {
+            Ok(config) => toml::from_slice(&config).context("failed to parse `miri.toml`")?,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                // Just ignore error if the file does not exist. Fall back to parsing the `.auto-*`
+                // files.
+                let mut config = Config::default();
+                let everything = path!(miri_dir / ".auto-everything").exists();
+                config.auto.toolchain = everything || path!(miri_dir / ".auto-toolchain").exists();
+                config.auto.fmt = everything || path!(miri_dir / ".auto-fmt").exists();
+                config.auto.clippy = everything || path!(miri_dir / ".auto-clippy").exists();
+                config
+            }
+            Err(err) => bail!("unable to open `miri.toml`: {err}"),
+        })
+    }
+}

--- a/miri-script/src/main.rs
+++ b/miri-script/src/main.rs
@@ -138,7 +138,8 @@ pub enum Command {
         /// List of benchmarks to run (default: run all benchmarks).
         benches: Vec<String>,
     },
-    /// Update and activate the rustup toolchain 'miri'.
+    /// Update and activate the rustup toolchain 'miri' (or whatever name is configured in
+    /// `miri.toml`).
     ///
     /// The `rust-version` file is used to determine the commit that will be intsalled.
     /// `rustup-toolchain-install-master` must be installed for this to work.

--- a/miri-script/src/main.rs
+++ b/miri-script/src/main.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::needless_question_mark, rustc::internal)]
 
 mod commands;
+mod config;
 mod coverage;
 mod util;
 
@@ -200,6 +201,10 @@ fn main() -> Result<()> {
     let args = Cli::parse_from(miri_args);
     let mut command = args.command;
     command.add_remainder(remainder)?;
-    command.exec()?;
-    Ok(())
+
+    // Parse config file.
+    let config = config::Config::load()?;
+
+    // Run the thing.
+    command.exec(&config)
 }

--- a/miri-script/src/main.rs
+++ b/miri-script/src/main.rs
@@ -143,6 +143,9 @@ pub enum Command {
     /// The `rust-version` file is used to determine the commit that will be intsalled.
     /// `rustup-toolchain-install-master` must be installed for this to work.
     Toolchain {
+        /// Overwrite the name the toolchain will have in `rustup`.
+        #[arg(long)]
+        name: Option<String>,
         /// Overwrite the commit to install.
         #[arg(long)]
         commit: Option<String>,


### PR DESCRIPTION
As discussed in https://github.com/rust-lang/miri/pull/4700, this adds a `miri.toml` config file for our `./miri` build script. The supported config flags in this PR are:
```toml
[toolchain]
# Overwrite the default toolchain name used by `./miri toolchain`.
# Note that all other commands will just use the currently active rustup toolchain!
# (Though note that if you have `auto.toolchain` enabled, most commands will run `./miri toolchain`
# first, which will activate the toolchain given here.)
name = "miri"
# Additional components to install with the toolchain. Note that if you remove `clippy` or `rustfmt`
# from this list then obviously `./miri clippy`/`./miri fmt` will not work.
# Only takes effect when a new toolchain is installed. Run `rustup toolchain remove <name>` followed
# by `./miri toolchain` to force this to have effect.
components = ["clippy", "rustfmt"]

[auto]
# Automatically run `./miri toolchain` before most commands.
# Uses the toolchain name configured above, if any.
toolchain = false
# Automatically run `./miri clippy` before most commands.
clippy = false
# Automatically run `./miri fmt` before most commands.
fmt = false
```
The old `.auto*` files are still supported: they are used as fallback if there is no `miri.toml` file.

@rust-lang/miri what do you think? Any feedback on the names for stuff in the config file?