### PR TITLE
Install cargo tools with locked dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
       - name: Install nightly toolchain
         run: rustup toolchain install nightly --profile minimal
       - name: Install rustup-toolchain-install-master
-        run: cargo install -f rustup-toolchain-install-master
+        run: cargo install --locked -f rustup-toolchain-install-master
       # Create a token for the next step so it can create a PR that actually runs CI.
       - uses: actions/create-github-app-token@v3
         id: app-token

--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -38,7 +38,7 @@ runs:
 
       - name: Install the tools we need
         if: steps.cache.outputs.cache-hit != 'true'
-        run: cargo install -f rustup-toolchain-install-master hyperfine
+        run: cargo install --locked -f rustup-toolchain-install-master hyperfine
         shell: bash
 
       - name: Install "master" toolchain

--- a/.github/workflows/sysroots.yml
+++ b/.github/workflows/sysroots.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build the sysroots
         run: |
           rustup toolchain install nightly
-          cargo install -f rustup-toolchain-install-master
+          cargo install --locked -f rustup-toolchain-install-master
           ./miri toolchain -c rust-docs # Docs are the only place targets are separated by tier
           ./miri install
           python3 -m pip install beautifulsoup4

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,7 +3,7 @@ image: ubuntu:latest
 tasks:
   - before: echo "..."
     init: |
-      cargo install rustup-toolchain-install-master
+      cargo install --locked rustup-toolchain-install-master
       ./miri toolchain
       ./miri build
     command: echo "Run tests with ./miri test"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,7 +252,7 @@ and on macOS, `rm -rf ~/Library/Caches/org.rust-lang.miri`).
 
 Miri comes with a few benchmarks; you can run `./miri bench` to run them with the locally built
 Miri. Note: this will run `./miri install` as a side-effect. Also requires `hyperfine` to be
-installed (`cargo install hyperfine`).
+installed (`cargo install --locked hyperfine`).
 
 To compare the benchmark results with a baseline, do the following:
 - Before applying your changes, run `./miri bench --save-baseline=baseline.json`.

--- a/miri-script/src/commands.rs
+++ b/miri-script/src/commands.rs
@@ -158,7 +158,7 @@ impl Command {
 
         cmd!(sh, "rustup-toolchain-install-master -n miri -c cargo -c rust-src -c rustc-dev -c llvm-tools -c rustfmt -c clippy {flags...} -- {new_commit}")
             .run()
-            .context("Failed to run rustup-toolchain-install-master. If it is not installed, run 'cargo install rustup-toolchain-install-master'.")?;
+            .context("Failed to run rustup-toolchain-install-master. If it is not installed, run 'cargo install --locked rustup-toolchain-install-master'.")?;
         cmd!(sh, "rustup override set miri").run()?;
         // Cleanup.
         cmd!(sh, "cargo clean").run()?;


### PR DESCRIPTION
Installing cargo tools (`cargo install`) without locked dependencies exposes users to supply-chain attacks to all the dependencies of the tool (https://blog.rust-lang.org/2026/08/20/supply-chain-attack-on-arrayref/). Using `cargo install --locked` reduces this risk to a compromise of the tool itself, while using the locked and hashed version of the dependencies.

I went through all `rg "cargo install"` hits in the repository and added `--locked` to all but explanatory examples (such as cargo's docs on `cargo install` itself). I validated that those tools publish functioning `Cargo.lock`s with https://gist.github.com/konstin/bcb1169c1c1120c259dca64e777a64d0.

See https://github.com/rust-lang/rust/pull/161428.

<!-- homu-ignore:start -->
<!--
Please read our [LLM policy] before opening a PR,
If you used an LLM to generate any part of this PR, including the PR description, please disclose that according to our [guidelines][disclosure guidelines].
LLM contributions are not banned, but are held to a higher standard of review and correctness.

[LLM policy]: https://forge.rust-lang.org/policies/llm-usage.html
[disclosure guidelines]: https://rustc-dev-guide.rust-lang.org/llm-guidance/writing.html#disclosure-guidelines

If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>

When merged, your PR's description becomes part of the commit message of a merge commit.
If you do not want certain parts of it (such as your LLM disclosure) to show up in the permanent git history,
surround them with a pair of HTML comments containing `homu-ignore:start` and `homu-ignore:end`.
-->
<!-- homu-ignore:end -->
