### PR TITLE
Refactor syscall shim with a macro

### DIFF
--- a/src/shims/unix/linux_like/syscall.rs
+++ b/src/shims/unix/linux_like/syscall.rs
@@ -8,6 +8,74 @@ use crate::shims::unix::linux_like::sync::futex;
 use crate::shims::unix::socket::EvalContextExt as _;
 use crate::*;
 
+/// Checks `SYS_foo(a: T, ...)` varargs and runs the handler with `&OpTy` bindings.
+macro_rules! dispatch_syscall_check_impl {
+    (
+        $ecx:expr, $varargs:expr, $SYS:ident, $handler:block,
+        [$($types:tt)*] [$($names:ident)*]
+    ) => {{
+        let msg = concat!("syscall(", stringify!($SYS), ", ...)");
+        let ([$($names),*], _rest) = $ecx.check_varargs(
+            shim_varargs![$($types)*],
+            $varargs,
+            msg,
+        )?;
+        $handler
+    }};
+    // `*_` needs its own arm since it is not a valid `:ty`.
+    (
+        $ecx:expr, $varargs:expr, $SYS:ident, $handler:block,
+        [$($types:tt)*] [$($names:ident)*]
+        $name:ident : *_ $(, $($tail:tt)*)?
+    ) => {
+        dispatch_syscall_check_impl!(
+            $ecx, $varargs, $SYS, $handler,
+            [$($types)* *_,] [$($names)* $name]
+            $($($tail)*)?
+        )
+    };
+    (
+        $ecx:expr, $varargs:expr, $SYS:ident, $handler:block,
+        [$($types:tt)*] [$($names:ident)*]
+        $name:ident : $ty:tt $(, $($tail:tt)*)?
+    ) => {
+        dispatch_syscall_check_impl!(
+            $ecx, $varargs, $SYS, $handler,
+            [$($types)* $ty,] [$($names)* $name]
+            $($($tail)*)?
+        )
+    };
+}
+
+macro_rules! dispatch_syscall_check {
+    ($ecx:expr, $varargs:expr, $SYS:ident, $handler:block,) => {
+        $handler
+    };
+    ($ecx:expr, $varargs:expr, $SYS:ident, $handler:block, $($pairs:tt)*) => {
+        dispatch_syscall_check_impl!(
+            $ecx, $varargs, $SYS, $handler,
+            [] []
+            $($pairs)*
+        )
+    };
+}
+
+/// Dispatches `SYS_*` numbers to shims; `SYS_foo(a: T, ...)` checks varargs.
+/// Bare `SYS_foo` passes `varargs` through untouched.
+macro_rules! dispatch_syscalls {
+    ($ecx:expr, $op:expr, $varargs:expr, $($SYS:ident $(($($pairs:tt)*))? => $handler:block),* $(,)?) => {{
+        $(#[allow(non_snake_case)] let $SYS = $ecx.eval_libc(stringify!($SYS)).to_target_usize($ecx)?;)*
+        match $ecx.read_target_usize($op)? {
+            $(
+                id if id == $SYS => {
+                    dispatch_syscall_check!($ecx, $varargs, $SYS, $handler, $($($pairs)*)?);
+                }
+            )*
+            num => throw_unsup_format!("syscall: unsupported syscall number {num}"),
+        }
+    }};
+}
+
 pub fn syscall<'tcx>(
     ecx: &mut MiriInterpCx<'tcx>,
     link_name: Symbol,
@@ -24,24 +92,11 @@ pub fn syscall<'tcx>(
     // argument, we have to also check all arguments *before* it to ensure that they
     // have the right type.
 
-    let sys_getrandom = ecx.eval_libc("SYS_getrandom").to_target_usize(ecx)?;
-    let sys_futex = ecx.eval_libc("SYS_futex").to_target_usize(ecx)?;
-    let sys_eventfd2 = ecx.eval_libc("SYS_eventfd2").to_target_usize(ecx)?;
-    let sys_gettid = ecx.eval_libc("SYS_gettid").to_target_usize(ecx)?;
-    let sys_accept4 = ecx.eval_libc("SYS_accept4").to_target_usize(ecx)?;
-
-    match ecx.read_target_usize(op)? {
-        // `libc::syscall(NR_GETRANDOM, buf.as_mut_ptr(), buf.len(), GRND_NONBLOCK)`
-        // is called if a `HashMap` is created the regular way (e.g. HashMap<K, V>).
-        num if num == sys_getrandom => {
+    dispatch_syscalls!(ecx, op, varargs,
+        SYS_getrandom(ptr: *_, len: usize, flags: i32) => {
+            // `libc::syscall(NR_GETRANDOM, buf.as_mut_ptr(), buf.len(), GRND_NONBLOCK)`
+            // is called if a `HashMap` is created the regular way (e.g. HashMap<K, V>).
             // Used by getrandom 0.1
-            // The first argument is the syscall id, so skip over it.
-            let ([ptr, len, flags], _) = ecx.check_varargs(
-                shim_varargs![*_, usize, i32],
-                varargs,
-                "syscall(SYS_getrandom, ...)",
-            )?;
-
             let ptr = ecx.read_pointer(ptr)?;
             let len = ecx.read_target_usize(len)?;
             // The only supported flags are GRND_RANDOM and GRND_NONBLOCK,
@@ -51,35 +106,24 @@ pub fn syscall<'tcx>(
 
             ecx.gen_random(ptr, len)?;
             ecx.write_scalar(Scalar::from_target_usize(len, ecx), dest)?;
-        }
-        // `futex` is used by some synchronization primitives.
-        num if num == sys_futex => {
+        },
+        SYS_futex => {
+            // `futex` is used by some synchronization primitives.
             futex(ecx, varargs, dest)?;
-        }
-        num if num == sys_eventfd2 => {
-            let ([initval, flags], _) =
-                ecx.check_varargs(shim_varargs![u32, i32], varargs, "syscall(SYS_evetfd2, ...)")?;
-
+        },
+        SYS_eventfd2(initval: u32, flags: i32) => {
             let result = ecx.eventfd(initval, flags)?;
             ecx.write_int(result.to_i32()?, dest)?;
-        }
-        num if num == sys_gettid => {
+        },
+        SYS_gettid => {
             let result = ecx.unix_gettid("SYS_gettid")?;
             ecx.write_int(result.to_u32()?, dest)?;
-        }
-        num if num == sys_accept4 => {
+        },
+        SYS_accept4(socket: i32, address: *_, address_len: *_, flags: i32) => {
             // Used on Android.
-            let ([socket, address, address_len, flags], _) = ecx.check_varargs(
-                shim_varargs![i32, *_, *_, i32],
-                varargs,
-                "syscall(SYS_accept4, ...)",
-            )?;
             ecx.accept4(socket, address, address_len, Some(flags), dest)?;
-        }
-        num => {
-            throw_unsup_format!("syscall: unsupported syscall number {num}");
-        }
-    };
+        },
+    );
 
     interp_ok(())
 }


### PR DESCRIPTION
This PR uses a macro to reduce some redundancy in the syscall shim. This doesn't improve loc number (yet; I hope to add syscall shim for every shim that miri already has its libc version in the future, in that case it would even help in line number), but it improves readability and make it less error-prone (the old code used the syscall name multiple times in some strings, and some of them were easy to miss even on tests since they only affected error messages).