### PR TITLE
Extend TCP socket shim to use `socket2` abstractions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,6 +1020,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+ "socket2",
  "tempfile",
  "ui_test",
 ]
@@ -1483,6 +1484,16 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "spanned"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ directories = "6"
 bitflags = "2.6"
 serde_json = { version = "1.0", optional = true }
 mio = { version = "1.1.1", features = ["os-poll", "net"] }
+socket2 = "0.6.5"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/priroda/Cargo.lock
+++ b/priroda/Cargo.lock
@@ -688,6 +688,7 @@ dependencies = [
  "rand 0.10.2",
  "serde",
  "smallvec",
+ "socket2",
 ]
 
 [[package]]
@@ -1114,6 +1115,16 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "spanned"

--- a/src/shims/unix/socket.rs
+++ b/src/shims/unix/socket.rs
@@ -10,14 +10,6 @@ use crate::shims::unix::socket_address::EvalContextExt as _;
 use crate::shims::unix::tcp_socket::TcpSocket;
 use crate::*;
 
-#[derive(Debug, PartialEq)]
-pub enum SocketFamily {
-    // IPv4 internet protocols
-    IPv4,
-    // IPv6 internet protocols
-    IPv6,
-}
-
 /// Represents unix-specific socket file descriptions.
 ///
 /// Not to be confused with Unix domain sockets.
@@ -204,9 +196,9 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         }
 
         let family = if domain == this.eval_libc_i32("AF_INET") {
-            SocketFamily::IPv4
+            socket2::Domain::IPV4
         } else if domain == this.eval_libc_i32("AF_INET6") {
-            SocketFamily::IPv6
+            socket2::Domain::IPV6
         } else {
             throw_unsup_format!(
                 "socket: domain {:#x} is unsupported, only AF_INET and \
@@ -229,8 +221,12 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             );
         }
 
+        let socket = match TcpSocket::new(family, is_non_block) {
+            Ok(socket) => socket,
+            Err(e) => return this.set_errno_and_return_neg1_i32(e),
+        };
         let fds = &mut this.machine.fds;
-        let fd = fds.new_ref(TcpSocket::new(family, is_non_block));
+        let fd = fds.new_ref(socket);
 
         interp_ok(Scalar::from_i32(fds.insert(fd)))
     }

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -1,7 +1,7 @@
 use std::cell::{Cell, RefCell, RefMut};
 use std::io;
 use std::io::Read;
-use std::net::{Shutdown, SocketAddr};
+use std::net::{Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::sync::atomic::AtomicBool;
 use std::time::Duration;
 
@@ -91,6 +91,8 @@ pub(super) struct TcpSocket {
     state: RefCell<SocketState>,
     /// Whether this fd is non-blocking or not.
     is_non_block: Cell<bool>,
+    /// Whether the socket is implicitly or explicitly bound to an address.
+    is_bound: Cell<bool>,
     /// The current blocking I/O readiness of the file description.
     io_readiness: RefCell<Readiness>,
     /// [`Some`] when the socket had an async error which has not yet been fetched via `SO_ERROR`.
@@ -123,6 +125,7 @@ impl TcpSocket {
             family,
             state: RefCell::new(SocketState::Initial(socket)),
             is_non_block: Cell::new(is_non_block),
+            is_bound: Cell::new(false),
             io_readiness: RefCell::new(INITIAL_TCP_SOCKET_READINESS),
             error: RefCell::new(None),
             read_timeout: Cell::new(None),
@@ -302,10 +305,14 @@ impl UnixSocketFileDescription for TcpSocket {
         let state = self.state.borrow();
         let socket = state.as_socket_ref();
 
-        match socket.bind(&socket2::SockAddr::from(address)) {
-            Ok(()) => interp_ok(Ok(())),
-            Err(e) => interp_ok(Err(IoError::HostError(e))),
+        if let Err(e) = socket.bind(&socket2::SockAddr::from(address)) {
+            return interp_ok(Err(IoError::HostError(e)));
         }
+
+        // The socket has been explicitly bound to a local address.
+        self.is_bound.set(true);
+
+        interp_ok(Ok(()))
     }
 
     fn listen<'tcx>(
@@ -328,9 +335,43 @@ impl UnixSocketFileDescription for TcpSocket {
             SocketState::ConnectionFailed(_) | SocketState::Transitioning => unreachable!(),
         };
 
+        if cfg!(windows) && !self.is_bound.get() {
+            // Implicitly binding a TCP socket by invoking `listen` on an
+            // unbound socket causes EINVAL on Windows hosts. We thus
+            // explicitly bind the socket to an unspecified address with
+            // a random port before listening.
+            //
+            // When the subsequent `listen` fails we behave incorrectly
+            // because a previously unbound socket is now bound. However,
+            // since `listen` can only fail for system ressource errors
+            // (e.g., ENOBUFS) this isn't a problem in reality.
+
+            let address = if self.family == socket2::Domain::IPV4 {
+                SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, /* port */ 0))
+            } else {
+                SocketAddr::V6(SocketAddrV6::new(
+                    Ipv6Addr::UNSPECIFIED,
+                    /* port */ 0,
+                    /* flowinfo */ 0,
+                    /* scope_id */ 0,
+                ))
+            };
+
+            if let Err(e) = socket.bind(&socket2::SockAddr::from(address)) {
+                return interp_ok(Err(IoError::HostError(e)));
+            }
+
+            // We just explicitly bound the socket to a local address.
+            self.is_bound.set(true);
+        }
+
         if let Err(e) = socket.listen(backlog) {
             return interp_ok(Err(IoError::HostError(e)));
         }
+
+        // Listening sockets are always implicitly bound to a local address if they
+        // weren't already bound.
+        self.is_bound.set(true);
 
         if let SocketState::Listening(_) = &*state {
             // The socket was already listening; we just changed the backlog.
@@ -505,6 +546,8 @@ impl UnixSocketFileDescription for TcpSocket {
          };
 
         self.state.replace(SocketState::Connecting(stream));
+        // Connecting sockets are implicitly bound to a local address.
+        self.is_bound.set(true);
 
         // After invoking `connect` on a TCP socket, it transitions out of the
         // TCP_CLOSE state which affects the socket's readiness. Because we
@@ -1115,6 +1158,8 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             family,
             state: RefCell::new(SocketState::Connected(stream)),
             is_non_block: Cell::new(is_client_sock_nonblock),
+            // Connected sockets are implicitly bound to a local address.
+            is_bound: Cell::new(true),
             io_readiness: RefCell::new(Readiness::EMPTY),
             error: RefCell::new(None),
             read_timeout: Cell::new(None),

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -954,6 +954,24 @@ impl UnixSocketFileDescription for TcpSocket {
         assert!(communicate_allowed, "cannot have `TcpSocket` with isolation enabled!");
         ecx.ensure_not_failed(&self, "getsockname")?;
 
+        if !self.is_bound.get() {
+            // Since Windows returns EINVAL when invoking `getsockname` on
+            // a socket which hasn't been bound yet, we need to manually
+            // return an unspecified address here.
+
+            let address = if self.family == socket2::Domain::IPV4 {
+                SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, /* port */ 0))
+            } else {
+                SocketAddr::V6(SocketAddrV6::new(
+                    Ipv6Addr::UNSPECIFIED,
+                    /* port */ 0,
+                    /* flowinfo */ 0,
+                    /* scope_id */ 0,
+                ))
+            };
+            return interp_ok(Ok(address));
+        }
+
         let state = self.state.borrow();
         let socket = state.as_socket_ref();
 

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -817,51 +817,26 @@ impl UnixSocketFileDescription for TcpSocket {
         ecx.ensure_not_failed(&self, "getsockname")?;
 
         let state = self.state.borrow();
+        let socket = state.as_socket_ref();
 
-        let address = match &*state {
-            SocketState::Bound(address) => {
-                if address.port() == 0 {
-                    // The socket is bound to a zero-port which means it gets assigned a random
-                    // port. Since we don't yet have an underlying socket, we don't know what this
-                    // random port will be and thus this is unsupported.
-                    throw_unsup_format!(
-                        "getsockname: when the port is 0, getting the tcp socket address before \
-                        calling `listen` or `connect` is unsupported"
-                    )
-                }
+        if cfg!(windows)
+            && let SocketState::Connecting(_) = &*state
+        {
+            // FIXME: On Windows hosts `getsockname` returns `0.0.0.0:0` whilst the socket is connecting:
+            // <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname#remarks>
+            // This is problematic because UNIX targets could expect a real local address even
+            // for a connecting non-blocking socket.
 
-                *address
+            static DEDUP: AtomicBool = AtomicBool::new(false);
+            if !DEDUP.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                ecx.emit_diagnostic(NonHaltingDiagnostic::ConnectingSocketGetsockname);
             }
-            SocketState::Listening(listener) =>
-                match listener.local_addr() {
-                    Ok(address) => address,
-                    Err(e) => return interp_ok(Err(IoError::HostError(e))),
-                },
-            SocketState::Connecting(stream) | SocketState::Connected(stream) => {
-                if cfg!(windows) && matches!(&*state, SocketState::Connecting(_)) {
-                    // FIXME: On Windows hosts `TcpStream::local_addr` returns `0.0.0.0:0` whilst
-                    // the socket is connecting:
-                    // <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname#remarks>
-                    // This is problematic because UNIX targets could expect a real local address even
-                    // for a connecting non-blocking socket.
+        }
 
-                    static DEDUP: AtomicBool = AtomicBool::new(false);
-                    if !DEDUP.swap(true, std::sync::atomic::Ordering::Relaxed) {
-                        ecx.emit_diagnostic(NonHaltingDiagnostic::ConnectingSocketGetsockname);
-                    }
-                }
-                match stream.local_addr() {
-                    Ok(address) => address,
-                    Err(e) => return interp_ok(Err(IoError::HostError(e))),
-                }
-            }
-            // For non-bound sockets the POSIX manual says the returned address is unspecified.
-            // Often this is 0.0.0.0:0 and thus we set it to this value.
-            SocketState::Initial => SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0)),
-            SocketState::ConnectionFailed(_) => unreachable!(),
-        };
-
-        interp_ok(Ok(address))
+        match socket.local_addr() {
+            Ok(address) => interp_ok(Ok(address.as_socket().unwrap())),
+            Err(e) => interp_ok(Err(IoError::HostError(e))),
+        }
     }
 
     fn getpeername<'tcx>(

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -591,6 +591,9 @@ impl UnixSocketFileDescription for TcpSocket {
         value_len: u64,
         ecx: &mut MiriInterpCx<'tcx>,
     ) -> InterpResult<'tcx, Result<(), IoError>> {
+        let state = self.state.borrow();
+        let socket = state.as_socket_ref();
+
         if level == ecx.eval_libc_i32("SOL_SOCKET") {
             let opt_so_rcvtimeo = ecx.eval_libc_i32("SO_RCVTIMEO");
             let opt_so_sndtimeo = ecx.eval_libc_i32("SO_SNDTIMEO");
@@ -658,19 +661,7 @@ impl UnixSocketFileDescription for TcpSocket {
                 let option_value = ecx.ptr_to_mplace(value_ptr, ecx.machine.layouts.u32);
                 let ttl = ecx.read_scalar(&option_value)?.to_u32()?;
 
-                let result = match &*self.state.borrow() {
-                    SocketState::Initial | SocketState::Bound(_) =>
-                        throw_unsup_format!(
-                            "setsockopt: setting option IP_TTL on level IPPROTO_IP is only supported \
-                           on connected and listening tcp sockets"
-                        ),
-                    SocketState::Listening(listener) => listener.set_ttl(ttl),
-                    SocketState::Connecting(stream) | SocketState::Connected(stream) =>
-                        stream.set_ttl(ttl),
-                    SocketState::ConnectionFailed(_) => unreachable!(),
-                };
-
-                return match result {
+                return match socket.set_ttl_v4(ttl) {
                     Ok(_) => interp_ok(Ok(())),
                     Err(e) => interp_ok(Err(IoError::HostError(e))),
                 };
@@ -690,18 +681,7 @@ impl UnixSocketFileDescription for TcpSocket {
                 let option_value = ecx.ptr_to_mplace(value_ptr, ecx.machine.layouts.i32);
                 let nodelay = ecx.read_scalar(&option_value)?.to_i32()? != 0;
 
-                let result = match &*self.state.borrow() {
-                    SocketState::Initial | SocketState::Bound(_) | SocketState::Listening(_) =>
-                        throw_unsup_format!(
-                            "setsockopt: setting option TCP_NODELAY on level IPPROTO_TCP is only supported \
-                           on connected tcp sockets"
-                        ),
-                    SocketState::Connecting(stream) | SocketState::Connected(stream) =>
-                        stream.set_nodelay(nodelay),
-                    SocketState::ConnectionFailed(_) => unreachable!(),
-                };
-
-                return match result {
+                return match socket.set_tcp_nodelay(nodelay) {
                     Ok(_) => interp_ok(Ok(())),
                     Err(e) => interp_ok(Err(IoError::HostError(e))),
                 };
@@ -724,12 +704,17 @@ impl UnixSocketFileDescription for TcpSocket {
         option: i32,
         ecx: &mut MiriInterpCx<'tcx>,
     ) -> InterpResult<'tcx, Result<MPlaceTy<'tcx>, IoError>> {
+        let state = self.state.borrow();
+        let socket = state.as_socket_ref();
+
         if level == ecx.eval_libc_i32("SOL_SOCKET") {
             let opt_so_error = ecx.eval_libc_i32("SO_ERROR");
             let opt_so_rcvtimeo = ecx.eval_libc_i32("SO_RCVTIMEO");
             let opt_so_sndtimeo = ecx.eval_libc_i32("SO_SNDTIMEO");
 
             if option == opt_so_error {
+                drop(state);
+
                 // Reading SO_ERROR should always return the latest async error. Because our stored
                 // `socket.error` could be outdated, we attempt to update it here.
                 ecx.update_last_error(&self);
@@ -783,19 +768,7 @@ impl UnixSocketFileDescription for TcpSocket {
             let opt_ip_ttl = ecx.eval_libc_i32("IP_TTL");
 
             if option == opt_ip_ttl {
-                let ttl = match &*self.state.borrow() {
-                    SocketState::Initial | SocketState::Bound(_) =>
-                        throw_unsup_format!(
-                            "getsockopt: reading option IP_TTL on level IPPROTO_IP is only supported \
-                            on connected and listening tcp sockets"
-                        ),
-                    SocketState::Listening(listener) => listener.ttl(),
-                    SocketState::Connecting(stream) | SocketState::Connected(stream) =>
-                        stream.ttl(),
-                    SocketState::ConnectionFailed(_) => unreachable!(),
-                };
-
-                let ttl = match ttl {
+                let ttl = match socket.ttl_v4() {
                     Ok(ttl) => ttl,
                     Err(e) => return interp_ok(Err(IoError::HostError(e))),
                 };
@@ -813,18 +786,7 @@ impl UnixSocketFileDescription for TcpSocket {
             let opt_tcp_nodelay = ecx.eval_libc_i32("TCP_NODELAY");
 
             if option == opt_tcp_nodelay {
-                let nodelay = match &*self.state.borrow() {
-                    SocketState::Initial | SocketState::Bound(_) | SocketState::Listening(_) =>
-                        throw_unsup_format!(
-                            "getsockopt: reading option TCP_NODELAY on level IPPROTO_TCP is only supported \
-                            on connected tcp sockets"
-                        ),
-                    SocketState::Connecting(stream) | SocketState::Connected(stream) =>
-                        stream.nodelay(),
-                    SocketState::ConnectionFailed(_) => unreachable!(),
-                };
-
-                let nodelay = match nodelay {
+                let nodelay = match socket.tcp_nodelay() {
                     Ok(nodelay) => nodelay,
                     Err(e) => return interp_ok(Err(IoError::HostError(e))),
                 };

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -482,10 +482,23 @@ impl UnixSocketFileDescription for TcpSocket {
 
         let socket = match &*state {
             SocketState::Initial(socket) => socket,
-            // The socket is already connected or listening.
+            SocketState::Listening(_) => {
+                let err = if matches!(ecx.tcx.sess.target.os, Os::Linux | Os::Android) {
+                    // Linux-like targets return EISCONN when attempting to invoke
+                    // `connect` on an already listening socket.
+                    // See <https://man7.org/linux/man-pages/man2/connect.2.html>
+                    LibcError("EISCONN")
+                } else {
+                    // POSIX specifies to return EOPNOTSUPP when attempting to invoke
+                    // `connect` on an already listening socket.
+                    // See <https://man7.org/linux/man-pages/man3/connect.3p.html>
+                    LibcError("EOPNOTSUPP")
+                };
+                return finish.call(ecx, Err(err));
+            }
+            // The socket is already connected.
             // Subsequent connection attempts return EISCONN for TCP sockets.
-            SocketState::Listening(_) | SocketState::Connected(_) =>
-                return finish.call(ecx, Err(LibcError("EISCONN"))),
+            SocketState::Connected(_) => return finish.call(ecx, Err(LibcError("EISCONN"))),
             // The socket is already in a connecting state.
             // Subsequent connection attempts return EALREADY for TCP sockets.
             SocketState::Connecting(_) => return finish.call(ecx, Err(LibcError("EALREADY"))),

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -61,6 +61,24 @@ enum SocketState {
     ConnectionFailed(TcpStream),
 }
 
+impl SocketState {
+    /// View the underlying host socket as a [`socket2::SockRef`].
+    ///
+    /// **Note**: Potentially blocking operations need to be performed on the
+    /// underlying [`TcpStream`] and [`TcpListener`] as it would break the mio
+    /// poll on Windows hosts when performed directly on the [`socket2::SockRef`].
+    fn as_socket_ref<'a>(&'a self) -> socket2::SockRef<'a> {
+        match self {
+            SocketState::Initial(socket) => socket.into(),
+            SocketState::Bound(_) => panic!("bound state will be removed"),
+            SocketState::Listening(listener) => listener.into(),
+            SocketState::Connecting(stream)
+            | SocketState::Connected(stream)
+            | SocketState::ConnectionFailed(stream) => stream.into(),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub(super) struct TcpSocket {
     /// Family of the socket, used to ensure socket only binds/connects to address of
@@ -257,47 +275,34 @@ impl UnixSocketFileDescription for TcpSocket {
         assert!(communicate_allowed, "cannot have `TcpSocket` with isolation enabled!");
         ecx.ensure_not_failed(&self, "bind")?;
 
-        let mut state = self.state.borrow_mut();
+        let address_family = match &address {
+            SocketAddr::V4(_) => socket2::Domain::IPV4,
+            SocketAddr::V6(_) => socket2::Domain::IPV6,
+        };
 
-        match *state {
-            SocketState::Initial => {
-                let address_family = match &address {
-                    SocketAddr::V4(_) => socket2::Domain::IPV4,
-                    SocketAddr::V6(_) => socket2::Domain::IPV6,
-                };
-
-                if self.family != address_family {
-                    // Attempted to bind an address from a family that doesn't match
-                    // the family of the socket.
-                    let err = if matches!(ecx.tcx.sess.target.os, Os::Linux | Os::Android) {
-                        // Linux man page states that `EINVAL` is used when there is an address family mismatch.
-                        // See <https://man7.org/linux/man-pages/man2/bind.2.html>
-                        LibcError("EINVAL")
-                    } else {
-                        // POSIX man page states that `EAFNOSUPPORT` should be used when there is an address
-                        // family mismatch.
-                        // See <https://man7.org/linux/man-pages/man3/bind.3p.html>
-                        LibcError("EAFNOSUPPORT")
-                    };
-                    return interp_ok(Err(err));
-                }
-
-                *state = SocketState::Bound(address);
-            }
-            SocketState::Connecting(_) | SocketState::Connected(_) =>
-                throw_unsup_format!(
-                    "bind: tcp socket is already connected and binding a
-                   connected socket is unsupported"
-                ),
-            SocketState::Bound(_) | SocketState::Listening(_) =>
-                throw_unsup_format!(
-                    "bind: tcp socket is already bound and binding a socket \
-                   multiple times is unsupported"
-                ),
-            SocketState::ConnectionFailed(_) => unreachable!(),
+        if self.family != address_family {
+            // Attempted to bind an address from a family that doesn't match
+            // the family of the socket.
+            let err = if matches!(ecx.tcx.sess.target.os, Os::Linux | Os::Android) {
+                // Linux man page states that `EINVAL` is used when there is an address family mismatch.
+                // See <https://man7.org/linux/man-pages/man2/bind.2.html>
+                LibcError("EINVAL")
+            } else {
+                // POSIX man page states that `EAFNOSUPPORT` should be used when there is an address
+                // family mismatch.
+                // See <https://man7.org/linux/man-pages/man3/bind.3p.html>
+                LibcError("EAFNOSUPPORT")
+            };
+            return interp_ok(Err(err));
         }
 
-        interp_ok(Ok(()))
+        let state = self.state.borrow();
+        let socket = state.as_socket_ref();
+
+        match socket.bind(&socket2::SockAddr::from(address)) {
+            Ok(()) => interp_ok(Ok(())),
+            Err(e) => interp_ok(Err(IoError::HostError(e))),
+        }
     }
 
     fn listen<'tcx>(

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -36,11 +36,9 @@ const INITIAL_TCP_SOCKET_READINESS: Readiness =
 enum SocketState {
     /// No syscall after `socket` has been made.
     Initial(socket2::Socket),
-    /// The `bind` syscall has been called on the socket.
-    /// This is only reachable from the [`SocketState::Initial`] state.
-    Bound(SocketAddr),
     /// The `listen` syscall has been called on the socket.
-    /// This is only reachable from the [`SocketState::Bound`] state.
+    /// This is reachable from the [`SocketState::Initial`] and the
+    /// [`SocketState::Listening`] states.
     Listening(TcpListener),
     /// The `connect` syscall has been called and we weren't yet able
     /// to ensure the connection is established. This is only reachable
@@ -75,7 +73,6 @@ impl SocketState {
     fn as_socket_ref<'a>(&'a self) -> socket2::SockRef<'a> {
         match self {
             SocketState::Initial(socket) => socket.into(),
-            SocketState::Bound(_) => panic!("bound state will be removed"),
             SocketState::Listening(listener) => listener.into(),
             SocketState::Connecting(stream)
             | SocketState::Connected(stream)
@@ -325,7 +322,6 @@ impl UnixSocketFileDescription for TcpSocket {
         let socket = match &*state {
             SocketState::Initial(socket) => socket2::SockRef::from(socket),
             SocketState::Listening(listener) => socket2::SockRef::from(listener),
-            SocketState::Bound(_) => panic!("state will be removed"),
             // POSIX states that connected sockets cannot start listening.
             SocketState::Connecting(_) | SocketState::Connected(_) =>
                 return interp_ok(Err(LibcError("EINVAL"))),
@@ -445,7 +441,6 @@ impl UnixSocketFileDescription for TcpSocket {
 
         let socket = match &*state {
             SocketState::Initial(socket) => socket,
-            SocketState::Bound(_) => panic!("state will be removed"),
             // The socket is already connected or listening.
             // Subsequent connection attempts return EISCONN for TCP sockets.
             SocketState::Listening(_) | SocketState::Connected(_) =>

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -1473,14 +1473,8 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     fn update_last_error(&self, socket: &FileDescriptionRef<TcpSocket>) {
         let mut state = socket.state.borrow_mut();
 
-        let new_error = match &*state {
-            SocketState::Listening(listener) =>
-                listener.take_error().expect("Reading SO_ERROR should not fail"),
-            SocketState::Connecting(stream) | SocketState::Connected(stream) =>
-                stream.take_error().expect("Reading SO_ERROR should not fail"),
-            SocketState::Initial | SocketState::Bound(_) | SocketState::ConnectionFailed(_) => None,
-        };
-
+        let new_error =
+            state.as_socket_ref().take_error().expect("Reading SO_ERROR should not fail");
         let Some(new_error) = new_error else { return };
 
         // Store the error such that we can return it when

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -14,7 +14,7 @@ use rustc_target::spec::Os;
 use crate::shims::files::{EvalContextExt as _, FdNum, FileDescription, FileDescriptionRef};
 use crate::shims::sig::Varargs;
 use crate::shims::unix::UnixFileDescription;
-use crate::shims::unix::socket::{SocketFamily, UnixSocketFileDescription};
+use crate::shims::unix::socket::UnixSocketFileDescription;
 use crate::*;
 
 /// On Linux a TCP socket is initally in the TCP_CLOSE state:
@@ -35,7 +35,7 @@ const INITIAL_TCP_SOCKET_READINESS: Readiness =
 #[derive(Debug)]
 enum SocketState {
     /// No syscall after `socket` has been made.
-    Initial,
+    Initial(socket2::Socket),
     /// The `bind` syscall has been called on the socket.
     /// This is only reachable from the [`SocketState::Initial`] state.
     Bound(SocketAddr),
@@ -65,7 +65,7 @@ enum SocketState {
 pub(super) struct TcpSocket {
     /// Family of the socket, used to ensure socket only binds/connects to address of
     /// same family.
-    family: SocketFamily,
+    family: socket2::Domain,
     /// Current state of the inner socket.
     state: RefCell<SocketState>,
     /// Whether this fd is non-blocking or not.
@@ -91,17 +91,23 @@ pub(super) struct TcpSocket {
 }
 
 impl TcpSocket {
-    pub fn new(family: SocketFamily, is_non_block: bool) -> Self {
-        TcpSocket {
+    pub fn new(family: socket2::Domain, is_non_block: bool) -> io::Result<Self> {
+        let socket =
+            socket2::Socket::new(family, socket2::Type::STREAM, Some(socket2::Protocol::TCP))?;
+        // The underlying host socket needs to be non-blocking. The actual
+        // blocking mode of the socket is stored in `is_non_block`.
+        socket.set_nonblocking(true)?;
+
+        Ok(TcpSocket {
             family,
-            state: RefCell::new(SocketState::Initial),
+            state: RefCell::new(SocketState::Initial(socket)),
             is_non_block: Cell::new(is_non_block),
             io_readiness: RefCell::new(INITIAL_TCP_SOCKET_READINESS),
             error: RefCell::new(None),
             read_timeout: Cell::new(None),
             write_timeout: Cell::new(None),
             watched: ReadinessWatched::default(),
-        }
+        })
     }
 }
 
@@ -256,8 +262,8 @@ impl UnixSocketFileDescription for TcpSocket {
         match *state {
             SocketState::Initial => {
                 let address_family = match &address {
-                    SocketAddr::V4(_) => SocketFamily::IPv4,
-                    SocketAddr::V6(_) => SocketFamily::IPv6,
+                    SocketAddr::V4(_) => socket2::Domain::IPV4,
+                    SocketAddr::V6(_) => socket2::Domain::IPV6,
                 };
 
                 if self.family != address_family {
@@ -1077,8 +1083,8 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         };
 
         let family = match addr {
-            SocketAddr::V4(_) => SocketFamily::IPv4,
-            SocketAddr::V6(_) => SocketFamily::IPv6,
+            SocketAddr::V4(_) => socket2::Domain::IPV4,
+            SocketAddr::V6(_) => socket2::Domain::IPV6,
         };
 
         let fd = this.machine.fds.new_ref(TcpSocket {

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -314,51 +314,81 @@ impl UnixSocketFileDescription for TcpSocket {
     fn listen<'tcx>(
         self: FileDescriptionRef<TcpSocket>,
         communicate_allowed: bool,
-        // Since the backlog value is just a performance hint we can ignore it.
-        _backlog: i32,
+        backlog: i32,
         ecx: &mut MiriInterpCx<'tcx>,
     ) -> InterpResult<'tcx, Result<(), IoError>> {
         assert!(communicate_allowed, "cannot have `TcpSocket` with isolation enabled!");
         ecx.ensure_not_failed(&self, "listen")?;
 
-        let mut state = self.state.borrow_mut();
+        let state = self.state.borrow();
 
-        match *state {
-            SocketState::Bound(socket_addr) =>
-                match TcpListener::bind(socket_addr) {
-                    Ok(listener) => {
-                        *state = SocketState::Listening(listener);
-                        drop(state);
-
-                        // After invoking `listen` on a TCP socket, it transitions out of the
-                        // TCP_CLOSE state which affects the socket's readiness. Because we
-                        // register the socket afterwards to the blocking I/O manager, we just
-                        // clear its readiness here as the blocking I/O manager will update its
-                        // readiness accordingly.
-                        self.io_readiness.replace(Readiness::EMPTY);
-                        ecx.update_fd_readiness(self.clone(), ReadinessUpdateFlags::DEFAULT)?;
-
-                        // Register the socket to the blocking I/O manager because
-                        // we now have an associated host socket.
-                        ecx.machine.blocking_io.register(self);
-                    }
-                    Err(e) => return interp_ok(Err(IoError::HostError(e))),
-                },
-            SocketState::Initial => {
-                throw_unsup_format!(
-                    "listen: listening on a tcp socket which isn't bound is unsupported"
-                )
-            }
-            SocketState::Listening(_) => {
-                throw_unsup_format!(
-                    "listen: listening on a tcp socket multiple times is unsupported"
-                )
-            }
-            SocketState::Connecting(_) | SocketState::Connected(_) => {
-                throw_unsup_format!("listen: listening on a connected tcp socket is unsupported")
-            }
+        let socket = match &*state {
+            SocketState::Initial(socket) => socket2::SockRef::from(socket),
+            SocketState::Listening(listener) => socket2::SockRef::from(listener),
+            SocketState::Bound(_) => panic!("state will be removed"),
+            // POSIX states that connected sockets cannot start listening.
+            SocketState::Connecting(_) | SocketState::Connected(_) =>
+                return interp_ok(Err(LibcError("EINVAL"))),
             SocketState::ConnectionFailed(_) | SocketState::Transitioning => unreachable!(),
+        };
+
+        if let Err(e) = socket.listen(backlog) {
+            return interp_ok(Err(IoError::HostError(e)));
         }
+
+        if let SocketState::Listening(_) = &*state {
+            // The socket was already listening; we just changed the backlog.
+            // The socket is already registered to the blocking I/O manager
+            // and we also don't need to perform a state transition.
+            return interp_ok(Ok(()));
+        }
+
+        drop(state);
+
+        // Temporarily use dummy state to take ownership of the underlying socket.
+        let SocketState::Initial(socket) = self.state.replace(SocketState::Transitioning) else {
+            unreachable!()
+        };
+
+        // Turn the `socket2::Socket` into a `mio::TcpListener`.
+        // This is the same what Tokio does in their TCP socket implementation:
+        // See <https://github.com/tokio-rs/tokio/blob/2120bee/tokio/src/net/tcp/socket.rs#L906-L925>
+        // SAFETY: mio specifies that it is safe to use `from_raw_fd` and
+        // `from_raw_socket` as long as it's ensured that the socket is non-blocking.
+        // Because we immediately make the socket non-blocking after creation, that
+        // is always guaranteed.
+
+        // FIXME: Rustfmt has a bug where it incorrectly removes the outer braces of {{ .. }} inside
+        // a `cfg_select!` block. See <https://github.com/rust-lang/rustfmt/issues/7045>.
+        #[rustfmt::skip]
+        let listener = cfg_select! {
+            unix => {{
+                use std::os::fd::{IntoRawFd, FromRawFd};
+                let raw_fd = socket.into_raw_fd();
+                unsafe { TcpListener::from_raw_fd(raw_fd) }
+            }},
+            windows => {{
+                use std::os::windows::io::{IntoRawSocket, FromRawSocket};
+                let raw_socket = socket.into_raw_socket();
+                unsafe { TcpListener::from_raw_socket(raw_socket) }
+            }},
+            _ => unreachable!("unsupported host platform")
+        };
+
+        self.state.replace(SocketState::Listening(listener));
+
+        // After invoking `listen` on a TCP socket, it transitions out of the
+        // TCP_CLOSE state which affects the socket's readiness. Because we
+        // register the socket afterwards to the blocking I/O manager, we just
+        // clear its readiness here as the blocking I/O manager will update its
+        // readiness accordingly.
+        self.io_readiness.replace(Readiness::EMPTY);
+        ecx.update_fd_readiness(self.clone(), ReadinessUpdateFlags::DEFAULT)?;
+
+        // Register the socket to the blocking I/O manager because
+        // the readiness of the underlying host socket is no longer
+        // known to always be the initial readiness.
+        ecx.machine.blocking_io.register(self);
 
         interp_ok(Ok(()))
     }

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -441,52 +441,103 @@ impl UnixSocketFileDescription for TcpSocket {
         assert!(communicate_allowed, "cannot have `TcpSocket` with isolation enabled!");
         ecx.ensure_not_failed(&self, "connect")?;
 
-        match &*self.state.borrow() {
-            SocketState::Initial => { /* fall-through to below */ }
+        let state = self.state.borrow();
+
+        let socket = match &*state {
+            SocketState::Initial(socket) => socket,
+            SocketState::Bound(_) => panic!("state will be removed"),
+            // The socket is already connected or listening.
+            // Subsequent connection attempts return EISCONN for TCP sockets.
+            SocketState::Listening(_) | SocketState::Connected(_) =>
+                return finish.call(ecx, Err(LibcError("EISCONN"))),
             // The socket is already in a connecting state.
+            // Subsequent connection attempts return EALREADY for TCP sockets.
             SocketState::Connecting(_) => return finish.call(ecx, Err(LibcError("EALREADY"))),
-            // We don't return EISCONN for already connected sockets, for which we're
-            // sure that the connection is established, since TCP sockets are usually
-            // allowed to be connected multiple times.
-            _ =>
-                throw_unsup_format!(
-                    "connect: connecting is only supported for tcp sockets which are neither \
-                   bound, listening nor already connected"
-                ),
+            SocketState::ConnectionFailed(_) | SocketState::Transitioning => unreachable!(),
+        };
+
+        let result = socket.connect(&socket2::SockAddr::from(address));
+
+        drop(state);
+
+        // Boolean whether the connection attempt "failed" because it could not be
+        // completed immediately without blocking.
+        let is_in_progress = result.as_ref().is_err_and(|e| {
+            if cfg!(windows) {
+                // On Windows hosts non-blocking connects fail with EWOULDBLOCK when the connection
+                // cannot be established immediately.
+                e.kind() == io::ErrorKind::WouldBlock
+            } else {
+                // On Unix-like hosts non-blocking connects fail with EINPROGRESS when the connection
+                // cannot be established immediately.
+                e.kind() == io::ErrorKind::InProgress
+            }
+        });
+
+        if !is_in_progress && let Err(e) = result {
+            // There was a "real" error during connection establishment.
+            return finish.call(ecx, Err(IoError::HostError(e)));
         }
 
-        // This begins establishing the connection, but does not block until the stream is fully connected.
-        // We deal with that below.
-        match TcpStream::connect(address) {
-            Ok(stream) => {
-                *self.state.borrow_mut() = SocketState::Connecting(stream);
-
-                // After invoking `connect` on a TCP socket, it transitions out of the
-                // TCP_CLOSE state which affects the socket's readiness. Because we
-                // register the socket afterwards to the blocking I/O manager, we just
-                // clear its readiness here as the blocking I/O manager will update its
-                // readiness accordingly.
-                self.io_readiness.replace(Readiness::EMPTY);
-                ecx.update_fd_readiness(self.clone(), ReadinessUpdateFlags::DEFAULT)?;
-
-                // Register the socket to the blocking I/O manager because
-                // we now have an associated host socket.
-                ecx.machine.blocking_io.register(self.clone());
-            }
-            Err(e) => return finish.call(ecx, Err(IoError::HostError(e))),
+        // Temporarily use dummy state to take ownership of the underlying socket.
+        let SocketState::Initial(socket) = self.state.replace(SocketState::Transitioning) else {
+            unreachable!()
         };
+
+        // Turn the `socket2::Socket` into a `mio::TcpStream`.
+        // This is the same what Tokio does in their TCP socket implementation:
+        // See <https://github.com/tokio-rs/tokio/blob/2120bee/tokio/src/net/tcp/socket.rs#L841-L869>
+        // SAFETY: mio specifies that it is safe to use `from_raw_fd` and
+        // `from_raw_socket` as long as it's ensured that the socket is non-blocking.
+        // Because we immediately make the socket non-blocking after creation, that
+        // is always guaranteed.
+
+        // FIXME: Rustfmt has a bug where it incorrectly removes the outer braces of {{ .. }} inside
+        // a `cfg_select!` block. See <https://github.com/rust-lang/rustfmt/issues/7045>.
+        #[rustfmt::skip]
+        let stream = cfg_select! {
+             unix => {{
+                 use std::os::fd::{IntoRawFd, FromRawFd};
+                 let raw_fd = socket.into_raw_fd();
+                 unsafe { TcpStream::from_raw_fd(raw_fd) }
+             }},
+             windows => {{
+                 use std::os::windows::io::{IntoRawSocket, FromRawSocket};
+                 let raw_socket = socket.into_raw_socket();
+                 unsafe { TcpStream::from_raw_socket(raw_socket) }
+             }},
+             _ => unreachable!("unsupported host platform")
+         };
+
+        self.state.replace(SocketState::Connecting(stream));
+
+        // After invoking `connect` on a TCP socket, it transitions out of the
+        // TCP_CLOSE state which affects the socket's readiness. Because we
+        // register the socket afterwards to the blocking I/O manager, we just
+        // clear its readiness here as the blocking I/O manager will update its
+        // readiness accordingly.
+        self.io_readiness.replace(Readiness::EMPTY);
+        ecx.update_fd_readiness(self.clone(), ReadinessUpdateFlags::DEFAULT)?;
+
+        // Register the socket to the blocking I/O manager because
+        // the readiness of the underlying host socket is no longer
+        // known to always be the initial readiness.
+        ecx.machine.blocking_io.register(self.clone());
 
         if self.is_non_block.get() {
             // We have a non-blocking socket and thus don't want to block until
             // the connection is established.
 
-            // Since the [`TcpStream::connect`] function of mio hides the EINPROGRESS
-            // we just always return EINPROGRESS and check whether the connection succeeded
-            // once we want to use the connected socket.
-            finish.call(ecx, Err(LibcError("EINPROGRESS")))
+            if is_in_progress {
+                finish.call(ecx, Err(LibcError("EINPROGRESS")))
+            } else {
+                finish.call(ecx, Ok(()))
+            }
         } else {
             // The socket is in blocking mode and thus the connect call should block
-            // until the connection with the server is established.
+            // until the connection with the server is established. A potential
+            // EWOULDBLOCK or EINPROGRESS error code is ignored as we emulate a
+            // blocking socket.
 
             if self.write_timeout.get().is_some() {
                 // Some Unixes like Linux also apply the SO_SNDTIMEO socket option

--- a/src/shims/unix/tcp_socket.rs
+++ b/src/shims/unix/tcp_socket.rs
@@ -1,7 +1,7 @@
 use std::cell::{Cell, RefCell, RefMut};
 use std::io;
 use std::io::Read;
-use std::net::{Ipv4Addr, Shutdown, SocketAddr, SocketAddrV4};
+use std::net::{Shutdown, SocketAddr};
 use std::sync::atomic::AtomicBool;
 use std::time::Duration;
 
@@ -59,6 +59,11 @@ enum SocketState {
     /// and thus nothing (except destroying the socket) should be
     /// supported when a socket is in this state.
     ConnectionFailed(TcpStream),
+    /// The socket state machine is transitioning between two states
+    /// which contain an underlying host socket. This state is never
+    /// observable, it's only needed as a placeholder state to safely
+    /// acquire ownership of the underlying host socket.
+    Transitioning,
 }
 
 impl SocketState {
@@ -75,6 +80,7 @@ impl SocketState {
             SocketState::Connecting(stream)
             | SocketState::Connected(stream)
             | SocketState::ConnectionFailed(stream) => stream.into(),
+            SocketState::Transitioning => unreachable!(),
         }
     }
 }
@@ -351,7 +357,7 @@ impl UnixSocketFileDescription for TcpSocket {
             SocketState::Connecting(_) | SocketState::Connected(_) => {
                 throw_unsup_format!("listen: listening on a connected tcp socket is unsupported")
             }
-            SocketState::ConnectionFailed(_) => unreachable!(),
+            SocketState::ConnectionFailed(_) | SocketState::Transitioning => unreachable!(),
         }
 
         interp_ok(Ok(()))
@@ -1432,13 +1438,11 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                     // The connection is established.
 
                     // Temporarily use dummy state to take ownership of the stream.
-                    let mut state = socket.state.borrow_mut();
-                    let SocketState::Connecting(stream) = std::mem::replace(&mut*state, SocketState::Initial) else {
+                    let SocketState::Connecting(stream) = socket.state.replace(SocketState::Transitioning) else {
                         // At the start of the function we ensured that we're currently connecting.
                         unreachable!()
                     };
-                    *state = SocketState::Connected(stream);
-                    drop(state);
+                    socket.state.replace(SocketState::Connected(stream));
                     action.call(this, Ok(()))
                 }
             ),
@@ -1471,7 +1475,7 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     /// state because we know that `socket` can no longer successfully establish a
     /// connection.
     fn update_last_error(&self, socket: &FileDescriptionRef<TcpSocket>) {
-        let mut state = socket.state.borrow_mut();
+        let state = socket.state.borrow_mut();
 
         let new_error =
             state.as_socket_ref().take_error().expect("Reading SO_ERROR should not fail");
@@ -1487,13 +1491,14 @@ trait EvalContextPrivExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             // specification, the socket is now in an unspecified state.
             // We thus change the socket state to `ConnectionFailed`.
 
+            drop(state);
+
             // Temporarily use dummy state to take ownership of the stream.
-            let SocketState::Connecting(stream) =
-                std::mem::replace(&mut *state, SocketState::Initial)
+            let SocketState::Connecting(stream) = socket.state.replace(SocketState::Transitioning)
             else {
                 unreachable!()
             };
-            *state = SocketState::ConnectionFailed(stream);
+            socket.state.replace(SocketState::ConnectionFailed(stream));
         }
     }
 }

--- a/tests/pass-dep/libc/libc-socket-no-blocking.rs
+++ b/tests/pass-dep/libc/libc-socket-no-blocking.rs
@@ -60,6 +60,7 @@ fn main() {
     test_getpeername_ipv4_nonblock_no_peer();
 
     test_listen_connecting();
+    test_connect_connecting();
 }
 
 /// Test that setting the O_NONBLOCK flag changes the blocking state of a socket.
@@ -822,4 +823,44 @@ fn test_listen_connecting() {
     assert_eq!(err.kind(), ErrorKind::InvalidInput);
     // Check that it is the right kind of `InvalidInput`.
     assert_eq!(err.raw_os_error(), Some(libc::EINVAL));
+}
+
+/// Test that invoking `connect` on an already connecting client
+/// TCP socket returns EALREADY.
+fn test_connect_connecting() {
+    let client_sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+
+    unsafe {
+        // Change client socket to be non-blocking.
+        errno_check(libc::fcntl(client_sockfd, libc::F_SETFL, libc::O_NONBLOCK));
+    }
+
+    // We cannot attempt to connect to a localhost address because
+    // it could be the case that a socket from another test is
+    // currently listening on `localhost:12321` because we bind to
+    // random ports everywhere. For `192.0.2.1` we know that nothing is
+    // listening because it's a blackhole address:
+    // <https://www.rfc-editor.org/rfc/rfc5737>
+    // The port `12321` is just a random non-zero port because Windows
+    // and Apple hosts return EADDRNOTAVAIL when attempting to connect to
+    // a zero port.
+    let addr = net::sock_addr_ipv4([192, 0, 2, 1], 12321);
+
+    // Non-blocking connect should fail with EINPROGRESS.
+    let err = net::connect_ipv4(client_sockfd, addr).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::InProgress);
+
+    // There should be no error during async connection.
+    let errno =
+        net::getsockopt::<libc::c_int>(client_sockfd, libc::SOL_SOCKET, libc::SO_ERROR).unwrap();
+    assert_eq!(errno, 0);
+
+    // Create a socket which listens on `addr`.
+    let (_, addr) = net::make_listener_ipv4().unwrap();
+
+    let err = net::connect_ipv4(client_sockfd, addr).unwrap_err();
+    // The standard library doesn't provide an error kind for EALREADY;
+    // we thus cannot assert the correct error kind.
+    assert_eq!(err.raw_os_error(), Some(libc::EALREADY));
 }

--- a/tests/pass-dep/libc/libc-socket-no-blocking.rs
+++ b/tests/pass-dep/libc/libc-socket-no-blocking.rs
@@ -58,6 +58,8 @@ fn main() {
 
     test_getpeername_ipv4_nonblock();
     test_getpeername_ipv4_nonblock_no_peer();
+
+    test_listen_connecting();
 }
 
 /// Test that setting the O_NONBLOCK flag changes the blocking state of a socket.
@@ -781,4 +783,43 @@ fn test_getpeername_ipv4_nonblock_no_peer() {
         unreachable!()
     };
     assert_eq!(err.kind(), ErrorKind::NotConnected);
+}
+
+/// Test that `listen` returns EINVAL for a non-blocking IPv4
+/// socket which is stuck at connecting to a remote address.
+fn test_listen_connecting() {
+    let client_sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+
+    unsafe {
+        // Change client socket to be non-blocking.
+        errno_check(libc::fcntl(client_sockfd, libc::F_SETFL, libc::O_NONBLOCK));
+    }
+
+    // We cannot attempt to connect to a localhost address because
+    // it could be the case that a socket from another test is
+    // currently listening on `localhost:12321` because we bind to
+    // random ports everywhere. For `192.0.2.1` we know that nothing is
+    // listening because it's a blackhole address:
+    // <https://www.rfc-editor.org/rfc/rfc5737>
+    // The port `12321` is just a random non-zero port because Windows
+    // and Apple hosts return EADDRNOTAVAIL when attempting to connect to
+    // a zero port.
+    let addr = net::sock_addr_ipv4([192, 0, 2, 1], 12321);
+
+    // Non-blocking connect should fail with EINPROGRESS.
+    let err = net::connect_ipv4(client_sockfd, addr).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::InProgress);
+
+    // There should be no error during async connection.
+    let errno =
+        net::getsockopt::<libc::c_int>(client_sockfd, libc::SOL_SOCKET, libc::SO_ERROR).unwrap();
+    assert_eq!(errno, 0);
+
+    // Connecting sockets cannot start listening, thus the operation should
+    // fail with EINVAL.
+    let err = unsafe { errno_result(libc::listen(client_sockfd, 16)).unwrap_err() };
+    assert_eq!(err.kind(), ErrorKind::InvalidInput);
+    // Check that it is the right kind of `InvalidInput`.
+    assert_eq!(err.raw_os_error(), Some(libc::EINVAL));
 }

--- a/tests/pass-dep/libc/libc-socket.rs
+++ b/tests/pass-dep/libc/libc-socket.rs
@@ -37,6 +37,8 @@ fn main() {
     test_bind_connected();
     test_bind_listening();
     test_listen();
+    test_listen_connected();
+    test_listen_listening();
 
     test_accept_connect();
     test_connect_error();
@@ -326,6 +328,34 @@ fn test_listen() {
     unsafe {
         errno_check(libc::listen(sockfd, 16));
     }
+}
+
+/// Test that `listen` returns EINVAL for a client TCP socket which
+/// is already connected to a peer socket.
+fn test_listen_connected() {
+    let (server_sockfd, addr) = net::make_listener_ipv4().unwrap();
+    let client_sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+
+    net::connect_ipv4(client_sockfd, addr).unwrap();
+    net::accept_ipv4(server_sockfd).unwrap();
+
+    // Connected sockets cannot start listening, thus the operation should
+    // fail with EINVAL.
+    let err = unsafe { errno_result(libc::listen(client_sockfd, 16)).unwrap_err() };
+    assert_eq!(err.kind(), ErrorKind::InvalidInput);
+    // Check that it is the right kind of `InvalidInput`.
+    assert_eq!(err.raw_os_error(), Some(libc::EINVAL));
+}
+
+/// Test that `listen` succeeds for a server TCP socket which is already
+/// listening.
+fn test_listen_listening() {
+    let (server_sockfd, _) = net::make_listener_ipv4().unwrap();
+
+    // Invoking `listen` multiple times should be allowed as it can be used to change
+    // the backlog value.
+    unsafe { errno_check(libc::listen(server_sockfd, 16)) };
 }
 
 /// Test accepting connections by running a server in a separate thread and connecting clients

--- a/tests/pass-dep/libc/libc-socket.rs
+++ b/tests/pass-dep/libc/libc-socket.rs
@@ -443,15 +443,26 @@ fn test_connect_connected() {
 }
 
 /// Test that invoking `connect` on an already listening server
-/// TCP socket returns EISCONN.
+/// TCP socket returns EOPNOTSUPP on non-Linux-like targets and
+/// EISCONN on Linux-like targets.
 fn test_connect_listening() {
     let (_, addr1) = net::make_listener_ipv4().unwrap();
     let (server_sockfd2, _) = net::make_listener_ipv4().unwrap();
 
     let err = net::connect_ipv4(server_sockfd2, addr1).unwrap_err();
-    // The standard library doesn't provide an error kind for EISCONN;
-    // we thus cannot assert the correct error kind.
-    assert_eq!(err.raw_os_error(), Some(libc::EISCONN));
+
+    if cfg!(any(target_os = "linux", target_os = "android")) {
+        // Linux-like targets return EISCONN when attempting to invoke
+        // `connect` on an already listening socket.
+
+        // The standard library doesn't provide an error kind for EISCONN;
+        // we thus cannot assert the correct error kind.
+        assert_eq!(err.raw_os_error(), Some(libc::EISCONN));
+    } else {
+        // POSIX specifies EOPNOTSUPP when attempting to invoke
+        // `connect` on an already listening socket.
+        assert_eq!(err.kind(), ErrorKind::Unsupported);
+    }
 }
 
 /// Test sending bytes into a connected stream and then peeking and receiving

--- a/tests/pass-dep/libc/libc-socket.rs
+++ b/tests/pass-dep/libc/libc-socket.rs
@@ -42,6 +42,8 @@ fn main() {
 
     test_accept_connect();
     test_connect_error();
+    test_connect_connected();
+    test_connect_listening();
     test_send_peek_recv();
     test_write_read();
     test_readv();
@@ -421,6 +423,35 @@ fn test_connect_error() {
             | ErrorKind::AddrNotAvailable
             | ErrorKind::NetworkUnreachable
     ));
+}
+
+/// Test that invoking `connect` on an already connected client
+/// TCP socket returns EISCONN.
+fn test_connect_connected() {
+    let (server_sockfd1, addr1) = net::make_listener_ipv4().unwrap();
+    let (_, addr2) = net::make_listener_ipv4().unwrap();
+    let client_sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+
+    net::connect_ipv4(client_sockfd, addr1).unwrap();
+    net::accept_ipv4(server_sockfd1).unwrap();
+
+    let err = net::connect_ipv4(client_sockfd, addr2).unwrap_err();
+    // The standard library doesn't provide an error kind for EISCONN;
+    // we thus cannot assert the correct error kind.
+    assert_eq!(err.raw_os_error(), Some(libc::EISCONN));
+}
+
+/// Test that invoking `connect` on an already listening server
+/// TCP socket returns EISCONN.
+fn test_connect_listening() {
+    let (_, addr1) = net::make_listener_ipv4().unwrap();
+    let (server_sockfd2, _) = net::make_listener_ipv4().unwrap();
+
+    let err = net::connect_ipv4(server_sockfd2, addr1).unwrap_err();
+    // The standard library doesn't provide an error kind for EISCONN;
+    // we thus cannot assert the correct error kind.
+    assert_eq!(err.raw_os_error(), Some(libc::EISCONN));
 }
 
 /// Test sending bytes into a connected stream and then peeking and receiving

--- a/tests/pass-dep/libc/libc-socket.rs
+++ b/tests/pass-dep/libc/libc-socket.rs
@@ -33,6 +33,9 @@ fn main() {
     }
     test_bind_ipv4_invalid_addr_len();
     test_bind_ipv6();
+    test_bind_twice();
+    test_bind_connected();
+    test_bind_listening();
     test_listen();
 
     test_accept_connect();
@@ -234,6 +237,78 @@ fn test_bind_ipv6() {
             size_of::<libc::sockaddr_in6>() as libc::socklen_t,
         ));
     }
+}
+
+/// Test that invoking `bind` on an already bound TCP socket
+/// returns EINVAL.
+fn test_bind_twice() {
+    let sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+    let addr = net::sock_addr_ipv4(net::IPV4_LOCALHOST, 0);
+    let err = unsafe {
+        errno_check(libc::bind(
+            sockfd,
+            (&addr as *const libc::sockaddr_in).cast::<libc::sockaddr>(),
+            size_of::<libc::sockaddr_in>() as libc::socklen_t,
+        ));
+        errno_result(libc::bind(
+            sockfd,
+            (&addr as *const libc::sockaddr_in).cast::<libc::sockaddr>(),
+            size_of::<libc::sockaddr_in>() as libc::socklen_t,
+        ))
+        .unwrap_err()
+    };
+    assert_eq!(err.kind(), ErrorKind::InvalidInput);
+    // Check that it is the right kind of `InvalidInput`.
+    assert_eq!(err.raw_os_error(), Some(libc::EINVAL));
+}
+
+/// Test that invoking `bind` on an already connected client
+/// TCP socket returns EINVAL.
+fn test_bind_connected() {
+    let (server_sockfd, addr) = net::make_listener_ipv4().unwrap();
+    let client_sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+
+    net::connect_ipv4(client_sockfd, addr).unwrap();
+    net::accept_ipv4(server_sockfd).unwrap();
+
+    let addr = net::sock_addr_ipv4(net::IPV4_LOCALHOST, 0);
+    let err = unsafe {
+        errno_result(libc::bind(
+            client_sockfd,
+            (&addr as *const libc::sockaddr_in).cast::<libc::sockaddr>(),
+            size_of::<libc::sockaddr_in>() as libc::socklen_t,
+        ))
+        .unwrap_err()
+    };
+    assert_eq!(err.kind(), ErrorKind::InvalidInput);
+    // Check that it is the right kind of `InvalidInput`.
+    assert_eq!(err.raw_os_error(), Some(libc::EINVAL));
+}
+
+/// Test that invoking `bind` on an already listening server
+/// TCP socket returns EINVAL.
+fn test_bind_listening() {
+    let server_sockfd =
+        unsafe { errno_result(libc::socket(libc::AF_INET, libc::SOCK_STREAM, 0)).unwrap() };
+
+    unsafe {
+        errno_check(libc::listen(server_sockfd, 16));
+    }
+
+    let addr = net::sock_addr_ipv4(net::IPV4_LOCALHOST, 0);
+    let err = unsafe {
+        errno_result(libc::bind(
+            server_sockfd,
+            (&addr as *const libc::sockaddr_in).cast::<libc::sockaddr>(),
+            size_of::<libc::sockaddr_in>() as libc::socklen_t,
+        ))
+        .unwrap_err()
+    };
+    assert_eq!(err.kind(), ErrorKind::InvalidInput);
+    // Check that it is the right kind of `InvalidInput`.
+    assert_eq!(err.raw_os_error(), Some(libc::EINVAL));
 }
 
 fn test_listen() {


### PR DESCRIPTION
This pull request extends the TCP socket shim to use the `Socket` and `SockRef` abstractions from the `socket2` crate.
This allows: 
- Removing the `SocketState::Bound` state from the state machine
- Supporting non-blocking socket operations (e.g., `listen`, `bind`, ...) outside the order specified by the standard library and mio abstractions (e.g., `socket` -> `bind` -> `connect`)
- Supporting the available TCP socket options even before a `connect` or `listen` invocation because we always have an underlying host socket

Since some of the commits contain quite some indentation changes, you'd probably want to hide whitespace changes in the GitHub diff viewer :) 

Closes rust-lang/miri#5206