### PR TITLE
Improve `intrinsics-x86-aes-vaes` test

### DIFF
--- a/tests/pass/shims/x86/intrinsics-x86-aes-vaes.rs
+++ b/tests/pass/shims/x86/intrinsics-x86-aes-vaes.rs
@@ -19,9 +19,6 @@ fn main() {
             test_aesenclast();
             test_aesdec();
             test_aesdeclast();
-
-            loop_test_aes_keygen();
-            loop_test_aes();
         }
 
         if is_x86_feature_detected!("vaes") {
@@ -30,8 +27,6 @@ fn main() {
                 test_aesenclast256();
                 test_aesdec256();
                 test_aesdeclast256();
-
-                loop_test_vaes256();
             }
 
             if is_x86_feature_detected!("avx512f") {
@@ -40,8 +35,6 @@ fn main() {
                     test_aesenclast512();
                     test_aesdec512();
                     test_aesdeclast512();
-
-                    loop_test_vaes512();
                 }
             } else {
                 println!("warning: skipping VAES+AVX-512 tests");
@@ -114,22 +107,6 @@ const EXPECTED_AESDECLAST: [u128; N] = [
     0x98C5F123B4967E2DA4F16F2EDB918529,
     0x319E3DBCE4268B35F215B038FD022054,
 ];
-// Expected value of `k` in loop tests
-const EXPECTED_LOOP_K: [u128; N] = [
-    0xD21928B8DEB8D0565C1FB92B010E2363,
-    0x8D2E2F5521147125F8E24489EA0D8D97,
-    0xEE26FC76F1CC0D3D849AAF838A16117B,
-    0xA4C8122B4F6C00362E3692B1B7854BF7,
-];
-// Expected value of `b` in loop tests
-const EXPECTED_LOOP_B: [u128; N] = [
-    0xE74F19EFD8C28BFE3BD285175F3F68FF,
-    0xCE70940A752A6E0A23AD14E31C033BBF,
-    0xE224ED621B046A2D337BB2EC5020424E,
-    0xE617A20C71EC216CF6DE4FF8EDB763B0,
-];
-/// Number of iternations used in loop tests
-const ITERATIONS: u64 = 128;
 
 #[target_feature(enable = "aes")]
 fn test_aesimc() {
@@ -179,38 +156,6 @@ fn test_aesdeclast() {
     }
 }
 
-#[target_feature(enable = "aes")]
-fn loop_test_aes_keygen() {
-    let k = K[0];
-    let expected_k = 0x8DD2144D60F310A85C3487481DDC6789;
-
-    let mut k = k.as_mm();
-    for _ in 0..ITERATIONS {
-        k = _mm_aeskeygenassist_si128(k, 0x36);
-        let t = _mm_aesimc_si128(k);
-        // use `aesenc` to "randomize" `k`
-        k = _mm_aesenc_si128(k, t);
-    }
-
-    assert!(expected_k.is_eq(k));
-}
-
-#[target_feature(enable = "aes")]
-fn loop_test_aes() {
-    for i in 0..N {
-        let mut k = K[i].as_mm();
-        let mut b = k;
-        for _ in 0..ITERATIONS {
-            b = _mm_aesenc_si128(b, k);
-            k = _mm_aesenclast_si128(k, b);
-            b = _mm_aesdec_si128(b, k);
-            k = _mm_aesdeclast_si128(k, b);
-        }
-        assert!(EXPECTED_LOOP_K[i].is_eq(k));
-        assert!(EXPECTED_LOOP_B[i].is_eq(b));
-    }
-}
-
 #[target_feature(enable = "vaes")]
 fn test_aesenc256() {
     let (b, _) = B.as_chunks::<2>();
@@ -255,29 +200,6 @@ fn test_aesdeclast256() {
     }
 }
 
-#[target_feature(enable = "vaes")]
-fn loop_test_vaes256() {
-    let (ks, tail) = K.as_chunks::<2>();
-    assert!(tail.is_empty());
-    let (expected_ks, tail) = EXPECTED_LOOP_K.as_chunks::<2>();
-    assert!(tail.is_empty());
-    let (expected_bs, tail) = EXPECTED_LOOP_B.as_chunks::<2>();
-    assert!(tail.is_empty());
-
-    for i in 0..N / 2 {
-        let mut k = ks[i].as_mm();
-        let mut b = k;
-        for _ in 0..ITERATIONS {
-            b = _mm256_aesenc_epi128(b, k);
-            k = _mm256_aesenclast_epi128(k, b);
-            b = _mm256_aesdec_epi128(b, k);
-            k = _mm256_aesdeclast_epi128(k, b);
-        }
-        assert!(expected_ks[i].is_eq(k));
-        assert!(expected_bs[i].is_eq(b));
-    }
-}
-
 #[target_feature(enable = "avx512f,vaes")]
 fn test_aesenc512() {
     let r = _mm512_aesenc_epi128(B.as_mm(), K.as_mm());
@@ -300,20 +222,6 @@ fn test_aesdec512() {
 fn test_aesdeclast512() {
     let r = _mm512_aesdeclast_epi128(B.as_mm(), K.as_mm());
     assert!(EXPECTED_AESDECLAST.is_eq(r));
-}
-
-#[target_feature(enable = "avx512f,vaes")]
-fn loop_test_vaes512() {
-    let mut k = K.as_mm();
-    let mut b = k;
-    for _ in 0..ITERATIONS {
-        b = _mm512_aesenc_epi128(b, k);
-        k = _mm512_aesenclast_epi128(k, b);
-        b = _mm512_aesdec_epi128(b, k);
-        k = _mm512_aesdeclast_epi128(k, b);
-    }
-    assert!(EXPECTED_LOOP_K.is_eq(k));
-    assert!(EXPECTED_LOOP_B.is_eq(b));
 }
 
 /// Trait for casting between `u128/[u128; 2]/[u128; 4]` and `__m128/256/512i` types

--- a/tests/pass/shims/x86/intrinsics-x86-aes-vaes.rs
+++ b/tests/pass/shims/x86/intrinsics-x86-aes-vaes.rs
@@ -3,307 +3,243 @@
 //@compile-flags: -C target-feature=+aes,+vaes,+avx512f
 //@run-native
 
-use core::mem::transmute;
 #[cfg(target_arch = "x86")]
-use std::arch::x86::*;
+use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
-use std::arch::x86_64::*;
+use core::arch::x86_64::*;
 
 fn main() {
-    assert!(is_x86_feature_detected!("aes"));
+    if is_x86_feature_detected!("aes") {
+        unsafe {
+            test_aes_keygen();
+            test_aes();
+        }
 
-    unsafe {
-        test_aes();
-    }
+        if is_x86_feature_detected!("vaes") {
+            unsafe {
+                test_vaes256();
+            }
 
-    // The tests below require vaes, which is recent enough that contributors may be using CPUs that
-    // do not support it. But we still want to run this natively if the machine happens to have vaes.
-    // So we bail out dynamically.
-    if !is_x86_feature_detected!("vaes") {
-        println!("warning: skipping vaes tests");
-        return;
-    }
-
-    unsafe {
-        test_vaes();
+            if is_x86_feature_detected!("avx512f") {
+                unsafe {
+                    test_vaes512();
+                }
+            }
+        }
     }
 }
 
-// The constants in the tests below are just bit patterns. They should not
-// be interpreted as integers; signedness does not make sense for them, but
-// __m128i happens to be defined in terms of signed integers.
-#[allow(overflowing_literals)]
+macro_rules! hex {
+    ($($s:literal)*) => {{
+        const STRINGS: &[&'static [u8]] = &[$($s.as_bytes(),)*];
+        const {
+            hex_literal::decode::<{ hex_literal::len(STRINGS) }>(STRINGS)
+                .expect("Output array length should be correct")
+        }
+    }};
+}
+
+const START_K: [u8; 64] = hex!(
+    "000102030405060708090A0B0C0D0E0F"
+    "101112131415161718191A1B1C1D1E1F"
+    "202122232425262728292A2B2C2D2E2F"
+    "303132333435363738393A3B3C3D3E3F"
+);
+const EXPECTED_K: [u8; 64] = hex!(
+    "3E20891643D63F40AB9858F40DF473EB"
+    "34FAD322139140B611EC284682B04712"
+    "7234EC1DF69957C127300335BB1E1F3F"
+    "118378FC9B461ED7CC4BCE7342A23269"
+);
+const EXPECTED_B: [u8; 64] = hex!(
+    "BD12A330F63C66D9220E0A15AE34C1A3"
+    "55AE92B160B72676D796AB343539B3F6"
+    "BCE5B43E431A685CD7BDC0393D6C7FDD"
+    "41F0604A1F8F16027483C220A8BDDD1F"
+);
+const N: u64 = 1000;
+
+// Test `_mm_aeskeygenassist_si128` and `_mm_aesimc_si128`
 #[target_feature(enable = "aes")]
-unsafe fn test_aes() {
-    // Mostly copied from library/stdarch/crates/core_arch/src/x86/aes.rs
+fn test_aes_keygen() {
+    let k = hex!("000102030405060708090A0B0C0D0E0F");
+    let expected_k = hex!("B5A5445BB9DF01C715DF84737CC240F3");
 
-    #[target_feature(enable = "aes")]
-    unsafe fn test_mm_aesdec_si128() {
-        // Constants taken from https://msdn.microsoft.com/en-us/library/cc664949.aspx.
-        let a = _mm_set_epi64x(0x0123456789abcdef, 0x8899aabbccddeeff);
-        let k = _mm_set_epi64x(0x1133557799bbddff, 0x0022446688aaccee);
-        let e = _mm_set_epi64x(0x044e4f5176fec48f, 0xb57ecfa381da39ee);
-        let r = _mm_aesdec_si128(a, k);
-        assert_eq_m128i(r, e);
+    let mut k = k.as_mm();
+    for _ in 0..N {
+        k = _mm_aeskeygenassist_si128(k, 0x36);
+        let t = _mm_aesimc_si128(k);
+        // use `aesenc` to "randomize" `k`
+        k = _mm_aesenc_si128(k, t);
     }
-    test_mm_aesdec_si128();
-
-    #[target_feature(enable = "aes")]
-    unsafe fn test_mm_aesdeclast_si128() {
-        // Constants taken from https://msdn.microsoft.com/en-us/library/cc714178.aspx.
-        let a = _mm_set_epi64x(0x0123456789abcdef, 0x8899aabbccddeeff);
-        let k = _mm_set_epi64x(0x1133557799bbddff, 0x0022446688aaccee);
-        let e = _mm_set_epi64x(0x36cad57d9072bf9e, 0xf210dd981fa4a493);
-        let r = _mm_aesdeclast_si128(a, k);
-        assert_eq_m128i(r, e);
-    }
-    test_mm_aesdeclast_si128();
-
-    #[target_feature(enable = "aes")]
-    unsafe fn test_mm_aesenc_si128() {
-        // Constants taken from https://msdn.microsoft.com/en-us/library/cc664810.aspx.
-        let a = _mm_set_epi64x(0x0123456789abcdef, 0x8899aabbccddeeff);
-        let k = _mm_set_epi64x(0x1133557799bbddff, 0x0022446688aaccee);
-        let e = _mm_set_epi64x(0x16ab0e57dfc442ed, 0x28e4ee1884504333);
-        let r = _mm_aesenc_si128(a, k);
-        assert_eq_m128i(r, e);
-    }
-    test_mm_aesenc_si128();
-
-    #[target_feature(enable = "aes")]
-    unsafe fn test_mm_aesenclast_si128() {
-        // Constants taken from https://msdn.microsoft.com/en-us/library/cc714136.aspx.
-        let a = _mm_set_epi64x(0x0123456789abcdef, 0x8899aabbccddeeff);
-        let k = _mm_set_epi64x(0x1133557799bbddff, 0x0022446688aaccee);
-        let e = _mm_set_epi64x(0xb6dd7df25d7ab320, 0x4b04f98cf4c860f8);
-        let r = _mm_aesenclast_si128(a, k);
-        assert_eq_m128i(r, e);
-    }
-    test_mm_aesenclast_si128();
-
-    #[target_feature(enable = "aes")]
-    unsafe fn test_mm_aesimc_si128() {
-        // Constants taken from https://msdn.microsoft.com/en-us/library/cc714195.aspx.
-        let a = _mm_set_epi64x(0x0123456789abcdef, 0x8899aabbccddeeff);
-        let e = _mm_set_epi64x(0xc66c82284ee40aa0, 0x6633441122770055);
-        let r = _mm_aesimc_si128(a);
-        assert_eq_m128i(r, e);
-    }
-    test_mm_aesimc_si128();
-
-    #[target_feature(enable = "aes")]
-    unsafe fn test_mm_aeskeygenassist_si128() {
-        // Constants taken from https://msdn.microsoft.com/en-us/library/cc714195.aspx.
-        let a = _mm_set_epi64x(0x0123456789abcdef, 0x8899aabbccddeeff);
-        let e = _mm_set_epi64x(0x857c266b7c266e85, 0xeac4eea9c4eeacea);
-        let r = _mm_aeskeygenassist_si128(a, 5);
-        assert_eq_m128i(r, e);
-    }
-    test_mm_aeskeygenassist_si128();
+    assert!(expected_k.is_eq(k));
 }
 
-// The constants in the tests below are just bit patterns. They should not
-// be interpreted as integers; signedness does not make sense for them, but
-// __m128i happens to be defined in terms of signed integers.
-#[allow(overflowing_literals)]
+/// Test `_mm_aesenc_si128`, `_mm_aesenclast_si128`,
+/// `_mm_aesdec_si128`, and `_mm_aesdeclast_si128`
+#[target_feature(enable = "aes")]
+fn test_aes() {
+    let (ks, tail) = START_K.as_chunks::<16>();
+    assert!(tail.is_empty());
+    let (expected_ks, tail) = EXPECTED_K.as_chunks::<16>();
+    assert!(tail.is_empty());
+    let (expected_bs, tail) = EXPECTED_B.as_chunks::<16>();
+    assert!(tail.is_empty());
+
+    for i in 0..ks.len() {
+        let mut k = ks[i].as_mm();
+        let mut b = k;
+        for _ in 0..N {
+            b = _mm_aesenc_si128(b, k);
+            k = _mm_aesenclast_si128(k, b);
+            b = _mm_aesdec_si128(b, k);
+            k = _mm_aesdeclast_si128(k, b);
+        }
+        assert!(expected_ks[i].is_eq(k));
+        assert!(expected_bs[i].is_eq(b));
+    }
+}
+
+/// Test `_mm256aesenc_epi128`, `_mm256_aesenclast_epi128`,
+/// `_mm256_aesdec_epi128`, and `_mm256_aesdeclast_epi128`
 #[target_feature(enable = "vaes")]
-unsafe fn test_vaes() {
-    #[target_feature(enable = "avx")]
-    unsafe fn get_a256() -> __m256i {
-        // Constants are random
-        _mm256_set_epi64x(
-            0xb89f43a558d3cd51,
-            0x57b3e81e369bd603,
-            0xf177a1a626933fd6,
-            0x50d8adbed1a2f9d7,
-        )
-    }
-    #[target_feature(enable = "avx")]
-    unsafe fn get_k256() -> __m256i {
-        // Constants are random
-        _mm256_set_epi64x(
-            0x503ff704588b5627,
-            0xe23d882ed9c3c146,
-            0x2785e5b670155b3c,
-            0xa750718e183549ff,
-        )
-    }
+fn test_vaes256() {
+    let (ks, tail) = START_K.as_chunks::<32>();
+    assert!(tail.is_empty());
+    let (expected_ks, tail) = EXPECTED_K.as_chunks::<32>();
+    assert!(tail.is_empty());
+    let (expected_bs, tail) = EXPECTED_B.as_chunks::<32>();
+    assert!(tail.is_empty());
 
-    #[target_feature(enable = "vaes")]
-    unsafe fn test_mm256_aesdec_epi128() {
-        let a = get_a256();
-        let k = get_k256();
-        let r = _mm256_aesdec_epi128(a, k);
-
-        // Check results.
-        let a: [u128; 2] = transmute(a);
-        let k: [u128; 2] = transmute(k);
-        let r: [u128; 2] = transmute(r);
-        for i in 0..2 {
-            let e: u128 = transmute(_mm_aesdec_si128(transmute(a[i]), transmute(k[i])));
-            assert_eq!(r[i], e);
+    for i in 0..ks.len() {
+        let mut k = ks[i].as_mm();
+        let mut b = k;
+        for _ in 0..N {
+            b = _mm256_aesenc_epi128(b, k);
+            k = _mm256_aesenclast_epi128(k, b);
+            b = _mm256_aesdec_epi128(b, k);
+            k = _mm256_aesdeclast_epi128(k, b);
         }
+        assert!(expected_ks[i].is_eq(k));
+        assert!(expected_bs[i].is_eq(b));
     }
-    test_mm256_aesdec_epi128();
-
-    #[target_feature(enable = "vaes")]
-    unsafe fn test_mm256_aesdeclast_epi128() {
-        let a = get_a256();
-        let k = get_k256();
-        let r = _mm256_aesdeclast_epi128(a, k);
-
-        // Check results.
-        let a: [u128; 2] = transmute(a);
-        let k: [u128; 2] = transmute(k);
-        let r: [u128; 2] = transmute(r);
-        for i in 0..2 {
-            let e: u128 = transmute(_mm_aesdeclast_si128(transmute(a[i]), transmute(k[i])));
-            assert_eq!(r[i], e);
-        }
-    }
-    test_mm256_aesdeclast_epi128();
-
-    #[target_feature(enable = "vaes")]
-    unsafe fn test_mm256_aesenc_epi128() {
-        let a = get_a256();
-        let k = get_k256();
-        let r = _mm256_aesenc_epi128(a, k);
-
-        // Check results.
-        let a: [u128; 2] = transmute(a);
-        let k: [u128; 2] = transmute(k);
-        let r: [u128; 2] = transmute(r);
-        for i in 0..2 {
-            let e: u128 = transmute(_mm_aesenc_si128(transmute(a[i]), transmute(k[i])));
-            assert_eq!(r[i], e);
-        }
-    }
-    test_mm256_aesenc_epi128();
-
-    #[target_feature(enable = "vaes")]
-    unsafe fn test_mm256_aesenclast_epi128() {
-        let a = get_a256();
-        let k = get_k256();
-        let r = _mm256_aesenclast_epi128(a, k);
-
-        // Check results.
-        let a: [u128; 2] = transmute(a);
-        let k: [u128; 2] = transmute(k);
-        let r: [u128; 2] = transmute(r);
-        for i in 0..2 {
-            let e: u128 = transmute(_mm_aesenclast_si128(transmute(a[i]), transmute(k[i])));
-            assert_eq!(r[i], e);
-        }
-    }
-    test_mm256_aesenclast_epi128();
-
-    // The tests below require avx512. GH runners don't have this, but we still want to run this
-    // natively if the machine happens to have AVX512. So we bail out dynamically.
-    if !is_x86_feature_detected!("avx512f") {
-        println!("warning: skipping avx512 tests");
-        return;
-    }
-
-    #[target_feature(enable = "avx512f")]
-    unsafe fn get_a512() -> __m512i {
-        // Constants are random
-        _mm512_set_epi64(
-            0xb89f43a558d3cd51,
-            0x57b3e81e369bd603,
-            0xf177a1a626933fd6,
-            0x50d8adbed1a2f9d7,
-            0xfbfee3116629db78,
-            0x6aef4a91f2ad50f4,
-            0x4258bb51ff1d476d,
-            0x31da65761c8016cf,
-        )
-    }
-    #[target_feature(enable = "avx512f")]
-    unsafe fn get_k512() -> __m512i {
-        // Constants are random
-        _mm512_set_epi64(
-            0x503ff704588b5627,
-            0xe23d882ed9c3c146,
-            0x2785e5b670155b3c,
-            0xa750718e183549ff,
-            0xdfb408830a65d3d9,
-            0x0de3d92adac81b0a,
-            0xed2741fe12877cae,
-            0x3251ddb5404e0974,
-        )
-    }
-
-    #[target_feature(enable = "vaes,avx512f")]
-    unsafe fn test_mm512_aesdec_epi128() {
-        let a = get_a512();
-        let k = get_k512();
-        let r = _mm512_aesdec_epi128(a, k);
-
-        // Check results.
-        let a: [u128; 4] = transmute(a);
-        let k: [u128; 4] = transmute(k);
-        let r: [u128; 4] = transmute(r);
-        for i in 0..4 {
-            let e: u128 = transmute(_mm_aesdec_si128(transmute(a[i]), transmute(k[i])));
-            assert_eq!(r[i], e);
-        }
-    }
-    test_mm512_aesdec_epi128();
-
-    #[target_feature(enable = "vaes,avx512f")]
-    unsafe fn test_mm512_aesdeclast_epi128() {
-        let a = get_a512();
-        let k = get_k512();
-        let r = _mm512_aesdeclast_epi128(a, k);
-
-        // Check results.
-        let a: [u128; 4] = transmute(a);
-        let k: [u128; 4] = transmute(k);
-        let r: [u128; 4] = transmute(r);
-        for i in 0..4 {
-            let e: u128 = transmute(_mm_aesdeclast_si128(transmute(a[i]), transmute(k[i])));
-            assert_eq!(r[i], e);
-        }
-    }
-    test_mm512_aesdeclast_epi128();
-
-    #[target_feature(enable = "vaes,avx512f")]
-    unsafe fn test_mm512_aesenc_epi128() {
-        let a = get_a512();
-        let k = get_k512();
-        let r = _mm512_aesenc_epi128(a, k);
-
-        // Check results.
-        let a: [u128; 4] = transmute(a);
-        let k: [u128; 4] = transmute(k);
-        let r: [u128; 4] = transmute(r);
-        for i in 0..4 {
-            let e: u128 = transmute(_mm_aesenc_si128(transmute(a[i]), transmute(k[i])));
-            assert_eq!(r[i], e);
-        }
-    }
-    test_mm512_aesenc_epi128();
-
-    #[target_feature(enable = "vaes,avx512f")]
-    unsafe fn test_mm512_aesenclast_epi128() {
-        let a = get_a512();
-        let k = get_k512();
-        let r = _mm512_aesenclast_epi128(a, k);
-
-        // Check results.
-        let a: [u128; 4] = transmute(a);
-        let k: [u128; 4] = transmute(k);
-        let r: [u128; 4] = transmute(r);
-        for i in 0..4 {
-            let e: u128 = transmute(_mm_aesenclast_si128(transmute(a[i]), transmute(k[i])));
-            assert_eq!(r[i], e);
-        }
-    }
-    test_mm512_aesenclast_epi128();
 }
 
-#[track_caller]
-#[target_feature(enable = "sse2")]
-unsafe fn assert_eq_m128i(a: __m128i, b: __m128i) {
-    assert_eq!(transmute::<_, [u64; 2]>(a), transmute::<_, [u64; 2]>(b))
+/// Test `_mm512aesenc_epi128`, `_mm512_aesenclast_epi128`,
+/// `_mm512_aesdec_epi128`, and `_mm512_aesdeclast_epi128`
+#[target_feature(enable = "avx512f,vaes")]
+fn test_vaes512() {
+    let mut k = START_K.as_mm();
+    let mut b = k;
+    for _ in 0..N {
+        b = _mm512_aesenc_epi128(b, k);
+        k = _mm512_aesenclast_epi128(k, b);
+        b = _mm512_aesdec_epi128(b, k);
+        k = _mm512_aesdeclast_epi128(k, b);
+    }
+    assert!(EXPECTED_K.is_eq(k));
+    assert!(EXPECTED_B.is_eq(b));
+}
+
+/// Trait for casting between `[u8; 16/32/64]` and `__m128/256/512i` types
+///
+/// # Safety
+/// The trait must not be implemented for any other type pairs.
+unsafe trait AsMm: Sized + core::cmp::Eq {
+    type Mm;
+
+    fn as_mm(&self) -> Self::Mm {
+        unsafe { core::mem::transmute_copy(self) }
+    }
+
+    fn is_eq(&self, v: Self::Mm) -> bool {
+        let r: Self = unsafe { core::mem::transmute_copy(&v) };
+        self.eq(&r)
+    }
+}
+
+unsafe impl AsMm for [u8; 16] {
+    type Mm = __m128i;
+}
+
+unsafe impl AsMm for [u8; 32] {
+    type Mm = __m256i;
+}
+
+unsafe impl AsMm for [u8; 64] {
+    type Mm = __m512i;
+}
+
+// Vendored from the `hex-literal` crate
+mod hex_literal {
+    const fn next_hex_char(string: &[u8], mut pos: usize) -> Option<(u8, usize)> {
+        while pos < string.len() {
+            let raw_val = string[pos];
+            pos += 1;
+            let val = match raw_val {
+                b'0'..=b'9' => raw_val - 48,
+                b'A'..=b'F' => raw_val - 55,
+                b'a'..=b'f' => raw_val - 87,
+                b' ' | b':' | b'\r' | b'\n' | b'\t' => continue,
+                0..=127 => panic!("Encountered invalid ASCII character"),
+                _ => panic!("Encountered non-ASCII character"),
+            };
+            return Some((val, pos));
+        }
+        None
+    }
+
+    const fn next_byte(string: &[u8], pos: usize) -> Option<(u8, usize)> {
+        let (half1, pos) = match next_hex_char(string, pos) {
+            Some(v) => v,
+            None => return None,
+        };
+        let (half2, pos) = match next_hex_char(string, pos) {
+            Some(v) => v,
+            None => panic!("Odd number of hex characters"),
+        };
+        Some(((half1 << 4) + half2, pos))
+    }
+
+    /// Compute length of a byte array which will be decoded from the strings.
+    ///
+    /// This function is an implementation detail and SHOULD NOT be called directly!
+    #[doc(hidden)]
+    #[must_use]
+    pub const fn len(strings: &[&[u8]]) -> usize {
+        let mut i = 0;
+        let mut len = 0;
+        while i < strings.len() {
+            let mut pos = 0;
+            while let Some((_, new_pos)) = next_byte(strings[i], pos) {
+                len += 1;
+                pos = new_pos;
+            }
+            i += 1;
+        }
+        len
+    }
+
+    /// Decode hex strings into a byte array of pre-computed length.
+    ///
+    /// This function is an implementation detail and SHOULD NOT be called directly!
+    #[doc(hidden)]
+    #[must_use]
+    pub const fn decode<const LEN: usize>(strings: &[&[u8]]) -> Option<[u8; LEN]> {
+        let mut string_pos = 0;
+        let mut buf = [0u8; LEN];
+        let mut buf_pos = 0;
+        while string_pos < strings.len() {
+            let mut pos = 0;
+            let string = &strings[string_pos];
+            string_pos += 1;
+
+            while let Some((byte, new_pos)) = next_byte(string, pos) {
+                buf[buf_pos] = byte;
+                buf_pos += 1;
+                pos = new_pos;
+            }
+        }
+        if LEN == buf_pos { Some(buf) } else { None }
+    }
 }

--- a/tests/pass/shims/x86/intrinsics-x86-aes-vaes.rs
+++ b/tests/pass/shims/x86/intrinsics-x86-aes-vaes.rs
@@ -12,18 +12,36 @@ fn main() {
     // Bail out dynamically if target feature is not supported
     if is_x86_feature_detected!("aes") {
         unsafe {
-            test_aes_keygen();
-            test_aes();
+            test_aesimc();
+            test_aeskeygenassist();
+
+            test_aesenc();
+            test_aesenclast();
+            test_aesdec();
+            test_aesdeclast();
+
+            loop_test_aes_keygen();
+            loop_test_aes();
         }
 
         if is_x86_feature_detected!("vaes") {
             unsafe {
-                test_vaes256();
+                test_aesenc256();
+                test_aesenclast256();
+                test_aesdec256();
+                test_aesdeclast256();
+
+                loop_test_vaes256();
             }
 
             if is_x86_feature_detected!("avx512f") {
                 unsafe {
-                    test_vaes512();
+                    test_aesenc512();
+                    test_aesenclast512();
+                    test_aesdec512();
+                    test_aesdeclast512();
+
+                    loop_test_vaes512();
                 }
             } else {
                 println!("warning: skipping VAES+AVX-512 tests");
@@ -36,30 +54,131 @@ fn main() {
     }
 }
 
-const START_K: [u128; 4] = [
+// Initial value of `k` used in tests
+const K: [u128; 4] = [
     0x000102030405060708090A0B0C0D0E0F,
     0x101112131415161718191A1B1C1D1E1F,
     0x202122232425262728292A2B2C2D2E2F,
     0x303132333435363738393A3B3C3D3E3F,
 ];
-const EXPECTED_K: [u128; 4] = [
+// Initial value of `b` used in tests
+const B: [u128; 4] = [
+    0x404142434445464748494A4B4C4D4E4F,
+    0x505152535455565758595A5B5C5D5E5F,
+    0x606162636465666768696A6B6C6D6E6F,
+    0x707172737475767778797A7B7C7D7E7F,
+];
+
+// Expected values after applying `aesimc` to `K`
+const EXPECTED_AESIMC: [u128; 4] = [
+    0x0E0B0C090A0F080D0603040102070005,
+    0x1E1B1C191A1F181D1613141112171015,
+    0x2E2B2C292A2F282D2623242122272025,
+    0x3E3B3C393A3F383D3633343132373035,
+];
+// Expected values after applying `aeskeygenassist` to `K` with `rcon` equal to 0x36
+const EXPECTED_AESKEYGENASSIST: [u128; 4] = [
+    0x7B637C41637C777B2B3001513001672B,
+    0x7DCA82FFCA82C97DAFADD494ADD4A2AF,
+    0x26B7FDA5B7FD9326F134A5D334A5E5F1,
+    0xC304C71504C723C3E20712B6071280E2,
+];
+// Expected values after applying `aesenc` to `B` and `K`
+const EXPECTED_AESENC: [u128; 4] = [
+    0x0C6F106694A292994D86BA323198861A,
+    0xEF4929D16168F387A7F6783AB27AFAEC,
+    0xD669AFCEACBDEDAAD550493F3B7685FF,
+    0xC097131CECBAE545E04D8582B4E7AE39,
+];
+// Expected values after applying `aesenclast` to `B` and `K`
+const EXPECTED_AESENCLAST: [u128; 4] = [
+    0x1B3A2D1956E62AA7218A50B80563D88B,
+    0x30DA4AFE7E59164C52C8AB224FE1A0D0,
+    0x63D8BDD861198CA278C61954FC602C87,
+    0xA287C1BC88CA76C2289A021A6DA0E4ED,
+];
+// Expected values after applying `aesdec` to `B` and `K`
+const EXPECTED_AESDEC: [u128; 4] = [
+    0x3B4CF684851A13D1FEF9C4C79E8115D2,
+    0x8FC125301FBECD1178BD94161F98F50D,
+    0xDF5BB3B842D66A8F10B4F343DE4E5721,
+    0x4B1C1B62454ED2A55A44C6B75C118C4A,
+];
+// Expected values after applying `aesdeclast` to `B` and `K`
+const EXPECTED_AESDECLAST: [u128; 4] = [
+    0x5DA59A6776605A118EF1BCC7D865F89D,
+    0xB704AB43789850CDE569874C42F0569B,
+    0x98C5F123B4967E2DA4F16F2EDB918529,
+    0x319E3DBCE4268B35F215B038FD022054,
+];
+// Expected value of `k` in loop tests
+const EXPECTED_LOOP_K: [u128; 4] = [
     0xD21928B8DEB8D0565C1FB92B010E2363,
     0x8D2E2F5521147125F8E24489EA0D8D97,
     0xEE26FC76F1CC0D3D849AAF838A16117B,
     0xA4C8122B4F6C00362E3692B1B7854BF7,
 ];
-const EXPECTED_B: [u128; 4] = [
+// Expected value of `b` in loop tests
+const EXPECTED_LOOP_B: [u128; 4] = [
     0xE74F19EFD8C28BFE3BD285175F3F68FF,
     0xCE70940A752A6E0A23AD14E31C033BBF,
     0xE224ED621B046A2D337BB2EC5020424E,
     0xE617A20C71EC216CF6DE4FF8EDB763B0,
 ];
+/// Number of iternations used in loop tests
 const ITERATIONS: u64 = 128;
 
-// Test `_mm_aeskeygenassist_si128` and `_mm_aesimc_si128`
 #[target_feature(enable = "aes")]
-fn test_aes_keygen() {
-    let k = 0x000102030405060708090A0B0C0D0E0F;
+fn test_aesimc() {
+    for i in 0..4 {
+        let r = _mm_aesimc_si128(K[i].as_mm());
+        assert!(EXPECTED_AESIMC[i].is_eq(r));
+    }
+}
+
+#[target_feature(enable = "aes")]
+fn test_aeskeygenassist() {
+    for i in 0..4 {
+        let r = _mm_aeskeygenassist_si128(K[i].as_mm(), 0x36);
+        assert!(EXPECTED_AESKEYGENASSIST[i].is_eq(r));
+    }
+}
+
+#[target_feature(enable = "aes")]
+fn test_aesenc() {
+    for i in 0..4 {
+        let r = _mm_aesenc_si128(B[i].as_mm(), K[i].as_mm());
+        assert!(EXPECTED_AESENC[i].is_eq(r));
+    }
+}
+
+#[target_feature(enable = "aes")]
+fn test_aesenclast() {
+    for i in 0..4 {
+        let r = _mm_aesenclast_si128(B[i].as_mm(), K[i].as_mm());
+        assert!(EXPECTED_AESENCLAST[i].is_eq(r));
+    }
+}
+
+#[target_feature(enable = "aes")]
+fn test_aesdec() {
+    for i in 0..4 {
+        let r = _mm_aesdec_si128(B[i].as_mm(), K[i].as_mm());
+        assert!(EXPECTED_AESDEC[i].is_eq(r));
+    }
+}
+
+#[target_feature(enable = "aes")]
+fn test_aesdeclast() {
+    for i in 0..4 {
+        let r = _mm_aesdeclast_si128(B[i].as_mm(), K[i].as_mm());
+        assert!(EXPECTED_AESDECLAST[i].is_eq(r));
+    }
+}
+
+#[target_feature(enable = "aes")]
+fn loop_test_aes_keygen() {
+    let k = K[0];
     let expected_k = 0x8DD2144D60F310A85C3487481DDC6789;
 
     let mut k = k.as_mm();
@@ -73,12 +192,10 @@ fn test_aes_keygen() {
     assert!(expected_k.is_eq(k));
 }
 
-/// Test `_mm_aesenc_si128`, `_mm_aesenclast_si128`,
-/// `_mm_aesdec_si128`, and `_mm_aesdeclast_si128`
 #[target_feature(enable = "aes")]
-fn test_aes() {
+fn loop_test_aes() {
     for i in 0..4 {
-        let mut k = START_K[i].as_mm();
+        let mut k = K[i].as_mm();
         let mut b = k;
         for _ in 0..ITERATIONS {
             b = _mm_aesenc_si128(b, k);
@@ -86,20 +203,62 @@ fn test_aes() {
             b = _mm_aesdec_si128(b, k);
             k = _mm_aesdeclast_si128(k, b);
         }
-        assert!(EXPECTED_K[i].is_eq(k));
-        assert!(EXPECTED_B[i].is_eq(b));
+        assert!(EXPECTED_LOOP_K[i].is_eq(k));
+        assert!(EXPECTED_LOOP_B[i].is_eq(b));
     }
 }
 
-/// Test `_mm256aesenc_epi128`, `_mm256_aesenclast_epi128`,
-/// `_mm256_aesdec_epi128`, and `_mm256_aesdeclast_epi128`
 #[target_feature(enable = "vaes")]
-fn test_vaes256() {
-    let (ks, tail) = START_K.as_chunks::<2>();
+fn test_aesenc256() {
+    let (b, _) = B.as_chunks::<2>();
+    let (k, _) = K.as_chunks::<2>();
+    let (e, _) = EXPECTED_AESENC.as_chunks::<2>();
+    for i in 0..2 {
+        let r = _mm256_aesenc_epi128(b[i].as_mm(), k[i].as_mm());
+        assert!(e[i].is_eq(r));
+    }
+}
+
+#[target_feature(enable = "vaes")]
+fn test_aesenclast256() {
+    let (b, _) = B.as_chunks::<2>();
+    let (k, _) = K.as_chunks::<2>();
+    let (e, _) = EXPECTED_AESENCLAST.as_chunks::<2>();
+    for i in 0..2 {
+        let r = _mm256_aesenclast_epi128(b[i].as_mm(), k[i].as_mm());
+        assert!(e[i].is_eq(r));
+    }
+}
+
+#[target_feature(enable = "vaes")]
+fn test_aesdec256() {
+    let (b, _) = B.as_chunks::<2>();
+    let (k, _) = K.as_chunks::<2>();
+    let (e, _) = EXPECTED_AESDEC.as_chunks::<2>();
+    for i in 0..2 {
+        let r = _mm256_aesdec_epi128(b[i].as_mm(), k[i].as_mm());
+        assert!(e[i].is_eq(r));
+    }
+}
+
+#[target_feature(enable = "vaes")]
+fn test_aesdeclast256() {
+    let (b, _) = B.as_chunks::<2>();
+    let (k, _) = K.as_chunks::<2>();
+    let (e, _) = EXPECTED_AESDECLAST.as_chunks::<2>();
+    for i in 0..2 {
+        let r = _mm256_aesdeclast_epi128(b[i].as_mm(), k[i].as_mm());
+        assert!(e[i].is_eq(r));
+    }
+}
+
+#[target_feature(enable = "vaes")]
+fn loop_test_vaes256() {
+    let (ks, tail) = K.as_chunks::<2>();
     assert!(tail.is_empty());
-    let (expected_ks, tail) = EXPECTED_K.as_chunks::<2>();
+    let (expected_ks, tail) = EXPECTED_LOOP_K.as_chunks::<2>();
     assert!(tail.is_empty());
-    let (expected_bs, tail) = EXPECTED_B.as_chunks::<2>();
+    let (expected_bs, tail) = EXPECTED_LOOP_B.as_chunks::<2>();
     assert!(tail.is_empty());
 
     for i in 0..2 {
@@ -116,11 +275,33 @@ fn test_vaes256() {
     }
 }
 
-/// Test `_mm512aesenc_epi128`, `_mm512_aesenclast_epi128`,
-/// `_mm512_aesdec_epi128`, and `_mm512_aesdeclast_epi128`
 #[target_feature(enable = "avx512f,vaes")]
-fn test_vaes512() {
-    let mut k = START_K.as_mm();
+fn test_aesenc512() {
+    let r = _mm512_aesenc_epi128(B.as_mm(), K.as_mm());
+    assert!(EXPECTED_AESENC.is_eq(r));
+}
+
+#[target_feature(enable = "avx512f,vaes")]
+fn test_aesenclast512() {
+    let r = _mm512_aesenclast_epi128(B.as_mm(), K.as_mm());
+    assert!(EXPECTED_AESENCLAST.is_eq(r));
+}
+
+#[target_feature(enable = "avx512f,vaes")]
+fn test_aesdec512() {
+    let r = _mm512_aesdec_epi128(B.as_mm(), K.as_mm());
+    assert!(EXPECTED_AESDEC.is_eq(r));
+}
+
+#[target_feature(enable = "avx512f,vaes")]
+fn test_aesdeclast512() {
+    let r = _mm512_aesdeclast_epi128(B.as_mm(), K.as_mm());
+    assert!(EXPECTED_AESDECLAST.is_eq(r));
+}
+
+#[target_feature(enable = "avx512f,vaes")]
+fn loop_test_vaes512() {
+    let mut k = K.as_mm();
     let mut b = k;
     for _ in 0..ITERATIONS {
         b = _mm512_aesenc_epi128(b, k);
@@ -128,8 +309,8 @@ fn test_vaes512() {
         b = _mm512_aesdec_epi128(b, k);
         k = _mm512_aesdeclast_epi128(k, b);
     }
-    assert!(EXPECTED_K.is_eq(k));
-    assert!(EXPECTED_B.is_eq(b));
+    assert!(EXPECTED_LOOP_K.is_eq(k));
+    assert!(EXPECTED_LOOP_B.is_eq(b));
 }
 
 /// Trait for casting between `u128/[u128; 2]/[u128; 4]` and `__m128/256/512i` types

--- a/tests/pass/shims/x86/intrinsics-x86-aes-vaes.rs
+++ b/tests/pass/shims/x86/intrinsics-x86-aes-vaes.rs
@@ -9,6 +9,7 @@ use core::arch::x86::*;
 use core::arch::x86_64::*;
 
 fn main() {
+    // Bail out dynamically if target feature is not supported
     if is_x86_feature_detected!("aes") {
         unsafe {
             test_aes_keygen();
@@ -24,54 +25,51 @@ fn main() {
                 unsafe {
                     test_vaes512();
                 }
+            } else {
+                println!("warning: skipping VAES+AVX-512 tests");
             }
+        } else {
+            println!("warning: skipping VAES tests");
         }
+    } else {
+        println!("warning: skipping AES tests");
     }
 }
 
-macro_rules! hex {
-    ($($s:literal)*) => {{
-        const STRINGS: &[&'static [u8]] = &[$($s.as_bytes(),)*];
-        const {
-            hex_literal::decode::<{ hex_literal::len(STRINGS) }>(STRINGS)
-                .expect("Output array length should be correct")
-        }
-    }};
-}
-
-const START_K: [u8; 64] = hex!(
-    "000102030405060708090A0B0C0D0E0F"
-    "101112131415161718191A1B1C1D1E1F"
-    "202122232425262728292A2B2C2D2E2F"
-    "303132333435363738393A3B3C3D3E3F"
-);
-const EXPECTED_K: [u8; 64] = hex!(
-    "3E20891643D63F40AB9858F40DF473EB"
-    "34FAD322139140B611EC284682B04712"
-    "7234EC1DF69957C127300335BB1E1F3F"
-    "118378FC9B461ED7CC4BCE7342A23269"
-);
-const EXPECTED_B: [u8; 64] = hex!(
-    "BD12A330F63C66D9220E0A15AE34C1A3"
-    "55AE92B160B72676D796AB343539B3F6"
-    "BCE5B43E431A685CD7BDC0393D6C7FDD"
-    "41F0604A1F8F16027483C220A8BDDD1F"
-);
-const N: u64 = 1000;
+const START_K: [u128; 4] = [
+    0x000102030405060708090A0B0C0D0E0F,
+    0x101112131415161718191A1B1C1D1E1F,
+    0x202122232425262728292A2B2C2D2E2F,
+    0x303132333435363738393A3B3C3D3E3F,
+];
+const EXPECTED_K: [u128; 4] = [
+    0xD21928B8DEB8D0565C1FB92B010E2363,
+    0x8D2E2F5521147125F8E24489EA0D8D97,
+    0xEE26FC76F1CC0D3D849AAF838A16117B,
+    0xA4C8122B4F6C00362E3692B1B7854BF7,
+];
+const EXPECTED_B: [u128; 4] = [
+    0xE74F19EFD8C28BFE3BD285175F3F68FF,
+    0xCE70940A752A6E0A23AD14E31C033BBF,
+    0xE224ED621B046A2D337BB2EC5020424E,
+    0xE617A20C71EC216CF6DE4FF8EDB763B0,
+];
+const ITERATIONS: u64 = 128;
 
 // Test `_mm_aeskeygenassist_si128` and `_mm_aesimc_si128`
 #[target_feature(enable = "aes")]
 fn test_aes_keygen() {
-    let k = hex!("000102030405060708090A0B0C0D0E0F");
-    let expected_k = hex!("B5A5445BB9DF01C715DF84737CC240F3");
+    let k = 0x000102030405060708090A0B0C0D0E0F;
+    let expected_k = 0x8DD2144D60F310A85C3487481DDC6789;
 
     let mut k = k.as_mm();
-    for _ in 0..N {
+    for _ in 0..ITERATIONS {
         k = _mm_aeskeygenassist_si128(k, 0x36);
         let t = _mm_aesimc_si128(k);
         // use `aesenc` to "randomize" `k`
         k = _mm_aesenc_si128(k, t);
     }
+
     assert!(expected_k.is_eq(k));
 }
 
@@ -79,24 +77,17 @@ fn test_aes_keygen() {
 /// `_mm_aesdec_si128`, and `_mm_aesdeclast_si128`
 #[target_feature(enable = "aes")]
 fn test_aes() {
-    let (ks, tail) = START_K.as_chunks::<16>();
-    assert!(tail.is_empty());
-    let (expected_ks, tail) = EXPECTED_K.as_chunks::<16>();
-    assert!(tail.is_empty());
-    let (expected_bs, tail) = EXPECTED_B.as_chunks::<16>();
-    assert!(tail.is_empty());
-
-    for i in 0..ks.len() {
-        let mut k = ks[i].as_mm();
+    for i in 0..4 {
+        let mut k = START_K[i].as_mm();
         let mut b = k;
-        for _ in 0..N {
+        for _ in 0..ITERATIONS {
             b = _mm_aesenc_si128(b, k);
             k = _mm_aesenclast_si128(k, b);
             b = _mm_aesdec_si128(b, k);
             k = _mm_aesdeclast_si128(k, b);
         }
-        assert!(expected_ks[i].is_eq(k));
-        assert!(expected_bs[i].is_eq(b));
+        assert!(EXPECTED_K[i].is_eq(k));
+        assert!(EXPECTED_B[i].is_eq(b));
     }
 }
 
@@ -104,17 +95,17 @@ fn test_aes() {
 /// `_mm256_aesdec_epi128`, and `_mm256_aesdeclast_epi128`
 #[target_feature(enable = "vaes")]
 fn test_vaes256() {
-    let (ks, tail) = START_K.as_chunks::<32>();
+    let (ks, tail) = START_K.as_chunks::<2>();
     assert!(tail.is_empty());
-    let (expected_ks, tail) = EXPECTED_K.as_chunks::<32>();
+    let (expected_ks, tail) = EXPECTED_K.as_chunks::<2>();
     assert!(tail.is_empty());
-    let (expected_bs, tail) = EXPECTED_B.as_chunks::<32>();
+    let (expected_bs, tail) = EXPECTED_B.as_chunks::<2>();
     assert!(tail.is_empty());
 
-    for i in 0..ks.len() {
+    for i in 0..2 {
         let mut k = ks[i].as_mm();
         let mut b = k;
-        for _ in 0..N {
+        for _ in 0..ITERATIONS {
             b = _mm256_aesenc_epi128(b, k);
             k = _mm256_aesenclast_epi128(k, b);
             b = _mm256_aesdec_epi128(b, k);
@@ -131,7 +122,7 @@ fn test_vaes256() {
 fn test_vaes512() {
     let mut k = START_K.as_mm();
     let mut b = k;
-    for _ in 0..N {
+    for _ in 0..ITERATIONS {
         b = _mm512_aesenc_epi128(b, k);
         k = _mm512_aesenclast_epi128(k, b);
         b = _mm512_aesdec_epi128(b, k);
@@ -141,7 +132,7 @@ fn test_vaes512() {
     assert!(EXPECTED_B.is_eq(b));
 }
 
-/// Trait for casting between `[u8; 16/32/64]` and `__m128/256/512i` types
+/// Trait for casting between `u128/[u128; 2]/[u128; 4]` and `__m128/256/512i` types
 ///
 /// # Safety
 /// The trait must not be implemented for any other type pairs.
@@ -158,88 +149,14 @@ unsafe trait AsMm: Sized + core::cmp::Eq {
     }
 }
 
-unsafe impl AsMm for [u8; 16] {
+unsafe impl AsMm for u128 {
     type Mm = __m128i;
 }
 
-unsafe impl AsMm for [u8; 32] {
+unsafe impl AsMm for [u128; 2] {
     type Mm = __m256i;
 }
 
-unsafe impl AsMm for [u8; 64] {
+unsafe impl AsMm for [u128; 4] {
     type Mm = __m512i;
-}
-
-// Vendored from the `hex-literal` crate
-mod hex_literal {
-    const fn next_hex_char(string: &[u8], mut pos: usize) -> Option<(u8, usize)> {
-        while pos < string.len() {
-            let raw_val = string[pos];
-            pos += 1;
-            let val = match raw_val {
-                b'0'..=b'9' => raw_val - 48,
-                b'A'..=b'F' => raw_val - 55,
-                b'a'..=b'f' => raw_val - 87,
-                b' ' | b':' | b'\r' | b'\n' | b'\t' => continue,
-                0..=127 => panic!("Encountered invalid ASCII character"),
-                _ => panic!("Encountered non-ASCII character"),
-            };
-            return Some((val, pos));
-        }
-        None
-    }
-
-    const fn next_byte(string: &[u8], pos: usize) -> Option<(u8, usize)> {
-        let (half1, pos) = match next_hex_char(string, pos) {
-            Some(v) => v,
-            None => return None,
-        };
-        let (half2, pos) = match next_hex_char(string, pos) {
-            Some(v) => v,
-            None => panic!("Odd number of hex characters"),
-        };
-        Some(((half1 << 4) + half2, pos))
-    }
-
-    /// Compute length of a byte array which will be decoded from the strings.
-    ///
-    /// This function is an implementation detail and SHOULD NOT be called directly!
-    #[doc(hidden)]
-    #[must_use]
-    pub const fn len(strings: &[&[u8]]) -> usize {
-        let mut i = 0;
-        let mut len = 0;
-        while i < strings.len() {
-            let mut pos = 0;
-            while let Some((_, new_pos)) = next_byte(strings[i], pos) {
-                len += 1;
-                pos = new_pos;
-            }
-            i += 1;
-        }
-        len
-    }
-
-    /// Decode hex strings into a byte array of pre-computed length.
-    ///
-    /// This function is an implementation detail and SHOULD NOT be called directly!
-    #[doc(hidden)]
-    #[must_use]
-    pub const fn decode<const LEN: usize>(strings: &[&[u8]]) -> Option<[u8; LEN]> {
-        let mut string_pos = 0;
-        let mut buf = [0u8; LEN];
-        let mut buf_pos = 0;
-        while string_pos < strings.len() {
-            let mut pos = 0;
-            let string = &strings[string_pos];
-            string_pos += 1;
-
-            while let Some((byte, new_pos)) = next_byte(string, pos) {
-                buf[buf_pos] = byte;
-                buf_pos += 1;
-                pos = new_pos;
-            }
-        }
-        if LEN == buf_pos { Some(buf) } else { None }
-    }
 }

--- a/tests/pass/shims/x86/intrinsics-x86-aes-vaes.rs
+++ b/tests/pass/shims/x86/intrinsics-x86-aes-vaes.rs
@@ -54,15 +54,18 @@ fn main() {
     }
 }
 
+/// Number of 128 bit values in test vectors.
+const N: usize = 4;
+
 // Initial value of `k` used in tests
-const K: [u128; 4] = [
+const K: [u128; N] = [
     0x000102030405060708090A0B0C0D0E0F,
     0x101112131415161718191A1B1C1D1E1F,
     0x202122232425262728292A2B2C2D2E2F,
     0x303132333435363738393A3B3C3D3E3F,
 ];
 // Initial value of `b` used in tests
-const B: [u128; 4] = [
+const B: [u128; N] = [
     0x404142434445464748494A4B4C4D4E4F,
     0x505152535455565758595A5B5C5D5E5F,
     0x606162636465666768696A6B6C6D6E6F,
@@ -70,56 +73,56 @@ const B: [u128; 4] = [
 ];
 
 // Expected values after applying `aesimc` to `K`
-const EXPECTED_AESIMC: [u128; 4] = [
+const EXPECTED_AESIMC: [u128; N] = [
     0x0E0B0C090A0F080D0603040102070005,
     0x1E1B1C191A1F181D1613141112171015,
     0x2E2B2C292A2F282D2623242122272025,
     0x3E3B3C393A3F383D3633343132373035,
 ];
 // Expected values after applying `aeskeygenassist` to `K` with `rcon` equal to 0x36
-const EXPECTED_AESKEYGENASSIST: [u128; 4] = [
+const EXPECTED_AESKEYGENASSIST: [u128; N] = [
     0x7B637C41637C777B2B3001513001672B,
     0x7DCA82FFCA82C97DAFADD494ADD4A2AF,
     0x26B7FDA5B7FD9326F134A5D334A5E5F1,
     0xC304C71504C723C3E20712B6071280E2,
 ];
 // Expected values after applying `aesenc` to `B` and `K`
-const EXPECTED_AESENC: [u128; 4] = [
+const EXPECTED_AESENC: [u128; N] = [
     0x0C6F106694A292994D86BA323198861A,
     0xEF4929D16168F387A7F6783AB27AFAEC,
     0xD669AFCEACBDEDAAD550493F3B7685FF,
     0xC097131CECBAE545E04D8582B4E7AE39,
 ];
 // Expected values after applying `aesenclast` to `B` and `K`
-const EXPECTED_AESENCLAST: [u128; 4] = [
+const EXPECTED_AESENCLAST: [u128; N] = [
     0x1B3A2D1956E62AA7218A50B80563D88B,
     0x30DA4AFE7E59164C52C8AB224FE1A0D0,
     0x63D8BDD861198CA278C61954FC602C87,
     0xA287C1BC88CA76C2289A021A6DA0E4ED,
 ];
 // Expected values after applying `aesdec` to `B` and `K`
-const EXPECTED_AESDEC: [u128; 4] = [
+const EXPECTED_AESDEC: [u128; N] = [
     0x3B4CF684851A13D1FEF9C4C79E8115D2,
     0x8FC125301FBECD1178BD94161F98F50D,
     0xDF5BB3B842D66A8F10B4F343DE4E5721,
     0x4B1C1B62454ED2A55A44C6B75C118C4A,
 ];
 // Expected values after applying `aesdeclast` to `B` and `K`
-const EXPECTED_AESDECLAST: [u128; 4] = [
+const EXPECTED_AESDECLAST: [u128; N] = [
     0x5DA59A6776605A118EF1BCC7D865F89D,
     0xB704AB43789850CDE569874C42F0569B,
     0x98C5F123B4967E2DA4F16F2EDB918529,
     0x319E3DBCE4268B35F215B038FD022054,
 ];
 // Expected value of `k` in loop tests
-const EXPECTED_LOOP_K: [u128; 4] = [
+const EXPECTED_LOOP_K: [u128; N] = [
     0xD21928B8DEB8D0565C1FB92B010E2363,
     0x8D2E2F5521147125F8E24489EA0D8D97,
     0xEE26FC76F1CC0D3D849AAF838A16117B,
     0xA4C8122B4F6C00362E3692B1B7854BF7,
 ];
 // Expected value of `b` in loop tests
-const EXPECTED_LOOP_B: [u128; 4] = [
+const EXPECTED_LOOP_B: [u128; N] = [
     0xE74F19EFD8C28BFE3BD285175F3F68FF,
     0xCE70940A752A6E0A23AD14E31C033BBF,
     0xE224ED621B046A2D337BB2EC5020424E,
@@ -130,7 +133,7 @@ const ITERATIONS: u64 = 128;
 
 #[target_feature(enable = "aes")]
 fn test_aesimc() {
-    for i in 0..4 {
+    for i in 0..N {
         let r = _mm_aesimc_si128(K[i].as_mm());
         assert!(EXPECTED_AESIMC[i].is_eq(r));
     }
@@ -138,7 +141,7 @@ fn test_aesimc() {
 
 #[target_feature(enable = "aes")]
 fn test_aeskeygenassist() {
-    for i in 0..4 {
+    for i in 0..N {
         let r = _mm_aeskeygenassist_si128(K[i].as_mm(), 0x36);
         assert!(EXPECTED_AESKEYGENASSIST[i].is_eq(r));
     }
@@ -146,7 +149,7 @@ fn test_aeskeygenassist() {
 
 #[target_feature(enable = "aes")]
 fn test_aesenc() {
-    for i in 0..4 {
+    for i in 0..N {
         let r = _mm_aesenc_si128(B[i].as_mm(), K[i].as_mm());
         assert!(EXPECTED_AESENC[i].is_eq(r));
     }
@@ -154,7 +157,7 @@ fn test_aesenc() {
 
 #[target_feature(enable = "aes")]
 fn test_aesenclast() {
-    for i in 0..4 {
+    for i in 0..N {
         let r = _mm_aesenclast_si128(B[i].as_mm(), K[i].as_mm());
         assert!(EXPECTED_AESENCLAST[i].is_eq(r));
     }
@@ -162,7 +165,7 @@ fn test_aesenclast() {
 
 #[target_feature(enable = "aes")]
 fn test_aesdec() {
-    for i in 0..4 {
+    for i in 0..N {
         let r = _mm_aesdec_si128(B[i].as_mm(), K[i].as_mm());
         assert!(EXPECTED_AESDEC[i].is_eq(r));
     }
@@ -170,7 +173,7 @@ fn test_aesdec() {
 
 #[target_feature(enable = "aes")]
 fn test_aesdeclast() {
-    for i in 0..4 {
+    for i in 0..N {
         let r = _mm_aesdeclast_si128(B[i].as_mm(), K[i].as_mm());
         assert!(EXPECTED_AESDECLAST[i].is_eq(r));
     }
@@ -194,7 +197,7 @@ fn loop_test_aes_keygen() {
 
 #[target_feature(enable = "aes")]
 fn loop_test_aes() {
-    for i in 0..4 {
+    for i in 0..N {
         let mut k = K[i].as_mm();
         let mut b = k;
         for _ in 0..ITERATIONS {
@@ -213,7 +216,7 @@ fn test_aesenc256() {
     let (b, _) = B.as_chunks::<2>();
     let (k, _) = K.as_chunks::<2>();
     let (e, _) = EXPECTED_AESENC.as_chunks::<2>();
-    for i in 0..2 {
+    for i in 0..N / 2 {
         let r = _mm256_aesenc_epi128(b[i].as_mm(), k[i].as_mm());
         assert!(e[i].is_eq(r));
     }
@@ -224,7 +227,7 @@ fn test_aesenclast256() {
     let (b, _) = B.as_chunks::<2>();
     let (k, _) = K.as_chunks::<2>();
     let (e, _) = EXPECTED_AESENCLAST.as_chunks::<2>();
-    for i in 0..2 {
+    for i in 0..N / 2 {
         let r = _mm256_aesenclast_epi128(b[i].as_mm(), k[i].as_mm());
         assert!(e[i].is_eq(r));
     }
@@ -235,7 +238,7 @@ fn test_aesdec256() {
     let (b, _) = B.as_chunks::<2>();
     let (k, _) = K.as_chunks::<2>();
     let (e, _) = EXPECTED_AESDEC.as_chunks::<2>();
-    for i in 0..2 {
+    for i in 0..N / 2 {
         let r = _mm256_aesdec_epi128(b[i].as_mm(), k[i].as_mm());
         assert!(e[i].is_eq(r));
     }
@@ -246,7 +249,7 @@ fn test_aesdeclast256() {
     let (b, _) = B.as_chunks::<2>();
     let (k, _) = K.as_chunks::<2>();
     let (e, _) = EXPECTED_AESDECLAST.as_chunks::<2>();
-    for i in 0..2 {
+    for i in 0..N / 2 {
         let r = _mm256_aesdeclast_epi128(b[i].as_mm(), k[i].as_mm());
         assert!(e[i].is_eq(r));
     }
@@ -261,7 +264,7 @@ fn loop_test_vaes256() {
     let (expected_bs, tail) = EXPECTED_LOOP_B.as_chunks::<2>();
     assert!(tail.is_empty());
 
-    for i in 0..2 {
+    for i in 0..N / 2 {
         let mut k = ks[i].as_mm();
         let mut b = k;
         for _ in 0..ITERATIONS {


### PR DESCRIPTION
Reworks old one-shot tests by reusing KAT values across 128, 256, and 512 bit tests. Additionally, reduces amount of unsafe code and removes reliance on overflowing literals. Expected values were generated on hardware with AES-NI instructions.